### PR TITLE
[XS Addin] Fix missing node on MonoDevelop

### DIFF
--- a/Source/Addins/Eto.Addin.XamarinStudio/Properties/Manifest.addin.xml
+++ b/Source/Addins/Eto.Addin.XamarinStudio/Properties/Manifest.addin.xml
@@ -55,6 +55,9 @@
 	<Extension path="/MonoDevelop/Ide/ProjectTemplateWizards">
 		<Class id="Eto.Addin.XamarinStudio.ProjectWizard" class="Eto.Addin.XamarinStudio.ProjectWizard" />
 	</Extension>
+	<Extension path="/MonoDevelop/Ide/ProjectTemplateCategories/crossplat">
+		<Category id="app" name="App" />
+	</Extension>
 	<Extension path="/MonoDevelop/Ide/ProjectTemplateCategories/crossplat/app">
 		<Category id="eto" name="Eto.Forms" />
 	</Extension>


### PR DESCRIPTION
MonoDevelop does not contain app under crossplat, it was removed for whatever reason in the last update. Xamarin Studio contains it.