### PR TITLE
Layout Rewrite

### DIFF
--- a/Source/Eto.Gtk/Eto.Gtk2 - net45.csproj
+++ b/Source/Eto.Gtk/Eto.Gtk2 - net45.csproj
@@ -260,6 +260,9 @@
     <Compile Include="..\Shared\BaseBitmapData.cs">
       <Link>Drawing\BaseBitmapData.cs</Link>
     </Compile>
+    <Compile Include="Forms\CustomLayoutHandler.cs">
+      <SubType>Code</SubType>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
   <PropertyGroup>

--- a/Source/Eto.Gtk/Eto.Gtk3 - net45.csproj
+++ b/Source/Eto.Gtk/Eto.Gtk3 - net45.csproj
@@ -281,6 +281,7 @@
     <Compile Include="..\Shared\BaseBitmapData.cs">
       <Link>Drawing\BaseBitmapData.cs</Link>
     </Compile>
+    <Compile Include="Forms\CustomLayoutHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
   <PropertyGroup>

--- a/Source/Eto.Gtk/Forms/Controls/TabControlHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/TabControlHandler.cs
@@ -86,5 +86,13 @@ namespace Eto.GtkSharp.Forms.Controls
 			get { return Control.TabPos.ToEto(); }
 			set { Control.TabPos = value.ToGtk(); }
 		}
+		
+		public override Size GetPreferredSize(Size availableSize)
+		{
+			var size = base.GetPreferredSize(availableSize);
+			var tabSize = Control.GetNthPage(0).SizeRequest();
+			size.Height += 50; // TODO: Get actual size somehow
+			return size;
+		}
 	}
 }

--- a/Source/Eto.Gtk/Forms/CustomLayoutHandler.cs
+++ b/Source/Eto.Gtk/Forms/CustomLayoutHandler.cs
@@ -1,0 +1,52 @@
+using Eto.Forms;
+using Eto.Drawing;
+using Eto.GtkSharp.Forms.Controls;
+
+namespace Eto.GtkSharp.Forms
+{
+	public class CustomLayoutHandler : GtkContainer<Gtk.Fixed, CustomLayout, CustomLayout.ICallback>, CustomLayout.IHandler
+	{
+		public CustomLayoutHandler()
+		{
+			Control = new Gtk.Fixed();
+		}
+
+		public void Add(Control child)
+		{
+			var ctl = child.GetGtkControlHandler();
+
+			var widget = ctl.ContainerControl;
+			if (widget.Parent != null)
+				((Gtk.Container)widget.Parent).Remove(widget);
+			Control.Put(widget, 0, 0);
+			//ctl.CurrentLocation = Point.Empty;
+			widget.ShowAll();
+		}
+
+		public void Move(Control child, Rectangle location)
+		{
+			var ctl = child.GetGtkControlHandler();
+			Control.Move(ctl.ContainerControl, location.X, location.Y);
+			ctl.ContainerControl.SetSizeRequest(location.Width, location.Height);
+			ctl.CurrentLocation = new Point(location.X, location.Y);
+		}
+
+		public void RemoveAll()
+		{
+			foreach (var ctl in Control.Children)
+			{
+				Control.Remove(ctl);
+			}
+		}
+
+		public void Remove(Control child)
+		{
+			Control.Remove(child.GetContainerWidget());
+		}
+
+		public void Update()
+		{
+			Control.ResizeChildren();
+		}
+	}
+}

--- a/Source/Eto.Gtk/Forms/GtkControl.cs
+++ b/Source/Eto.Gtk/Forms/GtkControl.cs
@@ -19,6 +19,8 @@ namespace Eto.GtkSharp.Forms
 		Color? SelectedBackgroundColor { get; }
 
 		void SetBackgroundColor();
+
+		void SetScale(bool scaled);
 	}
 
 	public static class GtkControlExtensions
@@ -58,6 +60,7 @@ namespace Eto.GtkSharp.Forms
 		bool mouseDownHandled;
 		Color? cachedBackgroundColor;
 		Color? backgroundColor;
+
 		public static float ScrollAmount = 2f;
 
 		public override IntPtr NativeHandle { get { return Control.Handle; } }
@@ -659,5 +662,20 @@ namespace Eto.GtkSharp.Forms
 			}
 		}
 
+		public virtual Size GetPreferredSize(Size availableSize)
+		{
+			var preferredSize = PreferredSize;
+
+			var request = Control.SizeRequest().ToEto();
+			if (preferredSize.Width == -1)
+				preferredSize.Width = request.Width;
+			if (preferredSize.Height == -1)
+				preferredSize.Height = request.Height;
+			return preferredSize;
+		}
+		
+		public virtual void SetScale(bool scaled)
+		{
+		}
 	}
 }

--- a/Source/Eto.Gtk/Forms/GtkPanel.cs
+++ b/Source/Eto.Gtk/Forms/GtkPanel.cs
@@ -108,11 +108,13 @@ namespace Eto.GtkSharp.Forms
 					if (content != null)
 						alignment.Remove(content.GetContainerWidget());
 					content = value;
-					var widget = content.GetContainerWidget();
-					if (widget != null)
+					var controlHandler = content.GetGtkControlHandler();
+					if (controlHandler != null)
 					{
+						var widget = controlHandler.ContainerControl;
 						if (widget.Parent != null)
 							((Gtk.Container)widget.Parent).Remove(widget);
+						controlHandler.SetScale(true);
 						alignment.Child = widget;
 						widget.ShowAll();
 					}

--- a/Source/Eto.Gtk/Forms/TableLayoutHandler.cs
+++ b/Source/Eto.Gtk/Forms/TableLayoutHandler.cs
@@ -157,9 +157,11 @@ namespace Eto.GtkSharp.Forms
 				}
 
 				controls[y, x] = child;
-				var widget = child.GetContainerWidget();
+				var childHandler = child.GetGtkControlHandler();
+				var widget = childHandler.ContainerControl;
 				if (widget.Parent != null)
 					((Gtk.Container)widget.Parent).Remove(widget);
+				childHandler.SetScale(columnScale[x] || x == lastColumnScale);
 				Control.Attach(widget, (uint)x, (uint)x + 1, (uint)y, (uint)y + 1, GetColumnOptions(x), GetRowOptions(y), 0, 0);
 				widget.ShowAll();
 				return true;

--- a/Source/Eto.Gtk/Platform.cs
+++ b/Source/Eto.Gtk/Platform.cs
@@ -169,6 +169,7 @@ namespace Eto.GtkSharp
 			p.Add<Screen.IScreensHandler>(() => new ScreensHandler());
 			p.Add<Keyboard.IHandler>(() => new KeyboardHandler());
 			p.Add<FixedMaskedTextProvider.IHandler>(() => new FixedMaskedTextProviderHandler());
+			p.Add<CustomLayout.IHandler>(() => new CustomLayoutHandler());
 
 			// IO
 			p.Add<SystemIcons.IHandler>(() => new SystemIconsHandler());

--- a/Source/Eto.Mac/Eto.Mac - net45.csproj
+++ b/Source/Eto.Mac/Eto.Mac - net45.csproj
@@ -222,6 +222,7 @@
       <Link>Drawing\BaseBitmapData.cs</Link>
     </Compile>
     <Compile Include="Forms\NativeFormHandler.cs" />
+    <Compile Include="Forms\CustomLayoutHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Source/Eto.Mac/Eto.Mac64 - net45.csproj
+++ b/Source/Eto.Mac/Eto.Mac64 - net45.csproj
@@ -222,6 +222,7 @@
       <Link>Drawing\BaseBitmapData.cs</Link>
     </Compile>
     <Compile Include="Forms\NativeFormHandler.cs" />
+    <Compile Include="Forms\CustomLayoutHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Source/Eto.Mac/Eto.XamMac - net45.csproj
+++ b/Source/Eto.Mac/Eto.XamMac - net45.csproj
@@ -234,6 +234,7 @@
       <Link>Drawing\BaseBitmapData.cs</Link>
     </Compile>
     <Compile Include="Forms\NativeFormHandler.cs" />
+    <Compile Include="Forms\CustomLayoutHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/Source/Eto.Mac/Eto.XamMac2 - net45.csproj
+++ b/Source/Eto.Mac/Eto.XamMac2 - net45.csproj
@@ -228,6 +228,7 @@
       <Link>Drawing\BaseBitmapData.cs</Link>
     </Compile>
     <Compile Include="Forms\NativeFormHandler.cs" />
+    <Compile Include="Forms\CustomLayoutHandler.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/Source/Eto.Mac/Forms/Controls/LinkButtonHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/LinkButtonHandler.cs
@@ -170,7 +170,7 @@ namespace Eto.Mac.Forms.Controls
 				if (value != DisabledTextColor)
 				{
 					Widget.Properties[DisabledTextColorKey] = value;
-					SetAttributes();
+					//SetAttributes();
 				}
 			}
 		}

--- a/Source/Eto.Mac/Forms/Controls/MacLabel.cs
+++ b/Source/Eto.Mac/Forms/Controls/MacLabel.cs
@@ -279,12 +279,13 @@ namespace Eto.Mac.Forms.Controls
 			set { ((EtoLabelFieldCell)Control.Cell).VerticalAlignment = value; }
 		}
 
-		protected virtual void SetAttributes()
+		public override void OnLoad(EventArgs e)
 		{
-			SetAttributes(false);
+			base.OnLoad(e);
+			SetAttributes(true);
 		}
 
-		void SetAttributes(bool force)
+		void SetAttributes(bool force = false)
 		{
 			if (Widget.Loaded || force)
 			{
@@ -317,12 +318,6 @@ namespace Eto.Mac.Forms.Controls
 					return col.Value.ToNSUI();
 				return null; 
 			}
-		}
-
-		public override void OnLoad(EventArgs e)
-		{
-			base.OnLoad(e);
-			SetAttributes(true);
 		}
 
 		public override void AttachEvent(string id)

--- a/Source/Eto.Mac/Forms/Controls/MacText.cs
+++ b/Source/Eto.Mac/Forms/Controls/MacText.cs
@@ -201,6 +201,12 @@ namespace Eto.Mac.Forms.Controls
 			SetCustomFieldEditor();
 			base.InnerMapPlatformCommand(systemAction, command, CustomFieldEditor);
 		}
+
+		public override SizeF GetPreferredSize(SizeF availableSize)
+		{
+			var size = base.GetPreferredSize(availableSize);
+			return size;
+		}
 	}
 }
 

--- a/Source/Eto.Mac/Forms/Controls/ScrollableHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/ScrollableHandler.cs
@@ -209,7 +209,7 @@ namespace Eto.Mac.Forms.Controls
 
 		protected override CGRect GetContentBounds()
 		{
-			var contentSize = Content.GetPreferredSize(SizeF.MaxValue);
+			var contentSize = Content.GetPreferredSize(ClientSize);
 
 			if (ExpandContentWidth)
 				contentSize.Width = Math.Max(ClientSize.Width, contentSize.Width);
@@ -373,5 +373,10 @@ namespace Eto.Mac.Forms.Controls
 		public float MaximumZoom { get { return 1f; } set { } }
 
 		public float Zoom { get { return 1f; } set { } }
+
+		public override SizeF GetPreferredSize(SizeF availableSize)
+		{
+			return base.GetPreferredSize(availableSize) + GetBorderSize();
+		}
 	}
 }

