### PR TITLE
Wpf: Fix creating/manipulating Bitmap objects from multiple threads

### DIFF
--- a/Source/Eto.Test/Eto.Test/UnitTests/TestBase.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/TestBase.cs
@@ -239,7 +239,7 @@ namespace Eto.Test.UnitTests
 		/// <param name="test">Delegate to execute on the form when shown</param>
 		/// <param name="replay">Replay the init and test again after shown</param>
 		/// <param name="timeout">Timeout to wait for the operation to complete</param>
-		public static void Shown<T>(Func<Form, T> init, Action<T> test, bool replay = false, int timeout = DefaultTimeout)
+		public static void Shown<T>(Func<Form, T> init, Action<T> test = null, bool replay = false, int timeout = DefaultTimeout)
 			where T : Control
 		{
 			var application = Application;
@@ -251,15 +251,18 @@ namespace Eto.Test.UnitTests
 				{
 					try
 					{
-						test(control);
-						if (replay)
+						if (test != null)
 						{
-							form.Content = null;
-							control = init(form);
-							if (control != null && form.Content == null && control != form)
-								form.Content = control;
-							if (application == null)
-								test(control);
+							test(control);
+							if (replay)
+							{
+								form.Content = null;
+								control = init(form);
+								if (control != null && form.Content == null && control != form)
+									form.Content = control;
+								if (application == null)
+									test(control);
+							}
 						}
 					}
 					catch (Exception ex)

--- a/Source/Eto.Wpf/Drawing/BitmapHandler.cs
+++ b/Source/Eto.Wpf/Drawing/BitmapHandler.cs
@@ -53,18 +53,12 @@ namespace Eto.Wpf.Drawing
 
 		public void Create(string fileName)
 		{
-			ApplicationHandler.InvokeIfNecessary(() =>
-			{
-				Control = swmi.BitmapFrame.Create(new Uri(fileName), swmi.BitmapCreateOptions.None, swmi.BitmapCacheOption.OnLoad);
-			});
+			Control = swmi.BitmapFrame.Create(new Uri(fileName), swmi.BitmapCreateOptions.None, swmi.BitmapCacheOption.OnLoad);
 		}
 
 		public void Create(Stream stream)
 		{
-			ApplicationHandler.InvokeIfNecessary(() =>
-			{
-				Control = swmi.BitmapFrame.Create(stream, swmi.BitmapCreateOptions.None, swmi.BitmapCacheOption.OnLoad);
-			});
+			Control = swmi.BitmapFrame.Create(stream, swmi.BitmapCreateOptions.None, swmi.BitmapCacheOption.OnLoad);
 		}
 
 		public void Create(int width, int height, PixelFormat pixelFormat)
@@ -87,11 +81,8 @@ namespace Eto.Wpf.Drawing
 				default:
 					throw new NotSupportedException();
 			}
-			ApplicationHandler.InvokeIfNecessary(() =>
-			{
-				var bf = new swmi.WriteableBitmap(width, height, 96, 96, format, null);
-				Control = bf;
-			});
+			var bf = new swmi.WriteableBitmap(width, height, 96, 96, format, null);
+			Control = bf;
 
 		}
 
