### PR TITLE
Splitter Sanity

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/SplitterHandler.cs
@@ -114,6 +114,38 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 			if (position != null)
 				Control.Position = position.Value;
+
+			if (fixedPanel != SplitterFixedPanel.Panel1)
+				Control.SizeAllocated += Control_SizeAllocated;
+		}
+
+		void Control_SizeAllocated(object o, Gtk.SizeAllocatedArgs args)
+		{
+			Control.SizeAllocated -= Control_SizeAllocated;
+			if (position == null)
+				return;
+			if (orientation == SplitterOrientation.Horizontal)
+			{
+				int width = PreferredSize.Width;
+				if (width <= 0)
+					return;
+				if (fixedPanel == SplitterFixedPanel.Panel2)
+					Control.Position = Math.Max(0,
+						position.Value + args.Allocation.Width - width);
+				else
+					Control.Position = position.Value * args.Allocation.Width / width;
+			}
+			else
+			{
+				int height = PreferredSize.Height;
+				if (height <= 0)
+					return;
+				if (fixedPanel == SplitterFixedPanel.Panel2)
+					Control.Position = Math.Max(0,
+						position.Value + args.Allocation.Height - height);
+				else
+					Control.Position = position.Value * args.Allocation.Height / height;
+			}
 		}
 
 		static Gtk.Widget EmptyContainer()

--- a/Source/Eto.Gtk/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/SplitterHandler.cs
@@ -10,7 +10,9 @@ namespace Eto.GtkSharp.Forms.Controls
 		Control panel2;
 		SplitterOrientation orientation;
 		SplitterFixedPanel fixedPanel;
+		SplitterPositionMode mode;
 		int? position;
+		bool created;
 
 		class EtoHPaned : Gtk.HPaned
 		{
@@ -57,8 +59,65 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public int Position
 		{
-			get { return Control.Position; }
-			set { position = Control.Position = value; }
+			get
+			{
+				switch (mode)
+				{
+					default:
+						return Control.Position;
+					case SplitterPositionMode.Far:
+						return Math.Max(0, (Orientation == SplitterOrientation.Horizontal ?
+							Control.Allocation.Width : Control.Allocation.Height) - Control.Position - SplitterWidth);
+					case SplitterPositionMode.Percent:
+						var width = (Orientation == SplitterOrientation.Horizontal ?
+							Control.Allocation.Width : Control.Allocation.Height) - SplitterWidth;
+						return width <= 0 ? 0 : Control.Position * 100 / width;
+				}
+			}
+			set
+			{
+				position = Control.Position = value;
+			}
+		}
+
+		int GetAvailableSize()
+		{
+			return GetAvailableSize(!created);
+		}
+		int GetAvailableSize(bool desired)
+		{
+			if (desired)
+			{
+				var size = PreferredSize;
+				var pick = Orientation == SplitterOrientation.Horizontal ?
+					size.Width : size.Height;
+				if (pick >= 0)
+					return pick - SplitterWidth;
+			}
+			return (Orientation == SplitterOrientation.Horizontal ?
+				Control.Allocation.Width : Control.Allocation.Height) - SplitterWidth;
+		}
+
+		void SetPosition(int pos, SplitterPositionMode mode)
+		{
+			int size = GetAvailableSize(false);
+			if (mode == SplitterPositionMode.Far)
+				pos = size - pos;
+			else if (mode == SplitterPositionMode.Percent)
+				pos = (1 + 2 * size * pos) / 200;
+			Control.Position = Math.Max(0, Math.Min(size, pos));
+		}
+
+		public SplitterPositionMode PositionMode
+		{
+			get { return mode; }
+			set { mode = value; }
+		}
+
+		public int SplitterWidth
+		{
+			get { return 5; /* just u guess :( */ }
+			set { /* unfortunatelly I cannot see binding for gtk_set_gutter_size in Gtk# */ }
 		}
 
 		public SplitterFixedPanel FixedPanel
@@ -69,7 +128,8 @@ namespace Eto.GtkSharp.Forms.Controls
 				if (fixedPanel != value)
 				{
 					fixedPanel = value;
-					Create();
+					((Gtk.Paned.PanedChild)Control[Control.Child1]).Resize = value != SplitterFixedPanel.Panel1;
+					((Gtk.Paned.PanedChild)Control[Control.Child2]).Resize = value != SplitterFixedPanel.Panel2;
 				}
 			}
 		}
@@ -115,37 +175,60 @@ namespace Eto.GtkSharp.Forms.Controls
 			if (position != null)
 				Control.Position = position.Value;
 
-			if (fixedPanel != SplitterFixedPanel.Panel1)
-				Control.SizeAllocated += Control_SizeAllocated;
+			created = false;
+			Control.SizeAllocated += Control_SizeAllocated;
 		}
