### PR TITLE
Fixes for Bitmap.Lock()

### DIFF
--- a/Source/Eto.Gtk/Drawing/GraphicsHandler.cs
+++ b/Source/Eto.Gtk/Drawing/GraphicsHandler.cs
@@ -130,7 +130,7 @@ namespace Eto.GtkSharp.Drawing
 				{
 
 					surface.Flush();
-					var bd = handler.Lock();
+					using (var bd = handler.Lock())
 					unsafe
 					{
 						var srcrow = (byte*)surface.DataPtr;
@@ -145,7 +145,6 @@ namespace Eto.GtkSharp.Drawing
 							srcrow += surface.Stride;
 						}
 					}
-					handler.Unlock(bd);
 				}
 			}
 #if GTK2

--- a/Source/Eto.Test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
@@ -324,5 +324,75 @@ namespace Eto.Test.UnitTests.Drawing
 				Assert.AreEqual(Colors.Blue, bmp.GetPixel(10, 0));
 			});
 		}
+
+		[TestCase(PixelFormat.Format24bppRgb, 265, 16)]
+		[TestCase(PixelFormat.Format32bppRgb, 265, 16)]
+		[TestCase(PixelFormat.Format32bppRgba, 265, 16)]
+		[TestCase(PixelFormat.Format24bppRgb, 256, 16)]
+		[TestCase(PixelFormat.Format32bppRgb, 256, 16)]
+		[TestCase(PixelFormat.Format32bppRgba, 256, 16)]
+		public void LockShouldSetPixelsCorrectly(PixelFormat format, int width, int height)
+		{
+			Invoke(() =>
+			{
+				var bitmap = new Bitmap(width, height, format);
+				// use Lock() to set pixels
+				using (var bd = bitmap.Lock())
+				{
+					for (int i = 0; i < width; ++i)
+					{
+						for (int j = 0; j < height; ++j)
+						{
+							var c = j < height / 2 ? Colors.Red : Colors.Green;
+							bd.SetPixel(i, j, c);
+						}
+					}
+				}
+
+				// use GetPixel() to get the pixel to verify (which is typically not implemented using lock())
+				for (int i = 0; i < width; ++i)
+				{
+					for (int j = 0; j < height; ++j)
+					{
+						var c = j < height / 2 ? Colors.Red : Colors.Green;
+						Assert.AreEqual(c, bitmap.GetPixel(i, j), $"Pixel at {i},{j} is incorrect");
+					}
+				}
+			});
+		}
+
+		[TestCase(PixelFormat.Format24bppRgb, 265, 16)]
+		[TestCase(PixelFormat.Format32bppRgb, 265, 16)]
+		[TestCase(PixelFormat.Format32bppRgba, 265, 16)]
+		[TestCase(PixelFormat.Format24bppRgb, 256, 16)]
+		[TestCase(PixelFormat.Format32bppRgb, 256, 16)]
+		[TestCase(PixelFormat.Format32bppRgba, 256, 16)]
+		public void LockShouldGetPixelsCorrectly(PixelFormat format, int width, int height)
+		{
+			Invoke(() =>
+			{
+				var bitmap = new Bitmap(width, height, format);
+				for (int i = 0; i < width; ++i)
+				{
+					for (int j = 0; j < height; ++j)
+					{
+						var c = j < height / 2 ? Colors.Red : Colors.Green;
+						bitmap.SetPixel(i, j, c);
+					}
+				}
+
+				using (var bd = bitmap.Lock())
+				{
+					for (int i = 0; i < width; ++i)
+					{
+						for (int j = 0; j < height; ++j)
+						{
+							var c = j < height / 2 ? Colors.Red : Colors.Green;
+							Assert.AreEqual(c, bd.GetPixel(i, j), $"Pixel at {i},{j} is incorrect");
+						}
+					}
+				}
+			});
+		}
 	}
 }

--- a/Source/Eto.Wpf/Drawing/BitmapHandler.cs
+++ b/Source/Eto.Wpf/Drawing/BitmapHandler.cs
@@ -153,7 +153,7 @@ namespace Eto.Wpf.Drawing
 				SetBitmap(wb);
 			}
 			wb.Lock();
-			return new BitmapDataHandler(Widget, wb.BackBuffer, Stride, wb.Format.BitsPerPixel, wb);
+			return new BitmapDataHandler(Widget, wb.BackBuffer, wb.BackBufferStride, wb.Format.BitsPerPixel, wb);
 		}
 
 		public void Unlock(BitmapData bitmapData)

--- a/Source/Eto/Drawing/Bitmap.cs
+++ b/Source/Eto/Drawing/Bitmap.cs
@@ -274,6 +274,9 @@ namespace Eto.Drawing
 		/// <returns>A BitmapData object that carries a pointer and functions for manipulating the data directly</returns>
 		public BitmapData Lock()
 		{
+			if (BitmapData.IsImageLocked(this))
+				throw new InvalidOperationException("Image is already locked. Ensure you dispose the BitmapData object explicitly or with a using() block.");
+
 			return Handler.Lock();
 		}
 

--- a/Source/Eto/Drawing/BitmapData.cs
+++ b/Source/Eto/Drawing/BitmapData.cs
@@ -29,10 +29,15 @@ namespace Eto.Drawing
 
 		static object IsLocked_Key = new object();
 
+		internal static bool IsImageLocked(Image image)
+		{
+			return image.Properties.Get<bool>(IsLocked_Key);
+		}
+
 		bool IsLocked
 		{
-			get { return image.Properties.Get<bool>(IsLocked_Key); }
-			set { image.Properties.Set(IsLocked_Key, value); }
+			get { return Image.Properties.Get<bool>(IsLocked_Key); }
+			set { Image.Properties.Set(IsLocked_Key, value); }
 		}
 
 		/// <summary>


### PR DESCRIPTION
Wpf: Fix getting/setting pixels using Lock() with odd width, which would give it a stride larger than the pixels multiplied by bytes per pixel. Fixes #558
Properly throw the InvalidOperationException when trying to call BitmapData.Lock() more than once, before we get to the handler so it doesn’t put the bitmap in an invalid state.