### PR TITLE
Fix removing controls from a TableLayout

### DIFF
--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Layout/StackLayoutTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Layout/StackLayoutTests.cs
@@ -107,6 +107,36 @@ namespace Eto.Test.UnitTests.Forms.Layout
 				Assert.IsNull(child.Parent);
 			});
 		}
+
+		[Test]
+		public void LogicalParentShouldChangeWhenAddedOrRemovedWhenLoaded()
+		{
+			Shown(form => new StackLayout(), stack =>
+			{
+				var child = new Panel();
+				stack.Items.Add(child);
+				Assert.IsNotNull(child.VisualParent);
+				Assert.IsInstanceOf<TableLayout>(child.VisualParent);
+				Assert.AreSame(stack, child.Parent);
+				stack.Items.Clear();
+				Assert.IsNull(child.VisualParent);
+				Assert.IsNull(child.Parent);
+				stack.Items.Add(child);
+				Assert.IsNotNull(child.VisualParent);
+				Assert.IsInstanceOf<TableLayout>(child.VisualParent);
+				Assert.AreSame(stack, child.Parent);
+				stack.Items.RemoveAt(0);
+				Assert.IsNull(child.VisualParent);
+				Assert.IsNull(child.Parent);
+				stack.Items.Insert(0, child);
+				Assert.IsNotNull(child.VisualParent);
+				Assert.IsInstanceOf<TableLayout>(child.VisualParent);
+				Assert.AreSame(stack, child.Parent);
+				stack.Items[0] = new StackLayoutItem();
+				Assert.IsNull(child.VisualParent);
+				Assert.IsNull(child.Parent);
+			});
+		}
 	}
 }
 

--- a/Source/Eto/Forms/Container.cs
+++ b/Source/Eto/Forms/Container.cs
@@ -277,7 +277,6 @@ namespace Eto.Forms
 				child.VisualParent = null;
 				if (child.LogicalParent == this)
 					child.LogicalParent = null;
-				//child.TriggerDataContextChanged(true);
 			}
 		}
 
@@ -318,6 +317,7 @@ namespace Eto.Forms
 			{
 				throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "The child control is not a logical child of this container. Ensure you only remove children that you own."));
 			}
+			child.Detach();
 			child.LogicalParent = null;
 		}
 

--- a/Source/Eto/Forms/Layout/TableCell.cs
+++ b/Source/Eto/Forms/Layout/TableCell.cs
@@ -47,9 +47,9 @@ namespace Eto.Forms
 				{
 					value?.Detach();
 					control?.Detach();
-					layout?.RemoveParent(control);
+					layout?.InternalRemoveLogicalParent(control);
 					control = value;
-					layout?.SetParent(control);
+					layout?.InternalSetLogicalParent(control);
 				}
 			}
 		}
@@ -132,9 +132,9 @@ namespace Eto.Forms
 		{
 			if (!ReferenceEquals(this.layout, layout))
 			{
-				this.layout?.RemoveParent(control);
+				this.layout?.InternalRemoveLogicalParent(control);
 				this.layout = layout;
-				layout?.SetParent(control);
+				layout?.InternalSetLogicalParent(control);
 			}
 		}
 	}

--- a/Source/Eto/Forms/Layout/TableLayout.cs
+++ b/Source/Eto/Forms/Layout/TableLayout.cs
@@ -574,16 +574,16 @@ namespace Eto.Forms
 			return new TableLayout(rows);
 		}
 
-		internal void SetParent(Control control)
+		internal void InternalSetLogicalParent(Control control)
 		{
 			if (control?.LogicalParent == null)
 				SetLogicalParent(control);
 		}
 
-		internal void RemoveParent(Control control)
+		internal void InternalRemoveLogicalParent(Control control)
 		{
 			if (ReferenceEquals(control?.LogicalParent, this))
 				RemoveLogicalParent(control);
 		}
-}
+	}
 }


### PR DESCRIPTION
- Also detach a control when it is removed from the logical parent, so that when you remove items from StackLayout/etc it will remove it from the visual tree immediately.