### PR TITLE
Splitter.RelativePosition

### DIFF
--- a/Source/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -35,6 +35,47 @@ namespace Eto.Mac.Forms.Controls
 {
 	public class SplitterHandler : MacView<NSSplitView, Splitter, Splitter.ICallback>, Splitter.IHandler
 	{
+
+		//TODO: RelativePosition - following is just stub, see WinForm/WPF/GTK or ThemedSplitter
+		public double RelativePosition
+		{
+			get
+			{
+				var pos = Position;
+				if (fixedPanel == SplitterFixedPanel.Panel1)
+					return pos;
+				var size = Orientation == SplitterOrientation.Horizontal
+					? Control.Bounds.Width : Control.Bounds.Height;
+				size -= SplitterWidth;
+				if (fixedPanel == SplitterFixedPanel.Panel2)
+					return size - pos;
+				return pos / (double)size;
+			}
+			set
+			{
+				if (fixedPanel == SplitterFixedPanel.Panel1)
+					Position = (int)Math.Round(value);
+				else
+				{
+					var size = Orientation == SplitterOrientation.Horizontal
+					? Control.Bounds.Width : Control.Bounds.Height;
+					size -= SplitterWidth;
+					if (fixedPanel == SplitterFixedPanel.Panel2)
+						Position = (int)Math.Round(size - value);
+					else
+						Position = (int)Math.Round(size * value);
+				}
+			}
+		}
+
+		//TODO: SplitterWidth - at least get correct value
+		public int SplitterWidth
+		{
+			get { return 5; }
+			set { }
+		}
+
+
 		Control panel1;
 		Control panel2;
 		int? position;

--- a/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
+++ b/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
@@ -130,6 +130,7 @@
     <Compile Include="UnitTests\Drawing\ClipTests.cs" />
     <Compile Include="UnitTests\Drawing\MatrixTests.cs" />
     <Compile Include="UnitTests\Forms\Controls\ComboBoxTests.cs" />
+    <Compile Include="UnitTests\Forms\Controls\SplitterTests.cs" />
     <Compile Include="UnitTests\Forms\GridViewUtils.cs" />
     <Compile Include="UnitTests\Forms\RangeTests.cs" />
     <Compile Include="UnitTests\Handlers\Controls\TestControlHandler.cs" />

--- a/Source/Eto.Test/Eto.Test/Eto.Test.csproj
+++ b/Source/Eto.Test/Eto.Test/Eto.Test.csproj
@@ -136,6 +136,7 @@
     <Compile Include="UnitTests\Drawing\BitmapTests.cs" />
     <Compile Include="UnitTests\Drawing\ClipTests.cs" />
     <Compile Include="UnitTests\Drawing\MatrixTests.cs" />
+    <Compile Include="UnitTests\Forms\Controls\SplitterTests.cs" />
     <Compile Include="UnitTests\Forms\RangeTests.cs" />
     <Compile Include="UnitTests\Handlers\Controls\TestCalendarHandler.cs" />
     <Compile Include="UnitTests\Handlers\Controls\TestGridColumnHandler.cs" />

--- a/Source/Eto.Test/Eto.Test/MainForm.cs
+++ b/Source/Eto.Test/Eto.Test/MainForm.cs
@@ -32,7 +32,7 @@ namespace Eto.Test
 
 		public MainForm(IEnumerable<Section> topNodes = null)
 		{
-			Title = "Test Application";
+			Title = string.Format("Test Application [{0}]", Platform.ID);
 			Style = "main";
 			MinimumSize = new Size(400, 400);
 			topNodes = topNodes ?? TestSections.Get();

--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
@@ -1,0 +1,270 @@
+﻿using Eto.Drawing;
+using Eto.Forms;
+using NUnit.Framework;
+using System;
+
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	[TestFixture, Category("ui"), Category(TestUtils.NoTestPlatformCategory)]
+	public class SplitterTests
+	{
+		// currently working only for WinForms
+		bool ReplayTests { get { return Platform.Instance.IsWinForms; } }
+
+		[Test]
+		public void PositionShouldNotChange()
+		{
+			bool replay = false;
+			Action<SplitterOrientation, SplitterFixedPanel>
+				test = (orient, fix) =>
+			{
+				TestUtils.Shown(form =>
+				{
+					return new Splitter()
+					{
+						Size = new Size(150, 150),
+						Orientation  = orient,
+						FixedPanel	 = fix,
+						Position	 = 50,
+						Panel1 = new Panel
+						{
+							BackgroundColor = Colors.White
+						},
+						Panel2 = new Panel
+						{
+							BackgroundColor = Colors.Black
+						}
+					};
+				},
+				it =>
+				{
+					Assert.AreEqual(50, it.Position, "Fix: {0}; {1} [replay={2}]", fix, orient, replay);
+					if (ReplayTests) replay = !replay;
+				},
+				replay: ReplayTests);
+			};
+			foreach (SplitterOrientation o in Enum.GetValues(typeof(SplitterOrientation)))
+				foreach (SplitterFixedPanel p in Enum.GetValues(typeof(SplitterFixedPanel)))
+					test(o, p);
+		}
+
+		[Test]
+		public void RelativePositionShouldNotChange()
+		{
+			bool replay = false;
+			Action<SplitterOrientation, SplitterFixedPanel>
+				test = (orient, fix) =>
+			{
+				double pos = fix == SplitterFixedPanel.None ? (1/3.0) : 50;
+				TestUtils.Shown(form =>
+				{
+					return new Splitter()
+					{
+						Size = new Size(150, 150),
+						Orientation  = orient,
+						FixedPanel	 = fix,
+						RelativePosition = pos,
+						Panel1 = new Panel
+						{
+							BackgroundColor = Colors.White
+						},
+						Panel2 = new Panel
+						{
+							BackgroundColor = Colors.Black
+						}
+					};
+				},
+				it =>
+				{
+					Assert.AreEqual(pos, it.RelativePosition, 1e-6, "Fix: {0}; {1} [replay={2}]", fix, orient, replay);
+					if (ReplayTests) replay = !replay;
+				},
+				replay: ReplayTests);
+			};
+			foreach (SplitterOrientation o in Enum.GetValues(typeof(SplitterOrientation)))
+				foreach (SplitterFixedPanel p in Enum.GetValues(typeof(SplitterFixedPanel)))
+					test(o, p);
+		}
+
+		[Test]
+		public void NoPositionShouldAutoSizeBasic()
+		{
+			bool replay = false;
+			Action<SplitterOrientation, SplitterFixedPanel>
+				test = (orient, fix) =>
+			{
+				var sz = new Size(50, 50);
+				TestUtils.Shown(form =>
+				{
+					return new Splitter
+					{
+						Orientation  = orient,
+						FixedPanel	 = fix,
+						Panel1 = new Panel
+						{
+							Size = sz,
+							BackgroundColor = Colors.White
+						},
+						Panel2 = new Panel
+						{
+							Size = sz,
+							BackgroundColor = Colors.Black
+						}
+					};
+				},
+				it =>
+				{
+					if (orient == SplitterOrientation.Horizontal)
+						Assert.AreEqual(it.Panel1.Height, it.Panel2.Height,
+							"Height! Fix: {0}; {1} [replay={2}]", fix, orient, replay);
+					else
+						Assert.AreEqual(it.Panel1.Width, it.Panel2.Width,
+							"Width! Fix: {0}; {1} [replay={2}]", fix, orient, replay);
+					switch (fix)
+					{
+						case SplitterFixedPanel.Panel1:
+							if (orient == SplitterOrientation.Horizontal)
+								Assert.AreEqual(sz.Width, it.Panel1.Width,
+									"P1.Width! Fix: {0}; {1} [replay={2}]", fix, orient, replay);
+							else
+								Assert.AreEqual(sz.Height, it.Panel1.Height,
+									"P1.Height! Fix: {0}; {1} [replay={2}]", fix, orient, replay);
+							break;
+						case SplitterFixedPanel.Panel2:
+							if (orient == SplitterOrientation.Horizontal)
+								Assert.AreEqual(sz.Width, it.Panel2.Width,
+									"P2.Width! Fix: {0}; {1} [replay={2}]", fix, orient, replay);
+							else
+								Assert.AreEqual(sz.Height, it.Panel2.Height,
+									"P2.Height! Fix: {0}; {1} [replay={2}]", fix, orient, replay);
+							break;
+						case SplitterFixedPanel.None:
+							if (orient == SplitterOrientation.Horizontal)
+								Assert.AreEqual(it.Panel1.Width, it.Panel2.Width, 1,
+									"Width! Fix: {0}; {1} [replay={2}]", fix, orient, replay);
+							else
+								Assert.AreEqual(it.Panel1.Height, it.Panel2.Height, 1,
+									"Height! Fix: {0}; {1} [replay={2}]", fix, orient, replay);
+							break;
+					}
+					if (ReplayTests) replay = !replay;
+				},
+				replay: ReplayTests);
+			};
+			foreach (SplitterOrientation o in Enum.GetValues(typeof(SplitterOrientation)))
+				foreach (SplitterFixedPanel	p in Enum.GetValues(typeof(SplitterFixedPanel)))
+					test(o, p);
+		}
+
+		[Test]
+		public void NoPositionShouldAutoSizeComplex()
+		{
+			Action<SplitterOrientation, SplitterFixedPanel, int>
+				test = (orient, fix, testN) =>
+			{
+				// +====test 1====+ +====test 2====+
+				// |        |     | |              |
+				// | tested |     | |-----+--------|  Tested splitter is placed inside two other splitters
+				// |        |     | |     |        |  to overcome minimal window/form size problems
+				// +--------+     | |     | tested |  ...or non-desktop plaforms
+				// |        |     | |     |        |
+				// +--------+-----+ +-----+--------+
+				TestUtils.Shown(form =>
+				{
+					var it = new Splitter
+					{
+						Orientation  = orient,
+						FixedPanel	 = fix,
+						Panel1 = new Panel
+						{
+							Size = new Size(40, 40),
+							BackgroundColor = Colors.White
+						},
+						Panel2 = new Panel
+						{
+							Size = new Size(60, 60),
+							BackgroundColor = Colors.Black
+						}
+					};
+					form.Content = testN == 1 ? new Splitter
+					{
+						Panel1 = new Splitter
+						{
+							Orientation = SplitterOrientation.Vertical,
+							Panel1 = it,
+							Panel2 = new Panel()
+						},
+						Panel2 = new Panel()
+					}
+					: new Splitter
+					{
+						Orientation = SplitterOrientation.Vertical,
+						FixedPanel = SplitterFixedPanel.Panel2,
+						Panel1 = new Panel(),
+						Panel2 = new Splitter
+						{
+							FixedPanel = SplitterFixedPanel.Panel2,
+							Panel1 = new Panel(),
+							Panel2 = it
+						}
+					};
+					return it;
+				},
+				it =>
+				{
+					Assert.AreEqual(40, it.Position, "{0}; {1}", fix, orient);
+					Assert.AreEqual(fix == SplitterFixedPanel.Panel1 ? 40
+						: fix == SplitterFixedPanel.Panel2 ? 60 : 0.4,
+						it.RelativePosition, "{0}; {1}", fix, orient);
+					var sz = orient == SplitterOrientation.Horizontal
+						? new Size(100 + it.SplitterWidth, 60)
+						: new Size(60, 100 + it.SplitterWidth);
+					Assert.AreEqual(sz, it.Size, "{0}; {1}", fix, orient);
+				},
+				replay: ReplayTests);
+			};
+			for (int testN = 1; testN < 2; testN++)
+				foreach (SplitterOrientation o in Enum.GetValues(typeof(SplitterOrientation)))
+					foreach (SplitterFixedPanel	p in Enum.GetValues(typeof(SplitterFixedPanel)))
+						test(o, p, testN);
+		}
+
+		[Test] // Issue #309
+		public void PositionShouldTrackInitialResize()
+		{
+			bool replay = false;
+			Action<SplitterOrientation, SplitterFixedPanel>
+				test = (orient, fix) =>
+				{
+					TestUtils.Shown(form =>
+					{
+						var it = new Splitter() {
+							Orientation = orient,
+							FixedPanel	= fix,
+							Position	= 50,
+							Panel1 = new Panel {
+								BackgroundColor = Colors.White
+							},
+							Panel2 = new Panel {
+								BackgroundColor = Colors.Black
+							}
+						};
+						it.Size = new Size(100, 100) + it.SplitterWidth;
+						form.ClientSize = new Size(150, 150) + it.SplitterWidth;
+						return it;
+					},
+					it =>
+					{
+						double pos = fix == SplitterFixedPanel.None ? 0.5 : 50.0;
+						Assert.AreEqual(pos, it.RelativePosition, 1e-6, "Fix: {0}; {1} [replay={2}]", fix, orient, replay);
+						if (ReplayTests)
+							replay = !replay;
+					},
+					replay: ReplayTests);
+				};
+			foreach (SplitterOrientation o in Enum.GetValues(typeof(SplitterOrientation)))
+				foreach (SplitterFixedPanel p in Enum.GetValues(typeof(SplitterFixedPanel)))
+					test(o, p);
+		}
+	}
+}

--- a/Source/Eto.WinForms/Forms/Controls/PanelHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/PanelHandler.cs
@@ -1,6 +1,7 @@
 using swf = System.Windows.Forms;
 using sd = System.Drawing;
 using Eto.Forms;
+using System;
 
 namespace Eto.WinForms.Forms.Controls
 {
@@ -8,6 +9,24 @@ namespace Eto.WinForms.Forms.Controls
 	{
 		public class EtoPanel : swf.Panel
 		{
+			public override sd.Size GetPreferredSize(sd.Size proposedSize)
+			{
+				// WinForms have problems with autosizing vs. docking
+				// this will solve some of its problems and speed things up.
+				// Not perfect, would be better to write it all new,
+				// especially if all inner controls are docked,
+				// but this is common scenairo when panels are emitted
+				// from Eto layout engine.
+				if (Controls.Count == 1 && Controls[0].Dock == swf.DockStyle.Fill)
+					return Controls[0].GetPreferredSize(new sd.Size(
+						Math.Max(0, proposedSize.Width - Padding.Horizontal),
+						Math.Max(0, proposedSize.Height - Padding.Vertical)))
+						+ Padding.Size;
+
+				// fallback to default engine
+				return base.GetPreferredSize(proposedSize);
+			}
+
 			// Need to override IsInputKey to capture 
 			// the arrow keys.
 			protected override bool IsInputKey (swf.Keys keyData)

--- a/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
@@ -16,8 +16,8 @@ namespace Eto.Wpf.Forms.Controls
 		SplitterOrientation orientation;
 		SplitterFixedPanel fixedPanel;
 		int? position;
-		int? initialWidth;
-		int? initialHeight;
+		int splitterWidth = 5;
+		double relative = double.NaN;
 		readonly sw.Style style;
 
 		Control panel1;
@@ -51,35 +51,59 @@ namespace Eto.Wpf.Forms.Controls
 			style.Setters.Add(new sw.Setter(sw.FrameworkElement.HorizontalAlignmentProperty, sw.HorizontalAlignment.Stretch));
 
 			UpdateOrientation();
-			Control.Loaded += delegate
-			{
-				// controls should be stretched to fit panels
-				SetStretch(panel1);
-				SetStretch(panel2);
-				UpdateColumnSizing();
-				if (FixedPanel == SplitterFixedPanel.Panel2)
-				{
-					var size = panel2.GetPreferredSize(WpfConversions.PositiveInfinitySize);
-					var currentOrientation = Orientation;
-					if (currentOrientation == SplitterOrientation.Horizontal)
-					{
-						var width = (int)Control.ActualWidth;
-						position = position ?? (int)(width - size.Width);
-						Position = Size.Width - (width - position.Value);
-					}
-					else if (currentOrientation == SplitterOrientation.Vertical)
-					{
-						var height = (int)Control.ActualHeight;
-						position = position ?? (int)(height - size.Height);
+			Control.Loaded += Control_Loaded;
+		}
 
-						Position = Size.Height - (height - position.Value);
+		void Control_Loaded(object sender, sw.RoutedEventArgs e)
+		{
+			// controls should be stretched to fit panels
+			SetStretch(panel1);
+			SetStretch(panel2);
+			UpdateColumnSizing(false);
+
+			if (position != null)
+			{
+				var pos = position.Value;
+				if (fixedPanel != SplitterFixedPanel.Panel1)
+				{
+					var size = GetAvailableSize(false);
+					var want = GetAvailableSize(true);
+					if (size != want)
+					{
+						if (FixedPanel == SplitterFixedPanel.Panel2)
+							pos += (int)Math.Round(size - want);
+						else
+						{
+							SetRelative(pos / (double)want);
+							return;
+						}
 					}
-					else if (position != null)
-						Position = position.Value;
+
 				}
-				else if (position != null)
-					Position = position.Value;
-			};
+				SetPosition(pos);
+			}
+			else if (!double.IsNaN(relative))
+			{
+				SetRelative(relative);
+			}
+			else if (fixedPanel == SplitterFixedPanel.Panel1)
+			{
+				var size1 = panel1.GetPreferredSize(WpfConversions.PositiveInfinitySize);
+				SetRelative(orientation == SplitterOrientation.Horizontal ? size1.Width : size1.Height);
+			}
+			else if (fixedPanel == SplitterFixedPanel.Panel2)
+			{
+				var size2 = panel2.GetPreferredSize(WpfConversions.PositiveInfinitySize);
+				SetRelative(orientation == SplitterOrientation.Horizontal ? size2.Width : size2.Height);
+			}
+			else
+			{
+				var size1 = panel1.GetPreferredSize(WpfConversions.PositiveInfinitySize);
+				var size2 = panel2.GetPreferredSize(WpfConversions.PositiveInfinitySize);
+				SetRelative(orientation == SplitterOrientation.Horizontal
+					? size1.Width / (double)(size1.Width + size2.Width)
+					: size1.Height / (double)(size1.Height + size2.Height));
+			}
 		}
 
 		static void SetStretch(Control panel)
@@ -118,7 +142,7 @@ namespace Eto.Wpf.Forms.Controls
 				swc.Grid.SetColumn(pane2, 2);
 				swc.Grid.SetRow(pane2, 0);
 
-				splitter.Width = 5;
+				splitter.Width = splitterWidth;
 				splitter.Height = double.NaN;
 			}
 			else
@@ -142,8 +166,9 @@ namespace Eto.Wpf.Forms.Controls
 				swc.Grid.SetRow(pane2, 2);
 
 				splitter.Width = double.NaN;
-				splitter.Height = 5;
+				splitter.Height = splitterWidth;
 			}
+			UpdateColumnSizing(position.HasValue || !double.IsNaN(relative));
 		}
 
 		public override Color BackgroundColor
@@ -152,9 +177,10 @@ namespace Eto.Wpf.Forms.Controls
 			set { Control.Background = value.ToWpfBrush(Control.Background); }
 		}
 
-		void UpdateColumnSizing()
+		void UpdateColumnSizing(bool updatePosition)
 		{
-			var pos = Position;
+			if (updatePosition && position == null && double.IsNaN(relative))
+				UpdateRelative();
 			switch (Orientation)
 			{
 				case SplitterOrientation.Horizontal:
@@ -162,15 +188,15 @@ namespace Eto.Wpf.Forms.Controls
 					var col2 = Control.ColumnDefinitions[2];
 					switch (fixedPanel)
 					{
-						case SplitterFixedPanel.None:
-							col1.Width = new sw.GridLength(1, sw.GridUnitType.Star);
-							col2.Width = new sw.GridLength(1, sw.GridUnitType.Star);
-							break;
 						case SplitterFixedPanel.Panel1:
 							col2.Width = new sw.GridLength(1, sw.GridUnitType.Star);
 							break;
 						case SplitterFixedPanel.Panel2:
 							col1.Width = new sw.GridLength(1, sw.GridUnitType.Star);
+							break;
+						case SplitterFixedPanel.None:
+							col1.Width = new sw.GridLength(1, sw.GridUnitType.Star);
+							col2.Width = new sw.GridLength(1, sw.GridUnitType.Star);
 							break;
 					}
 					break;
@@ -179,23 +205,28 @@ namespace Eto.Wpf.Forms.Controls
 					var row2 = Control.RowDefinitions[2];
 					switch (fixedPanel)
 					{
-						case SplitterFixedPanel.None:
-							row1.Height = new sw.GridLength(1, sw.GridUnitType.Star);
-							row2.Height = new sw.GridLength(1, sw.GridUnitType.Star);
-							break;
 						case SplitterFixedPanel.Panel1:
 							row2.Height = new sw.GridLength(1, sw.GridUnitType.Star);
 							break;
 						case SplitterFixedPanel.Panel2:
 							row1.Height = new sw.GridLength(1, sw.GridUnitType.Star);
 							break;
+						case SplitterFixedPanel.None:
+							row1.Height = new sw.GridLength(1, sw.GridUnitType.Star);
+							row2.Height = new sw.GridLength(1, sw.GridUnitType.Star);
+							break;
 					}
 					break;
 				default:
 					throw new NotSupportedException();
 			}
-			if (Widget.Loaded)
-				Position = pos;
+			if (updatePosition)
+			{
+				if (position.HasValue)
+					SetPosition(position.Value);
+				else if (!double.IsNaN(relative))
+					SetRelative(relative);
+			}
 		}
 
 		public SplitterOrientation Orientation
@@ -216,7 +247,6 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				orientation = value;
 				UpdateOrientation();
-				UpdateColumnSizing();
 			}
 		}
 
