### PR TITLE
[GTK3] Fix context menu... again...

### DIFF
--- a/Source/Eto.Gtk/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/Source/Eto.Gtk/Forms/Menu/ButtonMenuItemHandler.cs
@@ -65,14 +65,17 @@ namespace Eto.GtkSharp.Forms.Menu
             // unless the parrent menuitem is clicked
             public void HandleButtonReleased(object sender, EventArgs e)
             {
-				(Handler.Control.Parent as Gtk.Menu)?.Deactivate ();
 				HandleClick (sender, e, true);
             }
 
 			private void HandleClick (object sender, EventArgs e, bool result)
 			{
-				if (Handler.isSubMenu == result)
+				if (Handler.isSubMenu == result) {
+					if (result)
+						(Handler.Control.Parent as Gtk.Menu)?.Deactivate ();
+					
 					Handler.Callback.OnClick (Handler.Widget, e);
+				}
 			}
 		}
 


### PR DESCRIPTION
@cwensley  I am sorry for not noticing that I managed to brake something...

I added a deactivate event in Button release(because if I don't add that, something like recent menu won't be able to modify itself), but in doing so I managed to stop Activate event from ever occurring...