+
+		void SetInitialPosition()
+		{
+			if (position != null)
+			{
+				var pos = position.Value;
+				if (mode != SplitterPositionMode.Percent &&
+					(FixedPanel == SplitterFixedPanel.None ||
+					(FixedPanel == SplitterFixedPanel.Panel1) != (mode == SplitterPositionMode.Near)))
+				{
+					var size = GetAvailableSize(false);
+					var want = GetAvailableSize(true);
+					var diff = size - want;
+					if (diff != 0)
+					{
+						if (FixedPanel == SplitterFixedPanel.None)
+							pos = pos * size / want;
+						else
+							pos += mode == SplitterPositionMode.Near ? diff : -diff;
+					}
+				}
+				SetPosition(pos, mode);
+				return;
+			}
+			var horiz = Orientation == SplitterOrientation.Horizontal;
+			switch (FixedPanel)
+			{
+				case SplitterFixedPanel.Panel1:
+					var size1 = Control.Child1.SizeRequest();
+					SetPosition(horiz ? size1.Width : size1.Height, SplitterPositionMode.Near);
+					break;
+				case SplitterFixedPanel.Panel2:
+					var size2 = Control.Child2.SizeRequest();
+					SetPosition(horiz ? size2.Width : size2.Height, SplitterPositionMode.Far);
+					break;
+				default:
+					var sone = Control.Child1.SizeRequest();
+					var stwo = Control.Child2.SizeRequest();
+					var one = horiz ? sone.Width : sone.Height;
+					var two = horiz ? stwo.Width : stwo.Height;
+					SetPosition(one * GetAvailableSize(true) / (one + two), SplitterPositionMode.Near);
+					break;
+			}
+		}
+
 
 		void Control_SizeAllocated(object o, Gtk.SizeAllocatedArgs args)
 		{
 			Control.SizeAllocated -= Control_SizeAllocated;
-			if (position == null)
-				return;
-			if (orientation == SplitterOrientation.Horizontal)
-			{
-				int width = PreferredSize.Width;
-				if (width <= 0)
-					return;
-				if (fixedPanel == SplitterFixedPanel.Panel2)
-					Control.Position = Math.Max(0,
-						position.Value + args.Allocation.Width - width);
-				else
-					Control.Position = position.Value * args.Allocation.Width / width;
-			}
-			else
-			{
-				int height = PreferredSize.Height;
-				if (height <= 0)
-					return;
-				if (fixedPanel == SplitterFixedPanel.Panel2)
-					Control.Position = Math.Max(0,
-						position.Value + args.Allocation.Height - height);
-				else
-					Control.Position = position.Value * args.Allocation.Height / height;
-			}
+			SetInitialPosition();
+			created = true;
 		}
 
 		static Gtk.Widget EmptyContainer()

--- a/Source/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -224,6 +224,20 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
+		//TODO: SplitterPositionMode for Mac, now empty that it can at least be compiled
+		//..... take inspiration in WinForms/GTK or WPF implementation
+		public SplitterPositionMode PositionMode
+		{
+			get { return SplitterPositionMode.Near; }
+			set { /* TODO */ }
+		}
+
+		public int SplitterWidth
+		{
+			get { return 5; }
+			set { /* TODO */ }
+		}
+
 		public SplitterOrientation Orientation
 		{
 			get

--- a/Source/Eto.Test/Eto.Test/MainForm.cs
+++ b/Source/Eto.Test/Eto.Test/MainForm.cs
@@ -31,7 +31,7 @@ namespace Eto.Test
 
 		public MainForm(IEnumerable<Section> topNodes = null)
 		{
-			Title = "Test Application";
+			Title = string.Format("Test Application [{0}]", Platform.ID);
 			Style = "main";
 			MinimumSize = new Size(400, 400);
 			topNodes = topNodes ?? TestSections.Get();

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/SplitterSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/SplitterSection.cs
@@ -18,6 +18,7 @@ namespace Eto.Test.Sections.Controls
 			layout.AddCentered(Test2WithSize());
 			layout.AddCentered(Test2AutoSize());
 			layout.AddCentered(TestDynamic());
+			layout.AddCentered(TestInitResize());
 			layout.Add(null);
 			Content = layout;
 		}
@@ -68,7 +69,10 @@ namespace Eto.Test.Sections.Controls
 		static Form Test1(bool setSize, Action<Label[], Panel> layoutContent)
 		{
 			// Status bar
-			Label[] status = { new Label(), new Label(), new Label(), new Label(), new Label() };
+			Label[] status = {
+				new Label(), new Label(), new Label(),
+				new Label(), new Label(), new Label()
+			};
 			var statusLayout = new DynamicLayout { Padding = Padding.Empty, Spacing = Size.Empty };
 			statusLayout.BeginHorizontal();
 			for (var i = 0; i < status.Length; ++i)
@@ -138,7 +142,10 @@ namespace Eto.Test.Sections.Controls
 			mainPanel.Content = splitLayout.Layout(
 				i =>
 				{
-					var button = new Button { Text = "Click to update status " + i, BackgroundColor = splitLayout.PanelColors[i] };
+					var button = new Button {
+						Text = "Click to update status " + i,
+						BackgroundColor = splitLayout.PanelColors[i]
+					};
 					button.Click += (s, e) => status[i].Text = "New count: " + (count++);
 					return button;
 				});
@@ -175,11 +182,14 @@ namespace Eto.Test.Sections.Controls
 
 			public Panel[] Panels { get; private set; }
 
-			public Color[] PanelColors = { Colors.PaleTurquoise, Colors.Olive, Colors.NavajoWhite, Colors.Purple, Colors.Orange };
+			public Color[] PanelColors = {
+				Colors.PaleTurquoise, Colors.Olive, Colors.NavajoWhite,
+				Colors.Purple, Colors.Orange, Colors.Aqua };
 
 			public SplitLayout(Panel[] panels = null)
 			{
-				this.Panels = panels ?? new Panel[] { new Panel(), new Panel(), new Panel(), new Panel(), new Panel() };
+				this.Panels = panels ?? new Panel[] {
+					new Panel(), new Panel(), new Panel(), new Panel(), new Panel(), new Panel() };
 			}
 
 			public Control Layout(Func<int, Control>getContent)
@@ -188,21 +198,45 @@ namespace Eto.Test.Sections.Controls
 				// |---------------------------
 				// |        |      |          |
 				// |  P0    |  P2  |   P4     |
-				// | -------|      |          |  <== These are on MainPanel
-				// |  P1    |------|          |
+				// | -------|      |----------|  <== These are on MainPanel
+				// |  P1    |------|   P5     |
 				// |        |  P3  |          |
 				// |---------------------------
-				// |         status0..4,      |  <== These are on StatusPanel
+				// |         status0..5,      |  <== These are on StatusPanel
 				// ----------------------------
 
 				for (var i = 0; i < Panels.Length; ++i)
 					Panels[i].Content = getContent(i);
 
-				var p0_1 = new Splitter { Panel1 = Panels[0], Panel2 = Panels[1], Orientation = SplitterOrientation.Vertical, Position = 200 };
-				var p2_3 = new Splitter { Panel1 = Panels[2], Panel2 = Panels[3], Orientation = SplitterOrientation.Vertical, Position = 200, FixedPanel = SplitterFixedPanel.Panel2 };
-				var p01_23 = new Splitter { Panel1 = p0_1, Panel2 = p2_3, Orientation = SplitterOrientation.Horizontal, Position = 200 };
-				var p0123_4 = new Splitter { Panel1 = p01_23, Panel2 = Panels[4], Orientation = SplitterOrientation.Horizontal, Position = 400 };
-				return this.Root = p0123_4;
+				var p0_1 = new Splitter {
+					Panel1 = Panels[0], Panel2 = Panels[1],
+					Orientation = SplitterOrientation.Vertical,
+					Position = 200
+				};
+				var p2_3 = new Splitter {
+					Panel1 = Panels[2], Panel2 = Panels[3],
+					Orientation = SplitterOrientation.Vertical,
+					FixedPanel = SplitterFixedPanel.Panel2,
+					// -200px from bottom with minimal height for autosize test (p0_1 should preffer higher)
+					Position = 0, Height = 205
+				};
+				var p4_5 = new Splitter {
+					Panel1 = Panels[4], Panel2 = Panels[5],
+					Orientation = SplitterOrientation.Vertical,
+					FixedPanel = SplitterFixedPanel.None,
+				};
+				var p01_23 = new Splitter {
+					Panel1 = p0_1, Panel2 = p2_3,
+					Orientation = SplitterOrientation.Horizontal,
+					Position = 200
+				};
+				var p0123_45 = new Splitter {
+					Panel1 = p01_23, Panel2 = p4_5,
+					Orientation = SplitterOrientation.Horizontal,
+					FixedPanel = SplitterFixedPanel.Panel2,
+					Position = 405, Width = 610
+				};
+				return this.Root = p0123_45;
 			}
 		}
 
