### PR TITLE
Remove workaround for ButtonMenuItem Activated event

### DIFF
--- a/Source/Eto.Gtk/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/Source/Eto.Gtk/Forms/Menu/ButtonMenuItemHandler.cs
@@ -11,7 +11,6 @@ namespace Eto.GtkSharp.Forms.Menu
 		Keys shortcut;
 		Image image;
 		readonly Gtk.AccelLabel label;
-		bool isSubMenu;
 
 		public ButtonMenuItemHandler()
 		{
@@ -28,8 +27,6 @@ namespace Eto.GtkSharp.Forms.Menu
 		{
 			base.Initialize();
 			Control.Activated += Connector.HandleActivated;
-			Control.Selected += Connector.HandleSelected;
-            Control.ButtonReleaseEvent += Connector.HandleButtonReleased;
 		}
 
 		protected new ButtonMenuItemConnector Connector { get { return (ButtonMenuItemConnector)base.Connector; } }
@@ -47,35 +44,8 @@ namespace Eto.GtkSharp.Forms.Menu
 			{
 				if (Handler.Control.Submenu != null)
 					Handler.ValidateItems();
-
-				HandleClick (sender, e, false);
-			}
-
-			public void HandleSelected(object sender, EventArgs e)
-			{
-				var menu = Handler.Control.Parent as Gtk.MenuBar;
-
-				// if there's no submenu, trigger the click and deactivate the menu to make it act 'normally'.
-				// this does not work in ubuntu's unity menu
-				if (menu != null && Handler.Control.Submenu == null)
-					menu.Deactivate();
-			}
-
-            // This even is needed because submenus of context menus never get focus
-            // unless the parrent menuitem is clicked
-            public void HandleButtonReleased(object sender, EventArgs e)
-            {
-				HandleClick (sender, e, true);
-            }
-
-			private void HandleClick (object sender, EventArgs e, bool result)
-			{
-				if (Handler.isSubMenu == result) {
-					if (result)
-						(Handler.Control.Parent as Gtk.Menu)?.Deactivate ();
-					
-					Handler.Callback.OnClick (Handler.Widget, e);
-				}
+				
+				Handler.Callback.OnClick (Handler.Widget, e);
 			}
 		}
 
@@ -136,9 +106,6 @@ namespace Eto.GtkSharp.Forms.Menu
 			if (Control.Submenu == null) Control.Submenu = new Gtk.Menu();
 			((Gtk.Menu)Control.Submenu).Insert((Gtk.Widget)item.ControlObject, index);
 			SetChildAccelGroup(item);
-
-			if (item is ButtonMenuItem)
-				((item as ButtonMenuItem).Handler as ButtonMenuItemHandler).isSubMenu = true;
 		}
 
 		public void RemoveMenu(MenuItem item)
@@ -150,9 +117,6 @@ namespace Eto.GtkSharp.Forms.Menu
 			{
 				Control.Submenu = null;
 			}
-
-			if (item is ButtonMenuItem)
-				((item as ButtonMenuItem).Handler as ButtonMenuItemHandler).isSubMenu = false;
 		}
 
 		public void Clear()


### PR DESCRIPTION
The bug where submenu of contextmenu items were not firing activated signal was fixed in some recent release of Gtk 3 (the bug didn't exist in Gtk 2 afaik). This will also fix Ubuntu Unity menu not firing events, it didn't register ButtonPress and ButtonRelease events.