@@ -226,7 +256,7 @@ namespace Eto.Wpf.Forms.Controls
 			set
 			{
 				fixedPanel = value;
-				UpdateColumnSizing();
+				UpdateColumnSizing(Control.IsLoaded);
 			}
 		}
 
@@ -234,73 +264,188 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			get
 			{
-				if (!Widget.Loaded)
+				if (!Control.IsLoaded)
 					return position ?? 0;
 				if (splitter.ResizeDirection == swc.GridResizeDirection.Columns)
-					return (int)Control.ColumnDefinitions[0].ActualWidth;
-				return (int)Control.RowDefinitions[0].ActualHeight;
+					return (int)Math.Round(Control.ColumnDefinitions[0].ActualWidth);
+				return (int)Math.Round(Control.RowDefinitions[0].ActualHeight);
 			}
 			set
 			{
-				if (!Widget.Loaded)
-				{
-					position = value;
-					initialWidth = Size.Width;
-					initialHeight = Size.Height;
-				}
+				SetPosition(value);
+			}
+		}
+
+		public int SplitterWidth
+		{
+			get { return splitterWidth; }
+			set
+			{
+				if (splitterWidth == value)
+					return;
+				splitterWidth = value;
+				if (orientation == SplitterOrientation.Horizontal)
+					splitter.Width = value;
+				else
+					splitter.Height = value;
+			}
+		}
+
+		double GetAvailableSize()
+		{
+			return GetAvailableSize(!Control.IsLoaded);
+		}
+		double GetAvailableSize(bool desired)
+		{
+			if (desired)
+			{
+				var size = PreferredSize;
+				var pick = Orientation == SplitterOrientation.Horizontal ?
+					size.Width : size.Height;
+				if (pick >= 0)
+					return pick - splitterWidth;
+			}
+			var width = (Orientation == SplitterOrientation.Horizontal ?
+				Control.ActualWidth : Control.ActualHeight);
+			if (double.IsNaN(width))
+				width = (Orientation == SplitterOrientation.Horizontal ?
+					Control.Width : Control.Height);
+			return width - splitterWidth;
+		}
+
+		void UpdateRelative()
+		{
+			var pos = Position;
+			if (fixedPanel == SplitterFixedPanel.Panel1)
+				relative = pos;
+			else
+			{
+				var sz = GetAvailableSize();
+				if (fixedPanel == SplitterFixedPanel.Panel2)
+					relative = sz <= 0 ? 0 : sz - pos;
+				else
+					relative = sz <= 0 ? 0.5 : pos / (double)sz;
+			}
+		}
+
+		public double RelativePosition
+		{
+			get
+			{
+				if (double.IsNaN(relative))
+					UpdateRelative();
+				return relative;
+			}
+			set
+			{
+				if (relative == value)
+					return;
+				SetRelative(value);
+				Callback.OnPositionChanged(Widget, EventArgs.Empty);
+			}
+		}
+
+		void SetPosition(int newPosition)
+		{
+			if (!Control.IsLoaded)
+			{
+				position = newPosition;
+				relative = double.NaN;
 				if (splitter.ResizeDirection == swc.GridResizeDirection.Columns)
 				{
-					var col1 = Control.ColumnDefinitions[0];
-					var col2 = Control.ColumnDefinitions[2];
-					var controlWidth = Control.ActualWidth;
-					if (double.IsNaN(controlWidth))
-						controlWidth = Control.Width;
-					switch (fixedPanel)
-					{
-						case SplitterFixedPanel.None:
-							if (Widget.Loaded)
-							{
-								col1.Width = new sw.GridLength(value, sw.GridUnitType.Star);
-								col2.Width = new sw.GridLength(controlWidth - value, sw.GridUnitType.Star);
-							}
-							break;
-						case SplitterFixedPanel.Panel1:
-							col1.Width = new sw.GridLength(value, sw.GridUnitType.Pixel);
-							break;
-						case SplitterFixedPanel.Panel2:
-							if (Widget.Loaded)
-								col2.Width = new sw.GridLength(controlWidth - value, sw.GridUnitType.Pixel);
-							else
-								col1.Width = new sw.GridLength(value, sw.GridUnitType.Pixel);
-							break;
-					}
+					Control.ColumnDefinitions[0].Width = new sw.GridLength(Math.Max(0,
+						newPosition), sw.GridUnitType.Pixel);
+					Control.ColumnDefinitions[2].Width = new sw.GridLength(1, sw.GridUnitType.Star);
 				}
 				else
 				{
-					var row1 = Control.RowDefinitions[0];
-					var row2 = Control.RowDefinitions[2];
-					var controlHeight = Control.ActualHeight;
-					if (double.IsNaN(controlHeight))
-						controlHeight = Control.Height;
-					switch (fixedPanel)
-					{
-						case SplitterFixedPanel.None:
-							if (Widget.Loaded)
-							{
-								row1.Height = new sw.GridLength(value, sw.GridUnitType.Star);
-								row2.Height = new sw.GridLength(controlHeight - value, sw.GridUnitType.Star);
-							}
-							break;
-						case SplitterFixedPanel.Panel1:
-							row1.Height = new sw.GridLength(value, sw.GridUnitType.Pixel);
-							break;
-						case SplitterFixedPanel.Panel2:
-							if (Widget.Loaded)
-								row2.Height = new sw.GridLength(Math.Max(0, controlHeight - value), sw.GridUnitType.Pixel);
-							else
-								row1.Height = new sw.GridLength(value, sw.GridUnitType.Pixel);
-							break;
-					}
+					Control.RowDefinitions[0].Height = new sw.GridLength(Math.Max(0,
+						newPosition), sw.GridUnitType.Pixel);
+					Control.RowDefinitions[2].Height = new sw.GridLength(1, sw.GridUnitType.Star);
+				}
+				return;
+			}
+
+			position = null;
+			var size = GetAvailableSize(false);
+			relative = fixedPanel == SplitterFixedPanel.Panel1 ? Math.Max(0, newPosition)
+				: fixedPanel == SplitterFixedPanel.Panel2 ? Math.Max(0, size - newPosition)
+				: size <= 0 ? 0.5 : Math.Max(0.0, Math.Min(1.0, newPosition / (double)size));
+			if (splitter.ResizeDirection == swc.GridResizeDirection.Columns)
+			{
+				var col1 = Control.ColumnDefinitions[0];
+				var col2 = Control.ColumnDefinitions[2];
+				if (fixedPanel == SplitterFixedPanel.Panel1)
+					col1.Width = new sw.GridLength(Math.Max(0,
+						newPosition), sw.GridUnitType.Pixel);
+				else if (fixedPanel == SplitterFixedPanel.Panel2)
+					col2.Width = new sw.GridLength(Math.Max(0,
+						size - newPosition), sw.GridUnitType.Pixel);
+				else
+				{
+					col1.Width = new sw.GridLength(Math.Max(0,
+						newPosition), sw.GridUnitType.Star);
+					col2.Width = new sw.GridLength(Math.Max(0,
+						size - newPosition), sw.GridUnitType.Star);
+				}
+			}
+			else
+			{
+				var row1 = Control.RowDefinitions[0];
+				var row2 = Control.RowDefinitions[2];
+				if (fixedPanel == SplitterFixedPanel.Panel1)
+					row1.Height = new sw.GridLength(Math.Max(0,
+						newPosition), sw.GridUnitType.Pixel);
+				else if (fixedPanel == SplitterFixedPanel.Panel2)
+					row2.Height = new sw.GridLength(Math.Max(0,
+						size - newPosition), sw.GridUnitType.Pixel);
+				else
+				{
+					row1.Height = new sw.GridLength(Math.Max(0,
+						newPosition), sw.GridUnitType.Star);
+					row2.Height = new sw.GridLength(Math.Max(0,
+						size - newPosition), sw.GridUnitType.Star);
+				}
+			}
+		}
+		void SetRelative(double newRelative)
+		{
+			position = null;
+			relative = newRelative;
+			if (splitter.ResizeDirection == swc.GridResizeDirection.Columns)
+			{
+				var col1 = Control.ColumnDefinitions[0];
+				var col2 = Control.ColumnDefinitions[2];
+				if (fixedPanel == SplitterFixedPanel.Panel1)
+					col1.Width = new sw.GridLength(Math.Max(0,
+						relative), sw.GridUnitType.Pixel);
+				else if (fixedPanel == SplitterFixedPanel.Panel2)
+					col2.Width = new sw.GridLength(Math.Max(0,
+						relative), sw.GridUnitType.Pixel);
+				else
+				{
+					col1.Width = new sw.GridLength(Math.Max(0,
+						relative), sw.GridUnitType.Star);
+					col2.Width = new sw.GridLength(Math.Max(0,
+						1 - relative), sw.GridUnitType.Star);
+				}
+			}
+			else
+			{
+				var row1 = Control.RowDefinitions[0];
+				var row2 = Control.RowDefinitions[2];
+				if (fixedPanel == SplitterFixedPanel.Panel1)
+					row1.Height = new sw.GridLength(Math.Max(0,
+						relative), sw.GridUnitType.Pixel);
+				else if (fixedPanel == SplitterFixedPanel.Panel2)
+					row2.Height = new sw.GridLength(Math.Max(0,
+						relative), sw.GridUnitType.Pixel);
+				else
+				{
+					row1.Height = new sw.GridLength(Math.Max(0,
+						relative), sw.GridUnitType.Star);
+					row2.Height = new sw.GridLength(Math.Max(0,
+						1 - relative), sw.GridUnitType.Star);
 				}
 			}
 		}

