### PR TITLE
Fix TabControl's Scroll Bug && Beautify GridView

### DIFF
--- a/Source/Eto.WinForms/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/GridHandler.cs
@@ -67,8 +67,7 @@ namespace Eto.WinForms.Forms.Controls
 				AllowUserToResizeRows = false,
 				AutoSize = true,
 				AutoSizeColumnsMode = swf.DataGridViewAutoSizeColumnsMode.DisplayedCells,
-				ColumnHeadersHeightSizeMode = swf.DataGridViewColumnHeadersHeightSizeMode.DisableResizing,
-				ColumnHeadersBorderStyle = swf.DataGridViewHeaderBorderStyle.None
+				ColumnHeadersHeightSizeMode = swf.DataGridViewColumnHeadersHeightSizeMode.DisableResizing
 			};
 			Control.CellValueNeeded += (sender, e) =>
 			{


### PR DESCRIPTION
1. Fix TabControl's scroll bug, when use GetChildAtPoint, always return the first tabpage. Should use GetChildAtPoint with GetChildAtPointSkip.
2. Change GridView's ColumnHeadersBorderStyle in winform, more beautiful.
