### PR TITLE
Improved calculation of the PreferredSize for GroupBox in WPF.

### DIFF
--- a/Source/Eto.Wpf/Forms/Controls/GroupBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/GroupBoxHandler.cs
@@ -51,5 +51,26 @@ namespace Eto.Wpf.Forms.Controls
 			get { return AccessText.Foreground.ToEtoColor(); }
 			set { AccessText.Foreground = value.ToWpfBrush(AccessText.Foreground); }
 		}
+
+		protected override sw.Size GetContentPadding(sw.Size constraint)
+		{
+			sw.Size basePadding = base.GetContentPadding(constraint);
+
+			double headerHeight = 2;
+
+			sw.UIElement header = Control.Header as sw.UIElement;
+			if (header != null)
+			{
+				header.Measure(constraint.Subtract(basePadding));
+				// The default template for the GroupBox wraps the header in a border with Padding="3,1,3,0".
+				// Note: There is a slight error in this calculation. The actual header height is less the a pixel smaller than the calculated value.
+				headerHeight = header.DesiredSize.Height + 1;
+			}
+
+			// The default template for the GroupBox is a 4x4 grid with reserved 6 pixels on the left, right and bottom sides.
+			sw.Size contentPadding = new sw.Size(basePadding.Width + 2*6, basePadding.Height + headerHeight + 6);
+
+			return contentPadding;
+		}
 	}
 }

--- a/Source/Eto.Wpf/Forms/WpfPanel.cs
+++ b/Source/Eto.Wpf/Forms/WpfPanel.cs
@@ -61,10 +61,10 @@ namespace Eto.Wpf.Forms
                 sw.Size baseSize;
                 if (UseContentSize)
 				{
-                    var padding = border.Padding.Size();
+                    var padding = GetContentPadding(constraint);
                     var childConstraint = constraint.Subtract(padding).Subtract(margin);
 					baseSize = content.GetPreferredSize(childConstraint);
-                    baseSize = baseSize.Add(padding); // we add margin back at end
+                    baseSize = baseSize.Add(padding); // we add padding back at end
 				}
                 else
                     baseSize = base.GetPreferredSize(constraint).Subtract(margin);
@@ -74,6 +74,11 @@ namespace Eto.Wpf.Forms
             size = size.Max(ContainerControl.GetMinSize());
             size = size.Add(margin);
             return size;
+		}
+
+		protected virtual sw.Size GetContentPadding(sw.Size constraint)
+		{
+			return border.Padding.Size();
 		}
 
 		ContextMenu contextMenu;


### PR DESCRIPTION
This commit should more or less fix the issue #550.

It is slightly inaccurate.
The calculated PreferredSize value for GroupBox is less than a pixel greater than it should be.
This inaccuracy is visible if there are a lot of GroupBoxes in a Scrollable.

The default GroupBox template can be extracted as described here: http://stackoverflow.com/questions/8825030/how-to-extract-default-control-template-in-visual-studio