### PR TITLE
* WinForms: Makes LinkButton text size behave similarly to Label

### DIFF
--- a/Source/Eto.WinForms/Forms/Controls/LinkButtonHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/LinkButtonHandler.cs
@@ -9,9 +9,84 @@ namespace Eto.WinForms.Forms.Controls
 {
 	public class LinkButtonHandler : WindowsControl<swf.LinkLabel, LinkButton, LinkButton.ICallback>, LinkButton.IHandler
 	{
+		public class EtoLink : swf.LinkLabel
+		{
+			public override sd.Font Font
+			{
+				get
+				{
+					return base.Font;
+				}
+				set
+				{
+					base.Font = value;
+					ClearSize();
+				}
+			}
+
+			public override string Text
+			{
+				get
+				{
+					return base.Text;
+				}
+				set
+				{
+					base.Text = value;
+					ClearSize();
+				}
+			}
+			void ClearSize()
+			{
+				measuredSize = measuredSizeMax = null;
+			}
+
+			swf.TextFormatFlags textFormat = swf.TextFormatFlags.Default;
+			sd.SizeF? measuredSize;
+			sd.Size proposedSizeCache;
+			sd.SizeF? measuredSizeMax;
+
+			public override sd.Size GetPreferredSize(sd.Size proposedSize)
+			{
+				var bordersAndPadding = Margin.Size; // this.SizeFromClientSize (SD.Size.Empty);
+				if( proposedSize.Width <= 1 )
+					proposedSize.Width = int.MaxValue;
+
+				if( proposedSize.Width == int.MaxValue )
+				{
+					if( measuredSizeMax == null && string.IsNullOrEmpty(Text) )
+					{
+						var emptySize = swf.TextRenderer.MeasureText(" ", Font, new sd.Size(proposedSize.Width, int.MaxValue), textFormat);
+						measuredSizeMax = new sd.SizeF(0, emptySize.Height);
+					}
+					else if( measuredSizeMax == null )
+					{
+						proposedSize -= bordersAndPadding;
+						proposedSize.Height = Math.Max(0, proposedSize.Height);
+						measuredSizeMax = swf.TextRenderer.MeasureText(Text, Font, new sd.Size(proposedSize.Width, int.MaxValue), textFormat);
+					}
+					measuredSize = measuredSizeMax;
+				}
+				else if( measuredSize == null || proposedSizeCache != proposedSize )
+				{
+					proposedSizeCache = proposedSize;
+					proposedSize -= bordersAndPadding;
+					proposedSize.Height = Math.Max(0, proposedSize.Height);
+					measuredSize = swf.TextRenderer.MeasureText(Text, Font, new sd.Size(proposedSize.Width, int.MaxValue), textFormat);
+				}
+				var size = measuredSize.Value;
+				size += bordersAndPadding;
+				if( size.Width < MinimumSize.Width )
+					size.Width = MinimumSize.Width;
+				if( size.Height < MinimumSize.Height )
+					size.Height = MinimumSize.Height;
+				return sd.Size.Ceiling(size);
+			}
+		}
+		
 		public LinkButtonHandler()
 		{
-			Control = new swf.LinkLabel
+			Control = new EtoLink
 			{
 				AutoSize = true
 			};


### PR DESCRIPTION
Basically, a copy over from LabelHandler in WinForms that makes LinkButton behave similarly when Text property is set after it's been added to a layout.