### PR TITLE
Set default button for file dialogs

### DIFF
--- a/Source/Eto.Gtk/Forms/OpenFileDialog.cs
+++ b/Source/Eto.Gtk/Forms/OpenFileDialog.cs
@@ -12,6 +12,7 @@ namespace Eto.GtkSharp.Forms
 			
 			Control.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
 			Control.AddButton(Gtk.Stock.Open, Gtk.ResponseType.Ok);
+			Control.DefaultResponse = Gtk.ResponseType.Ok;
 		}
 
 		public bool MultiSelect

--- a/Source/Eto.Gtk/Forms/SaveFileDialog.cs
+++ b/Source/Eto.Gtk/Forms/SaveFileDialog.cs
@@ -12,6 +12,7 @@ namespace Eto.GtkSharp.Forms
 			
 			Control.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
 			Control.AddButton(Gtk.Stock.Save, Gtk.ResponseType.Ok);
+			Control.DefaultResponse = Gtk.ResponseType.Ok;
 		}
 	}
 }

--- a/Source/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
+++ b/Source/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
@@ -11,6 +11,7 @@ namespace Eto.GtkSharp.Forms
 			
 			Control.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
 			Control.AddButton(Gtk.Stock.Open, Gtk.ResponseType.Ok);
+			Control.DefaultResponse = Gtk.ResponseType.Ok;
 		}
 	
 


### PR DESCRIPTION
If this property is not set all the buttons will look the same. You can see the difference with Gtk buttons on the image bellow:

![]
(https://developer.gnome.org/gtk3/stable/colorchooser.png)