@@ -250,6 +284,92 @@ namespace Eto.Test.Sections.Controls
 			if (setSize)
 				form.Size = new Size(600, 400);
 			return form;
+		}
+
+		static Control TestInitResize()
+		{
+			var control = new Button { 
+				Text = "Show splitter test of initial resize"
+			};
+			Func<Control> makebox = () => {
+				var area = new TextArea();
+				area.SizeChanged += (s,e) => {
+					if (area.Width <= 0 || area.Height <= 0)
+						return;
+					area.Text = string.Format(
+						"W:{0} ({1}%)\r\nH:{2} ({3}%)",
+						area.Width, area.Width*100/area.Parent.Width,
+						area.Height, area.Height*100/area.Parent.Height);
+				};
+				return area;
+			};
+			Func<int,Form> makeform = (i) => {
+				var wa = new Rectangle(Screen.PrimaryScreen.WorkingArea);
+				var form = new Form {
+					Title = "Test Form #" + (i+1).ToString(),
+					Bounds = i == 0
+					? new Rectangle(wa.X + 20, wa.Y + 20, wa.Width/3, wa.Height/3)
+					: i == 1
+					? new Rectangle(wa.X + 20, wa.Y + 40 + wa.Height/3, wa.Width/3, wa.Height*2/3 - 60)
+					: new Rectangle(wa.X + wa.Width/3 + 40, wa.Y + 20, wa.Width*2/3 - 60, wa.Height - 40)
+				};
+				var left = new Splitter {
+					Position = 80
+				};
+				var middle = new Splitter {
+					FixedPanel = SplitterFixedPanel.Panel2,
+					Width = 200, Position = 115 // 5px less to make Panel2.Width = 50
+				};
+				var ltop = new Splitter {
+					Orientation = SplitterOrientation.Vertical,
+					Position = 80
+				};
+				var lbottom = new Splitter {
+					Orientation = SplitterOrientation.Vertical,
+					FixedPanel = SplitterFixedPanel.Panel2,
+					Height = 200, Position = 115
+				};
+				var right = new Splitter {
+					Orientation = SplitterOrientation.Vertical,
+					FixedPanel = SplitterFixedPanel.None,
+					Height = 300, Position = 100 // ~33%
+				};
+				var center = new Splitter {
+					FixedPanel = SplitterFixedPanel.None,
+					Width = 200, Position = 80 // ~40%
+				};
+				left	.Panel1 = ltop;
+				left	.Panel2 = middle;
+				ltop	.Panel1 = makebox();
+				ltop	.Panel2 = lbottom;
+				lbottom	.Panel1 = makebox();
+				lbottom	.Panel2 = makebox();
+				middle	.Panel1 = center;
+				middle	.Panel2 = right;
+				right	.Panel1 = makebox();
+				right	.Panel2 = makebox();
+				center	.Panel1 = makebox();
+				center	.Panel2 = makebox();
+				form.Content = left;
+				form.Show();
+				return form;
+			};
+			control.Click += (sender, e) => {
+				var forms = new Form[3];
+				for (int i = 0; i < 3; i++)
+				{
+					forms[i] = makeform(i);
+					forms[i].Closed += (fs, fe) => {
+						var all = forms;
+						forms = null;
+						if( all != null ) 
+							for (int j = 0; j < 3; j++)
+								if (all[j] != fs)
+									all[j].Close();
+					};
+				}
+			};
+			return control;
 		}
 	}
 }

