### PR TITLE
Fix for issue #349: Direct2D Matrix transform produces invalid output

### DIFF
--- a/Source/Eto.Direct2D/Drawing/GraphicsHandler.cs
+++ b/Source/Eto.Direct2D/Drawing/GraphicsHandler.cs
@@ -23,8 +23,8 @@ namespace Eto.Direct2D.Drawing
 		bool rectClip;
 		bool disposeControl = true;
 		Bitmap image;
-		float offset = 0.0f;
-		float fillOffset;
+		float offset = 0f;
+		float fillOffset = 0f;
 		sd.Layer helperLayer;
 		sd.Geometry clipGeometry;
 		sd.LayerParameters? clipParams;
@@ -298,12 +298,12 @@ namespace Eto.Direct2D.Drawing
 			{
 				if (value == PixelOffsetMode.None)
 				{
-					offset = .0f;
+					offset = 0f;
 					fillOffset = 0f;
 				}
 				else
 				{
-					offset = 0f;
+					offset = -.5f;
 					fillOffset = -.5f;
 				}
 			}
@@ -410,7 +410,7 @@ namespace Eto.Direct2D.Drawing
 		public void FillPath(Brush brush, IGraphicsPath path)
 		{
 			SaveTransform();
-			TranslateTransform(-fillOffset, -fillOffset);
+			TranslateTransform(fillOffset, fillOffset);
 			Control.FillGeometry(path.ToGeometry(), brush.ToDx(Control));
 			RestoreTransform();
 		}

--- a/Source/Eto.Direct2D/Drawing/GraphicsHandler.cs
+++ b/Source/Eto.Direct2D/Drawing/GraphicsHandler.cs
@@ -23,7 +23,7 @@ namespace Eto.Direct2D.Drawing
 		bool rectClip;
 		bool disposeControl = true;
 		Bitmap image;
-		float offset = 0.5f;
+		float offset = 0.0f;
 		float fillOffset;
 		sd.Layer helperLayer;
 		sd.Geometry clipGeometry;
@@ -298,7 +298,7 @@ namespace Eto.Direct2D.Drawing
 			{
 				if (value == PixelOffsetMode.None)
 				{
-					offset = .5f;
+					offset = .0f;
 					fillOffset = 0f;
 				}
 				else


### PR DESCRIPTION
This is fix for issue #349. The fix works for the PixelOffsetMode.None and the
PixelOffsetMode.Half. 

According to http://referencesource.microsoft.com/#System.Drawing/commonui/System/Drawing/Advanced/PixelOffsetMode.cs,2a8075968e055912
pixels are offset by -.5