### PR TITLE
Mac: Fix WebView redrawing and file upload issue

### DIFF
--- a/Source/Eto.Mac/Forms/ApplicationHandler.cs
+++ b/Source/Eto.Mac/Forms/ApplicationHandler.cs
@@ -48,6 +48,11 @@ namespace Eto.Mac.Forms
 
 		public bool AllowClosingMainForm { get; set; }
 
+		public ApplicationHandler()
+		{
+			Control = NSApplication.SharedApplication;
+		}
+
 		public static ApplicationHandler Instance
 		{
 			get { return Application.Instance == null ? null : Application.Instance.Handler as ApplicationHandler; }

--- a/Source/Eto.Mac/Forms/Controls/WebViewHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/WebViewHandler.cs
@@ -167,9 +167,7 @@ namespace Eto.Mac.Forms.Controls
 				var openDlg = new OpenFileDialog();
 				if (openDlg.ShowDialog(Handler.Widget.ParentWindow) == DialogResult.Ok)
 				{
-					var resultListenerObj = resultListener as wk.WebOpenPanelResultListener;
-					if (resultListenerObj != null)
-						resultListenerObj.ChooseFilenames(openDlg.Filenames.ToArray());
+					wk.WebOpenPanelResultListener_Extensions.ChooseFilenames(resultListener, openDlg.Filenames.ToArray());
 				}
 			}
 			#else


### PR DESCRIPTION
Two commits:

1. Adding back constructor for `ApplicationHandler` on Mac. Without this constructor, WebView on Mac doesn't redraw itself properly when rendering HTML/CSS with fixed positioned elements.

2. It turns out when overriding `UIRunOpenPanelForFileButton` method in WebView on Xamarin.Mac, `resultListener` argument will never be `WebOpenPanelResultListener` type therefore file upload function in WebView will be broken. Xamarin.Mac has new helper method which should be used instead and it fixes the issue with file upload.