### PR TITLE
Fixes issue #334

### DIFF
--- a/Source/Eto.Wpf/Forms/ToolBar/ButtonToolItemHandler.cs
+++ b/Source/Eto.Wpf/Forms/ToolBar/ButtonToolItemHandler.cs
@@ -1,8 +1,8 @@
 using System;
+using Eto.Drawing;
 using Eto.Forms;
 using swc = System.Windows.Controls;
 using swm = System.Windows.Media;
-using Eto.Drawing;
 
 namespace Eto.Wpf.Forms.ToolBar
 {
@@ -14,15 +14,16 @@ namespace Eto.Wpf.Forms.ToolBar
 
 		public ButtonToolItemHandler ()
 		{
-			Control = new swc.Button ();
+			Control = new swc.Button();
 			swcImage = new swc.Image { MaxHeight = 16, MaxWidth = 16 };
-			label = new swc.TextBlock ();
+			label = new swc.TextBlock();
 			var panel = new swc.StackPanel { Orientation = swc.Orientation.Horizontal };
-			panel.Children.Add (swcImage);
-			panel.Children.Add (label);
+			panel.Children.Add(swcImage);
+			panel.Children.Add(label);
 			Control.Content = panel;
-			Control.Click += delegate {
-				Widget.OnClick (EventArgs.Empty);
+			Control.Click += delegate
+			{
+				Widget.OnClick(EventArgs.Empty);
 			};
 		}
 
@@ -44,14 +45,18 @@ namespace Eto.Wpf.Forms.ToolBar
 			set
 			{
 				image = value;
-				swcImage.Source = image.ToWpf ((int)swcImage.MaxWidth);
+				swcImage.Source = image.ToWpf((int)swcImage.MaxWidth);
 			}
 		}
 
 		public override bool Enabled
 		{
 			get { return Control.IsEnabled; }
-			set { Control.IsEnabled = value; }
+			set
+			{
+				Control.IsEnabled = value;
+				swcImage.IsEnabled = value;
+			}
 		}
 	}
 }


### PR DESCRIPTION
The grayed out function of a ToolButton doesn't only depends on the
Control.IsEnabled. It also needs the image to be disabled to show it.
Include source code style cleanups.