### PR TITLE
Fix calling GetPixel on 24bpp bitmaps in Gtk2

### DIFF
--- a/Source/Eto.Direct2D/Drawing/ImageHandler.cs
+++ b/Source/Eto.Direct2D/Drawing/ImageHandler.cs
@@ -148,7 +148,11 @@ namespace Eto.Direct2D.Drawing
 			{
 				var output = new uint[1];
 				Control.CopyPixels(new s.Rectangle(x, y, 1, 1), output);
-				return new s.Color4(new s.ColorBGRA(output[0]).ToRgba()).ToEto();
+				var eto = new s.Color4(new s.ColorBGRA(output[0]).ToRgba()).ToEto();
+				if (Control.PixelFormat == sw.PixelFormat.Format24bppBGR)
+					return Color.FromRgb(eto.ToArgb());
+				else
+					return eto;
 			}
 			catch (s.SharpDXException ex)
 			{

--- a/Source/Eto.Gtk/Drawing/BitmapHandler.cs
+++ b/Source/Eto.Gtk/Drawing/BitmapHandler.cs
@@ -262,10 +262,7 @@ namespace Eto.GtkSharp.Drawing
 					}
 					if (data.BytesPerPixel == 3)
 					{
-						var b = *(srcrow++);
-						var g = *(srcrow++);
-						var r = *(srcrow++);
-						return Color.FromArgb(r, g, b);
+						return Color.FromRgb(data.TranslateDataToArgb(*(int*)srcrow));
 					}
 					throw new NotSupportedException();
 				}

--- a/Source/Eto.Mac/Drawing/BitmapHandler.cs
+++ b/Source/Eto.Mac/Drawing/BitmapHandler.cs
@@ -279,7 +279,7 @@ namespace Eto.Mac.Drawing
 			if (bmprep == null)
 				throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "Cannot get pixel data for this type of bitmap ({0})", rep?.GetType()));
 
-			return bmprep.ColorAt(x, y).ToEto();
+			return bmprep.ColorAt(x, y).ToEto(false);
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Source/Eto.Test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
@@ -61,6 +61,96 @@ namespace Eto.Test.UnitTests.Drawing
 			ValidateImages(image, clone, rect);
 		}
 
