### PR TITLE
Some updates

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/ButtonHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/ButtonHandler.cs
@@ -90,6 +90,7 @@ namespace Eto.GtkSharp
 				SetImagePosition();
 			}
 		}
+
 		public Image Image
 		{
 			get { return image; }

--- a/Source/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
@@ -104,24 +104,25 @@ namespace Eto.GtkSharp
 					Control.Buffer.ApplyTag(tag, Control.Buffer.StartIter, Control.Buffer.EndIter);
 			}
 		}
-        public virtual Color TextColor
-        {
-            get { return Control.Style.Foreground(Gtk.StateType.Normal).ToEto(); }
-            set { Control.ModifyText(Gtk.StateType.Normal, value.ToGdk()); }
-        }
 
-        public override Color BackgroundColor
-        {
-            get
-            {
-                return base.BackgroundColor;
-            }
-            set
-            {
-                //base.BackgroundColor = value;
-                Control.ModifyBase(Gtk.StateType.Normal, value.ToGdk());
-            }
-        }
+		public virtual Color TextColor
+		{
+			get { return Control.Style.Foreground(Gtk.StateType.Normal).ToEto(); }
+			set { Control.ModifyText(Gtk.StateType.Normal, value.ToGdk()); }
+		}
+
+		public override Color BackgroundColor
+		{
+			get
+			{
+				return base.BackgroundColor;
+			}
+			set
+			{
+				//base.BackgroundColor = value;
+				Control.ModifyBase(Gtk.StateType.Normal, value.ToGdk());
+			}
+		}
 
 		public bool ReadOnly
 		{

--- a/Source/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -193,11 +193,11 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-        public Color TextColor
-        {
-            get { return Control.TextColor.ToEto(); }
-            set { Control.TextColor = value.ToNSUI(); }
-        }
+		public Color TextColor
+		{
+			get { return Control.TextColor.ToEto(); }
+			set { Control.TextColor = value.ToNSUI(); }
+		}
 
 		Font font;
 

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/TextAreaSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/TextAreaSection.cs
@@ -28,16 +28,13 @@ namespace Eto.Test.Sections.Controls
 		Control Default()
 		{
 			var text = new TextArea { Text = "Some Text" };
-		    text.BackgroundColor = Colors.Black;
-		    text.TextColor = Colors.Gray;
-
 			LogEvents(text);
 
 			var layout = new DynamicLayout();
 
 			layout.Add(text);
 			layout.BeginVertical(Padding.Empty, Size.Empty);
-			layout.AddRow(null, ShowSelectedText(text), SetSelectedText(text), ReplaceSelected(text), SelectAll(text), SetCaret(text), null);
+			layout.AddRow(null, ShowSelectedText(text), SetSelectedText(text), ReplaceSelected(text), SelectAll(text), SetCaret(text),ChangeColor(text), null);
 			layout.EndVertical();
 
 			return layout;
@@ -88,6 +85,17 @@ namespace Eto.Test.Sections.Controls
 			control.Click += (sender, e) => {
 				textArea.CaretIndex = textArea.Text.Length / 2;
 				textArea.Focus();
+			};
+			return control;
+		}
+
+		Control ChangeColor(TextArea textArea)
+		{
+			var control = new Button { Text = "Change Color" };
+			control.Click += (sender, e) =>
+			{
+				textArea.BackgroundColor = Colors.Black;
+				textArea.TextColor = Colors.Blue;
 			};
 			return control;
 		}

--- a/Source/Eto.WinForms/Forms/Controls/TextAreaHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TextAreaHandler.cs
@@ -82,11 +82,11 @@ namespace Eto.WinForms
 			set { Control.WordWrap = value; }
 		}
 
-        public Color TextColor
-        {
-            get { return Control.ForeColor.ToEto(); }
-            set { Control.ForeColor = value.ToSD(); }
-        }
+		public Color TextColor
+		{
+			get { return Control.ForeColor.ToEto(); }
+			set { Control.ForeColor = value.ToSD(); }
+		}
 
 		public void Append(string text, bool scrollToCursor)
 		{

--- a/Source/Eto.WinRT/Forms/Controls/TextAreaHandler.cs
+++ b/Source/Eto.WinRT/Forms/Controls/TextAreaHandler.cs
@@ -108,6 +108,12 @@ namespace Eto.WinRT.Forms.Controls
 			set	{ Control.Text = value;	}
 		}
 
+		public Color TextColor
+		{
+			get { return Control.Foreground.ToEtoColor(); }
+			set { Control.Foreground = value.ToWpfBrush(); }
+		}
+
 		public bool Wrap
 		{
 			get { return Control.TextWrapping == sw.TextWrapping.Wrap; }

--- a/Source/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
@@ -86,11 +86,11 @@ namespace Eto.Wpf.Forms.Controls
 			set	{ Control.Text = value;	}
 		}
 
-        public Color TextColor
-        {
-            get { return Control.Foreground.ToEtoColor(); }
-            set { Control.Foreground = value.ToWpfBrush(Control.Foreground); }
-        }
+		public Color TextColor
+		{
+			get { return Control.Foreground.ToEtoColor(); }
+			set { Control.Foreground = value.ToWpfBrush(Control.Foreground); }
+		}
 
 		public bool Wrap
 		{

--- a/Source/Eto/Forms/Controls/TextArea.cs
+++ b/Source/Eto/Forms/Controls/TextArea.cs
@@ -133,18 +133,18 @@ namespace Eto.Forms
 			set { Handler.Wrap = value; }
 		}
 
-        /// <summary>
-        /// Gets or sets the color of the text.
-        /// </summary>
-        /// <remarks>
-        /// By default, the label will get a color based on the user's theme. However, this is usually black.
-        /// </remarks>
-        /// <value>The color of the text.</value>
-        public Color TextColor
-        {
-            get { return Handler.TextColor; }
-            set { Handler.TextColor = value; }
-        }
+		/// <summary>
+		/// Gets or sets the color of the text.
+		/// </summary>
+		/// <remarks>
+		/// By default, the label will get a color based on the user's theme. However, this is usually black.
+		/// </remarks>
+		/// <value>The color of the text.</value>
+		public Color TextColor
+		{
+			get { return Handler.TextColor; }
+			set { Handler.TextColor = value; }
+		}
 
 		/// <summary>
 		/// Gets or sets the selected text.
@@ -285,14 +285,14 @@ namespace Eto.Forms
 			/// <value><c>true</c> to wrap the text; otherwise, <c>false</c>.</value>
 			bool Wrap { get; set; }
 
-            /// <summary>
-            /// Gets or sets the color of the text.
-            /// </summary>
-            /// <remarks>
-            /// By default, the label will get a color based on the user's theme. However, this is usually black.
-            /// </remarks>
-            /// <value>The color of the text.</value>
-            Color TextColor { get; set; }
+			/// <summary>
+			/// Gets or sets the color of the text.
+			/// </summary>
+			/// <remarks>
+			/// By default, the label will get a color based on the user's theme. However, this is usually black.
+			/// </remarks>
+			/// <value>The color of the text.</value>
+			Color TextColor { get; set; }
 
 			/// <summary>
 			/// Append the specified text to the control and optionally scrolls to make the inserted text visible.


### PR DESCRIPTION
1. Fix a bug, when run in windows with mono, `TextArea.BackgroundColor` could't take effect.
2. Add new property `TextColor` to `TextArea`(Mac's TextColor not test).

![2](https://cloud.githubusercontent.com/assets/7532281/4055726/63d99fea-2dac-11e4-93c4-83c3ab487bb0.png)
