### PR TITLE
Fix RadioCommand NullException when using with Menu

### DIFF
--- a/Source/Eto/Forms/Menu/RadioMenuItem.cs
+++ b/Source/Eto/Forms/Menu/RadioMenuItem.cs
@@ -47,9 +47,9 @@ namespace Eto.Forms
 			: base(command)
 		{
 			Checked = command.Checked;
+			Handler.Create(controller);
 			CheckedChanged += (sender, e) => command.Checked = Checked;
 			command.CheckedChanged += (sender, e) => Checked = command.Checked;
-			Handler.Create(controller);
 			Initialize();
 			Handler.CreateFromCommand(command);
 		}


### PR DESCRIPTION
The error was happening because you were trying to connect events before creating the main object.