--- a/Source/Eto.WinForms/Forms/Controls/PanelHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/PanelHandler.cs
@@ -8,6 +8,21 @@ namespace Eto.WinForms.Forms.Controls
 	{
 		public class EtoPanel : swf.Panel
 		{
+			public override sd.Size GetPreferredSize(sd.Size proposedSize)
+			{
+				// WinForms have problems with autosizing vs. docking
+				// this will solve some of its problems and speed things up.
+				// Not perfect, would be better to write it all new,
+				// especially if all inner controls are docked,
+				// but this is common scenairo when panels are emitted
+				// from Eto layout engine.
+				if (Controls.Count == 1 && Controls[0].Dock == swf.DockStyle.Fill)
+					return Controls[0].GetPreferredSize(proposedSize);
+
+				// fallback to default engine
+				return base.GetPreferredSize(proposedSize);
+			}
+
 			// Need to override IsInputKey to capture 
 			// the arrow keys.
 			protected override bool IsInputKey (swf.Keys keyData)

--- a/Source/Eto.WinForms/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/SplitterHandler.cs
@@ -85,6 +85,7 @@ namespace Eto.WinForms.Forms.Controls
 			Control.HandleCreated += HandleCreated;
 		}
 
+		//TODO: Check that PositionChanged fires correctly
 		public override void AttachEvent(string id)
 		{
 			switch (id)
@@ -208,7 +209,7 @@ namespace Eto.WinForms.Forms.Controls
 					break;
 				default:
 					var sone = panel1.GetPreferredSize();
-					var stwo = panel1.GetPreferredSize();
+					var stwo = panel2.GetPreferredSize();
 					var one = horiz ? sone.Width : sone.Height;
 					var two = horiz ? stwo.Width : stwo.Height;
 					SetPosition(one * GetAvailableSize(true) / (one + two),	SplitterPositionMode.Near);

--- a/Source/Eto.WinForms/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/SplitterHandler.cs
@@ -63,6 +63,7 @@ namespace Eto.WinForms.Forms.Controls
 				FixedPanel = swf.FixedPanel.Panel1,
 				Panel1MinSize = 0,
 				Panel2MinSize = 0,
+				SplitterWidth = 5 // make it same as WPF & GTK
 			};
 			Control.HandleCreated += (sender, e) =>
 			{
@@ -185,7 +186,33 @@ namespace Eto.WinForms.Forms.Controls
 			Control.Panel2Collapsed = panel2 == null || !(panel2.GetWindowsHandler()).InternalVisible;
 			if (position != null)
 			{
-				SetPosition(position.Value);
+				var newPosition = position.Value;
+				if (fixedPanel == SplitterFixedPanel.None)
+				{
+					var orientation = Control.Orientation;
+					var desiredSize = orientation == swf.Orientation.Vertical ?
+						UserDesiredSize.Width : UserDesiredSize.Height;
+					if (desiredSize > 0)
+					{
+						var currentSize = orientation == swf.Orientation.Vertical ?
+							Control.Width : Control.Height;
+						newPosition = newPosition * currentSize / desiredSize;
+					}
+				}
+				else if (fixedPanel == SplitterFixedPanel.Panel2)
+				{
+					var orientation = Control.Orientation;
+					var desiredSize = orientation == swf.Orientation.Vertical ?
+						UserDesiredSize.Width : UserDesiredSize.Height;
+					if (desiredSize > 0)
+					{
+						var currentSize = orientation == swf.Orientation.Vertical ?
+							Control.Width : Control.Height;
+						newPosition = Math.Max(0,
+							newPosition + currentSize - desiredSize);
+					}
+				}
+				SetPosition(newPosition);
 			}
 			else
 			{
@@ -202,7 +229,16 @@ namespace Eto.WinForms.Forms.Controls
 							pos = Control.Width - size2.Width;
 						else
 							pos = Control.Height - size2.Height;
-						SetPosition(pos);
+						SetPosition(Math.Max(Control.Panel1MinSize, pos - Control.SplitterWidth));
+						break;
+					default:
+						var sone = panel1.GetPreferredSize();
+						var stwo = panel1.GetPreferredSize();
+						var ori = Control.Orientation;
+						var one = ori == swf.Orientation.Vertical ? sone.Width : sone.Height;
+						var two = ori == swf.Orientation.Vertical ? stwo.Width : stwo.Height;
+						var size = ori == swf.Orientation.Vertical ? Control.Width : Control.Height;
+						Position = one * (size - Control.SplitterWidth) / (one + two);
 						break;
 				}
 			}

--- a/Source/Eto.WinForms/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/SplitterHandler.cs
@@ -11,6 +11,9 @@ namespace Eto.WinForms.Forms.Controls
 		Control panel1;
 		Control panel2;
 		int? position;
+		SplitterPositionMode mode;
+		bool created;
+		int suppressSplitterMoved;
 
 		public bool RecurseToChildren { get { return true; } }
 
@@ -39,15 +42,29 @@ namespace Eto.WinForms.Forms.Controls
 				var size = new sd.Size();
 				var size1 = Handler.panel1.GetPreferredSize();
 				var size2 = Handler.panel2.GetPreferredSize();
+				var mode = Handler.mode;
+				var pos = Handler.position;
 				if (Orientation == swf.Orientation.Vertical)
 				{
-					size1.Width = Handler.position ?? size1.Width;
+					if(pos != null)
+					{
+						if(mode == SplitterPositionMode.Near)
+							size1.Width = pos.Value;
+						else if(mode == SplitterPositionMode.Far)
+							size2.Width = pos.Value;
+					}
 					size.Width = size1.Width + size2.Width + SplitterWidth;
 					size.Height = Math.Max(size1.Height, size2.Height);
 				}
 				else
 				{
-					size1.Height = Handler.position ?? size1.Height;
+					if(pos != null)
+					{
+						if(mode == SplitterPositionMode.Near)
+							size1.Height = pos.Value;
+						else if(mode == SplitterPositionMode.Far)
+							size2.Height = pos.Value;
+					}
 					size.Height = size1.Height + size2.Height + SplitterWidth;
 					size.Width = Math.Max(size1.Width, size2.Width);
 				}
@@ -65,12 +82,7 @@ namespace Eto.WinForms.Forms.Controls
 				Panel2MinSize = 0,
 				SplitterWidth = 5 // make it same as WPF & GTK
 			};
-			Control.HandleCreated += (sender, e) =>
-			{
-				SetInitialPosition();
-				HookEvents();
-				SetFixedPanel();
-			};
+			Control.HandleCreated += HandleCreated;
 		}
 
 		public override void AttachEvent(string id)
