### PR TITLE
Wpf: Fix menu shortcuts when adding items with children to a MenuBar …

### DIFF
--- a/Source/Eto.Test/Eto.Test.Wpf/Eto.Test.Wpf - net45.csproj
+++ b/Source/Eto.Test/Eto.Test.Wpf/Eto.Test.Wpf - net45.csproj
@@ -61,6 +61,7 @@
     </Compile>
     <Compile Include="Startup.cs" />
     <Compile Include="UnitTests\DataContextTests.cs" />
+    <Compile Include="UnitTests\MenuBarTests.cs" />
     <Compile Include="UnitTests\TransformStackTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Eto.Test/Eto.Test.Wpf/UnitTests/MenuBarTests.cs
+++ b/Source/Eto.Test/Eto.Test.Wpf/UnitTests/MenuBarTests.cs
@@ -1,0 +1,45 @@
+﻿using Eto.Forms;
+using Eto.Test.UnitTests;
+using Eto.Wpf.Forms.Menu;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using swi = System.Windows.Input;
+
+namespace Eto.Test.Wpf.UnitTests
+{
+	[TestFixture]
+	public class MenuBarTests : TestBase
+	{
+		[Test]
+		public void MenuBarShouldSetInputBindingsForChildren()
+		{
+			Invoke(() =>
+			{
+				var form = new Form();
+				form.Menu = new MenuBar();
+
+				var file = new ButtonMenuItem { Text = "File" };
+
+				var command = new Command { MenuText = "Click Me!" };
+				command.Shortcut = Keys.Control | Keys.N;
+				command.Executed += (sender, e) => MessageBox.Show("Woo!");
+				file.Items.Add(command);
+
+				// add the item (with child items) to the menu that is already set to the form
+				form.Menu.Items.Add(file);
+
+				// check to make sure the input binding for the command made it
+				var host = form.Handler as IInputBindingHost;
+				Assert.AreEqual(1, host.InputBindings.Count);
+				Assert.IsInstanceOf<swi.KeyBinding>(host.InputBindings[0]);
+				var kb = (swi.KeyBinding)host.InputBindings[0];
+				Assert.AreEqual(swi.Key.N, kb.Key);
+				Assert.AreEqual(swi.ModifierKeys.Control, kb.Modifiers);
+			});
+		}
+	}
+}

--- a/Source/Eto.Wpf/Forms/Menu/MenuHandler.cs
+++ b/Source/Eto.Wpf/Forms/Menu/MenuHandler.cs
@@ -12,7 +12,7 @@ namespace Eto.Wpf.Forms.Menu
 	{
 		protected void RemoveKeyBindings(sw.FrameworkElement element)
 		{
-			if (element == null || element.InputBindings.Count == 0)
+			if (element == null)
 				return;
 			var parentHost = Widget.Parents.Select(r => r.Handler).OfType<IInputBindingHost>().LastOrDefault();
 			if (parentHost == null)
@@ -22,7 +22,7 @@ namespace Eto.Wpf.Forms.Menu
 
 		protected void AddKeyBindings(sw.FrameworkElement element)
 		{
-			if (element == null || element.InputBindings.Count == 0)
+			if (element == null)
 				return;
 			var parentHost = Widget.Parents.Select(r => r.Handler).OfType<IInputBindingHost>().LastOrDefault();
 			if (parentHost == null)


### PR DESCRIPTION
…that is already connected to a form.

- And add a unit test

Fixes #584