@@ -102,82 +93,78 @@ namespace Eto.Wpf.Drawing
 
 		public void Create(Image image, int width, int height, ImageInterpolation interpolation)
 		{
-			ApplicationHandler.InvokeIfNecessary(() =>
-			{
-				var source = image.ToWpfScale(1, new Size(width, height));
-				// use drawing group to allow for better quality scaling
-				var group = new swm.DrawingGroup();
-				swm.RenderOptions.SetBitmapScalingMode(group, interpolation.ToWpf());
-				group.Children.Add(new swm.ImageDrawing(source, new sw.Rect(0, 0, width, height)));
+			var source = image.ToWpfScale(1, new Size(width, height));
+			// use drawing group to allow for better quality scaling
+			var group = new swm.DrawingGroup();
+			swm.RenderOptions.SetBitmapScalingMode(group, interpolation.ToWpf());
+			group.Children.Add(new swm.ImageDrawing(source, new sw.Rect(0, 0, width, height)));
 
-				var drawingVisual = new swm.DrawingVisual();
-				using (var drawingContext = drawingVisual.RenderOpen())
-					drawingContext.DrawDrawing(group);
+			var drawingVisual = new swm.DrawingVisual();
+			using (var drawingContext = drawingVisual.RenderOpen())
+				drawingContext.DrawDrawing(group);
 
-				var resizedImage = new swmi.RenderTargetBitmap(width, height, source.DpiX, source.DpiY, swm.PixelFormats.Default);
-				resizedImage.RenderWithCollect(drawingVisual);
-				Control = resizedImage;
-			});
+			var resizedImage = new swmi.RenderTargetBitmap(width, height, source.DpiX, source.DpiY, swm.PixelFormats.Default);
+			resizedImage.RenderWithCollect(drawingVisual);
+			Control = resizedImage;
+		}
+
+		protected override void Initialize()
+		{
+			base.Initialize();
+			SetFrozen();
 		}
 
 		public void SetBitmap(swmi.BitmapSource bitmap)
 		{
 			Control = bitmap;
+			SetFrozen();
 		}
 
 		public Color GetPixel(int x, int y)
 		{
-			return ApplicationHandler.InvokeIfNecessary(() =>
-			{
-				var rect = new sw.Int32Rect(x, y, 1, 1);
+			var rect = new sw.Int32Rect(x, y, 1, 1);
+			var control = FrozenControl;
 
-				var pixelStride = (rect.Width * Control.Format.BitsPerPixel + 7) / 8;
+			var pixelStride = (rect.Width * control.Format.BitsPerPixel + 7) / 8;
 
-				var pixels = new byte[pixelStride * rect.Height];
+			var pixels = new byte[pixelStride * rect.Height];
 
-				Control.CopyPixels(rect, pixels, stride: pixelStride, offset: 0);
+			control.CopyPixels(rect, pixels, stride: pixelStride, offset: 0);
 
-				if (Control.Format == swm.PixelFormats.Rgb24)
-					return Color.FromArgb(red: pixels[0], green: pixels[1], blue: pixels[2]);
-				if (Control.Format == swm.PixelFormats.Bgr24)
-					return Color.FromArgb(blue: pixels[0], green: pixels[1], red: pixels[2]);
-				if (Control.Format == swm.PixelFormats.Bgr32)
-					return Color.FromArgb(blue: pixels[0], green: pixels[1], red: pixels[2]);
-				if (Control.Format == swm.PixelFormats.Bgra32)
-					return Color.FromArgb(blue: pixels[0], green: pixels[1], red: pixels[2], alpha: pixels[3]);
-				if (Control.Format == swm.PixelFormats.Pbgra32)
-					return Color.FromArgb(blue: pixels[0], green: pixels[1], red: pixels[2], alpha: pixels[3]);
-				throw new NotSupportedException();
-			});
+			if (control.Format == swm.PixelFormats.Rgb24)
+				return Color.FromArgb(red: pixels[0], green: pixels[1], blue: pixels[2]);
+			if (control.Format == swm.PixelFormats.Bgr24)
+				return Color.FromArgb(blue: pixels[0], green: pixels[1], red: pixels[2]);
+			if (control.Format == swm.PixelFormats.Bgr32)
+				return Color.FromArgb(blue: pixels[0], green: pixels[1], red: pixels[2]);
+			if (control.Format == swm.PixelFormats.Bgra32)
+				return Color.FromArgb(blue: pixels[0], green: pixels[1], red: pixels[2], alpha: pixels[3]);
+			if (control.Format == swm.PixelFormats.Pbgra32)
+				return Color.FromArgb(blue: pixels[0], green: pixels[1], red: pixels[2], alpha: pixels[3]);
+			throw new NotSupportedException();
 		}
 
 		public BitmapData Lock()
 		{
-			return ApplicationHandler.InvokeIfNecessary(() =>
+			var wb = Control as swmi.WriteableBitmap;
+			if (wb == null || RequiresFrozen)
 			{
-				var wb = Control as swmi.WriteableBitmap;
-				if (wb == null)
-				{
-					wb = new swmi.WriteableBitmap(Control);
-					SetBitmap(wb);
-				}
-				wb.Lock();
-				return new BitmapDataHandler(Widget, wb.BackBuffer, Stride, Control.Format.BitsPerPixel, wb);
-			});
+				wb = new swmi.WriteableBitmap(FrozenControl);
+				SetBitmap(wb);
+			}
+			wb.Lock();
+			return new BitmapDataHandler(Widget, wb.BackBuffer, Stride, wb.Format.BitsPerPixel, wb);
 		}
 
 		public void Unlock(BitmapData bitmapData)
 		{
-			ApplicationHandler.InvokeIfNecessary(() =>
+			var wb = Control as swmi.WriteableBitmap;
+			if (wb != null)
 			{
-				var wb = Control as swmi.WriteableBitmap;
-				if (wb != null)
-				{
-
-					wb.AddDirtyRect(new sw.Int32Rect(0, 0, Size.Width, Size.Height));
-					wb.Unlock();
-				}
-			});
+				wb.AddDirtyRect(new sw.Int32Rect(0, 0, Size.Width, Size.Height));
+				wb.Unlock();
+				SetFrozen();
+			}
 		}
 
  		public void Save(string fileName, ImageFormat format)