--- a/Source/Eto.Mac/Forms/CustomLayoutHandler.cs
+++ b/Source/Eto.Mac/Forms/CustomLayoutHandler.cs
@@ -1,0 +1,179 @@
+using System;
+using Eto.Forms;
+using Eto.Drawing;
+using System.Collections.Generic;
+using System.Linq;
+using Eto.Mac.Forms.Controls;
+
+#if XAMMAC2
+using AppKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using CoreAnimation;
+using CoreImage;
+#else
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+using MonoMac.CoreGraphics;
+using MonoMac.ObjCRuntime;
+using MonoMac.CoreAnimation;
+using MonoMac.CoreImage;
+#if Mac64
+using CGSize = MonoMac.Foundation.NSSize;
+using CGRect = MonoMac.Foundation.NSRect;
+using CGPoint = MonoMac.Foundation.NSPoint;
+using nfloat = System.Double;
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+using nfloat = System.Single;
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+#endif
+
+namespace Eto.Mac.Forms
+{
+	public class CustomLayoutHandler : MacContainer<NSView, CustomLayout, CustomLayout.ICallback>, CustomLayout.IHandler
+	{
+		readonly Dictionary<Control, RectangleF> points = new Dictionary<Control, RectangleF>();
+
+		public override NSView ContainerControl { get { return Control; } }
+
+		public CustomLayoutHandler()
+		{
+			Control = new MacEventView { Handler = this };
+		}
+
+		public CGRect GetPosition(Control control)
+		{
+			RectangleF point;
+			if (points.TryGetValue(control, out point))
+			{
+				return point.ToNS();
+			}
+			return control.GetContainerView().Frame;
+		}
+
+		protected override SizeF GetNaturalSize(SizeF availableSize)
+		{
+			RectangleF size = RectangleF.Empty;
+			foreach (var item in points.Where(r => r.Key.Visible))
+			{
+				
+				size = RectangleF.Union(size, item.Value);
+			}
+			return (SizeF)size.BottomRight;
+		}
+
+		public override void OnLoadComplete(EventArgs e)
+		{
+			base.OnLoadComplete(e);
+			LayoutChildren();
+			Widget.SizeChanged += HandleSizeChanged;
+		}
+
+		public override void OnUnLoad(EventArgs e)
+		{
+			base.OnUnLoad(e);
+			Widget.SizeChanged -= HandleSizeChanged;
+		}
+
+		void HandleSizeChanged (object sender, EventArgs e)
+		{
+			LayoutChildren();
+		}
+
+		void SetPosition(Control control, RectangleF rect, float frameHeight, bool flipped)
+		{
+			var offset = ((IMacViewHandler)control.Handler).PositionOffset;
+			var childView = control.GetContainerView();
+			
+
+			CGPoint origin;
+			if (flipped)
+				origin = new CGPoint(
+					rect.X + offset.Width,
+					rect.Y + offset.Height
+				);
+			else
+				origin = new CGPoint(
+					rect.X + offset.Width,
+					frameHeight - (rect.Height + rect.Y + offset.Height)
+				);
+
+			var frame = new CGRect(origin, rect.Size.ToNS());
+			if (frame != childView.Frame)
+			{
+				childView.Frame = frame;
+			}
+		}
+
+		public override void LayoutChildren()
+		{
+			if (NeedsQueue())
+				return;
+			var controlPoints = points.ToArray();
+			var frameHeight = Control.Frame.Height;
+			var flipped = Control.IsFlipped;
+			foreach (var item in controlPoints)
+			{
+				SetPosition(item.Key, item.Value, (float)frameHeight, flipped);
+			}
+		}
+
+		public void Add(Control child)
+		{
+			points[child] = RectangleF.Empty;
+			var childView = child.GetContainerView();
+			if (Widget.Loaded)
+			{
+				var frameHeight = Control.Frame.Height;
+				SetPosition(child, RectangleF.Empty, (float)frameHeight, Control.IsFlipped);
+			}
+			Control.AddSubview(childView);
+			if (Widget.Loaded)
+				LayoutParent();
+		}
+
+		public void Move(Control child, Rectangle location)
+		{
+			//if (points[child] != location)
+			{
+				points[child] = location;
+				//if (Widget.Loaded)
+				{
+					var frameHeight = Control.Frame.Height;
+					SetPosition(child, location, (float)frameHeight, Control.IsFlipped);
+					if (Widget.Loaded)
+						LayoutParent();
+				}
+			}
+		}
+
+		public void Remove(Control child)
+		{
+			var childView = child.GetContainerView();
+			points.Remove(child);
+			childView.RemoveFromSuperview();
+			if (Widget.Loaded)
+				LayoutParent();
+		}
+
+		public void RemoveAll()
+		{
+			foreach (var child in points.Keys)
+			{
+				var childView = child.GetContainerView();
+				childView.RemoveFromSuperview();
+			}
+			points.Clear();
+			if (Widget.Loaded)
+				LayoutParent();
+		}
+	}
+}

--- a/Source/Eto.Mac/Forms/MacBase.cs
+++ b/Source/Eto.Mac/Forms/MacBase.cs
@@ -38,8 +38,6 @@ namespace Eto.Mac.Forms
 		NSView EventControl { get; }
 
 		bool AutoSize { get; }
-
-		SizeF GetPreferredSize(SizeF availableSize);
 	}
 
 	[Register("ObserverHelper")]

--- a/Source/Eto.Mac/Forms/MacControlExtensions.cs
+++ b/Source/Eto.Mac/Forms/MacControlExtensions.cs
@@ -47,27 +47,6 @@ namespace Eto.Mac.Forms
 {
 	public static class MacControlExtensions
 	{
-		public static SizeF GetPreferredSize(this Control control, SizeF availableSize)
-		{
-			if (control == null)
-				return Size.Empty;
-			var mh = control.GetMacControl();
-			if (mh != null)
-			{
-				return mh.GetPreferredSize(availableSize);
-			}
-			
-			var c = control.ControlObject as NSControl;
-			if (c != null)
-			{
-				c.SizeToFit();
-				return c.Frame.Size.ToEto();
-			}
-			var child = control.ControlObject as Control;
-			return child == null ? SizeF.Empty : child.GetPreferredSize(availableSize);
-
-		}
-
 		public static IMacContainer GetMacContainer(this Control control)
 		{
 			if (control == null)

--- a/Source/Eto.Mac/Forms/MacPanel.cs
+++ b/Source/Eto.Mac/Forms/MacPanel.cs
@@ -130,9 +130,8 @@ namespace Eto.Mac.Forms
 #endif
 		protected override SizeF GetNaturalSize(SizeF availableSize)
 		{
-			var contentControl = content.GetMacControl();
-			if (contentControl != null && content.Visible)
-				return contentControl.GetPreferredSize(availableSize - Padding.Size) + Padding.Size;
+			if (content != null && content.Visible)
+				return content.GetPreferredSize(availableSize - Padding.Size) + Padding.Size;
 			
 			return Padding.Size;
 		}

--- a/Source/Eto.Mac/Forms/MacView.cs
+++ b/Source/Eto.Mac/Forms/MacView.cs
@@ -216,6 +216,8 @@ namespace Eto.Mac.Forms
 				var size = (Widget.Loaded) ? (CGSize?)control.Frame.Size : null;
 				control.SizeToFit();
 				naturalSize = control.Frame.Size.ToEto();
+				if (naturalSize.Value.IsEmpty && control.Cell != null)
+					naturalSize = control.Cell.CellSizeForBounds(new RectangleF(Size.MaxValue).ToNS()).ToEtoSize();
 				if (size != null)
 					control.SetFrameSize(size.Value);
 				NaturalSize = naturalSize;
@@ -236,6 +238,11 @@ namespace Eto.Mac.Forms
 					size.Height = preferredSize.Height;
 			}
 			return SizeF.Min(SizeF.Max(size, MinimumSize), MaximumSize);
+		}
+
+		public Size GetPreferredSize(Size availableSize)
+		{
+			return Size.Round(GetPreferredSize((SizeF)availableSize));
 		}
 
 		public virtual Size PositionOffset { get { return Size.Empty; } }

--- a/Source/Eto.Mac/Forms/MacWindow.cs
+++ b/Source/Eto.Mac/Forms/MacWindow.cs
@@ -163,11 +163,7 @@ namespace Eto.Mac.Forms
 			SizeF naturalSize = new SizeF(200, 200);
 			if (Content != null && Content.Visible)
 			{
-				var contentControl = Content.GetMacControl();
-				if (contentControl != null)
-				{
-					naturalSize = contentControl.GetPreferredSize(availableSize - Padding.Size) + Padding.Size;
-				}
+				naturalSize = Content.GetPreferredSize(availableSize - Padding.Size) + Padding.Size;
 			}
 			if (PreferredClientSize != null)
 			{
@@ -540,6 +536,8 @@ namespace Eto.Mac.Forms
 				}
 			}
 		}
+
+		Size initialSize = new Size(-1, -1);
 
 		public override Size Size
 		{

--- a/Source/Eto.Mac/MacHelpers.cs
+++ b/Source/Eto.Mac/MacHelpers.cs
@@ -49,7 +49,7 @@ namespace Eto.Forms
 				control.AttachNative();
 				var macControl = control.GetMacControl();
 				if (macControl != null && macControl.AutoSize)
-					macControl.ContainerControl.SetFrameSize(macControl.GetPreferredSize(SizeF.MaxValue).ToNS());
+					macControl.ContainerControl.SetFrameSize(control.GetPreferredSize(SizeF.MaxValue).ToNS());
 			}
 			return control.GetContainerView();
 		}

--- a/Source/Eto.Mac/Platform.cs
+++ b/Source/Eto.Mac/Platform.cs
@@ -175,6 +175,7 @@ namespace Eto.Mac
 			p.Add<Screen.IScreensHandler>(() => new ScreensHandler());
 			p.Add<Keyboard.IHandler>(() => new KeyboardHandler());
 			p.Add<FixedMaskedTextProvider.IHandler>(() => new FixedMaskedTextProviderHandler());
+			p.Add<CustomLayout.IHandler>(() => new CustomLayoutHandler());
 
 			// IO
 			p.Add<SystemIcons.IHandler>(() => new SystemIconsHandler());

--- a/Source/Eto.Test/Eto.Test.Mac/Startup.cs
+++ b/Source/Eto.Test/Eto.Test.Mac/Startup.cs
@@ -4,6 +4,7 @@ using Eto.Mac;
 using System.Diagnostics;
 using Eto.Drawing;
 using Eto.Mac.Forms.ToolBar;
+using System.Collections.Generic;
 
 #if XAMMAC2
 using AppKit;

--- a/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
+++ b/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
@@ -193,6 +193,7 @@
     <Compile Include="UnitTests\Forms\Layout\DynamicLayoutTests.cs" />
     <Compile Include="Sections\Layouts\ScrollingLayouts\TablePaddingAndSpacingSection.cs" />
     <Compile Include="UnitTests\Forms\TestClasses.cs" />
+    <Compile Include="Sections\Layouts\PixelLayoutSection\FlowLayoutSection.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="TestIcon.ico" />

