### PR TITLE
Fix Form position with Gtk3

### DIFF
--- a/Source/Eto.Gtk/Forms/FormHandler.cs
+++ b/Source/Eto.Gtk/Forms/FormHandler.cs
@@ -13,11 +13,11 @@ namespace Eto.GtkSharp.Forms
 		{
 			Control = new Gtk.Window(Gtk.WindowType.Toplevel);
 #if GTK2
+			Control.SetPosition(Gtk.WindowPosition.Center);
 			Control.AllowGrow = true;
 #else
 			Control.Resizable = true;
 #endif
-			Control.SetPosition(Gtk.WindowPosition.Center);
 
 			var vbox = new Gtk.VBox();
 			vbox.PackStart(WindowActionControl, false, true, 0);


### PR DESCRIPTION
For `Control.SetPosition(Gtk.WindowPosition.Center);`:
 - on Gtk 2 it centers Window
 - on Gtk 3 it moves it to 0, 0, it doesn't even start it on the correct display, just moves it to 0, 0

This only disables the broken code on Gtk 3 so now the Window will at least start on the correct display.