@@ -91,158 +103,149 @@ namespace Eto.WinForms.Forms.Controls
 
 		public int Position
 		{
-			get { return Control.SplitterDistance; }
+			get
+			{
+				switch (mode)
+				{
+					default:
+						return Control.SplitterDistance;
+					case SplitterPositionMode.Far:
+						return Math.Max(0, (Orientation == SplitterOrientation.Horizontal ?
+							Control.Width : Control.Height) - Control.SplitterDistance - Control.SplitterWidth);
+					case SplitterPositionMode.Percent:
+						var width = (Orientation == SplitterOrientation.Horizontal ?
+							Control.Width : Control.Height) - Control.SplitterWidth;
+						return width <= 0 ? 0 : Control.SplitterDistance * 100 / width;
+				}
+			}
 			set
 			{
 				if (value != position)
 				{
-					suppressSplitterMoved++;
-					if (Control.IsHandleCreated)
-						SetPosition(value);
-					suppressSplitterMoved--;
 					position = value;
+					if (Control.IsHandleCreated)
+						SetPosition(value, mode);
 					Callback.OnPositionChanged(Widget, EventArgs.Empty);
 				}
 			}
 		}
 
-		void SetPosition(int newPosition)
+		public SplitterPositionMode PositionMode
 		{
-			position = newPosition;
-			if (Control.Orientation == swf.Orientation.Vertical)
-			{
-				if (Control.Width > 1)
-					Control.SplitterDistance = Math.Max(0, Math.Min(Control.Width - Control.Panel2MinSize - 1, newPosition));
-			}
-			else
-			{
-				if (Control.Height > 1)
-					Control.SplitterDistance = Math.Max(0, Math.Min(Control.Height - Control.Panel2MinSize - 1, newPosition));
-			}
+			get { return mode; }
+			set { mode = value; }
 		}
 
-		public override void OnLoad(EventArgs e)
+		public int SplitterWidth
 		{
-			base.OnLoad(e);
+			get { return Control.SplitterWidth; }
+			set { Control.SplitterWidth = value; }
+		}
+
+		int GetAvailableSize()
+		{
+			return GetAvailableSize(!created);
+		}
+		int GetAvailableSize(bool desired)
+		{
+			if (desired)
+			{
+				var size = UserDesiredSize;
+				var pick = Orientation == SplitterOrientation.Horizontal ?
+					size.Width : size.Height;
+				if (pick >= 0)
+					return pick - SplitterWidth;
+			}
+			return (Orientation == SplitterOrientation.Horizontal ?
+				Control.Width : Control.Height) - SplitterWidth;
+		}
+
+		void SetPosition(int pos, SplitterPositionMode mode)
+		{
 			suppressSplitterMoved++;
-			if (Control.IsHandleCreated)
-				SetInitialPosition();
-		}
-
-		public override void OnLoadComplete(EventArgs e)
-		{
-			base.OnLoadComplete(e);
+			int size = GetAvailableSize(false);
+			if (mode == SplitterPositionMode.Far)
+				pos = size - pos;
+			else if (mode == SplitterPositionMode.Percent)
+				pos = (1 + 2 * size * pos) / 200;
+			Control.SplitterDistance = Math.Max(0, Math.Min(size, pos));
 			suppressSplitterMoved--;
 		}
 
