### PR TITLE
Prevent possible stack overflow with EmbeddedAssemblyLoader

### DIFF
--- a/Source/Shared/EmbeddedAssemblyLoader.cs
+++ b/Source/Shared/EmbeddedAssemblyLoader.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Reflection;
 
@@ -18,7 +19,7 @@ namespace Eto
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	public class EmbeddedAssemblyLoader
 	{
-		readonly Dictionary<string, Assembly> loadedAssemblies = new Dictionary<string, Assembly> ();
+		readonly Dictionary<string, Assembly> loadedAssemblies = new Dictionary<string, Assembly>();
 
 		/// <summary>
 		/// Gets the assembly in which this loader will load assembly resources from
@@ -37,11 +38,11 @@ namespace Eto
 		/// <param name="assembly">Assembly to load the embedded assemblies from, or null to use the calling assembly</param>
 		/// <param name="domain">Application domain to load the assemblies in, or null to use the current app domain</param>
 		/// <returns>A new instance of an EmbeddedAssemblyLoader, registered for the specified namespace and assembly</returns>
-		public static EmbeddedAssemblyLoader Register (string resourceNamespace, Assembly assembly = null, AppDomain domain = null)
+		public static EmbeddedAssemblyLoader Register(string resourceNamespace, Assembly assembly = null, AppDomain domain = null)
 		{
-			assembly = assembly ?? Assembly.GetCallingAssembly ();
-			var loader = new EmbeddedAssemblyLoader (resourceNamespace, assembly);
-			loader.Register (domain);
+			assembly = assembly ?? Assembly.GetCallingAssembly();
+			var loader = new EmbeddedAssemblyLoader(resourceNamespace, assembly);
+			loader.Register(domain);
 			return loader;
 		}
 
@@ -50,36 +51,62 @@ namespace Eto
 		/// </summary>
 		/// <param name="resourceNamespace">Namespace of where the embedded assemblies should be loaded</param>
 		/// <param name="assembly">Assembly to load the embedded assemblies from, or null to use the calling assembly</param>
-		public EmbeddedAssemblyLoader (string resourceNamespace, Assembly assembly = null)
+		public EmbeddedAssemblyLoader(string resourceNamespace, Assembly assembly = null)
 		{
-			this.Assembly = assembly ?? Assembly.GetCallingAssembly ();
-			this.ResourceNamespace = resourceNamespace;
+			Assembly = assembly ?? Assembly.GetCallingAssembly();
+			ResourceNamespace = resourceNamespace;
 		}
 
 		/// <summary>
 		/// Registers this loader for the specified <paramref name="domain"/>
 		/// </summary>
 		/// <param name="domain">App domain to register this loader for, or null to use the current domain</param>
-		public void Register (AppDomain domain = null)
+		public void Register(AppDomain domain = null)
 		{
+			var resolving = false;
 			domain = domain ?? AppDomain.CurrentDomain;
-			domain.AssemblyResolve += (sender, args) => {
-				var assemblyName = new AssemblyName (args.Name);
-				if (assemblyName.Name.EndsWith (".resources", StringComparison.OrdinalIgnoreCase)) return null;
+			domain.AssemblyResolve += (sender, args) =>
+			{
+				// Prevent stack overflow in the case when someone handles AppDomain.ResourceResolve which will be called
+				// if the resource cannot be found below with GetManifestResourceStream, then tries to load a non-existant assembly
+				if (resolving)
+					return null;
 
-				string resourceName = ResourceNamespace + "." + assemblyName.Name + ".dll";
+				resolving = true;
 				Assembly loadedAssembly;
-				lock (loadedAssemblies) {
-					if (!loadedAssemblies.TryGetValue (resourceName, out loadedAssembly)) {
-						using (var stream = Assembly.GetManifestResourceStream (resourceName)) {
-							if (stream != null) {
-								using (var binaryReader = new BinaryReader (stream)) {
-									loadedAssembly = Assembly.Load (binaryReader.ReadBytes ((int)stream.Length));
-									loadedAssemblies.Add (resourceName, loadedAssembly);
+				try
+				{
+					var assemblyName = new AssemblyName(args.Name);
+					if (assemblyName.Name.EndsWith(".resources", StringComparison.OrdinalIgnoreCase)) return null;
+
+					string resourceName = $"{ResourceNamespace}.{assemblyName.Name}.dll";
+					lock (loadedAssemblies)
+					{
+						if (!loadedAssemblies.TryGetValue(resourceName, out loadedAssembly))
+						{
+							using (var stream = Assembly.GetManifestResourceStream(resourceName))
+							{
+								if (stream != null)
+								{
+									using (var binaryReader = new BinaryReader(stream))
+									{
+										loadedAssembly = Assembly.Load(binaryReader.ReadBytes((int)stream.Length));
+										loadedAssemblies.Add(resourceName, loadedAssembly);
+									}
 								}
 							}
 						}
 					}
+				}
+				catch (Exception ex)
+				{
+					// ignore errors here, just in case.
+					Debug.WriteLine($"Error trying to load assembly '{args.Name}':\n{ex}");
+					loadedAssembly = null;
+				}
+				finally
+				{
+					resolving = false;
 				}
 				return loadedAssembly;
 			};


### PR DESCRIPTION
Protects against poorly written code that handles AppDomain.ResourceResolve without first looking at the RequestingAssembly.  If the ResourceResolve attempts to load a non-existent assembly, it would cause a stack overflow.