### PR TITLE
Fix for issue #336

### DIFF
--- a/Source/Eto/Forms/Menu/ButtonMenuItem.cs
+++ b/Source/Eto/Forms/Menu/ButtonMenuItem.cs
@@ -10,6 +10,7 @@ namespace Eto.Forms
 	/// </summary>
 	/// <copyright>(c) 2014 by Curtis Wensley</copyright>
 	/// <license type="BSD-3">See LICENSE for full terms</license>
+	[ContentProperty("Items")]
 	[Handler(typeof(ButtonMenuItem.IHandler))]
 	public class ButtonMenuItem : MenuItem, ISubmenu
 	{

--- a/Source/Eto/Forms/Menu/ContextMenu.cs
+++ b/Source/Eto/Forms/Menu/ContextMenu.cs
@@ -22,6 +22,7 @@ namespace Eto.Forms
 	/// </summary>
 	/// <copyright>(c) 2014 by Curtis Wensley</copyright>
 	/// <license type="BSD-3">See LICENSE for full terms</license>
+	[ContentProperty("Items")]
 	[Handler(typeof(ContextMenu.IHandler))]
 	public class ContextMenu : Menu, ISubmenu
 	{

--- a/Source/Eto/Forms/Menu/MenuBar.cs
+++ b/Source/Eto/Forms/Menu/MenuBar.cs
@@ -34,6 +34,7 @@ namespace Eto.Forms
 	/// </summary>
 	/// <copyright>(c) 2014 by Curtis Wensley</copyright>
 	/// <license type="BSD-3">See LICENSE for full terms</license>
+	[ContentProperty("Items")]
 	[Handler(typeof(MenuBar.IHandler))]
 	public class MenuBar : Menu, ISubmenu
 	{

--- a/Source/Eto/Forms/ToolBar/ToolBar.cs
+++ b/Source/Eto/Forms/ToolBar/ToolBar.cs
@@ -61,6 +61,7 @@ namespace Eto.Forms
 	/// <seealso cref="Window.ToolBar"/>
 	/// <copyright>(c) 2014 by Curtis Wensley</copyright>
 	/// <license type="BSD-3">See LICENSE for full terms</license>
+	[ContentProperty("Items")]
 	[Handler(typeof(ToolBar.IHandler))]
 	public class ToolBar : Widget
 	{


### PR DESCRIPTION
Only MenuBar has more content items like ApplicationItems, HelpItems, IncludeSystemItems which have to be in ```<ContentType.Items>...</ContentType.Items>``` format.

Do we really need them? Like HelpItems seems to be a shortcut do nothing es than creating a submenu for the help items. But this functionality can be created directly via the MenuItems.

```XML
<Dialog.MenuBar>
    <MenuBar ID="MyMenubar">
...
          <ButtonMenuItem ID="MyHelpItem" ToolTip="MyHelpItem">
            <ButtonMenuItem ID="MyHelpItem1" ToolTip="MyHelpItem1" />
            <ButtonMenuItem ID="MyHelpItem2" ToolTip="MyHelpItem1" />
            <SeparatorMenuItem />
            <ButtonMenuItem ID="MyHelpItem3" ToolTip="MyHelpItem3" />
          </ButtonMenuItem>
    </MenuBar>
</Dialog.MenuBar>
```

This shortcut has no platform impact itself (e.g. special show-up of the Help-Menu). But every platform handler have to integrate it.