-		int suppressSplitterMoved;
-		void HookEvents()
+		void SetInitialPosition()
 		{
-			Control.SplitterMoved += (sender, e) =>
+			if (position != null)
+			{
+				var pos = position.Value;
+				if (mode != SplitterPositionMode.Percent &&
+					(FixedPanel == SplitterFixedPanel.None ||
+					(FixedPanel == SplitterFixedPanel.Panel1) != (mode == SplitterPositionMode.Near)))
+				{
+					var size = GetAvailableSize(false);
+					var want = GetAvailableSize(true);
+					var diff = size - want;
+					if( diff != 0 )
+					{
+						if (FixedPanel == SplitterFixedPanel.None)
+							pos = pos * size / want;
+						else
+							pos += mode == SplitterPositionMode.Near ? diff : -diff;
+					}
+				}
+				SetPosition(pos, mode);
+				return;
+			}
+			var horiz = Orientation == SplitterOrientation.Horizontal;
+			switch (FixedPanel)
+			{
+				case SplitterFixedPanel.Panel1:
+					var size1 = panel1.GetPreferredSize();
+					SetPosition(horiz ? size1.Width : size1.Height, SplitterPositionMode.Near);
+					break;
+				case SplitterFixedPanel.Panel2:
+					var size2 = panel2.GetPreferredSize();
+					SetPosition(horiz ? size2.Width : size2.Height, SplitterPositionMode.Far);
+					break;
+				default:
+					var sone = panel1.GetPreferredSize();
+					var stwo = panel1.GetPreferredSize();
+					var one = horiz ? sone.Width : sone.Height;
+					var two = horiz ? stwo.Width : stwo.Height;
+					SetPosition(one * GetAvailableSize(true) / (one + two),	SplitterPositionMode.Near);
+					break;
+			}
+		}
+
+		void HandleCreated(object sender, EventArgs e)
+		{
+			SetInitialPosition();
+			SetFixedPanel();
+			created = true;
+
+			Control.Panel1Collapsed = panel1 == null || !(panel1.GetWindowsHandler()).InternalVisible;
+			Control.Panel2Collapsed = panel2 == null || !(panel2.GetWindowsHandler()).InternalVisible;
+
+			Control.SplitterMoved += (s, a) =>
 			{
 				if (Widget.ParentWindow != null)
 				{
 					// keep track of the desired position (for removing/re-adding/resizing the control)
 					if (Widget.Loaded && suppressSplitterMoved == 0)
 					{
-						position = Control.SplitterDistance;
+						position = Position;
 						Callback.OnPositionChanged(Widget, EventArgs.Empty);
 					}
 				}
 			};
 
-			Size? oldSize = null;
-			Control.SizeChanged += (sender, e) =>
+			Control.SizeChanged += (s, a) =>
 			{
 				// SplitterDistance can only be at most width or height, but if the control's width is smaller than 
 				// desired position to start then gets a layout pass, try to set to the preferred position when resized
-				if (position != null && position.Value != Control.SplitterDistance)
-				{
-					suppressSplitterMoved++;
-					switch (FixedPanel)
-					{
-						case SplitterFixedPanel.Panel1:
-							SetPosition(position.Value);
-							break;
-						case SplitterFixedPanel.Panel2:
-							var size = Size;
-							if (oldSize != null)
-							{
-								position -= Orientation == SplitterOrientation.Vertical ? (oldSize.Value.Height - size.Height) : (oldSize.Value.Width - size.Width);
-								SetPosition(position.Value);
-							}
-							oldSize = size;
-							break;
-					}
-					suppressSplitterMoved--;
-				}
+				if (mode != SplitterPositionMode.Percent && FixedPanel != SplitterFixedPanel.None
+					&& position != null && position.Value != Position)
+					SetPosition(position.Value, mode);
 			};
-		}
-		
-		void SetInitialPosition()
-		{
-			suppressSplitterMoved++;
-			Control.Panel1Collapsed = panel1 == null || !(panel1.GetWindowsHandler()).InternalVisible;
-			Control.Panel2Collapsed = panel2 == null || !(panel2.GetWindowsHandler()).InternalVisible;
-			if (position != null)
-			{
-				var newPosition = position.Value;
-				if (fixedPanel == SplitterFixedPanel.None)
-				{
-					var orientation = Control.Orientation;
-					var desiredSize = orientation == swf.Orientation.Vertical ?
-						UserDesiredSize.Width : UserDesiredSize.Height;
-					if (desiredSize > 0)
-					{
-						var currentSize = orientation == swf.Orientation.Vertical ?
-							Control.Width : Control.Height;
-						newPosition = newPosition * currentSize / desiredSize;
-					}
-				}
-				else if (fixedPanel == SplitterFixedPanel.Panel2)
-				{
-					var orientation = Control.Orientation;
-					var desiredSize = orientation == swf.Orientation.Vertical ?
-						UserDesiredSize.Width : UserDesiredSize.Height;
-					if (desiredSize > 0)
-					{
-						var currentSize = orientation == swf.Orientation.Vertical ?
-							Control.Width : Control.Height;
-						newPosition = Math.Max(0,
-							newPosition + currentSize - desiredSize);
-					}
-				}
-				SetPosition(newPosition);
-			}
-			else
-			{
-				switch (FixedPanel)
-				{
-					case SplitterFixedPanel.Panel1:
-						var size1 = panel1.GetPreferredSize();
-						SetPosition(Control.Orientation == swf.Orientation.Vertical ? size1.Width : size1.Height);
-						break;
-					case SplitterFixedPanel.Panel2:
-						var size2 = panel2.GetPreferredSize();
-						int pos;
-						if (Control.Orientation == swf.Orientation.Vertical)
-							pos = Control.Width - size2.Width;
-						else
-							pos = Control.Height - size2.Height;
-						SetPosition(Math.Max(Control.Panel1MinSize, pos - Control.SplitterWidth));
-						break;
-					default:
-						var sone = panel1.GetPreferredSize();
-						var stwo = panel1.GetPreferredSize();
-						var ori = Control.Orientation;
-						var one = ori == swf.Orientation.Vertical ? sone.Width : sone.Height;
-						var two = ori == swf.Orientation.Vertical ? stwo.Width : stwo.Height;
-						var size = ori == swf.Orientation.Vertical ? Control.Width : Control.Height;
-						Position = one * (size - Control.SplitterWidth) / (one + two);
-						break;
-				}
-			}
-			suppressSplitterMoved--;
 		}
 
 		SplitterFixedPanel fixedPanel;

--- a/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
@@ -6,18 +6,20 @@ using sw = System.Windows;
 using swc = System.Windows.Controls;
 using Eto.Drawing;
 
+using System.Diagnostics;
+
 namespace Eto.Wpf.Forms.Controls
 {
 	public class SplitterHandler : WpfContainer<swc.Grid, Splitter, Splitter.ICallback>, Splitter.IHandler
 	{
+		const int splitterSize = 5;
+
 		readonly swc.GridSplitter splitter;
 		readonly swc.DockPanel pane1;
 		readonly swc.DockPanel pane2;
 		SplitterOrientation orientation;
 		SplitterFixedPanel fixedPanel;
 		int? position;
-		int? initialWidth;
-		int? initialHeight;
 		readonly sw.Style style;
 
 		Control panel1;
@@ -51,35 +53,62 @@ namespace Eto.Wpf.Forms.Controls
 			style.Setters.Add(new sw.Setter(sw.FrameworkElement.HorizontalAlignmentProperty, sw.HorizontalAlignment.Stretch));
 
 			UpdateOrientation();
-			Control.Loaded += delegate
-			{
-				// controls should be stretched to fit panels
-				SetStretch(panel1);
-				SetStretch(panel2);
-				UpdateColumnSizing();
-				if (FixedPanel == SplitterFixedPanel.Panel2)
-				{
-					var size = panel2.GetPreferredSize(Conversions.PositiveInfinitySize);
-					var currentOrientation = Orientation;
-					if (currentOrientation == SplitterOrientation.Horizontal)
-					{
-						var width = (int)Control.ActualWidth;
-						position = position ?? (int)(width - size.Width);
-						Position = Size.Width - (width - position.Value);
-					}
-					else if (currentOrientation == SplitterOrientation.Vertical)
-					{
-						var height = (int)Control.ActualHeight;
-						position = position ?? (int)(height - size.Height);
+			Control.Loaded += Control_Loaded;
+		}
 
-						Position = Size.Height - (height - position.Value);
-					}
-					else if (position != null)
-						Position = position.Value;
+		void Control_Loaded(object sender, sw.RoutedEventArgs e)
+		{
+			// usually called twice and the second could screw up the calculation
+			Control.Loaded -= Control_Loaded;
+			// controls should be stretched to fit panels
+			SetStretch(panel1);
+			SetStretch(panel2);
+			UpdateColumnSizing();
+
+			bool horiz = Orientation == SplitterOrientation.Horizontal;
+			var size = horiz ? Control.ActualWidth : Control.ActualHeight;
+
+			// use preferred size if no position set
+			// note: shall we rather use GetPreferredSize(OurSize)?
+			if (position == null)
+			{
+				if (fixedPanel == SplitterFixedPanel.Panel1)
+				{
+					var prefer = panel1.GetPreferredSize(Conversions.PositiveInfinitySize);
+					Position = (int)Math.Round(horiz ? prefer.Width : prefer.Height);
+					return;
 				}
-				else if (position != null)
+				if (fixedPanel == SplitterFixedPanel.Panel2)
+				{
+					var prefer = panel2.GetPreferredSize(Conversions.PositiveInfinitySize);
+					Position = Math.Max(0, (int)Math.Round(
+						size - splitterSize - (horiz ? prefer.Width : prefer.Height)));
+					return;
+				}
+				var sone = panel1.GetPreferredSize(Conversions.PositiveInfinitySize);
+				var stwo = panel1.GetPreferredSize(Conversions.PositiveInfinitySize);
+				var one = horiz ? sone.Width : sone.Height;
+				var two = horiz ? stwo.Width : stwo.Height;
+				Position = (int)Math.Round(one * (size - splitterSize) / (one + two));
+			}
+			else
+			{
+				var prefer = horiz ?
+					PreferredSize.Width : PreferredSize.Height;
+
+				if (fixedPanel == SplitterFixedPanel.Panel1 || !(prefer > 0)) //NaN-aware compare
+				{
 					Position = position.Value;
-			};
+				}
+				else if (fixedPanel == SplitterFixedPanel.Panel2)
+				{
+					Position = position.Value + (int)Math.Round(size - prefer);
+				}
+				else
+				{
+					Position = (int)Math.Round(position.Value * (size - splitterSize) / (prefer - splitterSize));
+				}
+			}
 		}
 
 		static void SetStretch(Control panel)
@@ -89,10 +118,6 @@ namespace Eto.Wpf.Forms.Controls
 				var control = panel.GetContainerControl();
 				control.VerticalAlignment = sw.VerticalAlignment.Stretch;
 				control.HorizontalAlignment = sw.HorizontalAlignment.Stretch;
-				/*
-				((sw.FrameworkElement)panel.ControlObject).Width = double.NaN;
-				((sw.FrameworkElement)panel.ControlObject).Height = double.NaN;
-				 * */
 			}
 		}
 