--- a/Source/Eto.Wpf/Forms/WpfWindow.cs
+++ b/Source/Eto.Wpf/Forms/WpfWindow.cs
@@ -84,6 +84,19 @@ namespace Eto.Wpf.Forms
 		{
 			switch (id)
 			{
+				case Eto.Forms.Control.ShownEvent:
+					Control.IsVisibleChanged += (sender, e) =>
+					{
+						if ((bool)e.NewValue)
+						{
+							// this is a trick to achieve similar behaviour as in WinForms
+							// (IsVisibleChanged triggers too early, we want it after measure-lay-render)
+							Control.Dispatcher.BeginInvoke(new Action(() =>
+								Callback.OnShown(Widget, EventArgs.Empty)),
+								sw.Threading.DispatcherPriority.ContextIdle, null);
+						}
+					};
+					break;
 				case Window.ClosedEvent:
 					Control.Closed += delegate
 					{

--- a/Source/Eto/Eto - pcl.csproj
+++ b/Source/Eto/Eto - pcl.csproj
@@ -74,6 +74,7 @@
     <Compile Include="Forms\Printing\PageSettings.cs" />
     <Compile Include="Forms\Printing\PrintDocument.cs" />
     <Compile Include="Forms\Printing\PrintSettings.cs" />
+    <Compile Include="Forms\ThemedControls\ThemedSplitterHandler.cs" />
     <Compile Include="Forms\ToolBar\RadioToolItem.cs" />
     <Compile Include="NamespaceInfo.cs" />
     <Compile Include="OperatingSystemPlatform.cs" />

--- a/Source/Eto/Eto.csproj
+++ b/Source/Eto/Eto.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Forms\Printing\PageSettings.cs" />
     <Compile Include="Forms\Printing\PrintDocument.cs" />
     <Compile Include="Forms\Printing\PrintSettings.cs" />
+    <Compile Include="Forms\ThemedControls\ThemedSplitterHandler.cs" />
     <Compile Include="NamespaceInfo.cs" />
     <Compile Include="OperatingSystemPlatform.cs" />
     <Compile Include="PropertyStore.cs" />

--- a/Source/Eto/Forms/Controls/Splitter.cs
+++ b/Source/Eto/Forms/Controls/Splitter.cs
@@ -142,6 +142,29 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Gets or sets the relative position of the splitter which is based on <see cref="FixedPanel"/>.
+		/// </summary>
+		/// <remarks>
+		/// Same as <see cref="Position"/> with SplitterFixedPanel.Panel1,
+		/// width/height of second panel with SplitterFixedPanel.Panel2
+		/// and ratio of width/height of first panel against available size with SplitterFixedPanel.None.
+		/// </remarks>
+		public double RelativePosition
+		{
+			get { return Handler.RelativePosition; }
+			set { Handler.RelativePosition = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets size of the splitter/gutter
+		/// </summary>
+		public int SplitterWidth
+		{
+			get { return Handler.SplitterWidth; }
+			set { Handler.SplitterWidth = value; }
+		}
+
+		/// <summary>
 		/// Gets or sets the top or left panel of the splitter.
 		/// </summary>
 		/// <value>The first panel.</value>
@@ -241,6 +264,21 @@ namespace Eto.Forms
 			/// </summary>
 			/// <value>The position of the splitter.</value>
 			int Position { get; set; }
+
+			/// <summary>
+			/// Gets or sets the relative position of the splitter which is based on <see cref="FixedPanel"/>.
+			/// </summary>
+			/// <remarks>
+			/// Same as <see cref="Position"/> with SplitterFixedPanel.Panel1,
+			/// width/height of second panel with SplitterFixedPanel.Panel2
+			/// and ratio of width/height of first panel against available size with SplitterFixedPanel.None.
+			/// </remarks>
+			double RelativePosition { get; set; }
+
+			/// <summary>
+			/// Gets or sets size of the splitter/gutter
+			/// </summary>
+			int SplitterWidth { get; set; }
 
 			/// <summary>
 			/// Gets or sets the top or left panel of the splitter.

--- a/Source/Eto/Forms/ThemedControls/ThemedSplitterHandler.cs
+++ b/Source/Eto/Forms/ThemedControls/ThemedSplitterHandler.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using Eto.Forms;
+using Eto.Drawing;
+
+namespace Eto.Forms.ThemedControls
+{
+	/// <summary>
+	/// ! UNDER CONSTRUCTION !
+	/// Themed splitter handler for the <see cref="Splitter"/> control
+	/// </summary>
+	public class ThemedSplitterHandler : ThemedContainerHandler<TableLayout, Splitter, Splitter.ICallback>, Splitter.IHandler
+	{
+		readonly Panel splitter = new Panel();
+		readonly Panel panel1 = new Panel();
+		readonly Panel panel2 = new Panel();
+		SplitterOrientation orient;
+		SplitterFixedPanel fix;
+		int? position;
+		int swidth = 5;
+		double relative = double.NaN;
+
+		/// <summary>
+		/// Called to initialize this widget after it has been constructed
+		/// </summary>
+		protected override void Initialize()
+		{
+			base.Initialize();
+			UpdateLayout();
+			splitter.MouseMove += SplitterMouseMove;
+		}
+
+		void SplitterMouseMove(object sender, MouseEventArgs e)
+		{
+			if (e.Buttons != MouseButtons.Primary)
+				return;
+			Position = (int)Math.Round((Orientation == SplitterOrientation.Horizontal
+				? e.Location.X + splitter.Location.X : e.Location.Y + splitter.Location.Y) - swidth*0.5);
+		}
+
+		void UpdateLayout(bool positionOnly = false)
+		{
+			panel1.SuspendLayout();
+			panel2.SuspendLayout();
+			if (positionOnly)
+				SuspendLayout();
+			else
+			{
+				if (!Widget.Loaded)
+				{
+					if (fix != SplitterFixedPanel.Panel1)
+						panel1.Size = new Size(-1, -1);
+					if (fix != SplitterFixedPanel.Panel2)
+						panel2.Size = new Size(-1, -1);
+				}
+			}
+			if (position.HasValue)
+			{
+				if (orient == SplitterOrientation.Horizontal)
+				{
+					panel1.Width = position.Value;
+					if (Widget.Loaded)
+						panel2.Width = Math.Max(0, Widget.Width - swidth - panel1.Width);
+				}
+				else
+				{
+					panel1.Height = position.Value;
+					if (Widget.Loaded)
+						panel2.Height = Math.Max(0, Widget.Height - swidth - panel1.Height);
+				}
+			}
+			else if (!double.IsNaN(relative)) switch (fix)
+			{
+				case SplitterFixedPanel.Panel1:
+					if (orient == SplitterOrientation.Horizontal)
+					{
+						panel1.Width = (int)Math.Round(relative);
+						if (Widget.Loaded)
+							panel2.Width = Math.Max(0, Widget.Width - swidth - panel1.Width);
+					}
+					else
+					{
+						panel1.Height = (int)Math.Round(relative);
+						if (Widget.Loaded)
+							panel2.Height = Math.Max(0, Widget.Height - swidth - panel1.Height);
+					}
+					break;
+				case SplitterFixedPanel.Panel2:
+					if (orient == SplitterOrientation.Horizontal)
+					{
+						panel2.Width = (int)Math.Round(relative);
+						if (Widget.Loaded)
+							panel1.Width = Math.Max(0, Widget.Width - swidth - panel2.Width);
+					}
+					else
+					{
+						panel2.Height = (int)Math.Round(relative);
+						if (Widget.Loaded)
+							panel1.Height = Math.Max(0, Widget.Height - swidth - panel2.Height);
+					}
+					break;
+				default:
+					if (orient == SplitterOrientation.Horizontal)
+					{
+						var sz = Control.Width - swidth;
+						panel1.Width = sz <= 0 ? -1 : (int)Math.Round(relative * sz);
+						panel2.Width = sz <= 0 ? -1 : (int)Math.Round((1-relative) * sz);
+					}
+					else
+					{
+						var sz = Control.Height - swidth;
+						panel1.Height = sz <= 0 ? -1 : (int)Math.Round(relative * sz);
+						panel2.Height = sz <= 0 ? -1 : (int)Math.Round((1-relative) * sz);
+					}
+					break;
+			}
+
+			if (!positionOnly)
+			{
+				if (orient == SplitterOrientation.Horizontal)
+				{
+					splitter.Cursor = Cursors.VerticalSplit;
+					splitter.Size = new Size(swidth, -1);
+					Control = new TableLayout {
+						Padding = Padding.Empty,
+						Spacing = Size.Empty,
+						Rows = { new TableRow(
+							new TableCell(panel1, fix != SplitterFixedPanel.Panel1),
+							new TableCell(splitter),
+							new TableCell(panel2, fix != SplitterFixedPanel.Panel2)
+						)}
+					};
+				}
+				else
+				{
+					splitter.Cursor = Cursors.HorizontalSplit;
+					splitter.Size = new Size(-1, swidth);
+					Control = new TableLayout {
+						Padding = Padding.Empty,
+						Spacing = Size.Empty,
+						Rows = { 
+							new TableRow(new TableCell(panel1, true)) {
+								ScaleHeight = fix != SplitterFixedPanel.Panel1
+							},
+							new TableRow(new TableCell(splitter, true)),
+							new TableRow(new TableCell(panel2, true)) {
+								ScaleHeight = fix != SplitterFixedPanel.Panel2
+							}
+						}
+					};
+				}
+			}
+			else
+				ResumeLayout();
+			panel1.ResumeLayout();
+			panel2.ResumeLayout();
+		}
+
+		/// <summary>
+		/// Gets or sets the orientation of the panels in the splitter.
+		/// </summary>
+		public SplitterOrientation Orientation
+		{
+			get { return orient; }
+			set
+			{
+				if (value == orient)
+					return;
+				orient = value;
+				UpdateLayout();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the panel with fixed size.
+		/// </summary>
+		public SplitterFixedPanel FixedPanel
+		{
+			get { return fix; }
+			set
+			{
+				if (value == fix)
+					return;
+				fix = value;
+				UpdateLayout();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the position of the splitter from the left or top, in pixels.
+		/// </summary>
+		public int Position
+		{
+			get
+			{
+				return panel1.Content == null || !panel1.Content.Visible ? 0
+					: orient == SplitterOrientation.Horizontal
+					? panel1.Width : panel2.Height;
+			}
+			set
+			{
+				if (value == position)
+					return;
+				position = value;
+				relative = double.NaN;
+				UpdateLayout(true);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the relative position of the splitter which is based on <see cref="FixedPanel"/>.
+		/// </summary>
+		public double RelativePosition
+		{
+			get
+			{
+			//	if (!double.IsNaN(relative))
+			//		return relative;
+				switch (fix)
+				{
+					case SplitterFixedPanel.Panel1:
+						return panel1.Width;
+					case SplitterFixedPanel.Panel2:
+						return panel2.Width;
+					default:
+						return panel1.Width / (double)(panel1.Width + panel2.Width);
+				}
+			}
+			set
+			{
+				position = null;
+				relative = value;
+				UpdateLayout(true);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets size of the splitter/gutter
+		/// </summary>
+		public int SplitterWidth
+		{
+			get { return swidth; }
+			set
+			{
+				if (value == swidth)
+					return;
+				swidth = value;
+				if (orient == SplitterOrientation.Horizontal)
+					splitter.Width = swidth;
+				else
+					splitter.Height = swidth;
+				UpdateLayout(true);
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the top or left panel of the splitter.
+		/// </summary>
+		public Control Panel1
+		{
+			get { return panel1; }
+			set { panel1.Content = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the bottom or right panel of the splitter.
+		/// </summary>
+		public Control Panel2
+		{
+			get { return panel2; }
+			set { panel2.Content = value; }
+		}
+	}
+}


### PR DESCRIPTION
replaces #311 and #310, fixes #309; Copy from #311:

*WinForms should be perfect - I am developing for WinForms for quite some time.
WPF looks good, but I still don't know all the corner-cases and am not sure about the events (will check later and possibly add more unit tests).
GTK2 should work fine, it is mostly based on WinForms implementation. GTK3 has different sizing mechanism, so, I guessed it (cannot curretnly test, but I will probably create some Linux VM in near future). SplitterWidth is guessed as well. I am not so familiar with GTK.*
***There is a stub for Mac, that should not break existing code, but new features are up to you.***
*ThemedSplitter is unfinished, tested under WinForms/D2D, but is not auto-sizing.*