### PR TITLE
Fix a bug, when set size in gtk

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/GtkControl.cs
+++ b/Source/Eto.Gtk/Forms/Controls/GtkControl.cs
@@ -64,7 +64,7 @@ namespace Eto.GtkSharp
 
 		protected GtkControl()
 		{
-			size = Size.Empty;
+			size = new Size(-1, -1);
 		}
 
 		public virtual Size DefaultSize { get { return new Size(-1, -1); } }

--- a/Source/Eto.WinForms/Forms/Controls/ComboBoxHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/ComboBoxHandler.cs
@@ -9,7 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Eto.Drawing;
 
-namespace Eto.WinForms.Forms
+namespace Eto.WinForms
 {
 	public class ComboBoxHandler : DropDownHandler, ComboBox.IHandler
 	{


### PR DESCRIPTION
Sometimes just need change `Width`, like this: 

```
var c = new ComboBox(); 
c.Size = new Size(200,c.Size.Height);
```