@@ -118,7 +143,7 @@ namespace Eto.Wpf.Forms.Controls
 				swc.Grid.SetColumn(pane2, 2);
 				swc.Grid.SetRow(pane2, 0);
 
-				splitter.Width = 5;
+				splitter.Width = splitterSize;
 				splitter.Height = double.NaN;
 			}
 			else
@@ -142,7 +167,7 @@ namespace Eto.Wpf.Forms.Controls
 				swc.Grid.SetRow(pane2, 2);
 
 				splitter.Width = double.NaN;
-				splitter.Height = 5;
+				splitter.Height = splitterSize;
 			}
 		}
 
@@ -243,63 +268,40 @@ namespace Eto.Wpf.Forms.Controls
 			set
 			{
 				if (!Widget.Loaded)
-				{
 					position = value;
-					initialWidth = Size.Width;
-					initialHeight = Size.Height;
-				}
+
 				if (splitter.ResizeDirection == swc.GridResizeDirection.Columns)
 				{
 					var col1 = Control.ColumnDefinitions[0];
 					var col2 = Control.ColumnDefinitions[2];
-					var controlWidth = Control.ActualWidth;
-					if (double.IsNaN(controlWidth))
-						controlWidth = Control.Width;
-					switch (fixedPanel)
+					var width = Control.ActualWidth;
+					if (fixedPanel == SplitterFixedPanel.Panel1)
+						col1.Width = new sw.GridLength(value, sw.GridUnitType.Pixel);
+					else if (fixedPanel == SplitterFixedPanel.Panel2)
+						col2.Width = new sw.GridLength(Math.Max(0,
+							width - splitter.Width - value), sw.GridUnitType.Pixel);
+					else
 					{
-						case SplitterFixedPanel.None:
-							if (Widget.Loaded)
-							{
-								col1.Width = new sw.GridLength(value, sw.GridUnitType.Star);
-								col2.Width = new sw.GridLength(controlWidth - value, sw.GridUnitType.Star);
-							}
-							break;
-						case SplitterFixedPanel.Panel1:
-							col1.Width = new sw.GridLength(value, sw.GridUnitType.Pixel);
-							break;
-						case SplitterFixedPanel.Panel2:
-							if (Widget.Loaded)
-								col2.Width = new sw.GridLength(controlWidth - value, sw.GridUnitType.Pixel);
-							else
-								col1.Width = new sw.GridLength(value, sw.GridUnitType.Pixel);
-							break;
+						col1.Width = new sw.GridLength(value, sw.GridUnitType.Star);
+						col2.Width = new sw.GridLength(Math.Max(0, 
+							width - splitter.Width - value), sw.GridUnitType.Star);
 					}
 				}
 				else
 				{
 					var row1 = Control.RowDefinitions[0];
 					var row2 = Control.RowDefinitions[2];
-					var controlHeight = Control.ActualHeight;
-					if (double.IsNaN(controlHeight))
-						controlHeight = Control.Height;
-					switch (fixedPanel)
+					var height = Control.ActualHeight;
+					if (fixedPanel == SplitterFixedPanel.Panel1)
+						row1.Height = new sw.GridLength(value, sw.GridUnitType.Pixel);
+					else if (fixedPanel == SplitterFixedPanel.Panel2)
+						row2.Height = new sw.GridLength(Math.Max(0,
+							height - splitter.Height - value), sw.GridUnitType.Pixel);
+					else
 					{
-						case SplitterFixedPanel.None:
-							if (Widget.Loaded)
-							{
-								row1.Height = new sw.GridLength(value, sw.GridUnitType.Star);
-								row2.Height = new sw.GridLength(controlHeight - value, sw.GridUnitType.Star);
-							}
-							break;
-						case SplitterFixedPanel.Panel1:
-							row1.Height = new sw.GridLength(value, sw.GridUnitType.Pixel);
-							break;
-						case SplitterFixedPanel.Panel2:
-							if (Widget.Loaded)
-								row2.Height = new sw.GridLength(Math.Max(0, controlHeight - value), sw.GridUnitType.Pixel);
-							else
-								row1.Height = new sw.GridLength(value, sw.GridUnitType.Pixel);
-							break;
+						row1.Height = new sw.GridLength(value, sw.GridUnitType.Star);
+						row2.Height = new sw.GridLength(Math.Max(0,
+							height - splitter.Height - value), sw.GridUnitType.Star);
 					}
 				}
 			}
