### PR TITLE
Fix for ToolItemCollection items being added in wrong order

### DIFF
--- a/Source/Eto/Forms/ToolBar/ToolItemCollection.cs
+++ b/Source/Eto/Forms/ToolBar/ToolItemCollection.cs
@@ -72,7 +72,8 @@ namespace Eto.Forms
 				else
 					break;
 			}
-			Insert(previousIndex + 1, item);
+
+			Insert(Count, item);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Happened to me only when toolbar items were being added as Command classes.