### PR TITLE
* Fixes Issue #200 Win32 SignedHIWORD

### DIFF
--- a/Source/Eto.Platform.Windows/Properties/AssemblyInfo.cs
+++ b/Source/Eto.Platform.Windows/Properties/AssemblyInfo.cs
@@ -1,4 +1,6 @@
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 [assembly: AssemblyTitle("Eto.Forms - Windows Forms Platform")]
 [assembly: AssemblyDescription("Windows Forms Platform for the Eto.Forms UI Framework")]
+[assembly: InternalsVisibleTo("Eto.Test.WinForms")]

--- a/Source/Eto.Platform.Windows/Win32.cs
+++ b/Source/Eto.Platform.Windows/Win32.cs
@@ -7,7 +7,7 @@ namespace Eto.Platform
 	static class Win32
 	{
 		// Analysis disable InconsistentNaming
-
+        
 		[Flags]
 		public enum SWP : uint
 		{
@@ -121,9 +121,9 @@ namespace Eto.Platform
 
 		public static int SignedLOWORD (IntPtr n) { return SignedLOWORD ((int)((long)n)); }
 
-		public static int SignedHIWORD (int n) { return (short)(n >> 16 & 65535); }
+		public static int SignedHIWORD (int n) { return (short)((n >> 16) & 0xFFFF); }
 
-		public static int SignedLOWORD (int n) { return (short)(n & 65535); }
+		public static int SignedLOWORD (int n) { return (short)(n & 0xFFFF); }
 
 		public static int GetWheelDeltaWParam (IntPtr wParam) { return SignedHIWORD (wParam); }
 

--- a/Source/Eto.Test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
+++ b/Source/Eto.Test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Startup.cs" />
     <Compile Include="UnitTests\MatrixTests.cs" />
+    <Compile Include="UnitTests\NativeTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Eto.Platform.Direct2D\Eto.Platform.Direct2D.csproj">

--- a/Source/Eto.Test/Eto.Test.WinForms/UnitTests/NativeTests.cs
+++ b/Source/Eto.Test/Eto.Test.WinForms/UnitTests/NativeTests.cs
@@ -1,0 +1,31 @@
+﻿using NUnit.Framework;
+
+namespace Eto.Test.WinForms.UnitTests
+{
+    [TestFixture]
+    public class NativeTests
+    {
+        [TestCase(0, 0)]
+        [TestCase(-0x00780000, -0x0078)]
+        [TestCase(0x00780000, 0x0078)]
+        [TestCase(-0x01100000, -0x0110)]
+        [TestCase(0x01100000, 0x0110)]
+        public void SignedHiWord_TestCases_WorkCorrectly(int value, int expected)
+        {
+            var actual = Platform.Win32.SignedHIWORD(value);
+            Assert.AreEqual(expected, actual);
+        }
+
+        [TestCase(0, 0)]
+        [TestCase(-0x00000078, -0x0078)]
+        [TestCase(0x00000078, 0x0078)]
+        [TestCase(-0x00000110, -0x0110)]
+        [TestCase(0x00000110, 0x0110)]
+        public void SignedLoWord_TestCases_WorkCorrectly(int value, int expected)
+        {
+            var actual = Platform.Win32.SignedLOWORD(value);
+            Assert.AreEqual(expected, actual);
+        }
+    }
+
+}


### PR DESCRIPTION
Seems to work correctly now.

Moving the mouse wheel forward results in a positive number.
Moving the mouse wheel backward results in a negative number.
