### PR TITLE
Splitter startup sanity for FixedPanel != Panel1 fix #309 [Wpf,Swf,Gtk2]

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/SplitterHandler.cs
@@ -114,6 +114,38 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 			if (position != null)
 				Control.Position = position.Value;
+
+			if (fixedPanel != SplitterFixedPanel.Panel1)
+				Control.SizeAllocated += Control_SizeAllocated;
+		}
+
+		void Control_SizeAllocated(object o, Gtk.SizeAllocatedArgs args)
+		{
+			Control.SizeAllocated -= Control_SizeAllocated;
+			if (position == null)
+				return;
+			if (orientation == SplitterOrientation.Horizontal)
+			{
+				int width = PreferredSize.Width;
+				if (width <= 0)
+					return;
+				if (fixedPanel == SplitterFixedPanel.Panel2)
+					Control.Position = Math.Max(0,
+						position.Value + args.Allocation.Width - width);
+				else
+					Control.Position = position.Value * args.Allocation.Width / width;
+			}
+			else
+			{
+				int height = PreferredSize.Height;
+				if (height <= 0)
+					return;
+				if (fixedPanel == SplitterFixedPanel.Panel2)
+					Control.Position = Math.Max(0,
+						position.Value + args.Allocation.Height - height);
+				else
+					Control.Position = position.Value * args.Allocation.Height / height;
+			}
 		}
 
 		static Gtk.Widget EmptyContainer()

--- a/Source/Eto.Test/Eto.Test/MainForm.cs
+++ b/Source/Eto.Test/Eto.Test/MainForm.cs
@@ -31,7 +31,7 @@ namespace Eto.Test
 
 		public MainForm(IEnumerable<Section> topNodes = null)
 		{
-			Title = "Test Application";
+			Title = string.Format("Test Application [{0}]", Platform.ID);
 			Style = "main";
 			MinimumSize = new Size(400, 400);
 			topNodes = topNodes ?? TestSections.Get();

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/SplitterSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/SplitterSection.cs
@@ -18,6 +18,7 @@ namespace Eto.Test.Sections.Controls
 			layout.AddCentered(Test2WithSize());
 			layout.AddCentered(Test2AutoSize());
 			layout.AddCentered(TestDynamic());
+			layout.AddCentered(TestInitResize());
 			layout.Add(null);
 			Content = layout;
 		}
