### PR TITLE
[Gtk] Allow combobox to be lower size than it's longest item

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/DropDownHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/DropDownHandler.cs
@@ -64,6 +64,20 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
+		public override Size Size
+		{
+			get { return base.Size; }
+			set
+			{
+				if (value.Width == -1)
+					text.Ellipsize = Pango.EllipsizeMode.None;
+				else
+					text.Ellipsize = Pango.EllipsizeMode.End;
+
+				base.Size = value;
+			}
+		}
+
 		public virtual int SelectedIndex
 		{
 			get { return Control.Active; }


### PR DESCRIPTION
This PR allows for the combobox to be lower width than it's longest item. In case the item cannot fit in the combobox it will have "..." at the end.