### PR TITLE
Fallback to Winforms even on Linux and Mac

### DIFF
--- a/Source/Eto/Platform.cs
+++ b/Source/Eto/Platform.cs
@@ -324,8 +324,6 @@ namespace Eto
 				else if (EtoEnvironment.Platform.IsWindows)
 				{
 					detected = Platform.Get(Platforms.Wpf, true);
-					if (detected == null)
-						detected = Platform.Get(Platforms.WinForms, true);
 				}
 
 				if (detected == null && EtoEnvironment.Platform.IsUnix)
@@ -334,7 +332,11 @@ namespace Eto
 					if (detected == null)
 						detected = Platform.Get(Platforms.Gtk2, true);
 				}
-				
+
+				// Fallback to Winforms - better than nothing even if it's not native look & feel
+				if (detected == null)
+					detected = Platform.Get(Platforms.WinForms, true);
+
 				if (detected == null)
 					throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Could not detect platform. Are you missing a platform assembly?"));
 					


### PR DESCRIPTION
Even though Winforms with Mono is buggy it is still helpful to be able to fallback to Winforms, especially when changing an existing application from Winforms to Eto.Forms.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/picoe/eto/395)
<!-- Reviewable:end -->
