### PR TITLE
Moved CellClick and CellDoubleClick from GridView to Grid

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -125,6 +125,16 @@ namespace Eto.GtkSharp.Forms.Controls
 				case Grid.CellFormattingEvent:
 					SetupColumnEvents();
 					break;
+				case Grid.CellDoubleClickEvent:
+					Tree.RowActivated += (sender, e) =>
+					{
+						var rowIndex = e.Path.Indices.Length > 0 ? e.Path.Indices[0] : -1;
+						var columnIndex = GetColumnOfItem(e.Column);
+						var item = GetItem(e.Path);
+						var column = columnIndex == -1 ? null : Widget.Columns[columnIndex];
+						Callback.OnCellDoubleClick(Widget, new GridViewCellEventArgs(column, rowIndex, columnIndex, item));
+					};
+					break;
 				case Grid.SelectionChangedEvent:
 					Tree.Selection.Changed += Connector.HandleGridSelectionChanged;
 					break;
@@ -225,6 +235,11 @@ namespace Eto.GtkSharp.Forms.Controls
 		}
 
 		public abstract object GetItem(Gtk.TreePath path);
+
+		public int GetColumnOfItem(Gtk.TreeViewColumn item)
+		{
+			return Widget.Columns.Select(r => r.Handler as GridColumnHandler).Select(r => r.Control).ToList().IndexOf(item);
+		}
 
 		public abstract Gtk.TreeIter GetIterAtRow(int row);
 

