### PR TITLE
Protect against calling Bitmap.Lock() more than once when there is still an open lock

### DIFF
--- a/Source/Eto.Test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
@@ -284,5 +284,45 @@ namespace Eto.Test.UnitTests.Drawing
 			});
 		}
 
+		[Test]
+		public void LockShouldThrowIfCalledWhileLocked()
+		{
+			Invoke(() =>
+			{
+				var bmp = new Bitmap(30, 30, PixelFormat.Format32bppRgba);
+
+				using (var bd = bmp.Lock())
+				{
+					Assert.Throws<InvalidOperationException>(() => bmp.Lock());
+				}
+			});
+		}
+
+		[Test]
+		public void LockShouldNowThrowIfCalledSequentially()
+		{
+			Invoke(() =>
+			{
+				var bmp = new Bitmap(30, 30, PixelFormat.Format32bppRgba);
+
+				using (var bd = bmp.Lock())
+				{
+					for (int y = 0; y < 10; y++)
+						for (int x = 0; x < 10; x++)
+							bd.SetPixel(x, y, Colors.Red);
+				}
+			
+				using (var bd = bmp.Lock())
+				{
+					for (int y = 0; y < 10; y++)
+						for (int x = 10; x < 20; x++)
+							bd.SetPixel(x, y, Colors.Blue);
+				}
+
+				// sanity check
+				Assert.AreEqual(Colors.Red, bmp.GetPixel(0, 0));
+				Assert.AreEqual(Colors.Blue, bmp.GetPixel(10, 0));
+			});
+		}
 	}
 }

--- a/Source/Eto/Drawing/BitmapData.cs
+++ b/Source/Eto/Drawing/BitmapData.cs
@@ -27,6 +27,14 @@ namespace Eto.Drawing
 		readonly int bitsPerPixel;
 		readonly int bytesPerPixel;
 
+		static object IsLocked_Key = new object();
+
+		bool IsLocked
+		{
+			get { return image.Properties.Get<bool>(IsLocked_Key); }
+			set { image.Properties.Set(IsLocked_Key, value); }
+		}
+
 		/// <summary>
 		/// Initializes a new instance of the BitmapData class
 		/// </summary>
@@ -38,6 +46,11 @@ namespace Eto.Drawing
 		protected BitmapData(Image image, IntPtr data, int scanWidth, int bitsPerPixel, object controlObject)
 		{
 			this.image = image;
+
+			if (IsLocked)
+				throw new InvalidOperationException("Image is already locked. Ensure you dispose the BitmapData object explicitly or with a using() block.");
+
+			IsLocked = true;
 			this.data = data;
 			this.scanWidth = scanWidth;
 			this.bitsPerPixel = bitsPerPixel;
@@ -214,6 +227,7 @@ namespace Eto.Drawing
 			{
 				var handler = (ILockableImage)image.Handler;
 				handler.Unlock(this);
+				IsLocked = false;
 			}
 			else
 			{


### PR DESCRIPTION
Since the behaviour is undefined, we throw an exception to ensure unintended functionality isn’t relied upon.