--- a/Source/Eto.Test/Eto.Test/Sections/Layouts/PixelLayoutSection/FlowLayoutSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Layouts/PixelLayoutSection/FlowLayoutSection.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Linq;
+using Eto.Forms;
+using Eto.Drawing;
+
+namespace Eto.Test.Sections.Layouts.PixelLayoutSection
+{
+	[Section("FlowLayout", "Test")]
+	public class FlowLayoutSection : Scrollable
+	{
+		public FlowLayoutSection()
+		{
+			var layout = new FlowLayout();
+
+			TextBox tb;
+			layout.Contents.Add(new Label { Text = "Hello", Margin = new Padding(10) });
+			layout.Contents.Add(tb = new TextBox { Text = "There", Margin = new Padding(20) });
+			layout.Contents.Add(new TextArea { Text = "There" });
+			layout.Contents.Add(new CheckBox { Text = "Curtis" });
+			layout.Contents.Add(new Button { Text = "Grow" }.With(r => r.Click += (sender, e) => {
+				var size = tb.Size;
+				size.Width += 100;
+				tb.Size = size;
+			}));
+			layout.Contents.Add(new Label { Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." });
+
+
+			var stack = new StackLayout
+			{
+				Orientation = Forms.Orientation.Horizontal,
+				Items = {
+					"Hello", "There"
+				}
+			};
+
+			layout.Contents.Add(stack);
+			layout.Contents.Add(new Label { Text = "After" });
+			/*for (int i = 0; i < 200; i++)
+			{
+				layout.Contents.Add(new TextBox { Text = "Hrm " + i });
+			}*/
+			Content = layout;
+		}
+	}
+}

--- a/Source/Eto.Test/Eto.Test/Sections/Layouts/TableLayoutSection/ChildWidthSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Layouts/TableLayoutSection/ChildWidthSection.cs
@@ -1,4 +1,5 @@
 using Eto.Forms;
+using System.Linq;
 
 namespace Eto.Test.Sections.Layouts.TableLayoutSection
 {
@@ -6,11 +7,13 @@ namespace Eto.Test.Sections.Layouts.TableLayoutSection
 	/// This tests a TableLayout that contains a control with a width larger than its container
 	/// </summary>
 	[Section("TableLayout", "Child Width")]
-	public class ChildWidthSection : TableLayout
+	public class ChildWidthSection : TableLayout2
 	{
 		public ChildWidthSection()
 			: base(1, 3)
 		{
+			//Columns[0].Width = TableLength.Star(1);
+			//Rows[2].Height = TableLength.Star(1);
 			var table = new GridView();
 			table.Columns.Add(new GridColumn { AutoSize = false, Width = 1000, HeaderText = "Title", DataCell = new TextBoxCell("FormattedTitle"), Editable = false, Sortable = true });
 

--- a/Source/Eto.Test/Eto.Test/Sections/Layouts/TableLayoutSection/ScalingSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Layouts/TableLayoutSection/ScalingSection.cs
@@ -8,44 +8,46 @@ namespace Eto.Test.Sections.Layouts.TableLayoutSection
 	{
 		public ScalingSection()
 		{
-			TableLayout tableLayout;
+			TableLayout2 tableLayout;
+			var padding = new Padding(5);
+			var spacing = new Size(5, 5);
 
-			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
+			var layout = new DynamicLayout { DefaultSpacing = spacing, Padding = padding };
 			var size = new Size(-1, 100);
 
-			tableLayout = new TableLayout(1, 1) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
+			tableLayout = new TableLayout2(1, 1) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
 			tableLayout.Add(new Label { Text = "1x1, should scale to fill entire region with 5px padding around border", BackgroundColor = Colors.Red }, 0, 0, false, false);
 			layout.Add(tableLayout, yscale: true);
 
-			tableLayout = new TableLayout(2, 2) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
+			tableLayout = new TableLayout2(2, 2) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
 			tableLayout.Add(new Label { Text = "2x2, should scale with extra space on top && left", BackgroundColor = Colors.Red }, 1, 1, false, false);
 			layout.Add(tableLayout, yscale: true);
 
-			tableLayout = new TableLayout(2, 2) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
+			tableLayout = new TableLayout2(2, 2) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
 			tableLayout.Add(new Label { Text = "2x2, should scale with extra space on bottom && right", BackgroundColor = Colors.Red }, 0, 0, true, true);
 			layout.Add(tableLayout, yscale: true);
 
-			tableLayout = new TableLayout(3, 3) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
+			tableLayout = new TableLayout2(3, 3) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
 			tableLayout.Add(new Label { Text = "3x3, should scale with extra space all around (10px)", BackgroundColor = Colors.Red }, 1, 1, true, true);
 			layout.Add(tableLayout, yscale: true);
 
-			tableLayout = new TableLayout(2, 2) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
+			tableLayout = new TableLayout2(2, 2) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
 			tableLayout.Add(new Label { Text = "2x2, should not scale and be top left", BackgroundColor = Colors.Red }, 0, 0, false, false);
 			layout.Add(tableLayout, yscale: true);
 
-			tableLayout = new TableLayout(2, 2) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
+			tableLayout = new TableLayout2(2, 2) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
 			tableLayout.SetColumnScale(0);
 			tableLayout.SetRowScale(0);
 			tableLayout.Add(new Label { Text = "2x2, should not scale and be bottom-right", BackgroundColor = Colors.Red }, 1, 1);
 			layout.Add(tableLayout, yscale: true);
 
-			tableLayout = new TableLayout(3, 3) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
+			tableLayout = new TableLayout2(3, 3) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
 			tableLayout.SetColumnScale(0);
 			tableLayout.SetRowScale(0);
 			tableLayout.Add(new Label { Text = "3x3, should not scale and be bottom-right", BackgroundColor = Colors.Red }, 1, 1);
 			layout.Add(tableLayout, yscale: true);
 
-			tableLayout = new TableLayout(3, 3) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
+			tableLayout = new TableLayout2(3, 3) { BackgroundColor = Colors.Blue, Size = size, Spacing = new Size(5, 5), Padding = new Padding(5) };
 			tableLayout.SetColumnScale(0);
 			tableLayout.SetColumnScale(2);
 			tableLayout.SetRowScale(0);

--- a/Source/Eto.Test/Eto.Test/TestApplication.cs
+++ b/Source/Eto.Test/Eto.Test/TestApplication.cs
@@ -9,6 +9,124 @@ using System.Reflection;
 
 namespace Eto.Test
 {
+	public class TestForm : Form
+	{
+		SizeF min;
+		public TestForm()
+		{
+			const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+			/**/
+			var myTable = new TableLayout2
+			{
+				//Padding = new Padding(20),
+				//Spacing = new Size(5, 5),
+				Rows =
+				{
+					new TableRow2 { Height = TableLength.Auto, Cells = { new Button { Text = "Hello!" } } },
+					new TableRow2 { Height = TableLength.Star(1), Cells = { text } },
+					new TableRow2 { new TextBox(), "Hello!", "There!" }
+				},
+				Columns =
+				{
+					new TableColumn { Width = TableLength.Star(1) },
+					new TableColumn { Width = TableLength.Auto },
+					new TableColumn { Width = TableLength.Auto },
+				}
+			};
+			for (int i = 0; i < 0; i++)
+			{
+				myTable.Rows.Add(new TableRow2 { Height = TableLength.Auto, Cells = { new TextBox(), "Hello!", "There!" } });
+			}
+			Content = myTable;
+			/**
+			var myTable = new TableLayout
+			{
+				Padding = new Padding(20),
+				Rows =
+				{
+					new TableRow { Cells = { new TableCell { Control = new Button { Text = "Hello!" }, ScaleWidth = true } } },
+					new TableRow { ScaleHeight = true, Cells = { text } },
+					new TableRow { Cells = { new TextBox(), "Hello!", "There!" } }
+				},
+				};
+			for (int i = 0; i < 100; i++)
+			{
+				myTable.Rows.Add(new TableRow { Cells = { new TextBox(), "Hello!", "There!" } });
+			}
+			Content = myTable;
+			/**/
+
+			#if blah
+			var button = new Button { Text = "Click Me!" };
+			button.Click += (sender, e) => button.Text = "Click me this is a longer title!";
+			var content = new FlowLayout
+			{
+				Contents =
+				{
+					button, new Label { Text = "Some other text that won't always wrap", VerticalAlignment = Forms.VerticalAlignment.Center },
+					new Label { Text = text, Wrap = WrapMode.Character },
+					new TextBox { Text = "Hello!" }
+				}
+			};
+
+			/*Content = new TabControl
+			{
+				Pages =
+				{
+					new TabPage { Text = "Tab 1", Content = new Scrollable { Content = content } }
+				}
+			};*/
+			Content = content; //new Scrollable { Content = content };
+			#endif
+
+			/*
+			//Menu = new MenuBar();
+			Width = 600;
+			//Height = 300;
+
+			const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum";
+			var label = new Label
+				{
+					Wrap = WrapMode.Word,
+					Text = text
+				};
+
+			Content = new TableLayout(
+				new TableRow(new TableLayout(new TableRow(new TableCell(label, true), new Button { Text = "Hello!"}))) { ScaleHeight = true },
+				new TextBox()
+			);
+			*/
+
+		}
+
+		protected override void OnLoadComplete(EventArgs e)
+		{
+			base.OnLoadComplete(e);
+
+			var size = Content.GetPreferredSize(new SizeF(400, 600));
+			var diff = Size - ClientSize;
+			//MinimumSize = Size.Round(size + diff);
+			Debug.WriteLine("Preferred Size: {0}", size);
+			ClientSize = Size.Round(size);
+		}
+
+		protected override void OnSizeChanged(EventArgs e)
+		{
+			base.OnSizeChanged(e);
+			var diff = Size - ClientSize;
+			//MinimumSize = Size.Round(Content.GetPreferredSize(ClientSize) + diff);
+			Debug.WriteLine("Size: {0}, ClientSize: {1}", Size, ClientSize);
+		}
+
+		protected override void OnShown(EventArgs e)
+		{
+			base.OnShown(e);
+			/*var size = Content.GetPreferredSize(new Size(200, int.MaxValue));
+			Debug.WriteLine("Preferred Size: {0}", size);*/
+		}
+	}
+
 	public class TestApplication : Application
 	{
 		public static IEnumerable<Assembly> DefaultTestAssemblies()
@@ -32,7 +150,17 @@ namespace Eto.Test
 
 		protected override void OnInitialized(EventArgs e)
 		{
+			Eto.Style.Add<TableLayout2>(null, c => c.LoadComplete += (sender, ee) =>
+			{
+				if (!c.Columns.Any(r => r.Width.IsStar))
+					c.Columns[c.Columns.Count - 1].Width = TableLength.Star(1);
+				if (!c.Rows.Any(r => r.Height.IsStar))
+					c.Rows[c.Rows.Count - 1].Height = TableLength.Star(1);
+			});
+
 			MainForm = new MainForm(TestSections.Get(TestAssemblies));
+			//MainForm = new TestForm();
+			//MainForm = new Form{ Content = new Sections.Layouts.TableLayoutSection.ScalingSection() };//.Show();
 
 			base.OnInitialized(e);
 

--- a/Source/Eto.Test/Eto.Test/TestApplication.cs
+++ b/Source/Eto.Test/Eto.Test/TestApplication.cs
@@ -12,13 +12,12 @@ namespace Eto.Test
 	public class TestForm : Form
 	{
 		SizeF min;
-		public TestForm()
+		public TestForm ()
 		{
 			const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
 			/**/
-			var myTable = new TableLayout2
-			{
+			var myTable = new TableLayout2 {
 				//Padding = new Padding(20),
 				//Spacing = new Size(5, 5),
 				Rows =
@@ -34,9 +33,8 @@ namespace Eto.Test
 					new TableColumn { Width = TableLength.Auto },
 				}
 			};
-			for (int i = 0; i < 0; i++)
-			{
-				myTable.Rows.Add(new TableRow2 { Height = TableLength.Auto, Cells = { new TextBox(), "Hello!", "There!" } });
+			for (int i = 0; i < 0; i++) {
+				myTable.Rows.Add (new TableRow2 { Height = TableLength.Auto, Cells = { new TextBox (), "Hello!", "There!" } });
 			}
 			Content = myTable;
 			/**
@@ -57,7 +55,7 @@ namespace Eto.Test
 			Content = myTable;
 			/**/
 
-			#if blah
+#if blah
 			var button = new Button { Text = "Click Me!" };
 			button.Click += (sender, e) => button.Text = "Click me this is a longer title!";
 			var content = new FlowLayout
@@ -78,7 +76,7 @@ namespace Eto.Test
 				}
 			};*/
 			Content = content; //new Scrollable { Content = content };
-			#endif
+#endif
 
 			/*
 			//Menu = new MenuBar();
@@ -100,28 +98,28 @@ namespace Eto.Test
 
 		}
 
-		protected override void OnLoadComplete(EventArgs e)
+		protected override void OnLoadComplete (EventArgs e)
 		{
-			base.OnLoadComplete(e);
+			base.OnLoadComplete (e);
 
-			var size = Content.GetPreferredSize(new SizeF(400, 600));
+			var size = Content.GetPreferredSize (new SizeF (400, 600));
 			var diff = Size - ClientSize;
 			//MinimumSize = Size.Round(size + diff);
-			Debug.WriteLine("Preferred Size: {0}", size);
-			ClientSize = Size.Round(size);
+			Debug.WriteLine ("Preferred Size: {0}", size);
+			ClientSize = Size.Round (size);
 		}
 
-		protected override void OnSizeChanged(EventArgs e)
+		protected override void OnSizeChanged (EventArgs e)
 		{
-			base.OnSizeChanged(e);
+			base.OnSizeChanged (e);
 			var diff = Size - ClientSize;
 			//MinimumSize = Size.Round(Content.GetPreferredSize(ClientSize) + diff);
-			Debug.WriteLine("Size: {0}, ClientSize: {1}", Size, ClientSize);
+			Debug.WriteLine ("Size: {0}, ClientSize: {1}", Size, ClientSize);
 		}
 
-		protected override void OnShown(EventArgs e)
+		protected override void OnShown (EventArgs e)
 		{
-			base.OnShown(e);
+			base.OnShown (e);
 			/*var size = Content.GetPreferredSize(new Size(200, int.MaxValue));
 			Debug.WriteLine("Preferred Size: {0}", size);*/
 		}
@@ -129,10 +127,10 @@ namespace Eto.Test
 
 	public class TestApplication : Application
 	{
-		public static IEnumerable<Assembly> DefaultTestAssemblies()
+		public static IEnumerable<Assembly> DefaultTestAssemblies ()
 		{
 #if PCL
-			yield return typeof(TestApplication).GetTypeInfo().Assembly;
+			yield return typeof (TestApplication).GetTypeInfo ().Assembly;
 #else
 			yield return typeof(TestApplication).Assembly;
 #endif
@@ -140,15 +138,15 @@ namespace Eto.Test
 
 		public List<Assembly> TestAssemblies { get; private set; }
 
-		public TestApplication(Platform platform)
-			: base(platform)
+		public TestApplication (Platform platform)
+			: base (platform)
 		{
-			TestAssemblies = DefaultTestAssemblies().ToList();
+			TestAssemblies = DefaultTestAssemblies ().ToList ();
 			this.Name = "Test Application";
 			this.Style = "application";
 		}
 
-		protected override void OnInitialized(EventArgs e)
+		protected override void OnInitialized (EventArgs e)
 		{
 			/*Eto.Style.Add<TableLayout2>(null, c => c.LoadComplete += (sender, ee) =>
 			{
@@ -158,11 +156,11 @@ namespace Eto.Test
 					c.Rows[c.Rows.Count - 1].Height = TableLength.Star(1);
 			});*/
 
-			//MainForm = new MainForm(TestSections.Get(TestAssemblies));
-			MainForm = new TestForm();
-			//MainForm = new Form{ Content = new Sections.Layouts.TableLayoutSection.ScalingSection() };//.Show();
+			MainForm = new MainForm(TestSections.Get(TestAssemblies));
+			//MainForm = new TestForm();
+			//MainForm = new Form { Content = new Sections.Layouts.TableLayoutSection.ScalingSection () };//.Show();
 
-			base.OnInitialized(e);
+			base.OnInitialized (e);
 
 			/**
 			Debug.WriteLine("Starting test...");
@@ -178,15 +176,15 @@ namespace Eto.Test
 			/**/
 
 			// show the main form
-			MainForm.Show();
+			MainForm.Show ();
 		}
 
-		protected override void OnTerminating(CancelEventArgs e)
+		protected override void OnTerminating (CancelEventArgs e)
 		{
-			base.OnTerminating(e);
-			Log.Write(this, "Terminating");
+			base.OnTerminating (e);
+			Log.Write (this, "Terminating");
 
-			var result = MessageBox.Show(MainForm, "Are you sure you want to quit?", MessageBoxButtons.YesNo, MessageBoxType.Question);
+			var result = MessageBox.Show (MainForm, "Are you sure you want to quit?", MessageBoxButtons.YesNo, MessageBoxType.Question);
 			if (result == DialogResult.No)
 				e.Cancel = true;
 		}

--- a/Source/Eto.Test/Eto.Test/TestApplication.cs
+++ b/Source/Eto.Test/Eto.Test/TestApplication.cs
@@ -150,16 +150,16 @@ namespace Eto.Test
 
 		protected override void OnInitialized(EventArgs e)
 		{
-			Eto.Style.Add<TableLayout2>(null, c => c.LoadComplete += (sender, ee) =>
+			/*Eto.Style.Add<TableLayout2>(null, c => c.LoadComplete += (sender, ee) =>
 			{
 				if (!c.Columns.Any(r => r.Width.IsStar))
 					c.Columns[c.Columns.Count - 1].Width = TableLength.Star(1);
 				if (!c.Rows.Any(r => r.Height.IsStar))
 					c.Rows[c.Rows.Count - 1].Height = TableLength.Star(1);
-			});
+			});*/
 
-			MainForm = new MainForm(TestSections.Get(TestAssemblies));
-			//MainForm = new TestForm();
+			//MainForm = new MainForm(TestSections.Get(TestAssemblies));
+			MainForm = new TestForm();
 			//MainForm = new Form{ Content = new Sections.Layouts.TableLayoutSection.ScalingSection() };//.Show();
 
 			base.OnInitialized(e);

--- a/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Controls/TestControlHandler.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Controls/TestControlHandler.cs
@@ -7,7 +7,7 @@ namespace Eto.Test.UnitTests.Handlers.Controls
 	interface IControlHandler
 	{
 		void OnShown();
-		Size GetPreferredSize();
+		Size GetPreferredSize(Size availableSize);
 		void SetBounds(Rectangle rect);
 	}
 
@@ -179,15 +179,15 @@ namespace Eto.Test.UnitTests.Handlers.Controls
 			Invalidate();
 		}
 
-		public virtual Size GetPreferredSize()
-		{
-			return desiredSize;
-		}
-
 		public virtual void SetBounds(Rectangle rect)
 		{
 			size = rect.Size;
 			Location = rect.Location;
+		}
+
+		public Size GetPreferredSize(Size availableSize)
+		{
+			return desiredSize;
 		}
 	}
 }

--- a/Source/Eto.Test/Eto.Test/UnitTests/Handlers/TestPanelHandler.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Handlers/TestPanelHandler.cs
@@ -48,7 +48,7 @@ namespace Eto.Test.UnitTests.Handlers
 				if (handler != null)
 				{
 					if (AutoSize)
-						ClientSize = handler.GetPreferredSize();
+						ClientSize = handler.GetPreferredSize(Size.MaxValue);
 					else
 						handler.SetBounds(new Rectangle(ClientSize));
 				}

--- a/Source/Eto.WinForms/Eto.WinForms - net45.csproj
+++ b/Source/Eto.WinForms/Eto.WinForms - net45.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Forms\Controls\TreeGridViewHandler.cs" />
     <Compile Include="Forms\Controls\TreeViewHandler.cs" />
     <Compile Include="Forms\MouseHandler.cs" />
+    <Compile Include="Forms\CustomLayoutHandler.cs" />
     <Compile Include="Forms\Printing\PrintDialogHandler.cs" />
     <Compile Include="Forms\Printing\PrintDocumentHandler.cs" />
     <Compile Include="Forms\Printing\PrintSettingsHandler.cs" />

--- a/Source/Eto.WinForms/Forms/Controls/LabelHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/LabelHandler.cs
@@ -105,13 +105,6 @@ namespace Eto.WinForms.Forms.Controls
 				Wrap = WrapMode.Word;
 			}
 
-			struct Position
-			{
-				public sd.Size Size;
-				public string Text;
-			}
-			List<Position> positions;
-
 			public override sd.Size GetPreferredSize(sd.Size proposedSize)
 			{
 				var bordersAndPadding = Padding.Size;

--- a/Source/Eto.WinForms/Forms/Controls/LabelHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/LabelHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Collections.Generic;
 using sd = System.Drawing;
 using swf = System.Windows.Forms;
 using Eto.Forms;
@@ -104,6 +105,13 @@ namespace Eto.WinForms.Forms.Controls
 				Wrap = WrapMode.Word;
 			}
 
+			struct Position
+			{
+				public sd.Size Size;
+				public string Text;
+			}
+			List<Position> positions;
+
 			public override sd.Size GetPreferredSize(sd.Size proposedSize)
 			{
 				var bordersAndPadding = Padding.Size;
@@ -194,11 +202,15 @@ namespace Eto.WinForms.Forms.Controls
 				{
 					case WrapMode.None:
 						textFormat |= swf.TextFormatFlags.SingleLine;
+						AutoSize = true;
 						break;
 					case WrapMode.Word:
 						textFormat |= swf.TextFormatFlags.WordBreak;
+						AutoSize = true;
 						break;
 					case WrapMode.Character:
+						//textFormat |= swf.TextFormatFlags.WordBreak;
+						AutoSize = true;
 						break;
 				}
 				switch (TextAlignment)
@@ -298,6 +310,8 @@ namespace Eto.WinForms.Forms.Controls
 					Control.Wrap = value;
 					SetMinimumSize(true);
 					Control.Invalidate();
+					if (Control.Parent != null)
+						Control.Parent.PerformLayout();
 				}
 			}
 		}

--- a/Source/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
@@ -5,6 +5,7 @@ using swf = System.Windows.Forms;
 using Eto.Forms;
 using System.Runtime.InteropServices;
 using System.ComponentModel;
+using Eto.Drawing;
 
 namespace Eto.WinForms.Forms.Controls
 {
@@ -65,6 +66,12 @@ namespace Eto.WinForms.Forms.Controls
 		public TextBoxHandler()
 		{
 			Control = new EtoTextBox();
+			Control.Margin = swf.Padding.Empty;
+		}
+
+		public override Size? DefaultSize
+		{
+			get { return new Size(100, -1); }
 		}
 
 		public bool ShowBorder

--- a/Source/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
@@ -69,9 +69,9 @@ namespace Eto.WinForms.Forms.Controls
 			Control.Margin = swf.Padding.Empty;
 		}
 
-		public override Size? DefaultSize
+		public override Size? GetDefaultSize(Size availableSize)
 		{
-			get { return new Size(100, -1); }
+			return new Size(100, -1);
 		}
 
 		public bool ShowBorder

--- a/Source/Eto.WinForms/Forms/CustomLayoutHandler.cs
+++ b/Source/Eto.WinForms/Forms/CustomLayoutHandler.cs
@@ -1,0 +1,65 @@
+using sd = System.Drawing;
+using swf = System.Windows.Forms;
+using Eto.Forms;
+using Eto.Drawing;
+
+namespace Eto.WinForms.Forms
+{
+	public class CustomLayoutHandler : WindowsContainer<swf.Panel, CustomLayout, CustomLayout.ICallback>, CustomLayout.IHandler
+	{
+		public CustomLayoutHandler()
+		{
+			Control = new swf.Panel
+			{
+				Size = sd.Size.Empty,
+				MinimumSize = sd.Size.Empty,
+				AutoSize = false,
+				AutoSizeMode = swf.AutoSizeMode.GrowAndShrink
+			};
+		}
+
+		public override void SetScale(bool xscale, bool yscale)
+		{
+			// do not call base class - pixel layout never scales the content
+		}
+
+		public override Size GetPreferredSize(Size availableSize, bool useCache)
+		{
+			return Size.Max(base.GetPreferredSize(availableSize, useCache), Control.PreferredSize.ToEto());
+		}
+
+		public void Add(Control child)
+		{
+			var childHandler = child.GetWindowsHandler();
+			var childControl = childHandler.ContainerControl;
+			childControl.Dock = swf.DockStyle.None;
+			childHandler.BeforeAddControl(Widget.Loaded);
+			Control.Controls.Add(childControl);
+			childControl.BringToFront();
+		}
+
+		public void Move(Control child, Rectangle location)
+		{
+			var ctl = child.GetContainerControl();
+			ctl.AutoSize = false;
+			ctl.SetBounds(location.X, location.Y, location.Width, location.Height, swf.BoundsSpecified.All);
+		}
+
+		public void Remove(Control child)
+		{
+			var ctl = child.GetContainerControl();
+			if (ctl.Parent == Control)
+				ctl.Parent = null;
+		}
+
+		public void RemoveAll()
+		{
+			Control.Controls.Clear();
+		}
+
+		public void Update()
+		{
+			Control.PerformLayout();
+		}
+	}
+}

--- a/Source/Eto.WinForms/Forms/FormHandler.cs
+++ b/Source/Eto.WinForms/Forms/FormHandler.cs
@@ -79,6 +79,9 @@ namespace Eto.WinForms.Forms
 
 		public void Show()
 		{
+			//ContainerContentControl.AutoSize = false;
+			//ContainerContentControl.MaximumSize = ContainerContentControl.MinimumSize = (Content.GetPreferredSize() + 100).ToSD();
+
 			Control.Show();
 		}
 

--- a/Source/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/Source/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -448,6 +448,11 @@ namespace Eto.WinForms.Forms
 			throw new NotImplementedException();
 		}
 
+		public Size GetPreferredSize(Size availableSize)
+		{
+			throw new NotImplementedException();
+		}
+
 		public string ToolTip
 		{
 			get

--- a/Source/Eto.WinForms/Forms/WindowHandler.cs
+++ b/Source/Eto.WinForms/Forms/WindowHandler.cs
@@ -114,10 +114,10 @@ namespace Eto.WinForms.Forms
 				// ensure we auto size to the content
 				if ((!clientWidthSet || !clientHeightSet) /*&& Control.AutoSize*/ && contentSize != null)
 				{
-					var sz = contentSize.Value.ToSD(); // Content.GetPreferredSize().ToSD();
+					var sz = Size.Truncate(contentSize.Value).ToSD(); // Content.GetPreferredSize().ToSD();
 					var min = new sd.Size();
 					if (!clientWidthSet)
-						 min.Width = sz.Width;
+						min.Width = sz.Width;
 					if (!clientHeightSet)
 						min.Height = sz.Height;
 					ContainerContentControl.MinimumSize = min;
@@ -164,7 +164,7 @@ namespace Eto.WinForms.Forms
 				contentSize = Content.GetPreferredSize(availableSize);
 			}
 		}
-		Size? contentSize;
+		SizeF? contentSize;
 
 		protected override void SetContent(swf.Control contentControl)
 		{

--- a/Source/Eto.WinForms/Forms/WindowsControl.cs
+++ b/Source/Eto.WinForms/Forms/WindowsControl.cs
@@ -682,5 +682,34 @@ namespace Eto.WinForms.Forms
 			get { return Control.ForeColor.ToEto(); }
 			set { Control.ForeColor = value.ToSD(); }
 		}
+
+		public virtual void SetFilledContent()
+		{
+		}
+
+		public Size GetPreferredSize(Size availableSize)
+		{
+			var size = UserDesiredSize;
+
+			Size? defSize;
+			if (true)
+				defSize = cachedDefaultSize ?? DefaultSize;
+			else
+				defSize = DefaultSize;
+			if (defSize != null)
+			{
+				var controlSize = Control.GetPreferredSize(availableSize.ToSD());
+				if (size.Width == -1) size.Width = Math.Max(defSize.Value.Width, controlSize.Width);
+				if (size.Height == -1) size.Height = Math.Max(defSize.Value.Height, controlSize.Height);
+			}
+			else if (size.Width == -1 || size.Height == -1)
+			{
+				var controlSize = Control.GetPreferredSize(availableSize.ToSD());
+				if (size.Width == -1) size.Width = controlSize.Width;
+				if (size.Height == -1) size.Height = controlSize.Height;
+			}
+
+			return Size.Max(parentMinimumSize, size);
+		}
 	}
 }

--- a/Source/Eto.WinForms/Forms/WindowsControl.cs
+++ b/Source/Eto.WinForms/Forms/WindowsControl.cs
@@ -693,9 +693,9 @@ namespace Eto.WinForms.Forms
 
 			Size? defSize;
 			if (true)
-				defSize = cachedDefaultSize ?? DefaultSize;
+				defSize = cachedDefaultSize ?? GetDefaultSize(availableSize);
 			else
-				defSize = DefaultSize;
+				defSize = GetDefaultSize(availableSize);
 			if (defSize != null)
 			{
 				var controlSize = Control.GetPreferredSize(availableSize.ToSD());

--- a/Source/Eto.WinForms/Platform.cs
+++ b/Source/Eto.WinForms/Platform.cs
@@ -138,6 +138,7 @@ namespace Eto.WinForms
 			p.Add<Screen.IScreensHandler>(() => new ScreensHandler());
 			p.Add<Keyboard.IHandler>(() => new KeyboardHandler());
 			p.Add<FixedMaskedTextProvider.IHandler>(() => new FixedMaskedTextProviderHandler());
+			p.Add<CustomLayout.IHandler>(() => new CustomLayoutHandler());
 
 			// IO
 			p.Add<SystemIcons.IHandler>(() => new SystemIconsHandler());

--- a/Source/Eto.Wpf/Eto.Wpf - net45.csproj
+++ b/Source/Eto.Wpf/Eto.Wpf - net45.csproj
@@ -172,6 +172,7 @@
     <Compile Include="Forms\Controls\WpfTreeItemHelper.cs" />
     <Compile Include="Forms\EnableThemingInScope.cs" />
     <Compile Include="Forms\KeyboardHandler.cs" />
+    <Compile Include="Forms\CustomLayoutHandler.cs" />
     <Compile Include="Forms\ToolBar\RadioToolItemHandler.cs" />
     <Compile Include="Forms\WpfPanel.cs" />
     <Compile Include="Forms\CursorHandler.cs" />

--- a/Source/Eto.Wpf/Forms/Controls/LabelHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/LabelHandler.cs
@@ -36,7 +36,7 @@ namespace Eto.Wpf.Forms.Controls
 			accessText.TextDecorations = decorations;
 		}
 
-		public LabelHandler ()
+		public LabelHandler()
 		{
 			accessText = new swc.AccessText();
 			Control = new EtoLabel
@@ -63,7 +63,6 @@ namespace Eto.Wpf.Forms.Controls
 			base.Initialize();
 			TextAlignment = TextAlignment.Left;
 			VerticalAlignment = VerticalAlignment.Top;
-			Wrap = WrapMode.Word;
 		}
 
 		public override void AttachEvent(string id)
@@ -108,7 +107,7 @@ namespace Eto.Wpf.Forms.Controls
 					case sw.TextWrapping.WrapWithOverflow:
 						return WrapMode.Word;
 					default:
-						throw new NotSupportedException ();
+						throw new NotSupportedException();
 				}
 			}
 			set
@@ -132,6 +131,7 @@ namespace Eto.Wpf.Forms.Controls
 					SetText();
                     UpdatePreferredSize();
 				}
+				Text = Text; // set text again to set correct non-breaking space
 			}
 		}
 