@@ -68,7 +69,10 @@ namespace Eto.Test.Sections.Controls
 		static Form Test1(bool setSize, Action<Label[], Panel> layoutContent)
 		{
 			// Status bar
-			Label[] status = { new Label(), new Label(), new Label(), new Label(), new Label() };
+			Label[] status = {
+				new Label(), new Label(), new Label(),
+				new Label(), new Label(), new Label()
+			};
 			var statusLayout = new DynamicLayout { Padding = Padding.Empty, Spacing = Size.Empty };
 			statusLayout.BeginHorizontal();
 			for (var i = 0; i < status.Length; ++i)
@@ -138,7 +142,10 @@ namespace Eto.Test.Sections.Controls
 			mainPanel.Content = splitLayout.Layout(
 				i =>
 				{
-					var button = new Button { Text = "Click to update status " + i, BackgroundColor = splitLayout.PanelColors[i] };
+					var button = new Button {
+						Text = "Click to update status " + i,
+						BackgroundColor = splitLayout.PanelColors[i]
+					};
 					button.Click += (s, e) => status[i].Text = "New count: " + (count++);
 					return button;
 				});
@@ -175,11 +182,14 @@ namespace Eto.Test.Sections.Controls
 
 			public Panel[] Panels { get; private set; }
 
-			public Color[] PanelColors = { Colors.PaleTurquoise, Colors.Olive, Colors.NavajoWhite, Colors.Purple, Colors.Orange };
+			public Color[] PanelColors = {
+				Colors.PaleTurquoise, Colors.Olive, Colors.NavajoWhite,
+				Colors.Purple, Colors.Orange, Colors.Aqua };
 
 			public SplitLayout(Panel[] panels = null)
 			{
-				this.Panels = panels ?? new Panel[] { new Panel(), new Panel(), new Panel(), new Panel(), new Panel() };
+				this.Panels = panels ?? new Panel[] {
+					new Panel(), new Panel(), new Panel(), new Panel(), new Panel(), new Panel() };
 			}
 
 			public Control Layout(Func<int, Control>getContent)
@@ -188,21 +198,45 @@ namespace Eto.Test.Sections.Controls
 				// |---------------------------
 				// |        |      |          |
 				// |  P0    |  P2  |   P4     |
-				// | -------|      |          |  <== These are on MainPanel
-				// |  P1    |------|          |
+				// | -------|      |----------|  <== These are on MainPanel
+				// |  P1    |------|   P5     |
 				// |        |  P3  |          |
 				// |---------------------------
-				// |         status0..4,      |  <== These are on StatusPanel
+				// |         status0..5,      |  <== These are on StatusPanel
 				// ----------------------------
 
 				for (var i = 0; i < Panels.Length; ++i)
 					Panels[i].Content = getContent(i);
 
-				var p0_1 = new Splitter { Panel1 = Panels[0], Panel2 = Panels[1], Orientation = SplitterOrientation.Vertical, Position = 200 };
-				var p2_3 = new Splitter { Panel1 = Panels[2], Panel2 = Panels[3], Orientation = SplitterOrientation.Vertical, Position = 200, FixedPanel = SplitterFixedPanel.Panel2 };
-				var p01_23 = new Splitter { Panel1 = p0_1, Panel2 = p2_3, Orientation = SplitterOrientation.Horizontal, Position = 200 };
-				var p0123_4 = new Splitter { Panel1 = p01_23, Panel2 = Panels[4], Orientation = SplitterOrientation.Horizontal, Position = 400 };
-				return this.Root = p0123_4;
+				var p0_1 = new Splitter {
+					Panel1 = Panels[0], Panel2 = Panels[1],
+					Orientation = SplitterOrientation.Vertical,
+					Position = 200
+				};
+				var p2_3 = new Splitter {
+					Panel1 = Panels[2], Panel2 = Panels[3],
+					Orientation = SplitterOrientation.Vertical,
+					FixedPanel = SplitterFixedPanel.Panel2,
+					// -200px from bottom with minimal height for autosize test (p0_1 should preffer higher)
+					Position = 0, Height = 205
+				};
+				var p4_5 = new Splitter {
+					Panel1 = Panels[4], Panel2 = Panels[5],
+					Orientation = SplitterOrientation.Vertical,
+					FixedPanel = SplitterFixedPanel.None,
+				};
+				var p01_23 = new Splitter {
+					Panel1 = p0_1, Panel2 = p2_3,
+					Orientation = SplitterOrientation.Horizontal,
+					Position = 200
+				};
+				var p0123_45 = new Splitter {
+					Panel1 = p01_23, Panel2 = p4_5,
+					Orientation = SplitterOrientation.Horizontal,
+					FixedPanel = SplitterFixedPanel.Panel2,
+					Position = 405, Width = 610
+				};
+				return this.Root = p0123_45;
 			}
 		}
 
@@ -250,6 +284,92 @@ namespace Eto.Test.Sections.Controls
 			if (setSize)
 				form.Size = new Size(600, 400);
 			return form;
+		}
+
+		static Control TestInitResize()
+		{
+			var control = new Button { 
+				Text = "Show splitter test of initial resize"
+			};
+			Func<Control> makebox = () => {
+				var area = new TextArea();
+				area.SizeChanged += (s,e) => {
+					if (area.Width <= 0 || area.Height <= 0)
+						return;
+					area.Text = string.Format(
+						"W:{0} ({1}%)\r\nH:{2} ({3}%)",
+						area.Width, area.Width*100/area.Parent.Width,
+						area.Height, area.Height*100/area.Parent.Height);
+				};
+				return area;
+			};
+			Func<int,Form> makeform = (i) => {
+				var wa = new Rectangle(Screen.PrimaryScreen.WorkingArea);
+				var form = new Form {
+					Title = "Test Form #" + (i+1).ToString(),
+					Bounds = i == 0
+					? new Rectangle(wa.X + 20, wa.Y + 20, wa.Width/3, wa.Height/3)
+					: i == 1
+					? new Rectangle(wa.X + 20, wa.Y + 40 + wa.Height/3, wa.Width/3, wa.Height*2/3 - 60)
+					: new Rectangle(wa.X + wa.Width/3 + 40, wa.Y + 20, wa.Width*2/3 - 60, wa.Height - 40)
+				};
+				var left = new Splitter {
+					Position = 80
+				};
+				var middle = new Splitter {
+					FixedPanel = SplitterFixedPanel.Panel2,
+					Width = 200, Position = 115 // 5px less to make Panel2.Width = 50
+				};
+				var ltop = new Splitter {
+					Orientation = SplitterOrientation.Vertical,
+					Position = 80
+				};
+				var lbottom = new Splitter {
+					Orientation = SplitterOrientation.Vertical,
+					FixedPanel = SplitterFixedPanel.Panel2,
+					Height = 200, Position = 115
+				};
+				var right = new Splitter {
+					Orientation = SplitterOrientation.Vertical,
+					FixedPanel = SplitterFixedPanel.None,
+					Height = 300, Position = 100 // ~33%
+				};
+				var center = new Splitter {
+					FixedPanel = SplitterFixedPanel.None,
+					Width = 200, Position = 80 // ~40%
+				};
+				left	.Panel1 = ltop;
+				left	.Panel2 = middle;
+				ltop	.Panel1 = makebox();
+				ltop	.Panel2 = lbottom;
+				lbottom	.Panel1 = makebox();
+				lbottom	.Panel2 = makebox();
+				middle	.Panel1 = center;
+				middle	.Panel2 = right;
+				right	.Panel1 = makebox();
+				right	.Panel2 = makebox();
+				center	.Panel1 = makebox();
+				center	.Panel2 = makebox();
+				form.Content = left;
+				form.Show();
+				return form;
+			};
+			control.Click += (sender, e) => {
+				var forms = new Form[3];
+				for (int i = 0; i < 3; i++)
+				{
+					forms[i] = makeform(i);
+					forms[i].Closed += (fs, fe) => {
+						var all = forms;
+						forms = null;
+						if( all != null ) 
+							for (int j = 0; j < 3; j++)
+								if (all[j] != fs)
+									all[j].Close();
+					};
+				}
+			};
+			return control;
 		}
 	}
 }