--- a/Source/Eto.Gtk/Forms/Controls/GridViewHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/GridViewHandler.cs
@@ -71,16 +71,6 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			switch (id)
 			{
-				case GridView.CellDoubleClickEvent:
-					Tree.RowActivated += (sender, e) =>
-					{
-						var rowIndex = e.Path.Indices.Length > 0 ? e.Path.Indices[0] : -1;
-						var columnIndex = GetColumnOfItem(e.Column);
-						var item = GetItem(e.Path);
-						var column = columnIndex == -1 ? null : Widget.Columns[columnIndex];
-						Callback.OnCellDoubleClick(Widget, new GridViewCellEventArgs(column, rowIndex, columnIndex, item));
-					};
-					break;
 				default:
 					base.AttachEvent(id);
 					break;
@@ -162,11 +152,6 @@ namespace Eto.GtkSharp.Forms.Controls
 		public int GetRowOfItem(object item)
 		{
 			return collection != null ? collection.IndexOf(item) : -1;
-		}
-
-		public int GetColumnOfItem(Gtk.TreeViewColumn item)
-		{
-			return Widget.Columns.Select(r => r.Handler as GridColumnHandler).Select(r => r.Control).ToList().IndexOf(item);
 		}
 
 		public EnumerableChangedHandler<object> Collection

--- a/Source/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -288,6 +288,19 @@ namespace Eto.Mac.Forms.Controls
 		{
 			switch (id)
 			{
+				case Grid.CellDoubleClickEvent:
+					Control.DoubleClick += (sender, e) =>
+					{
+						int rowIndex;
+						if ((rowIndex = (int)Control.ClickedRow) >= 0)
+						{
+							var columnIndex = (int)Control.ClickedColumn;
+							var item = GetItem(rowIndex);
+							var column = columnIndex == -1 ? null : Widget.Columns[columnIndex];
+							Callback.OnCellDoubleClick(Widget, new GridViewCellEventArgs(column, rowIndex, columnIndex, item));
+						}
+					};
+					break;
 				default:
 					base.AttachEvent(id);
 					break;

--- a/Source/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -184,19 +184,6 @@ namespace Eto.Mac.Forms.Controls
 					break;
 				case Grid.CellFormattingEvent:
 					break;
-				case GridView.CellDoubleClickEvent:
-					Control.DoubleClick += (sender, e) =>
-					{
-						int rowIndex;
-						if ((rowIndex = (int)Control.ClickedRow) >= 0)
-						{
-							var columnIndex = (int)Control.ClickedColumn;
-							var item = GetItem(rowIndex);
-							var column = columnIndex == -1 ? null : Widget.Columns[columnIndex];
-							Callback.OnCellDoubleClick(Widget, new GridViewCellEventArgs(column, rowIndex, columnIndex, item));
-						}
-					};
-					break;
 				default:
 					base.AttachEvent(id);
 					break;

--- a/Source/Eto.WinForms/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/GridHandler.cs
@@ -215,6 +215,25 @@ namespace Eto.WinForms.Forms.Controls
 						Callback.OnCellEdited(Widget, new GridViewCellEventArgs(column, e.RowIndex, e.ColumnIndex, item));
 					};
 					break;
+				case Grid.CellClickEvent:
+					Control.CellClick += (sender, e) =>
+					{
+						var item = GetItemAtRow(e.RowIndex);
+						var column = Widget.Columns[e.ColumnIndex];
+						Callback.OnCellClick(Widget, new GridViewCellEventArgs(column, e.RowIndex, e.ColumnIndex, item));
+					};
+					break;
+				case Grid.CellDoubleClickEvent:
+					Control.CellDoubleClick += (sender, e) =>
+					{
+						if (e.RowIndex > -1)
+						{
+							var item = GetItemAtRow(e.RowIndex);
+							var column = Widget.Columns[e.ColumnIndex];
+							Callback.OnCellDoubleClick(Widget, new GridViewCellEventArgs(column, e.RowIndex, e.ColumnIndex, item));
+						}
+					};
+					break;
 				case Grid.SelectionChangedEvent:
 					// handled automatically
 					break;

--- a/Source/Eto.WinForms/Forms/Controls/GridViewHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/GridViewHandler.cs
@@ -21,25 +21,6 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			switch (id)
 			{
-				case GridView.CellClickEvent:
-					Control.CellClick += (sender, e) =>
-					{
-						var item = GetItemAtRow(e.RowIndex);
-						var column = Widget.Columns[e.ColumnIndex];
-						Callback.OnCellClick(Widget, new GridViewCellEventArgs(column, e.RowIndex, e.ColumnIndex, item));
-					};
-					break;
-				case GridView.CellDoubleClickEvent:
-					Control.CellDoubleClick += (sender, e) =>
-					{
-						if (e.RowIndex > -1)
-						{
-							var item = GetItemAtRow(e.RowIndex);
-							var column = Widget.Columns[e.ColumnIndex];
-							Callback.OnCellDoubleClick(Widget, new GridViewCellEventArgs(column, e.RowIndex, e.ColumnIndex, item));
-						}
-					};
-					break;
 				default:
 					base.AttachEvent(id);
 					break;

--- a/Source/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -77,6 +77,19 @@ namespace Eto.Wpf.Forms.Controls
 				case Grid.CellEditedEvent:
 					// handled by each cell after value is set with the CellEdited method
 					break;
+				case Grid.CellDoubleClickEvent:
+					Control.MouseDoubleClick += (sender, e) =>
+					{
+						int rowIndex;
+						if ((rowIndex = Control.SelectedIndex) >= 0)
+						{
+							var columnIndex = Control.CurrentColumn == null ? -1 : Control.CurrentColumn.DisplayIndex;
+							var item = Control.SelectedItem;
+							var column = Widget.Columns[columnIndex];
+							Callback.OnCellDoubleClick(Widget, new GridViewCellEventArgs(column, rowIndex, columnIndex, item));
+						}
+					};
+					break;
 				case Grid.SelectionChangedEvent:
 					Control.SelectedCellsChanged += (sender, e) =>
 					{

--- a/Source/Eto.Wpf/Forms/Controls/GridViewHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/GridViewHandler.cs
@@ -26,19 +26,6 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			switch (id)
 			{
-				case GridView.CellDoubleClickEvent:
-					Control.MouseDoubleClick += (sender, e) =>
-					{
-						int rowIndex;
-						if ((rowIndex = Control.SelectedIndex) >= 0)
-						{
-							var columnIndex = Control.CurrentColumn == null ? -1 : Control.CurrentColumn.DisplayIndex;
-							var item = Control.SelectedItem;
-							var column = Widget.Columns[columnIndex];
-							Callback.OnCellDoubleClick(Widget, new GridViewCellEventArgs(column, rowIndex, columnIndex, item));
-						}
-					};
-					break;
 				default:
 					base.AttachEvent(id);
 					break;

--- a/Source/Eto/Forms/Controls/Grid.cs
+++ b/Source/Eto/Forms/Controls/Grid.cs
@@ -176,6 +176,52 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Event identifier for the <see cref="CellClick"/> event.
+		/// </summary>
+		public const string CellClickEvent = "Grid.CellClick";
+
+		/// <summary>
+		/// Occurs when an individual cell is clicked.
+		/// </summary>
+		public event EventHandler<GridViewCellEventArgs> CellClick
+		{
+			add { Properties.AddHandlerEvent(CellClickEvent, value); }
+			remove { Properties.RemoveEvent(CellClickEvent, value); }
+		}
+
+		/// <summary>
+		/// Raises the <see cref="CellClick"/> event.
+		/// </summary>
+		/// <param name="e">Grid cell event arguments.</param>
+		protected virtual void OnCellClick(GridViewCellEventArgs e)
+		{
+			Properties.TriggerEvent(CellClickEvent, this, e);
+		}
+
+		/// <summary>
+		/// Event identifier for the <see cref="CellDoubleClick"/> event.
+		/// </summary>
+		public const string CellDoubleClickEvent = "Grid.CellDoubleClick";
+
+		/// <summary>
+		/// Occurs when an individual cell is double clicked.
+		/// </summary>
+		public event EventHandler<GridViewCellEventArgs> CellDoubleClick
+		{
+			add { Properties.AddHandlerEvent(CellDoubleClickEvent, value); }
+			remove { Properties.RemoveEvent(CellDoubleClickEvent, value); }
+		}
+
+		/// <summary>
+		/// Raises the <see cref="CellDoubleClick"/> event.
+		/// </summary>
+		/// <param name="e">Grid cell event arguments.</param>
+		protected virtual void OnCellDoubleClick(GridViewCellEventArgs e)
+		{
+			Properties.TriggerEvent(CellDoubleClickEvent, this, e);
+		}
+
+		/// <summary>
 		/// Event identifier for handlers when attaching the <see cref="Grid.SelectionChanged"/> event
 		/// </summary>
 		public const string SelectionChangedEvent = "Grid.SelectionChanged";
@@ -269,6 +315,8 @@ namespace Eto.Forms
 			EventLookup.Register<Grid>(c => c.OnCellEdited(null), Grid.CellEditedEvent);
 			EventLookup.Register<Grid>(c => c.OnCellEditing(null), Grid.CellEditingEvent);
 			EventLookup.Register<Grid>(c => c.OnCellFormatting(null), Grid.CellFormattingEvent);
+			EventLookup.Register<Grid>(c => c.OnCellClick(null), Grid.CellClickEvent);
+			EventLookup.Register<Grid>(c => c.OnCellDoubleClick(null), Grid.CellDoubleClickEvent);
 			EventLookup.Register<Grid>(c => c.OnSelectionChanged(null), Grid.SelectionChangedEvent);
 			EventLookup.Register<Grid>(c => c.OnColumnHeaderClick(null), Grid.ColumnHeaderClickEvent);
 		}
@@ -495,6 +543,16 @@ namespace Eto.Forms
 			void OnCellEdited(Grid widget, GridViewCellEventArgs e);
 
 			/// <summary>
+			/// Raises the cell click event.
+			/// </summary>
+			void OnCellClick(Grid widget, GridViewCellEventArgs e);
+
+			/// <summary>
+			/// Raises the cell double click event.
+			/// </summary>
+			void OnCellDoubleClick(Grid widget, GridViewCellEventArgs e);
+
+			/// <summary>
 			/// Raises the selection changed event.
 			/// </summary>
 			void OnSelectionChanged(Grid widget, EventArgs e);
@@ -529,6 +587,22 @@ namespace Eto.Forms
 			public void OnCellEdited(Grid widget, GridViewCellEventArgs e)
 			{
 				widget.Platform.Invoke(() => widget.OnCellEdited(e));
+			}
+
+			/// <summary>
+			/// Raises the cell click event.
+			/// </summary>
+			public void OnCellClick(Grid widget, GridViewCellEventArgs e)
+			{
+				widget.Platform.Invoke(() => widget.OnCellClick(e));
+			}
+
+			/// <summary>
+			/// Raises the cell double click event.
+			/// </summary>
+			public void OnCellDoubleClick(Grid widget, GridViewCellEventArgs e)
+			{
+				widget.Platform.Invoke(() => widget.OnCellDoubleClick(e));
 			}
 
 			/// <summary>

--- a/Source/Eto/Forms/Controls/GridView.cs
+++ b/Source/Eto/Forms/Controls/GridView.cs
@@ -156,11 +156,6 @@ namespace Eto.Forms
 		/// </summary>
 		public Func<object, string> DeleteConfirmationTitle { get; set; }
 
-		static GridView()
-		{
-			EventLookup.Register<GridView>(c => c.OnCellClick(null), GridView.CellClickEvent);
-		}
-
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Eto.Forms.GridView"/> class.
 		/// </summary>
@@ -235,56 +230,6 @@ namespace Eto.Forms
 			get { return GridLines != GridLines.None; }
 			set { GridLines = value ? GridLines.Both : GridLines.None; }
 		}
-
-		#region Events
-
-		/// <summary>
-		/// Event identifier for the <see cref="CellClick"/> event.
-		/// </summary>
-		public const string CellClickEvent = "GridView.CellClick";
-
-		/// <summary>
-		/// Occurs when an individual cell is clicked.
-		/// </summary>
-		public event EventHandler<GridViewCellEventArgs> CellClick
-		{
-			add { Properties.AddHandlerEvent(CellClickEvent, value); }
-			remove { Properties.RemoveEvent(CellClickEvent, value); }
-		}
-
-		/// <summary>
-		/// Raises the <see cref="CellClick"/> event.
-		/// </summary>
-		/// <param name="e">Grid cell event arguments.</param>
-		protected virtual void OnCellClick(GridViewCellEventArgs e)
-		{
-			Properties.TriggerEvent(CellClickEvent, this, e);
-		}
-
-		/// <summary>
-		/// Event identifier for the <see cref="CellDoubleClick"/> event.
-		/// </summary>
-		public const string CellDoubleClickEvent = "GridView.CellDoubleClick";
-
-		/// <summary>
-		/// Occurs when an individual cell is double clicked.
-		/// </summary>
-		public event EventHandler<GridViewCellEventArgs> CellDoubleClick
-		{
-			add { Properties.AddHandlerEvent(CellDoubleClickEvent, value); }
-			remove { Properties.RemoveEvent(CellDoubleClickEvent, value); }
-		}
-
-		/// <summary>
-		/// Raises the <see cref="CellDoubleClick"/> event.
-		/// </summary>
-		/// <param name="e">Grid cell event arguments.</param>
-		protected virtual void OnCellDoubleClick(GridViewCellEventArgs e)
-		{
-			Properties.TriggerEvent(CellDoubleClickEvent, this, e);
-		}
-
-		#endregion
 
 		class SelectionPreserverHelper : ISelectionPreserver
 		{
@@ -419,44 +364,6 @@ namespace Eto.Forms
 		protected override object GetCallback()
 		{
 			return callback;
-		}
-
-		/// <summary>
-		/// Callback interface for the <see cref="GridView"/>
-		/// </summary>
-		public new interface ICallback : Grid.ICallback
-		{
-			/// <summary>
-			/// Raises the cell click event.
-			/// </summary>
-			void OnCellClick(GridView widget, GridViewCellEventArgs e);
-
-			/// <summary>
-			/// Raises the cell double click event.
-			/// </summary>
-			void OnCellDoubleClick(GridView widget, GridViewCellEventArgs e);
-		}
-
-		/// <summary>
-		/// Callback implementation for handlers of the <see cref="GridView"/>.
-		/// </summary>
-		protected new class Callback : Grid.Callback, ICallback
-		{
-			/// <summary>
-			/// Raises the cell click event.
-			/// </summary>
-			public void OnCellClick(GridView widget, GridViewCellEventArgs e)
-			{
-				widget.Platform.Invoke(() => widget.OnCellClick(e));
-			}
-
-			/// <summary>
-			/// Raises the cell double click event.
-			/// </summary>
-			public void OnCellDoubleClick(GridView widget, GridViewCellEventArgs e)
-			{
-				widget.Platform.Invoke(() => widget.OnCellDoubleClick(e));
-			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
This is my first pull request so any tips are welcome. :)

This moves the events CellClick and CellDoubleClick from GridView to Grid.
It also moves the event implementations from GridViewHandler to GridHandler for
the following platforms. WinForms, Wpf, Gtk, Mac

fixes #271 

It doesn't implement the CellClick and CellDoubleClick events in GridHandler in the platforms that miss it.
We can create a new issue for that.

Platforms that have CellClick:
- WinForms

Platforms that have CellDoubleClick:
- WinForms
- Wpf
- Gtk
- Mac