@@ -147,6 +147,8 @@ namespace Eto.Wpf.Forms.Controls
 			get { return accessText.Foreground.ToEtoColor(); }
 			set { accessText.Foreground = value.ToWpfBrush(accessText.Foreground); }
 		}
+
+		static readonly object Text_Key = new object();
 
 		public string Text
 		{

--- a/Source/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
@@ -66,7 +66,7 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				var content = (swc.Border)scroller.Content;
 				var viewportSize = new sw.Size(info.ViewportWidth, info.ViewportHeight);
-				var prefSize = Content.GetPreferredSize(new sw.Size(content.ActualWidth, content.ActualHeight));
+				var prefSize = Content.GetPreferredSize(new SizeF((float)content.ActualWidth, (float)content.ActualHeight));
 
 				// hack for when a scrollable is in a group box it expands vertically indefinitely
 				// -2 since when you resize the scrollable it grows slowly

--- a/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
@@ -90,18 +90,18 @@ namespace Eto.Wpf.Forms.Controls
 			}
 			else if (fixedPanel == SplitterFixedPanel.Panel1)
 			{
-				var size1 = panel1.GetPreferredSize(WpfConversions.PositiveInfinitySize);
+				var size1 = panel1.GetPreferredSize(Size.MaxValue);
 				SetRelative(orientation == Orientation.Horizontal ? size1.Width : size1.Height);
 			}
 			else if (fixedPanel == SplitterFixedPanel.Panel2)
 			{
-				var size2 = panel2.GetPreferredSize(WpfConversions.PositiveInfinitySize);
+				var size2 = panel2.GetPreferredSize(Size.MaxValue);
 				SetRelative(orientation == Orientation.Horizontal ? size2.Width : size2.Height);
 			}
 			else
 			{
-				var size1 = panel1.GetPreferredSize(WpfConversions.PositiveInfinitySize);
-				var size2 = panel2.GetPreferredSize(WpfConversions.PositiveInfinitySize);
+				var size1 = panel1.GetPreferredSize(Size.MaxValue);
+				var size2 = panel2.GetPreferredSize(Size.MaxValue);
 				SetRelative(orientation == Orientation.Horizontal
 					? size1.Width / (double)(size1.Width + size2.Width)
 					: size1.Height / (double)(size1.Height + size2.Height));

--- a/Source/Eto.Wpf/Forms/CustomLayoutHandler.cs
+++ b/Source/Eto.Wpf/Forms/CustomLayoutHandler.cs
@@ -1,0 +1,156 @@
+using System;
+using System.Linq;
+using swc = System.Windows.Controls;
+using sw = System.Windows;
+using Eto.Forms;
+using Eto.Drawing;
+
+namespace Eto.Wpf.Forms
+{
+	public class CustomLayoutHandler : WpfLayout<swc.Canvas, CustomLayout, CustomLayout.ICallback>, CustomLayout.IHandler
+	{
+		public override sw.Size GetPreferredSize(sw.Size constraint)
+		{
+			var size = new sw.Size();
+			foreach (var control in Widget.Controls)
+			{
+				var container = control.GetContainerControl();
+				var preferredSize = control.GetPreferredSize(constraint.ToEtoSize());
+				var left = swc.Canvas.GetLeft(container) + preferredSize.Width;
+				var top = swc.Canvas.GetTop(container) + preferredSize.Height;
+				if (size.Width < left) size.Width = left;
+				if (size.Height < top) size.Height = top;
+			}
+			return size;
+		}
+
+		static readonly object Location_Key = new object();
+
+		public class EtoCanvas : swc.Canvas
+		{
+			protected override sw.Size MeasureOverride(sw.Size constraint)
+			{
+				var availableSize = new sw.Size(double.PositiveInfinity, double.PositiveInfinity);
+				foreach (sw.UIElement element in base.InternalChildren)
+				{
+					if (element != null)
+					{
+						var handler = ((sw.FrameworkElement)element).Tag as Control.IHandler;
+						var location = handler.Widget.Properties.Get<Rectangle>(Location_Key);
+						var desiredSize = location.Size.ToWpf();
+						element.Measure(desiredSize);
+					}
+				}
+				return default(sw.Size);
+			}
+
+			protected override sw.Size ArrangeOverride(sw.Size arrangeSize)
+			{
+				foreach (sw.UIElement element in InternalChildren)
+				{
+					if (element != null)
+					{
+						double x = 0.0;
+						double y = 0.0;
+						double left = swc.Canvas.GetLeft(element);
+						var handler = ((sw.FrameworkElement)element).Tag as Control.IHandler;
+						var location = handler.Widget.Properties.Get<Rectangle>(Location_Key);
+						var desiredSize = location.Size.ToWpf();
+
+						if (!double.IsNaN(left))
+						{
+							x = left;
+						}
+						else
+						{
+							double right = swc.Canvas.GetRight(element);
+							if (!double.IsNaN(right))
+							{
+								x = arrangeSize.Width - desiredSize.Width - right;
+							}
+						}
+						double top = swc.Canvas.GetTop(element);
+						if (!double.IsNaN(top))
+						{
+							y = top;
+						}
+						else
+						{
+							double bottom = swc.Canvas.GetBottom(element);
+							if (!double.IsNaN(bottom))
+							{
+								y = arrangeSize.Height - desiredSize.Height - bottom;
+							}
+						}
+						element.Arrange(new sw.Rect(new sw.Point(x, y), desiredSize));
+					}
+				}
+				return arrangeSize; 
+				
+				var size = base.ArrangeOverride(arrangeSize);
+				var bounds = Rectangle.Empty;
+
+				foreach (var ctl in this.InternalChildren.OfType<sw.FrameworkElement>())
+				{
+					var handler = ctl.Tag as Control.IHandler;
+					var location = handler.Widget.Properties.Get<Rectangle>(Location_Key);
+
+					ctl.Arrange(location.ToWpf());
+					bounds.Union(location);
+				}
+
+				return size; // bounds.Size.ToWpf();
+			}
+		}
+
+		public CustomLayoutHandler()
+		{
+			Control = new EtoCanvas
+			{
+				SnapsToDevicePixels = true,
+				ClipToBounds = true
+			};
+		}
+
+		public override Color BackgroundColor
+		{
+			get { return Control.Background.ToEtoColor(); }
+			set { Control.Background = value.ToWpfBrush(Control.Background); }
+		}
+
+		public void Add(Control child)
+		{
+			var element = child.GetContainerControl();
+			Control.Children.Add(element);
+			UpdatePreferredSize();
+		}
+
+		public void Move(Control child, Rectangle location)
+		{
+			var element = child.GetContainerControl();
+			swc.Canvas.SetLeft(element, location.X);
+			swc.Canvas.SetTop(element, location.Y);
+			//element.Tag = child;
+			child.Properties[Location_Key] = location;
+			UpdatePreferredSize();
+		}
+
+		public void RemoveAll()
+		{
+			Control.Children.Clear();
+		}
+
+		public void Remove(Control child)
+		{
+			var element = child.GetContainerControl();
+			Control.Children.Remove(element);
+			UpdatePreferredSize();
+		}
+
+		public override void Remove(sw.FrameworkElement child)
+		{
+			Control.Children.Remove(child);
+			UpdatePreferredSize();
+		}
+	}
+}

--- a/Source/Eto.Wpf/Forms/FormHandler.cs
+++ b/Source/Eto.Wpf/Forms/FormHandler.cs
@@ -1,4 +1,5 @@
 using Eto.Forms;
+using Eto.Drawing;
 using sw = System.Windows;
 using swc = System.Windows.Controls;
 
@@ -19,6 +20,10 @@ namespace Eto.Wpf.Forms
 		public void Show()
 		{
 			Control.WindowStartupLocation = sw.WindowStartupLocation.Manual;
+			var size = Widget.Content.GetPreferredSize(Size.MaxValue); //.Round(Widget.Screen.Bounds.Size));
+			//InnerContent.MinWidth = size.Width;
+			//InnerContent.MinHeight = size.Height;
+
 			if (ApplicationHandler.Instance.IsStarted)
 				Control.Show();
 			else

--- a/Source/Eto.Wpf/Forms/PixelLayoutHandler.cs
+++ b/Source/Eto.Wpf/Forms/PixelLayoutHandler.cs
@@ -14,7 +14,7 @@ namespace Eto.Wpf.Forms
 			foreach (var control in Widget.VisualControls)
 			{
 				var container = control.GetContainerControl();
-				var preferredSize = control.GetPreferredSize(constraint);
+				var preferredSize = control.GetPreferredSize(constraint.ToEtoSize());
 				var left = swc.Canvas.GetLeft(container) + preferredSize.Width;
 				var top = swc.Canvas.GetTop(container) + preferredSize.Height;
 				if (size.Width < left) size.Width = left;

--- a/Source/Eto.Wpf/Forms/TableLayoutHandler.cs
+++ b/Source/Eto.Wpf/Forms/TableLayoutHandler.cs
@@ -88,7 +88,7 @@ namespace Eto.Wpf.Forms
                             var childControl = control.GetWpfFrameworkElement();
                             if (childControl != null && control.Visible)
                             {
-                                var preferredSize = childControl.GetPreferredSize(cellConstraint);
+                                var preferredSize = control.GetPreferredSize(cellConstraint.ToEto());
                                 if (!hasColScale)
                                     widths[x] = Math.Max(widths[x], preferredSize.Width);
                                 if (!hasRowScale)
@@ -127,7 +127,7 @@ namespace Eto.Wpf.Forms
                             var childControl = control.GetWpfFrameworkElement();
                             if (childControl != null && control.Visible)
                             {
-                                var preferredSize = childControl.GetPreferredSize(cellConstraint);
+                                var preferredSize = control.GetPreferredSize(cellConstraint.ToEto());
                                 widths[x] = Math.Max(widths[x], preferredSize.Width);
                                 heights[y] = Math.Max(heights[y], preferredSize.Height);
                             }

--- a/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -12,7 +12,6 @@ namespace Eto.Wpf.Forms
 {
 	public interface IWpfFrameworkElement
 	{
-		sw.Size GetPreferredSize(sw.Size constraint);
 		sw.FrameworkElement ContainerControl { get; }
 		void SetScale(bool xscale, bool yscale);
 		sw.Size ParentMinimumSize { get; set; }
@@ -55,14 +54,6 @@ namespace Eto.Wpf.Forms
 				return controlObject.GetContainerControl();
 
 			return control.ControlObject as sw.FrameworkElement;
-		}
-
-		public static sw.Size GetPreferredSize(this Control control, sw.Size available)
-		{
-			var handler = control.GetWpfFrameworkElement();
-			if (handler != null)
-				return handler.GetPreferredSize(available);
-			return WpfConversions.ZeroSize;
 		}
 	}
 
@@ -556,6 +547,11 @@ namespace Eto.Wpf.Forms
 					return Point.Empty;
 				return Control.TranslatePoint(new sw.Point(0, 0), Widget.VisualParent.GetContainerControl()).ToEtoPoint();
 			}
+		}
+
+		public Size GetPreferredSize(Size availableSize)
+		{
+			return GetPreferredSize(availableSize.ToWpf()).ToEtoSize();
 		}
 	}
 }