--- a/Source/Eto.WinForms/Forms/Controls/PanelHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/PanelHandler.cs
@@ -8,6 +8,21 @@ namespace Eto.WinForms.Forms.Controls
 	{
 		public class EtoPanel : swf.Panel
 		{
+			public override sd.Size GetPreferredSize(sd.Size proposedSize)
+			{
+				// WinForms have problems with autosizing vs. docking
+				// this will solve some of its problems and speed things up.
+				// Not perfect, would be better to write it all new,
+				// especially if all inner controls are docked,
+				// but this is common scenairo when panels are emitted
+				// from Eto layout engine.
+				if (Controls.Count == 1 && Controls[0].Dock == swf.DockStyle.Fill)
+					return Controls[0].GetPreferredSize(proposedSize);
+
+				// fallback to default engine
+				return base.GetPreferredSize(proposedSize);
+			}
+
 			// Need to override IsInputKey to capture 
 			// the arrow keys.
 			protected override bool IsInputKey (swf.Keys keyData)

--- a/Source/Eto.WinForms/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/SplitterHandler.cs
@@ -63,6 +63,7 @@ namespace Eto.WinForms.Forms.Controls
 				FixedPanel = swf.FixedPanel.Panel1,
 				Panel1MinSize = 0,
 				Panel2MinSize = 0,
+				SplitterWidth = 5 // make it same as WPF & GTK
 			};
 			Control.HandleCreated += (sender, e) =>
 			{
@@ -185,7 +186,33 @@ namespace Eto.WinForms.Forms.Controls
 			Control.Panel2Collapsed = panel2 == null || !(panel2.GetWindowsHandler()).InternalVisible;
 			if (position != null)
 			{
-				SetPosition(position.Value);
+				var newPosition = position.Value;
+				if (fixedPanel == SplitterFixedPanel.None)
+				{
+					var orientation = Control.Orientation;
+					var desiredSize = orientation == swf.Orientation.Vertical ?
+						UserDesiredSize.Width : UserDesiredSize.Height;
+					if (desiredSize > 0)
+					{
+						var currentSize = orientation == swf.Orientation.Vertical ?
+							Control.Width : Control.Height;
+						newPosition = newPosition * currentSize / desiredSize;
+					}
+				}
+				else if (fixedPanel == SplitterFixedPanel.Panel2)
+				{
+					var orientation = Control.Orientation;
+					var desiredSize = orientation == swf.Orientation.Vertical ?
+						UserDesiredSize.Width : UserDesiredSize.Height;
+					if (desiredSize > 0)
+					{
+						var currentSize = orientation == swf.Orientation.Vertical ?
+							Control.Width : Control.Height;
+						newPosition = Math.Max(0,
+							newPosition + currentSize - desiredSize);
+					}
+				}
+				SetPosition(newPosition);
 			}
 			else
 			{
@@ -202,7 +229,16 @@ namespace Eto.WinForms.Forms.Controls
 							pos = Control.Width - size2.Width;
 						else
 							pos = Control.Height - size2.Height;
-						SetPosition(pos);
+						SetPosition(Math.Max(Control.Panel1MinSize, pos - Control.SplitterWidth));
+						break;
+					default:
+						var sone = panel1.GetPreferredSize();
+						var stwo = panel1.GetPreferredSize();
+						var ori = Control.Orientation;
+						var one = ori == swf.Orientation.Vertical ? sone.Width : sone.Height;
+						var two = ori == swf.Orientation.Vertical ? stwo.Width : stwo.Height;
+						var size = ori == swf.Orientation.Vertical ? Control.Width : Control.Height;
+						Position = one * (size - Control.SplitterWidth) / (one + two);
 						break;
 				}
 			}

--- a/Source/Eto/Forms/Menu/MenuItemCollection.cs
+++ b/Source/Eto/Forms/Menu/MenuItemCollection.cs
@@ -134,15 +134,9 @@ namespace Eto.Forms
 		/// <param name="items">Items to add.</param>
 		public void AddRange(IEnumerable<MenuItem> items)
 		{
-			var list = Items as List<MenuItem>;
-			if (list != null)
-				list.AddRange(items);
-			else
+			foreach (var item in items)
 			{
-				foreach (var item in items)
-				{
-					Add(item);
-				}
+				Add(item);
 			}
 		}
 


### PR DESCRIPTION
fix #309 

These changes will take care about initial position vs. inital (default, requested) size.
Fixes problems when FixedPanel != Panel1 and/or when not using designer (I prefer not to use designer except for simple dialogs or few user controls - but never for main form).

**NOTE:** Mac code not touched, will probably need similar changes. Gtk3 not tested.

Test code:

```C#
using System;
using System.Collections.Generic;
using System.Linq;

using Eto;
using Eto.Forms;
using Eto.Drawing;

using System.Threading;

namespace SplitterTests
{
	class MainForm : Form
	{
		[STAThread]
		static void Main()
		{
			new Application(Platforms.WinForms).Run(new MainForm());
		}

		MainForm()
		{
		#if DEBUG
			if(Platform.IsWinForms)
			{
				swfForm = this;
				swfApp = Application.Instance;
				var wpf = new Thread(delegate()
				{
					(wpfApp = new Application(Platforms.Wpf)).Run(
						wpfForm = new MainForm() {
						Location = new Point(60, 400) });
				});
				wpf.SetApartmentState(ApartmentState.STA);
				wpf.Start();
			}
			if (Platform.IsWpf)
			{
				var gtk = new Thread(delegate()
				{
					(gtkApp = new Application(Platforms.Gtk2)).Run(
						gtkForm = new MainForm() {
						Location = new Point(600, 60) });
				});
				gtk.SetApartmentState(ApartmentState.STA);
				gtk.Start();
			}
			Location = new Point(60, 60);
		#endif
			Size = new Size(400, 300);
		//	split.FixedPanel	= SplitterFixedPanel.Panel2;
			split.FixedPanel	= SplitterFixedPanel.None;
			split.Width			= 300;
			split.Position		= 100;
			split.Panel1		= area1;
			split.Panel2		= area2;
			Content = split;

			area1.SizeChanged += area_SizeChanged;
			area2.SizeChanged += area_SizeChanged;
		}

		Splitter split = new Splitter();
		TextArea area1 = new TextArea();
		TextArea area2 = new TextArea();

		void area_SizeChanged(object sender, EventArgs e)
		{
			area1.Text = string.Format(
				"W: {0}\r\nP: {1}\r\n({2}%)",
				area1.Width, split.Position,
				area1.Width*100/split.Width);
			area2.Text = string.Format(
				"W: {0}\r\nP: {1}\r\n({2}%)",
				area2.Width, split.Position,
				area2.Width*100/split.Width);
		}

	#if DEBUG
		static Application wpfApp, gtkApp, swfApp;
		static MainForm wpfForm, gtkForm, swfForm;
		protected override void OnClosed(EventArgs e)
		{
			base.OnClosed(e);
			if (this != wpfForm)
				wpfApp.AsyncInvoke(() => wpfForm.Close());
			if (this != gtkForm)
				gtkApp.AsyncInvoke(() => gtkForm.Close());
			if (this != swfForm)
				swfApp.AsyncInvoke(() => swfForm.Close());
		}
	#endif
	}
}
```

BTW: I had problems when trying to create more threads for each platform simultaneously. There seems to be some lock needed and better Widget-Application/Platform connection for such multi-platform testing/usage.