@@ -348,8 +350,6 @@ namespace Eto.Wpf.Forms.Controls
 				{
 					var control = panel2.GetWpfFrameworkElement();
 					control.ContainerControl.Style = style;
-					//swc.DockPanel.SetDock (control, swc.Dock.Top);
-					//control.Height = double.NaN;
 					SetStretch(panel2);
 					if (Widget.Loaded)
 						control.SetScale(true, true);

--- a/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
@@ -6,8 +6,6 @@ using sw = System.Windows;
 using swc = System.Windows.Controls;
 using Eto.Drawing;
 
-using System.Diagnostics;
-
 namespace Eto.Wpf.Forms.Controls
 {
 	public class SplitterHandler : WpfContainer<swc.Grid, Splitter, Splitter.ICallback>, Splitter.IHandler
@@ -82,7 +80,7 @@ namespace Eto.Wpf.Forms.Controls
 						break;
 					default:
 						var sone = panel1.GetPreferredSize(Conversions.PositiveInfinitySize);
-						var stwo = panel1.GetPreferredSize(Conversions.PositiveInfinitySize);
+						var stwo = panel2.GetPreferredSize(Conversions.PositiveInfinitySize);
 						var one = horiz ? sone.Width : sone.Height;
 						var two = horiz ? stwo.Width : stwo.Height;
 						SetPosition(one * size / (one + two), SplitterPositionMode.Near);

--- a/Source/Eto/Forms/Controls/Splitter.cs
+++ b/Source/Eto/Forms/Controls/Splitter.cs
@@ -19,6 +19,27 @@ namespace Eto.Forms
 	}
 
 	/// <summary>
+	/// Meaning if <see cref="Splitter.Position"/>.
+	/// </summary>
+	public enum SplitterPositionMode
+	{
+		/// <summary>
+		/// Default mode - pixels from top/left (width/height of Panel1)
+		/// </summary>
+		Near,
+		/// <summary>
+		/// Inverted mode - pixels from bottom/right (width/height of Panel2)
+		/// - usefull with <see cref="Splitter.FixedPanel"/> = <see cref="SplitterFixedPanel.Panel2"/>.
+		/// </summary>
+		Far,
+		/// <summary>
+		/// Percent ratio mode of first panel vs. full size excluding splitter size
+		/// - usefull with <see cref="Splitter.FixedPanel"/> = <see cref="SplitterFixedPanel.None"/>
+		/// </summary>
+		Percent
+	}
+
+	/// <summary>
 	/// Specifies which panel has a fixed size the parent container is resized.
 	/// </summary>
 	public enum SplitterFixedPanel
@@ -142,6 +163,23 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Gets or sets the position mode.
+		/// </summary>
+		public SplitterPositionMode PositionMode {
+			get { return Handler.PositionMode; }
+			set { Handler.PositionMode = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets size of the splitter
+		/// </summary>
+		public int SplitterWidth
+		{
+			get { return Handler.SplitterWidth; }
+			set { Handler.SplitterWidth = value; }
+		}
+
+		/// <summary>
 		/// Gets or sets the top or left panel of the splitter.
 		/// </summary>
 		/// <value>The first panel.</value>
@@ -241,6 +279,16 @@ namespace Eto.Forms
 			/// </summary>
 			/// <value>The position of the splitter.</value>
 			int Position { get; set; }
+
+			/// <summary>
+			/// Gets or sets the position mode.
+			/// </summary>
+			SplitterPositionMode PositionMode { get; set; }
+
+			/// <summary>
+			/// Gets or sets size of the splitter
+			/// </summary>
+			int SplitterWidth { get; set; }
 
 			/// <summary>
 			/// Gets or sets the top or left panel of the splitter.

--- a/Source/Eto/Forms/Menu/MenuItemCollection.cs
+++ b/Source/Eto/Forms/Menu/MenuItemCollection.cs
@@ -134,15 +134,9 @@ namespace Eto.Forms
 		/// <param name="items">Items to add.</param>
 		public void AddRange(IEnumerable<MenuItem> items)
 		{
-			var list = Items as List<MenuItem>;
-			if (list != null)
-				list.AddRange(items);
-			else
+			foreach (var item in items)
 			{
-				foreach (var item in items)
-				{
-					Add(item);
-				}
+				Add(item);
 			}
 		}
 


### PR DESCRIPTION
I finally got how WPF autosizing works - set_Position needs to update the control to make it work.
WPF/SWF and GTK#2 now support setting FixedPanel=None/Panel2 with Position and Width or Height to properly size it at startup. Autosizing checked and is working fine. WinForms needed one hack of EtoPanel to bypass system measurement for panel with one fully docked (filled) control (there is some cache-magic to blame from what I have seen in ILSpy). Original tests worked without it, but once I have added another splitter to the tests, it started to fail - fixed with that workaround.

list of squashed commints:

(merge) Fix MenuItemCollection.AddRange so that the items actually get added to the parent menu. Fixes #308
Splitter tests of initial resize (wpf: 1px error when fixing second)
Splitters improved, Wpf 1px error fixed, more tests
Hackish Swf autosizing fix for Dock=Fill in panel
Splitter tests
Minor change in tests to re-enable auto-size tests.
Wpf Splitter autosizing (removed return if Widget.Loaded in set_Position)

fix #309, replaces #310 