--- a/Source/Eto.Wpf/Forms/WpfPanel.cs
+++ b/Source/Eto.Wpf/Forms/WpfPanel.cs
@@ -63,7 +63,7 @@ namespace Eto.Wpf.Forms
 				{
                     var padding = border.Padding.Size();
                     var childConstraint = constraint.Subtract(padding).Subtract(margin);
-					baseSize = content.GetPreferredSize(childConstraint);
+					baseSize = content.GetPreferredSize(childConstraint.ToEto()).ToWpf();
                     baseSize = baseSize.Add(padding); // we add margin back at end
 				}
                 else

--- a/Source/Eto.Wpf/Forms/WpfWindow.cs
+++ b/Source/Eto.Wpf/Forms/WpfWindow.cs
@@ -41,6 +41,11 @@ namespace Eto.Wpf.Forms
 		bool maximizable = true;
 		bool minimizable = true;
 
+		protected swc.DockPanel InnerContent
+		{
+			get { return content; }
+		}
+
 		public override IntPtr NativeHandle
 		{
 			get { return new System.Windows.Interop.WindowInteropHelper(Control).EnsureHandle(); }
@@ -66,14 +71,15 @@ namespace Eto.Wpf.Forms
 			Control.Content = main;
 			Control.Loaded += delegate
 			{
+				// stop form from auto-sizing after it is shown
+				Control.SizeToContent = sw.SizeToContent.Manual;
+
 				SetResizeMode();
 				if (initialClientSize != null)
 				{
 					initialClientSize = null;
-					SetContentSize();
 				}
-				// stop form from auto-sizing after it is shown
-				Control.SizeToContent = sw.SizeToContent.Manual;
+				SetContentSize();
 				Control.MoveFocus(new swi.TraversalRequest(swi.FocusNavigationDirection.Next));
 			};
 			Control.PreviewKeyDown += (sender, e) =>

--- a/Source/Eto.Wpf/Platform.cs
+++ b/Source/Eto.Wpf/Platform.cs
@@ -143,6 +143,7 @@ namespace Eto.Wpf
 			p.Add<Screen.IScreensHandler>(() => new ScreensHandler());
 			p.Add<Keyboard.IHandler>(() => new KeyboardHandler());
 			p.Add<FixedMaskedTextProvider.IHandler>(() => new FixedMaskedTextProviderHandler());
+			p.Add<CustomLayout.IHandler>(() => new CustomLayoutHandler());
 			
 			// IO
 			p.Add<SystemIcons.IHandler>(() => new SystemIconsHandler());

--- a/Source/Eto/Drawing/Size.cs
+++ b/Source/Eto/Drawing/Size.cs
@@ -44,7 +44,7 @@ namespace Eto.Drawing
 		/// <returns>A new instance of a Size struct with truncated width and height values of the specified <paramref name="size"/></returns>
 		public static Size Truncate (SizeF size)
 		{
-			return new Size ((int)size.Width, (int)size.Height);
+			return new Size ((int)Math.Truncate(size.Width), (int)Math.Truncate(size.Height));
 		}
 		
 		/// <summary>

--- a/Source/Eto/Eto - pcl.csproj
+++ b/Source/Eto/Eto - pcl.csproj
@@ -94,7 +94,6 @@
     <Compile Include="Forms\Key.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Forms\Layout\Layout.cs" />
     <Compile Include="Forms\MessageBox.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -327,6 +326,10 @@
     <Compile Include="Forms\ToolBar\ToolItemConverter.cs" />
     <Compile Include="Forms\KeysConverter.cs" />
     <Compile Include="Drawing\FontConverter.cs" />
+    <Compile Include="Forms\Layout\FlowLayout.cs" />
+    <Compile Include="Forms\Layout\Layout.cs" />
+    <Compile Include="Forms\Layout\TableLayout2.cs" />
+    <Compile Include="Forms\Layout\TableRow2.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\LICENSE">

--- a/Source/Eto/Forms/Controls/Control.cs
+++ b/Source/Eto/Forms/Controls/Control.cs
@@ -1000,6 +1000,15 @@ namespace Eto.Forms
 			base.Dispose(disposing);
 		}
 