@@ -190,67 +177,77 @@ namespace Eto.Wpf.Drawing
 
 		public void Save(Stream stream, ImageFormat format)
 		{
-			ApplicationHandler.InvokeIfNecessary(() =>
+			swmi.BitmapEncoder encoder;
+			switch (format)
 			{
-				swmi.BitmapEncoder encoder;
-				switch (format)
-				{
-					case ImageFormat.Png:
-						encoder = new swmi.PngBitmapEncoder();
-						break;
-					case ImageFormat.Gif:
-						encoder = new swmi.GifBitmapEncoder();
-						break;
-					case ImageFormat.Bitmap:
-						encoder = new swmi.BmpBitmapEncoder();
-						break;
-					case ImageFormat.Jpeg:
-						encoder = new swmi.JpegBitmapEncoder();
-						break;
-					case ImageFormat.Tiff:
-						encoder = new swmi.TiffBitmapEncoder();
-						break;
-					default:
-						throw new NotSupportedException();
-				}
-				encoder.Frames.Add(swmi.BitmapFrame.Create(Control));
-				encoder.Save(stream);
-			});
+				case ImageFormat.Png:
+					encoder = new swmi.PngBitmapEncoder();
+					break;
+				case ImageFormat.Gif:
+					encoder = new swmi.GifBitmapEncoder();
+					break;
+				case ImageFormat.Bitmap:
+					encoder = new swmi.BmpBitmapEncoder();
+					break;
+				case ImageFormat.Jpeg:
+					encoder = new swmi.JpegBitmapEncoder();
+					break;
+				case ImageFormat.Tiff:
+					encoder = new swmi.TiffBitmapEncoder();
+					break;
+				default:
+					throw new NotSupportedException();
+			}
+			encoder.Frames.Add(swmi.BitmapFrame.Create(Control));
+			encoder.Save(stream);
 		}
 
 		public Size Size
 		{
-			get { return ApplicationHandler.InvokeIfNecessary(() => new Size(Control.PixelWidth, Control.PixelHeight)); }
+			get { return new Size(FrozenControl.PixelWidth, FrozenControl.PixelHeight); }
+		}
+
+
+		bool RequiresFrozen => Control.Dispatcher?.CheckAccess() != true;
+		swmi.BitmapSource frozenControl;
+		swmi.BitmapSource FrozenControl
+		{
+			get
+			{
+				if (!RequiresFrozen)
+					return Control;
+				return frozenControl ?? Control;
+			}
+		}
+
+		void SetFrozen()
+		{
+			frozenControl = Control.GetAsFrozen() as swmi.BitmapSource;
 		}
 
 		public swmi.BitmapSource GetImageClosestToSize(int? width)
 		{
-			return Control;
+			return FrozenControl;
 		}
 
 		public Bitmap Clone(Rectangle? rectangle = null)
 		{
-			var clone = ApplicationHandler.InvokeIfNecessary(() =>
+			if (rectangle != null)
 			{
-				if (rectangle != null)
-				{
-					var rect = rectangle.Value;
-					var data = new byte[Stride * Control.PixelHeight];
-					Control.CopyPixels(data, Stride, 0);
-					var target = new swmi.WriteableBitmap(rect.Width, rect.Height, Control.DpiX, Control.DpiY, Control.Format, Control.Palette);
-					target.WritePixels(rect.ToWpfInt32(), data, Stride, destinationX: 0, destinationY: 0);
-					return target;
-				}
-				else
-					return Control.Clone();
-			});
-
-			return new Bitmap(new BitmapHandler(clone));
+				var rect = rectangle.Value;
+				var data = new byte[Stride * Control.PixelHeight];
+				FrozenControl.CopyPixels(data, Stride, 0);
+				var target = new swmi.WriteableBitmap(rect.Width, rect.Height, Control.DpiX, Control.DpiY, Control.Format, Control.Palette);
+				target.WritePixels(rect.ToWpfInt32(), data, Stride, destinationX: 0, destinationY: 0);
+				return new Bitmap(new BitmapHandler(target));
+			}
+			else
+				return new Bitmap(new BitmapHandler(FrozenControl.Clone()));
 		}
 
 		int Stride
 		{
-			get { return (Control.PixelWidth * Control.Format.BitsPerPixel + 7) / 8; }
+			get { return (FrozenControl.PixelWidth * FrozenControl.Format.BitsPerPixel + 7) / 8; }
 		}
 	}
 }

--- a/Source/Eto.Wpf/Drawing/GraphicsHandler.cs
+++ b/Source/Eto.Wpf/Drawing/GraphicsHandler.cs
@@ -82,7 +82,7 @@ namespace Eto.Wpf.Drawing
 			drawingVisual = new swm.DrawingVisual();
 			visual = drawingVisual;
 			Control = drawingVisual.RenderOpen();
-			Control.DrawImage(image.ControlObject as swm.ImageSource, bounds);
+			Control.DrawImage(image.ToWpf(), bounds);
         }
 
 		protected override void Initialize()
@@ -323,14 +323,13 @@ namespace Eto.Wpf.Drawing
 			{
 				Control.Close();
 				var handler = (BitmapHandler)image.Handler;
-				var bmp = handler.Control;
+				var bmp = image.ToWpf();
 				var newbmp = bmp as swmi.RenderTargetBitmap;
-				if (newbmp == null)
-				{
+				if (newbmp == null || newbmp.IsFrozen)
 					newbmp = new swmi.RenderTargetBitmap(bmp.PixelWidth, bmp.PixelHeight, bmp.DpiX, bmp.DpiY, swm.PixelFormats.Pbgra32);
-					handler.SetBitmap(newbmp);
-				}
+
 				newbmp.RenderWithCollect(visual);
+				handler.SetBitmap(newbmp);
 				return true;
 			}
 			return false;


### PR DESCRIPTION
Also added tests to ensure bitmaps can be created/updated from multiple threads using Graphics and/or Lock()

Fixes #485