### PR TITLE
Wpf Splitter.set_Position fix #302

### DIFF
--- a/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
@@ -242,8 +242,6 @@ namespace Eto.Wpf.Forms.Controls
 			}
 			set
 			{
-				var col1 = Control.ColumnDefinitions[0];
-				var col2 = Control.ColumnDefinitions[2];
 				if (!Widget.Loaded)
 				{
 					position = value;
@@ -252,14 +250,18 @@ namespace Eto.Wpf.Forms.Controls
 				}
 				if (splitter.ResizeDirection == swc.GridResizeDirection.Columns)
 				{
-					var controlWidth = Control.IsLoaded ? Control.ActualWidth : Control.Width;
+					var col1 = Control.ColumnDefinitions[0];
+					var col2 = Control.ColumnDefinitions[2];
+					var controlWidth = Control.ActualWidth;
+					if (double.IsNaN(controlWidth))
+						controlWidth = Control.Width;
 					switch (fixedPanel)
 					{
 						case SplitterFixedPanel.None:
 							if (Widget.Loaded)
 							{
-								var scale = (col1.Width.Value + col2.Width.Value) / controlWidth;
-								col1.Width = new sw.GridLength(value * scale, sw.GridUnitType.Star);
+								col1.Width = new sw.GridLength(value, sw.GridUnitType.Star);
+								col2.Width = new sw.GridLength(controlWidth - value, sw.GridUnitType.Star);
 							}
 							break;
 						case SplitterFixedPanel.Panel1:
@@ -277,14 +279,16 @@ namespace Eto.Wpf.Forms.Controls
 				{
 					var row1 = Control.RowDefinitions[0];
 					var row2 = Control.RowDefinitions[2];
-					var controlHeight = Control.IsLoaded ? Control.ActualHeight : Control.Height;
+					var controlHeight = Control.ActualHeight;
+					if (double.IsNaN(controlHeight))
+						controlHeight = Control.Height;
 					switch (fixedPanel)
 					{
 						case SplitterFixedPanel.None:
 							if (Widget.Loaded)
 							{
-								var scale = (row1.Height.Value + row2.Height.Value) / controlHeight;
-								row1.Height = new sw.GridLength(value * scale, sw.GridUnitType.Star);
+								row1.Height = new sw.GridLength(value, sw.GridUnitType.Star);
+								row2.Height = new sw.GridLength(controlHeight - value, sw.GridUnitType.Star);
 							}
 							break;
 						case SplitterFixedPanel.Panel1:


### PR DESCRIPTION
fix #302

1. Method of choosing between Control.ActualWidth and Control.Width
  (now based on `double.IsNaN` instead of `Control.IsLoaded`)
2. Adjustements for `FixedPanel = None` to behave correctly (visually checked against WinForms)

Note: AppVeyor failed due to XamMac.dll download failure
https://ci.appveyor.com/project/firda-cze/eto/build/2.1.0.1#L15

    appveyor DownloadFile %XAMMAC_LOCATION%/XamMac.dll -FileName %BASE%\BuildOutput\net40\Release\XamMac.dll
    Error downloading file: Could not find file 'C:\XamMac.dll'.
    Command exited with code 2

Eto - Free.sln change (by VS) excluded, I cannot open Mac projects on Windows with VS2013 Community Edition.