+		public HorizontalAlignment HorizontalAlignment { get; set; }
+		public VerticalAlignment VerticalAlignment { get; set; }
+		public Padding Margin { get; set; }
+
+		public virtual SizeF GetPreferredSize(SizeF availableSize)
+		{
+			return Handler.GetPreferredSize(Size.Truncate(availableSize));
+		}
+
 		/// <summary>
 		/// Converts a string to a label control implicitly.
 		/// </summary>
@@ -1419,6 +1428,8 @@ namespace Eto.Forms
 			/// </summary>
 			/// <value>The mouse cursor</value>
 			Cursor Cursor { get; set; }
+
+			Size GetPreferredSize(Size availableSize);
 		}
 		#endregion
 	}

--- a/Source/Eto/Forms/Controls/Label.cs
+++ b/Source/Eto/Forms/Controls/Label.cs
@@ -99,6 +99,7 @@ namespace Eto.Forms
 			set { Handler.TextAlignment = value; }
 		}
 
+		/*
 		/// <summary>
 		/// Gets or sets the vertical alignment of the text.
 		/// </summary>
@@ -110,7 +111,7 @@ namespace Eto.Forms
 		{
 			get { return Handler.VerticalAlignment; }
 			set { Handler.VerticalAlignment = value; }
-		}
+		}*/
 
 		/// <summary>
 		/// Gets or sets the vertical alignment of the text.

--- a/Source/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/Source/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -244,6 +244,11 @@ namespace Eto.Forms
 			Control.MapPlatformCommand(systemAction, action);
 		}
 
+		public Size GetPreferredSize(Size availableSize)
+		{
+			return Size.Round(Control.GetPreferredSize(availableSize));
+		}
+
 		/// <summary>
 		/// Gets the location of the control as positioned by the container
 		/// </summary>

--- a/Source/Eto/Forms/Layout/FlowLayout.cs
+++ b/Source/Eto/Forms/Layout/FlowLayout.cs
@@ -1,0 +1,191 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using Eto.Drawing;
+
+namespace Eto.Forms
+{
+	[ContentProperty("Contents")]
+	public class FlowLayout : CustomLayout
+	{
+		readonly FlowCollection collection;
+
+		public override IEnumerable<Control> Controls
+		{
+			get { return collection; }
+		}
+
+		public IList<Control> Contents
+		{
+			get { return collection; }
+		}
+
+		class FlowCollection : Collection<Control>
+		{
+			public FlowLayout Layout { get; set; }
+
+			protected override void InsertItem(int index, Control item)
+			{
+				base.InsertItem(index, item);
+				Layout.Handler.Add(item);
+				item.SizeChanged += Layout.UpdateSize;
+			}
+
+			protected override void RemoveItem(int index)
+			{
+				var item = this[index];
+				item.SizeChanged -= Layout.UpdateSize;
+				base.RemoveItem(index);
+				Layout.Handler.Remove(item);
+			}
+
+			protected override void SetItem(int index, Control item)
+			{
+				var oldItem = this[index];
+				oldItem.SizeChanged -= Layout.UpdateSize;
+				base.SetItem(index, item);
+				Layout.Handler.Remove(oldItem);
+				Layout.Handler.Add(item);
+				item.SizeChanged += Layout.UpdateSize;
+			}
+
+			protected override void ClearItems()
+			{
+				Layout.Handler.RemoveAll();
+				base.ClearItems();
+			}
+		}
+
+		public FlowLayout()
+		{
+			collection = new FlowCollection { Layout = this };
+			HandleEvent(SizeChangedEvent);
+		}
+
+		protected override void OnSizeChanged(EventArgs e)
+		{
+			UpdateLayout();
+			base.OnSizeChanged(e);
+		}
+
+		bool updating;
+
+		public override void UpdateLayout()
+		{
+			base.UpdateLayout();
+			if (updating)
+				return;
+			updating = true;
+			try
+			{
+				var size = this.Size;
+				var location = PointF.Empty;
+				var maxSize = SizeF.Empty;
+				var oldMargin = 0;
+				var alignControls = new List<Tuple<Control, RectangleF>>();
+				for (int i = 0; i < collection.Count; i++)
+				{
+					var item = collection[i];
+					var margin = item.Margin;
+					var prefSize = item.GetPreferredSize(size);
+					location.X += margin.Left;
+					if (location.X + Math.Max(margin.Left, oldMargin) + prefSize.Width + margin.Right > size.Width)
+					{
+						AlignRow(maxSize, alignControls);
+						location.X = 0;
+						location.Y += maxSize.Height;
+						oldMargin = 0;
+						maxSize = Size.Empty;
+					}
+					maxSize = SizeF.Max(maxSize, prefSize + margin.Size);
+
+					var controlLoc = location;
+					controlLoc.X += Math.Max(margin.Left, oldMargin);
+					controlLoc.Y += margin.Top;
+					oldMargin = margin.Right;
+					var controlRect = new RectangleF(controlLoc, prefSize);
+					if (item.VerticalAlignment != Forms.VerticalAlignment.Top)
+						alignControls.Add(Tuple.Create(item, controlRect));
+					else
+						Handler.Move(item, Rectangle.Round(controlRect));
+					location.X = controlLoc.X + prefSize.Width;
+
+				}
+
+				AlignRow(maxSize, alignControls);
+
+			}
+			finally
+			{
+				updating = false;
+			}
+		}
+
+		void AlignRow(Drawing.SizeF maxSize, List<Tuple<Control, RectangleF>> adjustControls)
+		{
+			foreach (var c in adjustControls)
+			{
+				var rect = c.Item2;
+				switch (c.Item1.VerticalAlignment)
+				{
+					case Forms.VerticalAlignment.Center:
+						rect.Y += (maxSize.Height - rect.Height) / 2;
+						break;
+					case Forms.VerticalAlignment.Bottom:
+						rect.Y += maxSize.Height - rect.Height;
+						break;
+					case Forms.VerticalAlignment.Stretch:
+						rect.Height = maxSize.Height;
+						break;
+				}
+				Handler.Move(c.Item1, Rectangle.Round(rect));
+			}
+			adjustControls.Clear();
+		}
+
+		public override SizeF GetPreferredSize(SizeF availableSize)
+		{
+			var size = availableSize;
+			var location = PointF.Empty;
+			var maxSize = SizeF.Empty;
+			var oldMargin = 0;
+			float maxX = 0;
+			for (int i = 0; i < collection.Count; i++)
+			{
+				var item = collection[i];
+				var margin = item.Margin;
+				var prefSize = item.GetPreferredSize(size);
+				location.X += margin.Left;
+				if (location.X + Math.Max(margin.Left, oldMargin) + prefSize.Width + margin.Right > size.Width)
+				{
+					location.X = 0;
+					location.Y += maxSize.Height;
+					oldMargin = 0;
+					maxSize = Size.Empty;
+				}
+				maxSize = SizeF.Max(maxSize, prefSize + margin.Size);
+
+				var controlLoc = location;
+				controlLoc.X += Math.Max(margin.Left, oldMargin);
+				controlLoc.Y += margin.Top;
+				oldMargin = margin.Right;
+				location.X = controlLoc.X + prefSize.Width;
+
+				maxX = Math.Max(maxX, location.X);
+			}
+			return new SizeF(maxX, location.Y + maxSize.Height);
+		}
+
+		public override void Remove(Control child)
+		{
+			collection.Remove(child);
+		}
+
+		void UpdateSize(object sender, EventArgs e)
+		{
+			if (Loaded)
+				UpdateLayout();
+		}
+	}
+}
+

--- a/Source/Eto/Forms/Layout/Layout.cs
+++ b/Source/Eto/Forms/Layout/Layout.cs
@@ -1,9 +1,27 @@
 using System;
 using System.Linq;
 using System.ComponentModel;
