### PR TITLE
TreeView/Mac: text in cells is now correctly vertically centered

### DIFF
--- a/Source/Eto.Platform.Mac/Forms/Controls/MacImageAndTextCell.cs
+++ b/Source/Eto.Platform.Mac/Forms/Controls/MacImageAndTextCell.cs
@@ -190,6 +190,14 @@ namespace Eto.Platform.Mac.Forms.Controls
 					}
 				}
 			}
+
+			SD.SizeF titleSize = this.AttributedStringValue.Size;
+			
+			// test to see if the text height is bigger then the cell, if it is,
+			// don't try to center it or it will be pushed up out of the cell!
+			if (titleSize.Height < cellFrame.Size.Height) {
+				cellFrame.Y = cellFrame.Y + (cellFrame.Size.Height - titleSize.Height) / 2;
+			}
 			
 			if (UseTextShadow) {
 				var str = new NSMutableAttributedString(this.StringValue);


### PR DESCRIPTION
Solution to: https://github.com/picoe/Eto/issues/73
