### PR TITLE
Gtk2/3: Fix getting page ranges from PrintSettings

### DIFF
--- a/Source/Eto.Gtk/Forms/Printing/PrintSettingsHandler.cs
+++ b/Source/Eto.Gtk/Forms/Printing/PrintSettingsHandler.cs
@@ -61,13 +61,8 @@ namespace Eto.GtkSharp.Forms.Printing
 
 		public Range<int> SelectedPageRange
 		{
-			get {
-				int num_ranges;
-				return Control.GetPageRanges (out num_ranges).ToEto ();
-			}
-			set {
-				Control.SetPageRanges(value.ToGtkPageRange (), 1);
-			}
+			get { return NativeMethods.gtk_print_settings_get_page_ranges(Control).ToEto(); }
+			set { Control.SetPageRanges(value.ToGtkPageRange (), 1); }
 		}
 
 		public PrintSelection PrintSelection {

--- a/Source/Eto.Gtk/GtkConversions.cs
+++ b/Source/Eto.Gtk/GtkConversions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using Eto.Drawing;
 using Eto.Forms;
 using Eto.GtkSharp.Drawing;
@@ -290,9 +291,11 @@ namespace Eto.GtkSharp
 			return new Gtk.PageRange { Start = range.Start - 1, End = range.End - 1 };
 		}
 
-		public static Range<int> ToEto(this Gtk.PageRange range)
+		public static Range<int> ToEto(this Gtk.PageRange[] ranges)
 		{
-			return new Range<int>(range.Start + 1, range.End);
+			if (ranges == null || ranges.Length == 0)
+				return new Range<int>(1, 0);
+			return new Range<int>(ranges.Min(r => r.Start) + 1, ranges.Max(r => r.End));
 		}
 
 		public static Gtk.PrintPages ToGtk(this PrintSelection value)

--- a/Source/Eto.Gtk/NativeMethods.cs
+++ b/Source/Eto.Gtk/NativeMethods.cs
@@ -34,6 +34,8 @@ namespace Eto.GtkSharp
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_entry_set_placeholder_text(IntPtr entry, IntPtr text);
 
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gtk_print_settings_get_page_ranges(IntPtr handle, out int num_ranges);
 #if GTK3
 
             [DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
@@ -74,6 +76,8 @@ namespace Eto.GtkSharp
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_entry_set_placeholder_text(IntPtr entry, IntPtr text);
 
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gtk_print_settings_get_page_ranges(IntPtr handle, out int num_ranges);
 #if GTK3
 
             [DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
@@ -114,6 +118,8 @@ namespace Eto.GtkSharp
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_entry_set_placeholder_text(IntPtr entry, IntPtr text);
 
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gtk_print_settings_get_page_ranges(IntPtr handle, out int num_ranges);
 #if GTK3
 
             [DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
@@ -145,6 +151,9 @@ namespace Eto.GtkSharp
 
             public static readonly Action<IntPtr, IntPtr> gtk_entry_set_placeholder_text;
 
+			public delegate IntPtr PrintSettingsGetPageRanges(IntPtr handle, out int num_ranges);
+
+			public static readonly PrintSettingsGetPageRanges gtk_print_settings_get_page_ranges;
 #if GTK3
 
             public delegate IntPtr ColorChooserNew(string title, IntPtr parent);
@@ -209,6 +218,20 @@ namespace Eto.GtkSharp
 			Marshaller.Free(textPtr);
 		}
 
+		public static Gtk.PageRange[] gtk_print_settings_get_page_ranges(Gtk.PrintSettings settings)
+		{
+			if (Impl.gtk_entry_set_placeholder_text == null)
+				return null;
+			int num_ranges;
+			IntPtr intPtr = Impl.gtk_print_settings_get_page_ranges(settings.Handle, out num_ranges);
+			Gtk.PageRange[] array = new Gtk.PageRange[num_ranges];
+			for (int i = 0; i < num_ranges; i++)
+			{
+				array[i] = Gtk.PageRange.New(intPtr + i * IntPtr.Size);
+			}
+			Marshaller.Free(intPtr);
+			return array;
+		}
 #if GTK3
 
         public static IntPtr gtk_color_chooser_dialog_new(string title, IntPtr parrent)


### PR DESCRIPTION
Some genius decided to change the existing API to return an array of Gtk.PageRange objects instead of a single instance. We now use the native method directly to overcome differences in gtk# versions.