+using Eto.Drawing;
 
 namespace Eto.Forms
 {
+	[Handler(typeof(IHandler))]
+	public abstract class CustomLayout : Layout
+	{
+		protected new IHandler Handler { get { return (IHandler)base.Handler; } }
+
+		public new interface IHandler : Layout.IHandler
+		{
+			void Add(Control control);
+
+			void Remove(Control control);
+
+			void RemoveAll();
+
+			void Move(Control control, Rectangle location);
+		}
+	}
+
 	/// <summary>
 	/// Base class for all layout-based containers
 	/// </summary>
@@ -38,7 +56,7 @@ namespace Eto.Forms
 		/// All layouts should theoretically work without having to manually update them, but in certain cases
 		/// this may be necessary to be called.
 		/// </remarks>
-		public virtual void Update()
+		public virtual void UpdateLayout()
 		{
 			UpdateContainers(this);
 			Handler.Update();
@@ -48,7 +66,7 @@ namespace Eto.Forms
 		{
 			foreach (var c in container.VisualControls.OfType<Layout>())
 			{
-				c.Update();
+				c.UpdateLayout();
 			}
 		}
 

--- a/Source/Eto/Forms/Layout/PixelLayout.cs
+++ b/Source/Eto/Forms/Layout/PixelLayout.cs
@@ -36,7 +36,7 @@ namespace Eto.Forms
 		/// When adding children using this, you can position them using the <see cref="SetLocation"/> static method.
 		/// </remarks>
 		/// <value>The contents of the container.</value>
-		public List<Control> Contents
+		public IList<Control> Contents
 		{
 			get
 			{

--- a/Source/Eto/Forms/Layout/StackLayout.cs
+++ b/Source/Eto/Forms/Layout/StackLayout.cs
@@ -401,24 +401,24 @@ namespace Eto.Forms
 				{
 					case Orientation.Horizontal:
 						label.VerticalAlignment = item.VerticalAlignment ?? VerticalContentAlignment;
-						item.VerticalAlignment = VerticalAlignment.Stretch;
+						item.VerticalAlignment = Forms.VerticalAlignment.Stretch;
 						break;
 					case Orientation.Vertical:
 						switch (item.HorizontalAlignment ?? HorizontalContentAlignment)
 						{
-							case HorizontalAlignment.Left:
+							case Forms.HorizontalAlignment.Left:
 								label.TextAlignment = TextAlignment.Left;
 								break;
-							case HorizontalAlignment.Center:
+							case Forms.HorizontalAlignment.Center:
 								label.TextAlignment = TextAlignment.Center;
 								break;
-							case HorizontalAlignment.Right:
+							case Forms.HorizontalAlignment.Right:
 								label.TextAlignment = TextAlignment.Right;
 								break;
 							default:
 								return;
 						}
-						item.HorizontalAlignment = HorizontalAlignment.Stretch;
+						item.HorizontalAlignment = Forms.HorizontalAlignment.Stretch;
 						break;
 					default:
 						throw new ArgumentOutOfRangeException();
@@ -502,16 +502,16 @@ namespace Eto.Forms
 						var cell = new TableCell { ScaleWidth = item.Expand };
 						switch (item.VerticalAlignment ?? VerticalContentAlignment)
 						{
-							case VerticalAlignment.Top:
+							case Forms.VerticalAlignment.Top:
 								cell.Control = new TableLayout(control, null);
 								break;
-							case VerticalAlignment.Center:
+							case Forms.VerticalAlignment.Center:
 								cell.Control = new TableLayout(null, control, null);
 								break;
-							case VerticalAlignment.Bottom:
+							case Forms.VerticalAlignment.Bottom:
 								cell.Control = new TableLayout(null, control);
 								break;
-							case VerticalAlignment.Stretch:
+							case Forms.VerticalAlignment.Stretch:
 								cell.Control = control;
 								break;
 							default:
@@ -533,16 +533,16 @@ namespace Eto.Forms
 						var vrow = new TableRow { ScaleHeight = item.Expand };
 						switch (item.HorizontalAlignment ?? HorizontalContentAlignment)
 						{
-							case HorizontalAlignment.Left:
+							case Forms.HorizontalAlignment.Left:
 								vrow.Cells.Add(TableLayout.Horizontal(control, null));
 								break;
-							case HorizontalAlignment.Center:
+							case Forms.HorizontalAlignment.Center:
 								vrow.Cells.Add(TableLayout.Horizontal(null, control, null));
 								break;
-							case HorizontalAlignment.Right:
+							case Forms.HorizontalAlignment.Right:
 								vrow.Cells.Add(TableLayout.Horizontal(null, control));
 								break;
-							case HorizontalAlignment.Stretch:
+							case Forms.HorizontalAlignment.Stretch:
 								vrow.Cells.Add(control);
 								break;
 							default:

--- a/Source/Eto/Forms/Layout/TableLayout2.cs
+++ b/Source/Eto/Forms/Layout/TableLayout2.cs
@@ -1,0 +1,491 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using Eto.Drawing;
+using System.Linq;
+using System.Collections;
+
+namespace Eto.Forms
+{
+	[ContentProperty("Rows")]
+	public class TableLayout2 : CustomLayout
+	{
+		readonly RowCollection collection;
+
+		public override IEnumerable<Control> Controls
+		{
+			get { return collection.SelectMany(r => r.Where(c => c != null)); }
+		}
+
+		List<TableColumn> columns = new List<TableColumn>();
+
+		public IList<TableColumn> Columns
+		{
+			get { return columns; }
+		}
+
+		public IList<TableRow2> Rows
+		{
+			get { return collection; }
+		}
+
+		class RowCollection : Collection<TableRow2>, IList
+		{
+			public TableLayout2 Layout { get; set; }
+
+			protected override void InsertItem(int index, TableRow2 item)
+			{
+				if (item == null)
+					item = new TableRow2 { Height = new TableLength(1f, TableUnit.Star) };
+				base.InsertItem(index, item);
+				AddRow(item);
+			}
+
+			void AddRow(TableRow2 row)
+			{
+				if (row == null)
+					return;
+				row.Layout = Layout;
+				foreach (var ctl in row.Where(r => r != null))
+					Layout.Handler.Add(ctl);
+			}
+			void RemoveRow(TableRow2 row)
+			{
+				if (row == null)
+					return;
+				foreach (var ctl in row.Where(r => r != null))
+					Layout.Handler.Remove(ctl);
+			}
+
+			protected override void RemoveItem(int index)
+			{
+				var item = this[index];
+				base.RemoveItem(index);
+				RemoveRow(item);
+			}
+
+			protected override void SetItem(int index, TableRow2 item)
+			{
+				if (item == null)
+					item = new TableRow2 { ScaleHeight = true };
+
+				var oldItem = this[index];
+				base.SetItem(index, item);
+				RemoveRow(oldItem);
+				AddRow(item);
+			}
+
+			protected override void ClearItems()
+			{
+				Layout.Handler.RemoveAll();
+				base.ClearItems();
+			}
+
+			int IList.Add(object value)
+			{
+				// allow adding a control directly from xaml
+				var control = value as Control;
+				if (control != null)
+					Add((TableRow2)control);
+				else
+					Add((TableRow2)value);
+				return Count - 1;
+			}
+
+		}
+
+		public TableLayout2()
+		{
+			collection = new RowCollection { Layout = this };
+			HandleEvent(SizeChangedEvent);
+		}
+
+		[Obsolete("Use the Rows/Columns properties instead")]
+		public TableLayout2(int columns, int rows)
+			: this()
+		{
+			Ensure(columns, rows);
+		}
+
+		[Obsolete("Use the Rows/Columns properties instead")]
+		public TableLayout2(Size dimensions)
+			: this(dimensions.Width, dimensions.Height)
+		{
+		}
+
+		[Obsolete("Use the Rows/Columns properties instead")]
+		public void Add(Control control, int x, int y)
+		{
+			EnsureRows(y + 1);
+			var row = Rows[y];
+			while (row.Count < x + 1)
+			{
+				row.Add(new Panel());
+			}
+			row[x] = control;
+		}
+
+		[Obsolete("Use the Rows/Columns properties instead")]
+		public void Add(Control control, int x, int y, bool xscale, bool yscale)
+		{
+			Add(control, x, y);
+			SetRowScale(y, yscale);
+			SetColumnScale(x, xscale);
+		}
+
+		[Obsolete("Use the Rows/Columns properties instead")]
+		public void Add(Control control, Point location)
+		{
+			Add(control, location.X, location.Y);
+		}
+
+		[Obsolete("Use TableRow.Height instead")]
+		public void SetRowScale(int row, bool scale = true)
+		{
+			Rows[row].Height = scale ? TableLength.Star() : TableLength.Auto;
+		}
+
+		[Obsolete("Use TableRow.Height instead")]
+		public bool GetRowScale(int row)
+		{
+			return Rows[row].Height.IsStar;
+		}
+
+		[Obsolete("Use TableColumn.Width instead")]
+		public void SetColumnScale(int column, bool scale = true)
+		{
+			EnsureColumns();
+			Columns[column].Width = scale ? TableLength.Star() : TableLength.Auto;
+		}
+
+		[Obsolete("Use TableColumn.Width instead")]
+		public bool GetColumnScale(int column)
+		{
+			return Columns[column].Width.IsStar;
+		}
+
+		protected override void OnSizeChanged(EventArgs e)
+		{
+			base.OnSizeChanged(e);
+			UpdateLayout();
+		}
+
+		public Size Spacing { get; set; }
+
+		public Padding Padding { get; set; }
+
+		bool updating;
+
+		protected override void OnLoadComplete(EventArgs e)
+		{
+			base.OnLoadComplete(e);
+			EnsureColumns();
+			UpdateLayout();
+		}
+
+		void EnsureColumns()
+		{
+			var columnCount = Rows.Max(r => r.Count);
+			while (Columns.Count < columnCount)
+			{
+				Columns.Add(new TableColumn());
+			}
+		}
+
+		public override void UpdateLayout()
+		{
+			//base.UpdateLayout();
+			if (!Loaded || updating)
+				return;
+			updating = true;
+			try
+			{
+				var controlSize = ClientSize;
+				var totalPadding = new SizeF(
+					Padding.Horizontal + Spacing.Width * (Columns.Count - 1),
+					Padding.Vertical + Spacing.Height * (Rows.Count - 1)
+				);
+				var required = SizeF.Empty;
+
+				var num = new Size(Math.Max(1, Columns.Count(r => r.Width.IsStar)), Math.Max(1, Rows.Count(r => r.Height.IsStar)));
+
+				var availableChildSize = SizeF.Max(SizeF.Empty, controlSize - totalPadding);
+
+				var weight = SizeF.Empty;
+				for (int x = 0; x < Columns.Count; x++)
+				{
+					var col = Columns[x];
+					col.ActualWidth = col.Width.IsAbsolute ? col.Width.Value : 0;
+					required.Width += col.ActualWidth;
+					if (col.Width.IsStar)
+						weight.Width += col.Width.Value;
+				}
+
+				for (int y = 0; y < Rows.Count; y++)
+				{
+					var row = Rows[y];
+					row.ActualHeight = row.Height.IsAbsolute ? row.Height.Value : 0;
+					required.Height += row.ActualHeight;
+					if (row.Height.IsStar)
+						weight.Height += row.Height.Value;
+					for (int x = 0; x < row.Count; x++)
+					{	
+						var col = Columns[x];
+						var view = row[x];
+						if (view != null && view.Visible && (col.Width.IsAuto || row.Height.IsAuto))
+						{
+							var size = view.GetPreferredSize(availableChildSize);
+							if (col.Width.IsAuto && size.Width > col.ActualWidth)
+							{
+								required.Width += size.Width - col.ActualWidth;
+								col.ActualWidth = size.Width;
+							}
+							if (row.Height.IsAuto && size.Height > row.ActualHeight)
+							{
+								required.Height += size.Height - row.ActualHeight;
+								row.ActualHeight = size.Height;
+							}
+						}
+					}
+				}
+				var availStarSize = SizeF.Max(SizeF.Empty, availableChildSize - required);
+				for (int y = 0; y < Rows.Count; y++)
+				{
+					var row = Rows[y];
+					var ystar = row.Height.IsStar;
+					var availCellSize = SizeF.Empty;
+					if (ystar)
+						availCellSize.Height = availStarSize.Height * row.Height.Value / weight.Height;
+					else
+						availCellSize.Height = row.ActualHeight;
+					for (int x = 0; x < row.Count; x++)
+					{	
+						var view = row[x];
+						var col = Columns[x];
+						var xstar = col.Width.IsStar;
+						if (xstar)
+							availCellSize.Width = availStarSize.Width * col.Width.Value / weight.Width;
+						else
+							availCellSize.Width = col.ActualWidth;
+						if (view != null && view.Visible && (xstar || ystar))
+						{
+							var size = view.GetPreferredSize(availCellSize);
+							if (xstar && size.Width > col.ActualWidth)
+							{
+								required.Width += size.Width - col.ActualWidth;
+								col.ActualWidth = size.Width;
+							}
+							if ((xstar || ystar) && size.Height > row.ActualHeight)
+							{
+								required.Height += size.Height - row.ActualHeight;
+								row.ActualHeight = size.Height;
+							}
+						}
+					}
+				}
+				var total = controlSize - totalPadding;
+				if (controlSize.Width < required.Width + totalPadding.Width)
+				{
+					//total.Width = required.Width;
+				}
+				if (controlSize.Height < required.Height + totalPadding.Height)
+				{
+					//total.Height = required.Height;
+				}
+
+				for (int y = 0; y < Rows.Count; y++)
+				{
+					var row = Rows[y];
+					if (!row.Height.IsStar)
+						total.Height -= row.ActualHeight;
+				}
+				for (int x = 0; x < Columns.Count; x++)
+				{
+					var col = Columns[x];
+					if (!col.Width.IsStar)
+						total.Width -= col.ActualWidth;
+				}
+
+				for (int x = 0; x < Columns.Count; x++)
+				{
+					var col = Columns[x];
+					if (col.Width.IsStar)
+						col.ActualWidth = total.Width * col.Width.Value / weight.Width;
+				}
+
+				float starty = Padding.Top;
+				for (int y = 0; y < Rows.Count; y++)
+				{
+					var row = Rows[y];
+					if (row.Height.IsStar)
+						row.ActualHeight = total.Height * row.Height.Value / weight.Height;
+					float startx = Padding.Left;
+					for (int x = 0; x < row.Count; x++)
+					{
+						var view = row[x];
+						var col = Columns[x];
+						if (view != null && view.Visible)
+						{
+							var location = new Rectangle((int)startx, (int)starty, (int)col.ActualWidth, (int)row.ActualHeight);
+							Handler.Move(view, location);
+						}
+						startx += col.ActualWidth + Spacing.Width;
+					}
+					starty += row.ActualHeight + Spacing.Height;
+				}
+			}
+			finally
+			{
+				updating = false;
+			}
+		}
+
+		public override SizeF GetPreferredSize(SizeF availableSize)
+		{
+			EnsureColumns();
+			var totalPadding = new SizeF(
+				Padding.Horizontal + Spacing.Width * (Columns.Count - 1),
+				Padding.Vertical + Spacing.Height * (Rows.Count - 1)
+			);
+			var required = SizeF.Empty;
+			var availableChildSize = SizeF.Max(SizeF.Empty, availableSize - totalPadding);
+			var num = new Size(Math.Max(1, Columns.Count(r => r.Width.IsStar)), Math.Max(1, Rows.Count(r => r.Height.IsStar)));
+
+			var weight = SizeF.Empty;
+			for (int x = 0; x < Columns.Count; x++)
+			{
+				var col = Columns[x];
+				col.MeasureWidth = col.Width.IsAbsolute ? col.Width.Value : 0;
+				required.Width += col.MeasureWidth;
+				if (col.Width.IsStar)
+					weight.Width += col.Width.Value;
+			}
+
+			for (int y = 0; y < Rows.Count; y++)
+			{
+				var row = Rows[y];
+				row.MeasureHeight = row.Height.IsAbsolute ? row.Height.Value : 0;
+				required.Height += row.MeasureHeight;
+				if (row.Height.IsStar)
+					weight.Height += row.Height.Value;
+				for (int x = 0; x < row.Count; x++)
+				{	
+					var col = Columns[x];
+					var view = row[x];
+					if (view != null && view.Visible && (!col.Width.IsStar || !row.Height.IsStar))
+					{
+						var size = view.GetPreferredSize(availableChildSize);
+						if (col.Width.IsAuto && size.Width > col.MeasureWidth)
+						{
+							required.Width += size.Width - col.MeasureWidth;
+							col.MeasureWidth = size.Width;
+						}
+						if (row.Height.IsAuto && size.Height > row.MeasureHeight)
+						{
+							required.Height += size.Height - row.MeasureHeight;
+							row.MeasureHeight = size.Height;
+						}
+					}
+				}
+			}
+			var availStarSize = SizeF.Max(SizeF.Empty, availableChildSize - required);
+			for (int y = 0; y < Rows.Count; y++)
+			{
+				var row = Rows[y];
+				var yscale = row.Height.IsStar;
+				var availCellSize = SizeF.Empty;
+				if (yscale)
+					availCellSize.Height = availStarSize.Height * row.Height.Value / weight.Height;
+				else
+					availCellSize.Height = row.MeasureHeight;
+				for (int x = 0; x < row.Count; x++)
+				{	
+					var col = Columns[x];
+					var xscale = col.Width.IsStar;
+					if (xscale)
+						availCellSize.Width = availStarSize.Width * col.Width.Value / weight.Width;
+					else
+						availCellSize.Width = col.MeasureWidth;
+
+					var view = row[x];
+					if (view != null && view.Visible && (xscale || yscale))
+					{
+						var size = view.GetPreferredSize(availCellSize);
+						if (xscale && size.Width > col.MeasureWidth)
+						{
+							required.Width += size.Width - col.MeasureWidth;
+							col.MeasureWidth = size.Width;
+						}
+						if ((xscale || yscale) && size.Height > row.MeasureHeight)
+						{
+							required.Height += size.Height - row.MeasureHeight;
+							row.MeasureHeight = size.Height;
+						}
+					}
+				}
+			}
+			var maxWidth = Columns.Where(r => r.Width.IsStar).Select(r => r.MeasureWidth * weight.Width / r.Width.Value).DefaultIfEmpty().Max();
+			for (int x = 0; x < Columns.Count; x++)
+			{
+				var col = Columns[x];
+				if (!col.Width.IsStar)
+					continue;
+				var width = maxWidth * col.Width.Value / weight.Width;
+				if (width > col.MeasureWidth)
+				{
+					required.Width += width - col.MeasureWidth;
+					col.MeasureWidth = width;
+				}
+				
+			}
+			var maxHeight = Rows.Where(r => r.Height.IsStar).Select(r => r.MeasureHeight * weight.Height / r.Height.Value).DefaultIfEmpty().Max();
+			for (int y = 0; y < Rows.Count; y++)
+			{
+				var row = Rows[y];
+				if (!row.Height.IsStar)
+					continue;
+				var height = maxHeight * row.Height.Value / weight.Height;
+				if (height > row.MeasureHeight)
+				{
+					required.Height += height - row.MeasureHeight;
+					row.MeasureHeight = height;
+				}
+
+			}
+			return required + totalPadding;
+		}
+
+		public override void Remove(Control child)
+		{
+			collection.Remove(child);
+		}
+
+		void UpdateSize(object sender, EventArgs e)
+		{
+			UpdateLayout();
+		}
+
+		internal void EnsureColumns(int columnCount)
+		{
+			while (Columns.Count < columnCount)
+			{
+				Columns.Add(new TableColumn());
+			}
+		}
+
+		void EnsureRows(int rowCount)
+		{
+			while (Rows.Count < rowCount)
+			{
+				Rows.Add(new TableRow2());
+			}
+		}
+
+		internal void Ensure(int columnCount, int rowCount)
+		{
+			EnsureColumns(columnCount);
+			EnsureRows(rowCount);
+		}
+	}
+}
+

--- a/Source/Eto/Forms/Layout/TableRow2.cs
+++ b/Source/Eto/Forms/Layout/TableRow2.cs
@@ -1,0 +1,241 @@
+using System;
+using Eto.Drawing;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Runtime.Serialization;
+using System.Collections.ObjectModel;
+using System.Collections;
+
+namespace Eto.Forms
+{
+
+	public enum TableUnit
+	{
+		Auto,
+		Pixel,
+		Star
+	}
+
+	public struct TableLength
+	{
+		readonly TableUnit type;
+		readonly float value;
+
+		public TableUnit Type { get { return type; } }
+
+		public float Value { get { return value; } }
+
+		public bool IsStar { get { return type == TableUnit.Star; } }
+
+		public bool IsAuto { get { return type == TableUnit.Auto; } }
+
+		public bool IsAbsolute { get { return type == TableUnit.Pixel; } }
+
+		public static readonly TableLength Auto = new TableLength(0, TableUnit.Auto);
+
+		public static TableLength Star(float weight = 1)
+		{
+			return new TableLength(weight, TableUnit.Star);
+		}
+
+		public TableLength(float value, TableUnit type)
+		{
+			this.type = type;
+			this.value = value;
+		}
+
+		public TableLength(float value)
+		{
+			this.type = TableUnit.Pixel;
+			this.value = value;
+		}
+
+		public static implicit operator TableLength(float pixel)
+		{
+			return new TableLength(pixel);
+		}
+
+		public override string ToString()
+		{
+			switch (type)
+			{
+				case TableUnit.Auto:
+					return "Auto";
+				case TableUnit.Pixel:
+					return value.ToString();
+				case TableUnit.Star:
+					return Math.Abs(value - 1.0f) < float.Epsilon ? "*" : value + "*";
+				default:
+					throw new NotSupportedException();
+			}
+		}
+	}
+
+	public class TableColumn
+	{
+		internal float MeasureWidth;
+
+		public float ActualWidth { get; internal set; }
+
+		public TableLength Width { get; set; }
+
+		public TableLength MaxWidth { get; set; }
+
+		public TableLength MinWidth { get; set; }
+	}
+
+	/// <summary>
+	/// Represents the contents of a row in a <see cref="TableLayout"/> 
+	/// </summary>
+	[ContentProperty("Cells")]
+	[TypeConverter(typeof(TableRowConverter))]
+	public class TableRow2 : Collection<Control>
+	{
+		internal TableLayout2 Layout { get; set; }
+		TableLayout2.IHandler Handler { get { return Layout != null ? Layout.Handler as TableLayout2.IHandler : null; } }
+
+		internal float MeasureHeight;
+
+		public float ActualHeight { get; internal set; }
+
+		public TableLength MinHeight { get; set; }
+
+		public TableLength MaxHeight { get; set; }
+
+		public TableLength Height { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="Eto.Forms.TableCell"/> will scale its height
+		/// </summary>
+		/// <remarks>
+		/// All controls in the same row of this cell will get the same scaling value.
+		/// Scaling will make the row expand to fit the rest of the height of the container, minus the preferred
+		/// height of any non-scaled rows.
+		/// 
+		/// If there are no rows with height scaling, the last row will automatically get scaled.
+		/// 
+		/// With scaling turned off, cells in the row will fit the preferred size of the tallest control.
+		/// </remarks>
+		/// <value><c>true</c> if scale height; otherwise, <c>false</c>.</value>
+		[Obsolete("Set Height to TableLenth.Star() instead")]
+		public bool ScaleHeight
+		{
+			get { return Height.IsStar; }
+			set
+			{
+				Height = value ? TableLength.Star() : TableLength.Auto;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the cells in this row.
+		/// </summary>
+		/// <value>The cells in the row.</value>
+		public Collection<Control> Cells
+		{ 
+			get { return this; }
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.TableRow"/> class.
+		/// </summary>
+		public TableRow2()
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.TableRow"/> class with the specified cells.
+		/// </summary>
+		/// <param name="cells">Cells to populate the row.</param>
+		public TableRow2(params Control[] cells)
+		{
+			foreach (var cell in cells)
+				Add(cell);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.TableRow"/> class with the specified cells.
+		/// </summary>
+		/// <param name="cells">Cells to populate the row.</param>
+		public TableRow2(IEnumerable<Control> cells)
+		{
+			foreach (var cell in cells)
+				Add(cell);
+		}
+
+		/// <summary>
+		/// Implicitly converts a control to a TableRow
+		/// </summary>
+		/// <remarks>
+		/// Used to make defining a table's contents easier by allowing you to pass a control as a table row
+		/// </remarks>
+		/// <param name="control">Control to convert.</param>
+		public static implicit operator TableRow2(Control control)
+		{
+			return new TableRow2(control);
+		}
+
+		/// <summary>
+		/// Implicitly converts an array of cells to a TableRow
+		/// </summary>
+		/// <param name="cells">Cells to convert.</param>
+		public static implicit operator TableRow2(Control[] cells)
+		{
+			return new TableRow2(cells);
+		}
+
+		/// <summary>
+		/// Converts a string to a TableRow with a label control implicitly.
+		/// </summary>
+		/// <remarks>
+		/// This provides an easy way to add labels to your layout through code, without having to create <see cref="Label"/> instances.
+		/// </remarks>
+		/// <param name="labelText">Text to convert to a Label control.</param>
+		public static implicit operator TableRow2(string labelText)
+		{
+			return new TableRow2(new Label { Text = labelText });
+		}
+
+		/// <summary>
+		/// Implicitly converts a TableRow to a control
+		/// </summary>
+		/// <remarks>
+		/// Used to make defining a table's contents easier by allowing you to pass a table row as a control.
+		/// </remarks>
+		/// <param name="row">Row to convert.</param>
+		public static implicit operator Control(TableRow2 row)
+		{
+			return new TableLayout2 { Rows = { row } };
+		}
+
+		protected override void InsertItem(int index, Control item)
+		{
+			//if (item == null)
+			//	item = new Panel { HorizontalAlignment = HorizontalAlignment.Stretch };
+			base.InsertItem(index, item);
+			if (Layout != null)
+			{
+				Layout.EnsureColumns(index + 1);
+				if (item != null)
+					Handler.Add(item);
+			}
+		}
+
+		protected override void SetItem(int index, Control item)
+		{
+			var handler = Handler;
+			if (handler != null && this[index] != null)
+			{
+				handler.Remove(this[index]);
+			}
+			//if (item == null)
+			//	item = new Panel { HorizontalAlignment = HorizontalAlignment.Stretch };
+			base.SetItem(index, item);
+			if (handler != null && item != null)
+			{
+				handler.Add(item);
+			}
+		}
+	}
+}


### PR DESCRIPTION
This PR is the initial layout re-write to move layout logic into Eto.Forms instead of relying on each platform control to provide this functionality (which each have hacks to make them behave similarly).

Ideally we can get rid of the hacks, and just make sure each control supports a Measure() and Layout() pass, where the Measure() would determine its preferred size based on the container, and Layout() would position its child controls.  This would greatly simplify the layout logic, make it easier to add other platforms, and also make it much easier to add additional layout options, such as a FlowLayout (which is included in this PR), etc.
