### PR TITLE
Fix Gtk2/Gtk3 button menu event firing for Ubuntu

### DIFF
--- a/Source/Eto.Gtk/Drawing/SystemColorsHandler.cs
+++ b/Source/Eto.Gtk/Drawing/SystemColorsHandler.cs
@@ -6,10 +6,11 @@ namespace Eto.GtkSharp.Drawing
 	public class SystemColorsHandler : SystemColors.IHandler
 	{
 		readonly Gtk.TextView entry = new Gtk.TextView();
+		readonly Gtk.Entry textEntry = new Gtk.Entry();
 
 		public Color ControlText
 		{
-			get { return entry.GetTextColor(GtkStateFlags.Normal); }
+			get { return textEntry.GetTextColor(GtkStateFlags.Normal); }
 		}
 
 		public Color HighlightText

--- a/Source/Eto.Gtk/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/Source/Eto.Gtk/Forms/Menu/ButtonMenuItemHandler.cs
@@ -73,9 +73,8 @@ namespace Eto.GtkSharp.Forms.Menu
 				if (Handler.isSubMenu == result) {
 					if (result)
 						(Handler.Control.Parent as Gtk.Menu)?.Deactivate ();
-					
-					Handler.Callback.OnClick (Handler.Widget, e);
 				}
+				Handler.Callback.OnClick (Handler.Widget, e);
 			}
 		}
 


### PR DESCRIPTION
Ubuntu application menus act slightly differently than standard Gtk menus. This one line change fixes menu items not firing to the event handlers in client code.