+		[TestCase(1.0f, 0.0f, 0.0f)]
+		[TestCase(0.0f, 1.0f, 0.0f)]
+		[TestCase(0.0f, 0.0f, 1.0f)]
+		[TestCase(0.0f, 1.0f, 1.0f)]
+		[TestCase(1.0f, 0.0f, 1.0f)]
+		[TestCase(1.0f, 1.0f, 0.0f)]
+		public void TestGetPixelWithLock24bit(float red, float green, float blue)
+		{
+			var colorSet = new Color(red, green, blue);
+
+			var image = new Bitmap(new Size(1, 1), PixelFormat.Format24bppRgb);
+			image.SetPixel(0, 0, colorSet);
+
+			using (var data = image.Lock())
+			{
+				var colorGet = data.GetPixel(0, 0);
+
+				if (colorSet != colorGet)
+				{
+					Assert.Fail("Pixels are not the same (SetPixel: {0}, GetPixel: {1})", colorSet, colorGet);
+				}
+			}
+		}
+
+		[TestCase(1.0f, 0.0f, 0.0f)]
+		[TestCase(0.0f, 1.0f, 0.0f)]
+		[TestCase(0.0f, 0.0f, 1.0f)]
+		[TestCase(0.0f, 1.0f, 1.0f)]
+		[TestCase(1.0f, 0.0f, 1.0f)]
+		[TestCase(1.0f, 1.0f, 0.0f)]
+		public void TestGetPixelWithoutLock24bit(float red, float green, float blue)
+		{
+			var colorSet = new Color(red, green, blue);
+
+			var image = new Bitmap(new Size(1, 1), PixelFormat.Format24bppRgb);
+			image.SetPixel(0, 0, colorSet);
+
+			var colorGet = image.GetPixel(0, 0);
+
+			if (colorSet != colorGet)
+			{
+				Assert.Fail("Pixels are not the same (SetPixel: {0}, GetPixel: {1})", colorSet, colorGet);
+			}
+		}
+
+		[TestCase(1.0f, 0.0f, 0.0f, 1.0f)]
+		[TestCase(0.0f, 1.0f, 0.0f, 0.5f)]
+		[TestCase(0.0f, 0.0f, 1.0f, 0.0f)]
+		[TestCase(0.0f, 1.0f, 1.0f, 1.0f)]
+		[TestCase(1.0f, 0.0f, 1.0f, 0.5f)]
+		[TestCase(1.0f, 1.0f, 0.0f, 0.0f)]
+		public void TestGetPixelWithLock32bit(float red, float green, float blue, float alpha)
+		{
+			var colorSet = new Color(red, green, blue, alpha);
+
+			var image = new Bitmap(new Size(1, 1), PixelFormat.Format32bppRgba);
+			image.SetPixel(0, 0, colorSet);
+
+			using (var data = image.Lock())
+			{
+				var colorGet = data.GetPixel(0, 0);
+
+				if (colorSet != colorGet)
+				{
+					Assert.Fail("Pixels are not the same (SetPixel: {0}, GetPixel: {1})", colorSet, colorGet);
+				}
+			}
+		}
+
+		[TestCase(1.0f, 0.0f, 0.0f, 1.0f)]
+		[TestCase(0.0f, 1.0f, 0.0f, 0.5f)]
+		[TestCase(0.0f, 0.0f, 1.0f, 0.0f)]
+		[TestCase(0.0f, 1.0f, 1.0f, 1.0f)]
+		[TestCase(1.0f, 0.0f, 1.0f, 0.5f)]
+		[TestCase(1.0f, 1.0f, 0.0f, 0.0f)]
+		public void TestGetPixelWithoutLock32bit(float red, float green, float blue, float alpha)
+		{
+			var colorSet = new Color(red, green, blue, alpha);
+
+			var image = new Bitmap(new Size(1, 1), PixelFormat.Format32bppRgba);
+			image.SetPixel(0, 0, colorSet);
+
+			var colorGet = image.GetPixel(0, 0);
+
+			if (colorSet != colorGet)
+			{
+				Assert.Fail("Pixels are not the same (SetPixel: {0}, GetPixel: {1})", colorSet, colorGet);
+			}
+		}
+
 		static void ValidateImages(Bitmap image, Bitmap clone, Rectangle? rect = null)
 		{
 			var testRect = rect ?? new Rectangle(image.Size);

--- a/Source/Eto.Wpf/Drawing/BitmapHandler.cs
+++ b/Source/Eto.Wpf/Drawing/BitmapHandler.cs
@@ -139,6 +139,8 @@ namespace Eto.Wpf.Drawing
 
 				if (Control.Format == swm.PixelFormats.Rgb24)
 					return Color.FromArgb(red: pixels[0], green: pixels[1], blue: pixels[2]);
+				if (Control.Format == swm.PixelFormats.Bgr24)
+					return Color.FromArgb(blue: pixels[0], green: pixels[1], red: pixels[2]);
 				if (Control.Format == swm.PixelFormats.Bgr32)
 					return Color.FromArgb(blue: pixels[0], green: pixels[1], red: pixels[2]);
 				if (Control.Format == swm.PixelFormats.Bgra32)


### PR DESCRIPTION
I've been toying with the as-yet-unofficial OpenGL control you, Phil Stopford and the SharpFlame devs have been working on, and in the process of dealing with texture loading I was led to a small bug in Eto's Bitmap class:

In Gtk2, when calling GetPixel on a 24bpp Bitmap without explicitly using Lock, the returned color has its red and blue components swapped. Conversely, calling Lock and using the version of GetPixel provided by the returned BitmapData works as expected.

Comparing the two functions, I think I see why [the BitmapData method](https://github.com/picoe/Eto/blob/develop/Source/Shared/BaseBitmapData.cs#L41) works, while [the BitmapHandler version](https://github.com/picoe/Eto/blob/develop/Source/Eto.Gtk/Drawing/BitmapHandler.cs#L250) is broken, with the latter assuming BGR ordering. Instead of just switching the 'r' and 'b' variables, though, I've taken the liberty of bringing the 24bpp code in line with the 32bpp code. I've tested my changes in Gtk2 under Windows 10 and Ubuntu 14.04 and everything seems to be in order, but please rap me on the knuckles if I should have handled this differently.

This being my first PR, I've tried not to overreach, but I do notice there could be call for further changes to make this GetPixel more closely match the other one. Variable names, whitespace, and perhaps the addition of the IndexedBitmap stuff? I'm not sure how similar the two methods need to be, but I'll gladly amend this commit if you want me to make any other modifications.