### PR TITLE
Add Stepper and TextStepper, rename NumericUpDown to NumericStepper.

### DIFF
--- a/Source/Eto.Gtk/Eto.Gtk2 - net45.csproj
+++ b/Source/Eto.Gtk/Eto.Gtk2 - net45.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Forms\Controls\NativeControlHandler.cs" />
     <Compile Include="Forms\Controls\PasswordBoxHandler.cs" />
     <Compile Include="Forms\Controls\ProgressBarHandler.cs" />
+    <Compile Include="Forms\Controls\StepperHandler.cs" />
     <Compile Include="Forms\Controls\TreeViewHandler.cs" />
     <Compile Include="Forms\FontDialogHandler.cs" />
     <Compile Include="Drawing\BitmapHandler.cs">
@@ -123,7 +124,7 @@
     <Compile Include="Forms\Controls\GroupBoxHandler.cs" />
     <Compile Include="Forms\Controls\ImageViewHandler.cs" />
     <Compile Include="Forms\Controls\LabelHandler.cs" />
-    <Compile Include="Forms\Controls\NumericUpDownHandler.cs" />
+    <Compile Include="Forms\Controls\NumericStepperHandler.cs" />
     <Compile Include="Forms\Controls\PanelHandler.cs" />
     <Compile Include="Forms\Controls\RadioButtonHandler.cs" />
     <Compile Include="Forms\Controls\ScrollableHandler.cs" />
@@ -263,6 +264,7 @@
     <Compile Include="Drawing\IconFrameHandler.cs" />
     <Compile Include="Forms\ColorDialogHandlerGtk34.cs" />
     <Compile Include="Forms\AboutDialogHandler.cs" />
+    <Compile Include="Forms\Controls\TextStepperHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
   <PropertyGroup>

--- a/Source/Eto.Gtk/Eto.Gtk3 - net45.csproj
+++ b/Source/Eto.Gtk/Eto.Gtk3 - net45.csproj
@@ -23,7 +23,6 @@
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
     <OutputPath>..\..\BuildOutput\net45\Debug\</OutputPath>
     <DefineConstants>CAIRO;DEBUG;TRACE;GTK3</DefineConstants>
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <Optimize>false</Optimize>
     <DebugType>full</DebugType>
   </PropertyGroup>
@@ -150,7 +149,7 @@
     <Compile Include="Forms\Controls\ImageViewHandler.cs" />
     <Compile Include="Forms\Controls\LabelHandler.cs" />
     <Compile Include="Forms\Controls\ListBoxHandler.cs" />
-    <Compile Include="Forms\Controls\NumericUpDownHandler.cs" />
+    <Compile Include="Forms\Controls\NumericStepperHandler.cs" />
     <Compile Include="Forms\Controls\PanelHandler.cs" />
     <Compile Include="Forms\Controls\RadioButtonHandler.cs" />
     <Compile Include="Forms\Controls\ScrollableHandler.cs" />
@@ -270,6 +269,8 @@
     <Compile Include="Drawing\IconFrameHandler.cs" />
     <Compile Include="Forms\ColorDialogHandlerGtk34.cs" />
     <Compile Include="Forms\AboutDialogHandler.cs" />
+    <Compile Include="Forms\Controls\StepperHandler.cs" />
+    <Compile Include="Forms\Controls\TextStepperHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />
   <PropertyGroup>

--- a/Source/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
@@ -5,7 +5,7 @@ using System.Globalization;
 
 namespace Eto.GtkSharp.Forms.Controls
 {
-	public class NumericUpDownHandler : GtkControl<Gtk.SpinButton, NumericUpDown, NumericUpDown.ICallback>, NumericUpDown.IHandler
+	public class NumericStepperHandler : GtkControl<Gtk.SpinButton, NumericStepper, NumericStepper.ICallback>, NumericStepper.IHandler
 	{
 		class EtoSpinButton : Gtk.SpinButton
 		{
@@ -15,7 +15,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
-		public NumericUpDownHandler()
+		public NumericStepperHandler()
 		{
 			Control = new EtoSpinButton();
 			Control.WidthRequest = 120;
@@ -39,16 +39,16 @@ namespace Eto.GtkSharp.Forms.Controls
 			Control.ValueChanged += Connector.HandleValueChanged;
 		}
 
-		protected new NumericUpDownConnector Connector { get { return (NumericUpDownConnector)base.Connector; } }
+		protected new NumericStepperConnector Connector { get { return (NumericStepperConnector)base.Connector; } }
 
 		protected override WeakConnector CreateConnector()
 		{
-			return new NumericUpDownConnector();
+			return new NumericStepperConnector();
 		}
 
-		protected class NumericUpDownConnector : GtkControlConnector
+		protected class NumericStepperConnector : GtkControlConnector
 		{
-			public new NumericUpDownHandler Handler { get { return (NumericUpDownHandler)base.Handler; } }
+			public new NumericStepperHandler Handler { get { return (NumericStepperHandler)base.Handler; } }
 
 			public void HandleValueChanged(object sender, EventArgs e)
 			{

--- a/Source/Eto.Gtk/Forms/Controls/StepperHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/StepperHandler.cs
@@ -1,0 +1,165 @@
+﻿
+using Eto.Forms;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+using Eto.Drawing;
+
+namespace Eto.GtkSharp.Forms.Controls
+{
+	/// <summary>
+	/// Note: not used currently as we can't hide the text input portion of the SpinButton
+	/// </summary>
+	public class StepperHandler : GtkControl<Gtk.SpinButton, Stepper, Stepper.ICallback>, Stepper.IHandler
+	{
+#if GTK2
+		static Gtk.Adjustment DefaultAdjustment = new Gtk.Adjustment(0, 0, 2, 1, 1, 1);
+#else
+		// in gtk3 the upper adjustment is not inclusive?? ugh
+		static Gtk.Adjustment DefaultAdjustment = new Gtk.Adjustment(0, 0, 3, 1, 1, 1);
+#endif
+		int disableNotification;
+
+		public StepperHandler()
+		{
+			Control = new Gtk.SpinButton(DefaultAdjustment, 0, 1)
+			{
+				Wrap = true,
+				Numeric = false,
+				IsEditable = false,
+				WidthChars = 0,
+				Text = string.Empty,
+				UpdatePolicy = Gtk.SpinButtonUpdatePolicy.Always
+			};
+		}
+
+		protected override void Initialize()
+		{
+			base.Initialize();
+			Control.Output += Connector.HandleOutput;
+			Control.Input += Connector.HandleInput;
+		}
+
+		static object ValidDirection_Key = new object();
+
+		public StepperValidDirections ValidDirection
+		{
+			get { return Widget.Properties.Get(ValidDirection_Key, StepperValidDirections.Both); }
+			set { Widget.Properties.Set(ValidDirection_Key, value, UpdateState, StepperValidDirections.Both); }
+		}
+
+		void UpdateState()
+		{
+			int oldValue = Control.ValueAsInt;
+			disableNotification++;
+			switch (ValidDirection)
+			{
+				case StepperValidDirections.Both:
+					Control.Wrap = true;
+					Control.Adjustment = DefaultAdjustment;
+					Control.Value = 0;
+					break;
+				case StepperValidDirections.Up:
+					Control.Wrap = false;
+					Control.Adjustment = DefaultAdjustment;
+					Control.Value = 0;
+					break;
+				case StepperValidDirections.Down:
+					Control.Wrap = false;
+					Control.Adjustment = DefaultAdjustment;
+					Control.Value = 2;
+					break;
+				case StepperValidDirections.None:
+					Control.Wrap = false;
+					Control.Adjustment = new Gtk.Adjustment(0, 0, 0, 0, 0, 0);
+					break;
+			}
+			disableNotification--;
+		}
+
+		StepperDirection? GetDirection()
+		{
+			StepperDirection? dir = null;
+			int? newValue = null;
+			switch (ValidDirection)
+			{
+				case StepperValidDirections.Both:
+					dir = Control.ValueAsInt == 1 ? StepperDirection.Up : StepperDirection.Down;
+					newValue = 0;
+					break;
+				case StepperValidDirections.Up:
+					dir = StepperDirection.Up;
+					newValue = 0;
+					break;
+				case StepperValidDirections.Down:
+					dir = StepperDirection.Down;
+					newValue = 2;
+					break;
+			}
+			if (newValue != null && Control.ValueAsInt != newValue.Value)
+			{
+				disableNotification++;
+				Application.Instance.AsyncInvoke(() =>
+				{
+					Control.Value = newValue.Value;
+					disableNotification--;
+				});
+			}
+
+			return dir;
+		}
+
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Stepper.StepEvent:
+					Control.ValueChanged += Connector.HandleValueChanged;
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		protected new StepperConnector Connector { get { return (StepperConnector)base.Connector; } }
+
+		protected override WeakConnector CreateConnector()
+		{
+			return new StepperConnector();
+		}
+
+		protected class StepperConnector : GtkControlConnector
+		{
+			public new StepperHandler Handler { get { return (StepperHandler)base.Handler; } }
+
+			[GLib.ConnectBefore]
+			public void HandleValueChanged(object sender, EventArgs e)
+			{
+				var h = Handler;
+				if (h == null)
+					return;
+				var dir = h.GetDirection();
+				if (dir != null)
+					h.Callback.OnStep(h.Widget, new StepperEventArgs(dir.Value));
+			}
+
+			[GLib.ConnectBefore]
+			public void HandleOutput(object o, Gtk.OutputArgs args)
+			{
+				args.RetVal = 1;
+			}
+
+			[GLib.ConnectBefore]
+			public void HandleInput(object o, Gtk.InputArgs args)
+			{
+				args.NewValue = Handler.Control.Value;
+				args.RetVal = 1;
+			}
+		}
+	}
+}

--- a/Source/Eto.Gtk/Forms/Controls/TextStepperHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/TextStepperHandler.cs
@@ -1,0 +1,190 @@
+﻿using Eto.Forms;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.ComponentModel;
+
+namespace Eto.GtkSharp.Forms.Controls
+{
+	public class TextStepperHandler : TextBoxHandler<Gtk.SpinButton, TextStepper, TextStepper.ICallback>, TextStepper.IHandler
+	{
+		#if GTK2
+		static Gtk.Adjustment DefaultAdjustment = new Gtk.Adjustment(0, 0, 2, 1, 1, 1);
+		#else
+		// in gtk3 the upper adjustment is not inclusive?? ugh
+		static Gtk.Adjustment DefaultAdjustment = new Gtk.Adjustment(0, 0, 3, 1, 1, 1);
+		#endif
+		int disableNotification;
+		bool readOnly;
+
+		public TextStepperHandler()
+		{
+			Control = new Gtk.SpinButton(DefaultAdjustment, 0, 1)
+			{
+				Wrap = true,
+				Numeric = false,
+				IsEditable = true,
+				WidthChars = 12,
+				Text = string.Empty,
+				UpdatePolicy = Gtk.SpinButtonUpdatePolicy.Always
+			};
+		}
+
+		protected override void Initialize()
+		{
+			base.Initialize();
+			Control.Output += Connector.HandleOutput;
+			Control.Input += Connector.HandleInput;
+			Widget.TextChanging += (sender, e) =>
+			{
+				e.Cancel = ReadOnly;
+			};
+			Widget.KeyDown += (sender, e) =>
+			{
+				if (e.KeyData == Keys.Up || e.KeyData == Keys.Down)
+					e.Handled = true;
+			};
+		}
+
+		public override bool ReadOnly
+		{
+			get { return readOnly; }
+			set { readOnly = value; }
+		}
+
+		static object ValidDirection_Key = new object();
+
+		public StepperValidDirections ValidDirection
+		{
+			get { return Widget.Properties.Get(ValidDirection_Key, StepperValidDirections.Both); }
+			set { Widget.Properties.Set(ValidDirection_Key, value, UpdateState, StepperValidDirections.Both); }
+		}
+
+		void UpdateState()
+		{
+			int oldValue = Control.ValueAsInt;
+			disableNotification++;
+			switch (ValidDirection)
+			{
+				case StepperValidDirections.Both:
+					Control.Wrap = true;
+					Control.Adjustment = DefaultAdjustment;
+					Control.Value = 0;
+					break;
+				case StepperValidDirections.Up:
+					Control.Wrap = false;
+					Control.Adjustment = DefaultAdjustment;
+					Control.Value = 0;
+					break;
+				case StepperValidDirections.Down:
+					Control.Wrap = false;
+					Control.Adjustment = DefaultAdjustment;
+					Control.Value = 2;
+					break;
+				case StepperValidDirections.None:
+					Control.Wrap = false;
+					Control.Adjustment = new Gtk.Adjustment(0, 0, 0, 0, 0, 0);
+					break;
+			}
+			disableNotification--;
+		}
+
+		StepperDirection? GetDirection()
+		{
+			StepperDirection? dir = null;
+			int? newValue = null;
+			switch (ValidDirection)
+			{
+				case StepperValidDirections.Both:
+					dir = Control.ValueAsInt == 1 ? StepperDirection.Up : StepperDirection.Down;
+					newValue = 0;
+					break;
+				case StepperValidDirections.Up:
+					dir = StepperDirection.Up;
+					newValue = 0;
+					break;
+				case StepperValidDirections.Down:
+					dir = StepperDirection.Down;
+					newValue = 2;
+					break;
+			}
+			if (newValue != null && Control.ValueAsInt != newValue.Value)
+			{
+				disableNotification++;
+				Application.Instance.AsyncInvoke (() => {
+					Control.Value = newValue.Value;
+					disableNotification--;
+				});
+			}
+
+			return dir;
+		}
+
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case TextStepper.StepEvent:
+					Control.ValueChanged += Connector.HandleValueChanged;
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		protected new TextStepperConnector Connector { get { return (TextStepperConnector)base.Connector; } }
+
+		protected override WeakConnector CreateConnector()
+		{
+			return new TextStepperConnector();
+		}
+
+		protected class TextStepperConnector : TextBoxConnector
+		{
+			public new TextStepperHandler Handler { get { return (TextStepperHandler)base.Handler; } }
+
+			[GLib.ConnectBefore]
+			public void HandleValueChanged(object sender, EventArgs e)
+			{
+				var h = Handler;
+				if (h == null)
+					return;
+				if (h.disableNotification > 0)
+				{
+					//h.disableNotification--;
+					return;
+				}
+				var dir = h.GetDirection();
+				if (dir != null)
+					h.Callback.OnStep(h.Widget, new StepperEventArgs(dir.Value));
+			}
+
+#if GTK2
+			public override void HandleExposeEvent(object o, Gtk.ExposeEventArgs args)
+			{
+				if (args.Event.Window == Handler.Control.GdkWindow.Children[0]) // skip painting over up/down
+					return;
+				base.HandleExposeEvent(o, args);
+			}
+#endif
+
+			[GLib.ConnectBefore]
+			public void HandleOutput(object o, Gtk.OutputArgs args)
+			{
+				args.RetVal = 1;
+			}
+
+			[GLib.ConnectBefore]
+			public void HandleInput(object o, Gtk.InputArgs args)
+			{
+				args.NewValue = Handler.Control.Value;
+				args.RetVal = 1;
+			}
+		}
+
+	}
+}

--- a/Source/Eto.Gtk/Platform.cs
+++ b/Source/Eto.Gtk/Platform.cs
@@ -108,7 +108,7 @@ namespace Eto.GtkSharp
 			p.Add<Label.IHandler>(() => new LabelHandler());
 			p.Add<LinkButton.IHandler>(() => new LinkButtonHandler());
 			p.Add<ListBox.IHandler>(() => new ListBoxHandler());
-			p.Add<NumericUpDown.IHandler>(() => new NumericUpDownHandler());
+			p.Add<NumericStepper.IHandler>(() => new NumericStepperHandler());
 			p.Add<Panel.IHandler>(() => new PanelHandler());
 			p.Add<PasswordBox.IHandler>(() => new PasswordBoxHandler());
 			p.Add<ProgressBar.IHandler>(() => new ProgressBarHandler());
@@ -125,6 +125,8 @@ namespace Eto.GtkSharp
 			p.Add<TreeView.IHandler>(() => new TreeViewHandler());
 			p.Add<WebView.IHandler>(() => new WebViewHandler());
 			p.Add<RichTextArea.IHandler>(() => new RichTextAreaHandler());
+			p.Add<Stepper.IHandler>(() => new ThemedStepperHandler());
+			p.Add<TextStepper.IHandler>(() => new TextStepperHandler());
 
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/Source/Eto.Mac/Eto.Mac - net45.csproj
+++ b/Source/Eto.Mac/Eto.Mac - net45.csproj
@@ -105,7 +105,7 @@
     <Compile Include="Forms\Controls\ImageViewHandler.cs" />
     <Compile Include="Forms\Controls\LabelHandler.cs" />
     <Compile Include="Forms\Controls\ListBoxHandler.cs" />
-    <Compile Include="Forms\Controls\NumericUpDownHandler.cs" />
+    <Compile Include="Forms\Controls\NumericStepperHandler.cs" />
     <Compile Include="Forms\Controls\ScrollableHandler.cs" />
     <Compile Include="Forms\Controls\SplitterHandler.cs" />
     <Compile Include="Forms\Controls\TabControlHandler.cs" />
@@ -224,6 +224,7 @@
     </Compile>
     <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="Drawing\IconFrameHandler.cs" />
+    <Compile Include="Forms\Controls\StepperHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Source/Eto.Mac/Eto.Mac64 - net45.csproj
+++ b/Source/Eto.Mac/Eto.Mac64 - net45.csproj
@@ -107,7 +107,7 @@
     <Compile Include="Forms\Controls\ImageViewHandler.cs" />
     <Compile Include="Forms\Controls\LabelHandler.cs" />
     <Compile Include="Forms\Controls\ListBoxHandler.cs" />
-    <Compile Include="Forms\Controls\NumericUpDownHandler.cs" />
+    <Compile Include="Forms\Controls\NumericStepperHandler.cs" />
     <Compile Include="Forms\Controls\ScrollableHandler.cs" />
     <Compile Include="Forms\Controls\SplitterHandler.cs" />
     <Compile Include="Forms\Controls\TabControlHandler.cs" />
@@ -224,6 +224,7 @@
     </Compile>
     <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="Drawing\IconFrameHandler.cs" />
+    <Compile Include="Forms\Controls\StepperHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Source/Eto.Mac/Eto.XamMac - net45.csproj
+++ b/Source/Eto.Mac/Eto.XamMac - net45.csproj
@@ -122,7 +122,7 @@
     <Compile Include="Forms\Controls\ImageViewHandler.cs" />
     <Compile Include="Forms\Controls\LabelHandler.cs" />
     <Compile Include="Forms\Controls\ListBoxHandler.cs" />
-    <Compile Include="Forms\Controls\NumericUpDownHandler.cs" />
+    <Compile Include="Forms\Controls\NumericStepperHandler.cs" />
     <Compile Include="Forms\Controls\ScrollableHandler.cs" />
     <Compile Include="Forms\Controls\SplitterHandler.cs" />
     <Compile Include="Forms\Controls\TabControlHandler.cs" />
@@ -242,6 +242,7 @@
     </Compile>
     <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="Drawing\IconFrameHandler.cs" />
+    <Compile Include="Forms\Controls\StepperHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/Source/Eto.Mac/Eto.XamMac2 - mobile.csproj
+++ b/Source/Eto.Mac/Eto.XamMac2 - mobile.csproj
@@ -112,7 +112,7 @@
     <Compile Include="Forms\Controls\ImageViewHandler.cs" />
     <Compile Include="Forms\Controls\LabelHandler.cs" />
     <Compile Include="Forms\Controls\ListBoxHandler.cs" />
-    <Compile Include="Forms\Controls\NumericUpDownHandler.cs" />
+    <Compile Include="Forms\Controls\NumericStepperHandler.cs" />
     <Compile Include="Forms\Controls\ScrollableHandler.cs" />
     <Compile Include="Forms\Controls\SplitterHandler.cs" />
     <Compile Include="Forms\Controls\TabControlHandler.cs" />
@@ -233,6 +233,7 @@
     </Compile>
     <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="Drawing\IconFrameHandler.cs" />
+    <Compile Include="Forms\Controls\StepperHandler.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/Source/Eto.Mac/Eto.XamMac2 - net45.csproj
+++ b/Source/Eto.Mac/Eto.XamMac2 - net45.csproj
@@ -110,7 +110,7 @@
     <Compile Include="Forms\Controls\ImageViewHandler.cs" />
     <Compile Include="Forms\Controls\LabelHandler.cs" />
     <Compile Include="Forms\Controls\ListBoxHandler.cs" />
-    <Compile Include="Forms\Controls\NumericUpDownHandler.cs" />
+    <Compile Include="Forms\Controls\NumericStepperHandler.cs" />
     <Compile Include="Forms\Controls\ScrollableHandler.cs" />
     <Compile Include="Forms\Controls\SplitterHandler.cs" />
     <Compile Include="Forms\Controls\TabControlHandler.cs" />
@@ -230,6 +230,7 @@
     </Compile>
     <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="Drawing\IconFrameHandler.cs" />
+    <Compile Include="Forms\Controls\StepperHandler.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/Source/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
@@ -43,7 +43,7 @@ using nnint = System.UInt32;
 
 namespace Eto.Mac.Forms.Controls
 {
-	public class NumericUpDownHandler : MacView<NumericUpDownHandler.EtoNumericUpDownView, NumericUpDown, NumericUpDown.ICallback>, NumericUpDown.IHandler
+	public class NumericStepperHandler : MacView<NumericStepperHandler.EtoNumericStepperView, NumericStepper, NumericStepper.ICallback>, NumericStepper.IHandler
 	{
 		Size? naturalSize;
 
@@ -60,7 +60,7 @@ namespace Eto.Mac.Forms.Controls
 			public WeakReference WeakHandler { get; set; }
 		}
 
-		public class EtoNumericUpDownView : NSView, IMacControl
+		public class EtoNumericStepperView : NSView, IMacControl
 		{
 			public NSTextField TextField { get; private set; }
 			public NSStepper Stepper { get; private set; }
@@ -80,7 +80,7 @@ namespace Eto.Mac.Forms.Controls
 				splitter.SetFrameOrigin(new CGPoint(newSize.Width - splitter.Frame.Width, offset));
 			}
 
-			public EtoNumericUpDownView(NumericUpDownHandler handler)
+			public EtoNumericStepperView(NumericStepperHandler handler)
 			{
 				AutoresizesSubviews = false;
 				TextField = new EtoTextField
@@ -125,14 +125,14 @@ namespace Eto.Mac.Forms.Controls
 			MaximumFractionDigits = 0
 		};
 
-		protected override EtoNumericUpDownView CreateControl()
+		protected override EtoNumericStepperView CreateControl()
 		{
-			return new EtoNumericUpDownView(this);
+			return new EtoNumericStepperView(this);
 		}
 
 		static void HandleStepperActivated(object sender, EventArgs e)
 		{
-			var handler = GetHandler(((NSView)sender).Superview) as NumericUpDownHandler;
+			var handler = GetHandler(((NSView)sender).Superview) as NumericStepperHandler;
 			if (handler != null)
 			{
 				// prevent spinner from accumulating an inprecise value, which would eventually 
@@ -153,7 +153,7 @@ namespace Eto.Mac.Forms.Controls
 
 		static void HandleTextChanged(object sender, EventArgs e)
 		{
-			var handler = GetHandler(((NSView)((NSNotification)sender).Object).Superview) as NumericUpDownHandler;
+			var handler = GetHandler(((NSView)((NSNotification)sender).Object).Superview) as NumericStepperHandler;
 			if (handler != null)
 			{
 				var formatter = (NSNumberFormatter)handler.TextField.Formatter;
@@ -392,7 +392,14 @@ namespace Eto.Mac.Forms.Controls
 
 			TextField.Formatter = formatter;
 			if (Widget.Loaded)
+			{
 				TextField.SetNeedsDisplay();
+				var currentEditor = TextField.CurrentEditor;
+				if (currentEditor != null)
+				{
+					currentEditor.Value = TextField.StringValue;
+				}
+			}
 		}
 
 		public Color TextColor

--- a/Source/Eto.Mac/Forms/Controls/StepperHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/StepperHandler.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using Eto.Forms;
+using Eto.Drawing;
+
+#if XAMMAC2
+using AppKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using CoreAnimation;
+#else
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+using MonoMac.CoreGraphics;
+using MonoMac.ObjCRuntime;
+using MonoMac.CoreAnimation;
+#if Mac64
+using nfloat = System.Double;
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nfloat = System.Single;
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
+#endif
+
+namespace Eto.Mac.Forms.Controls
+{
+	public class StepperHandler : MacControl<NSStepper, Stepper, Stepper.ICallback>, Stepper.IHandler
+	{
+		public class EtoStepper : NSStepper, IMacControl
+		{
+			public WeakReference WeakHandler { get; set; }
+		}
+
+		public StepperHandler()
+		{
+			Control = new EtoStepper
+			{
+				WeakHandler = new WeakReference(this),
+				MinValue = 0,
+				MaxValue = 2
+			};
+			Control.SizeToFit();
+		}
+
+		static object ValidDirection_Key = new object();
+
+		public StepperValidDirections ValidDirection
+		{
+			get { return Widget.Properties.Get(ValidDirection_Key, StepperValidDirections.Both); }
+			set { Widget.Properties.Set(ValidDirection_Key, value, UpdateState, StepperValidDirections.Both); }
+		}
+
+		void UpdateState()
+		{
+			switch (ValidDirection)
+			{
+				case StepperValidDirections.Both:
+					Control.ValueWraps = true;
+					Control.MaxValue = 2;
+					Control.IntValue = 0;
+					break;
+				case StepperValidDirections.Up:
+					Control.ValueWraps = false;
+					Control.MaxValue = 1;
+					Control.IntValue = 0;
+					break;
+				case StepperValidDirections.Down:
+					Control.ValueWraps = false;
+					Control.MaxValue = 1;
+					Control.IntValue = 1;
+					break;
+				case StepperValidDirections.None:
+					Control.ValueWraps = false;
+					Control.MaxValue = 0;
+					break;
+			}
+			SetStepperEnabled();
+		}
+
+		static object Enabled_Key = new object();
+
+		public override bool Enabled
+		{
+			get { return Widget.Properties.Get(Enabled_Key, true); }
+			set { Widget.Properties.Set(Enabled_Key, value, SetStepperEnabled, true); }
+		}
+
+		void SetStepperEnabled()
+		{
+			Control.Enabled = Enabled && ValidDirection != StepperValidDirections.None;
+		}
+
+		StepperDirection? GetDirection()
+		{
+			switch (ValidDirection)
+			{
+				case StepperValidDirections.Both:
+					var dir = Control.IntValue == 1 ? StepperDirection.Up : StepperDirection.Down;
+					Control.IntValue = 0;
+					return dir;
+				case StepperValidDirections.Up:
+					if (Control.IntValue == 1)
+					{
+						Control.IntValue = 0;
+						return StepperDirection.Up;
+					}
+					break;
+				case StepperValidDirections.Down:
+					if (Control.IntValue == 0)
+					{
+						Control.IntValue = 1;
+						return StepperDirection.Down;
+					}
+					break;
+			}
+			return null;
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Stepper.StepEvent:
+					Control.Activated += (sender, e) =>
+					{
+						var dir = GetDirection();
+						if (dir != null)
+							Callback.OnStep(Widget, new StepperEventArgs(dir.Value));
+					};
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+	}
+}

--- a/Source/Eto.Mac/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/TextBoxHandler.cs
@@ -66,13 +66,10 @@ namespace Eto.Mac.Forms.Controls
 	{
 		public WeakReference WeakHandler { get; set; }
 
-		public TextBoxHandler Handler
-		{ 
-			get { return (TextBoxHandler)WeakHandler.Target; }
-			set { WeakHandler = new WeakReference(value); } 
-		}
+		IMacText TextHandler => WeakHandler.Target as IMacText;
+		ITextBoxWithMaxLength MaxLengthHandler => WeakHandler.Target as ITextBoxWithMaxLength;
 
-		public int MaxLength { get { return Handler.MaxLength; } }
+		public int MaxLength { get { return MaxLengthHandler?.MaxLength ?? -1; } }
 
 		public EtoTextField()
 		{
@@ -88,12 +85,22 @@ namespace Eto.Mac.Forms.Controls
 		[Export("textViewDidChangeSelection:")]
 		public void TextViewDidChangeSelection(NSNotification notification)
 		{
-			var textView = (NSTextView)notification.Object;
-			Handler.LastSelection = textView.SelectedRange.ToEto();
+			if (TextHandler != null)
+			{
+				var textView = (NSTextView)notification.Object;
+				TextHandler.LastSelection = textView.SelectedRange.ToEto();
+			}
 		}
 	}
 
-	public class TextBoxHandler : MacText<EtoTextField, TextBox, TextBox.ICallback>, TextBox.IHandler, ITextBoxWithMaxLength
+
+	public class TextBoxHandler : TextBoxHandler<TextBox, TextBox.ICallback>
+	{
+	}
+
+	public class TextBoxHandler<TWidget, TCallback> : MacText<EtoTextField, TWidget, TCallback>, TextBox.IHandler, ITextBoxWithMaxLength
+		where TWidget: TextBox
+		where TCallback: TextBox.ICallback
 	{
 		protected override void Initialize()
 		{
@@ -134,14 +141,14 @@ namespace Eto.Mac.Forms.Controls
 
 		static void HandleTextChanged (object sender, EventArgs e)
 		{
-			var h = GetHandler(sender) as TextBoxHandler;
+			var h = GetHandler(sender) as TextBoxHandler<TWidget, TCallback>;
 			h.Callback.OnTextChanged(h.Widget, EventArgs.Empty);
 		}
 
 		static bool TriggerShouldChangeText(IntPtr sender, IntPtr sel, NSRange affectedCharRange, IntPtr replacementStringPtr)
 		{
 			var obj = Runtime.GetNSObject(sender);
-			var handler = GetHandler(obj) as TextBoxHandler;
+			var handler = GetHandler(obj) as TextBoxHandler<TWidget, TCallback>;
 
 			if (handler != null)
 			{

--- a/Source/Eto.Mac/Platform.cs
+++ b/Source/Eto.Mac/Platform.cs
@@ -122,7 +122,7 @@ namespace Eto.Mac
 			p.Add<Label.IHandler>(() => new LabelHandler());
 			p.Add<LinkButton.IHandler>(() => new LinkButtonHandler());
 			p.Add<ListBox.IHandler>(() => new ListBoxHandler());
-			p.Add<NumericUpDown.IHandler>(() => new NumericUpDownHandler());
+			p.Add<NumericStepper.IHandler>(() => new NumericStepperHandler());
 			p.Add<Panel.IHandler>(() => new PanelHandler());
 			p.Add<PasswordBox.IHandler>(() => new PasswordBoxHandler());
 			p.Add<ProgressBar.IHandler>(() => new ProgressBarHandler());
@@ -140,6 +140,8 @@ namespace Eto.Mac
 			p.Add<TreeView.IHandler>(() => new TreeViewHandler());
 			p.Add<WebView.IHandler>(() => new WebViewHandler());
 			p.Add<RichTextArea.IHandler>(() => new RichTextAreaHandler());
+			p.Add<Stepper.IHandler>(() => new StepperHandler());
+			p.Add<TextStepper.IHandler>(() => new ThemedTextStepperHandler());
 
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/Source/Eto.NativeGtk/Eto.NativeGtk - net45.csproj
+++ b/Source/Eto.NativeGtk/Eto.NativeGtk - net45.csproj
@@ -150,7 +150,7 @@
     <Compile Include="..\Eto.Gtk\Forms\Controls\ImageViewHandler.cs" />
     <Compile Include="..\Eto.Gtk\Forms\Controls\LabelHandler.cs" />
     <Compile Include="..\Eto.Gtk\Forms\Controls\ListBoxHandler.cs" />
-    <Compile Include="..\Eto.Gtk\Forms\Controls\NumericUpDownHandler.cs" />
+    <Compile Include="..\Eto.Gtk\Forms\Controls\NumericStepperHandler.cs" />
     <Compile Include="..\Eto.Gtk\Forms\Controls\PanelHandler.cs" />
     <Compile Include="..\Eto.Gtk\Forms\Controls\RadioButtonHandler.cs" />
     <Compile Include="..\Eto.Gtk\Forms\Controls\ScrollableHandler.cs" />
@@ -273,6 +273,12 @@
     </Compile>
     <Compile Include="..\Eto.Gtk\Forms\AboutDialogHandler.cs">
       <Link>AboutDialogHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\Eto.Gtk\Forms\Controls\StepperHandler.cs">
+      <Link>StepperHandler.cs</Link>
+    </Compile>
+    <Compile Include="..\Eto.Gtk\Forms\Controls\TextStepperHandler.cs">
+      <Link>TextStepperHandler.cs</Link>
     </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSHARP.Targets" />

--- a/Source/Eto.Test/Eto.Test.Mac/Eto.Test.XamMac2 - net45.csproj
+++ b/Source/Eto.Test/Eto.Test.Mac/Eto.Test.XamMac2 - net45.csproj
@@ -9,6 +9,7 @@
     <RootNamespace>Eto.Test.Mac</RootNamespace>
     <LastXamMacNagTime>14/12/2012 1:15:16 AM</LastXamMacNagTime>
     <AssemblyName>Eto.Test.XamMac2</AssemblyName>
+    <UseXamMacFullFramework>true</UseXamMacFullFramework>
   </PropertyGroup>
   <PropertyGroup>
     <FileAlignment>512</FileAlignment>

--- a/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
+++ b/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
@@ -90,7 +90,7 @@
     <Compile Include="Sections\Controls\GroupBoxSection.cs" />
     <Compile Include="Sections\Controls\LabelSection.cs" />
     <Compile Include="Sections\Controls\ListBoxSection.cs" />
-    <Compile Include="Sections\Controls\NumericUpDownSection.cs" />
+    <Compile Include="Sections\Controls\NumericStepperSection.cs" />
     <Compile Include="Sections\Controls\RadioButtonSection.cs" />
     <Compile Include="Sections\Controls\ScrollableSection.cs" />
     <Compile Include="Sections\Controls\SliderSection.cs" />
@@ -200,6 +200,8 @@
     <Compile Include="UnitTests\Forms\DataContextTests.cs" />
     <Compile Include="UnitTests\Forms\Controls\SliderTests.cs" />
     <Compile Include="Sections\Dialogs\AboutDialogSection.cs" />
+    <Compile Include="Sections\Controls\StepperSection.cs" />
+    <Compile Include="Sections\Controls\TextStepperSection.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Sections\Serialization\Json\Test.json">

--- a/Source/Eto.Test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
@@ -26,7 +26,7 @@ namespace Eto.Test.Sections.Behaviors
 			layout.EndHorizontal();
 
 			layout.AddRow(null, CheckBoxControl(), RadioButtonControl());
-			layout.AddRow(null, DateTimeControl(), NumericUpDownControl());
+			layout.AddRow(null, DateTimeControl(), NumericStepperControl());
 			layout.AddRow(null, DropDownControl(), ComboBoxControl());
 
 			layout.BeginHorizontal();
@@ -107,9 +107,9 @@ namespace Eto.Test.Sections.Behaviors
 			return control;
 		}
 
-		Control NumericUpDownControl()
+		Control NumericStepperControl()
 		{
-			var control = new NumericUpDown();
+			var control = new NumericStepper();
 			LogEvents(control);
 			return control;
 		}

--- a/Source/Eto.Test/Eto.Test/Sections/Behaviors/DynamicFocusSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Behaviors/DynamicFocusSection.cs
@@ -28,7 +28,7 @@ namespace Eto.Test.Sections.Behaviors
 				() => new ColorPicker(),
 				() => new PasswordBox(),
 				() => new ListBox { Items = { "Item 1", "Item 2", "Item 3" } },
-				() => new NumericUpDown(),
+				() => new NumericStepper(),
 			};
 
 			var count = 0;

--- a/Source/Eto.Test/Eto.Test/Sections/Behaviors/WindowsSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Behaviors/WindowsSection.cs
@@ -248,11 +248,11 @@ namespace Eto.Test.Sections.Behaviors
 			var setLocationCheckBox = new CheckBox { Text = "Initial Location" };
 			setLocationCheckBox.CheckedBinding.Bind(() => setInitialLocation, v => setInitialLocation = v ?? false);
 
-			var left = new NumericUpDown();
+			var left = new NumericStepper();
 			left.Bind(c => c.Enabled, setLocationCheckBox, c => c.Checked);
 			left.ValueBinding.Bind(() => initialLocation.X, v => initialLocation.X = (int)v);
 
-			var top = new NumericUpDown();
+			var top = new NumericStepper();
 			top.Bind(c => c.Enabled, setLocationCheckBox, c => c.Checked);
 			top.ValueBinding.Bind(() => initialLocation.Y, v => initialLocation.Y = (int)v);
 
@@ -276,11 +276,11 @@ namespace Eto.Test.Sections.Behaviors
 			var setClientSize = new CheckBox { Text = "Size" };
 			setClientSize.CheckedBinding.Bind(() => setInitialSize, v => setInitialSize = v ?? false);
 
-			var left = new NumericUpDown();
+			var left = new NumericStepper();
 			left.Bind(c => c.Enabled, setClientSize, c => c.Checked);
 			left.ValueBinding.Bind(() => initialSize.Width, v => initialSize.Width = (int)v);
 
-			var top = new NumericUpDown();
+			var top = new NumericStepper();
 			top.Bind(c => c.Enabled, setClientSize, c => c.Checked);
 			top.ValueBinding.Bind(() => initialSize.Height, v => initialSize.Height = (int)v);
 
@@ -305,11 +305,11 @@ namespace Eto.Test.Sections.Behaviors
 			var setClientSize = new CheckBox { Text = "ClientSize" };
 			setClientSize.CheckedBinding.Bind(() => setInitialClientSize, v => setInitialClientSize = v ?? false);
 
-			var left = new NumericUpDown();
+			var left = new NumericStepper();
 			left.Bind(c => c.Enabled, setClientSize, c => c.Checked);
 			left.ValueBinding.Bind(() => initialClientSize.Width, v => initialClientSize.Width = (int)v);
 
-			var top = new NumericUpDown();
+			var top = new NumericStepper();
 			top.Bind(c => c.Enabled, setClientSize, c => c.Checked);
 			top.ValueBinding.Bind(() => initialClientSize.Height, v => initialClientSize.Height = (int)v);
 
@@ -339,7 +339,7 @@ namespace Eto.Test.Sections.Behaviors
 					child.MinimumSize = initialMinimumSize;
 			});
 
-			var width = new NumericUpDown();
+			var width = new NumericStepper();
 			width.Bind(c => c.Enabled, setMinimumSize, c => c.Checked);
 			width.ValueBinding.Bind(() => initialMinimumSize.Width, v =>
 			{
@@ -348,7 +348,7 @@ namespace Eto.Test.Sections.Behaviors
 					child.MinimumSize = initialMinimumSize;
 			});
 
-			var height = new NumericUpDown();
+			var height = new NumericStepper();
 			height.Bind(c => c.Enabled, setMinimumSize, c => c.Checked);
 			height.ValueBinding.Bind(() => initialMinimumSize.Height, v => initialMinimumSize.Height = (int)v);
 

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/ControlColorsSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/ControlColorsSection.cs
@@ -73,9 +73,9 @@ namespace Eto.Test.Sections.Controls
 			if (textControl != null)
 				foregroundUpdates.Add(c => textControl.TextColor = c);
 
-			var numericUpDown = control as NumericUpDown;
-			if (numericUpDown != null)
-				foregroundUpdates.Add(c => numericUpDown.TextColor = c);
+			var numericStepper = control as NumericStepper;
+			if (numericStepper != null)
+				foregroundUpdates.Add(c => numericStepper.TextColor = c);
 
 			var button = control as Button;
 			if (button != null)

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/KitchenSinkSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/KitchenSinkSection.cs
@@ -77,7 +77,7 @@ namespace Eto.Test.Sections.Controls
 			layout.EndBeginVertical();
 			layout.AddRow(ComboBox(), new DateTimePicker { Value = DateTime.Now }, null);
 			layout.EndBeginVertical();
-			layout.AddRow(new NumericUpDown { Value = 50 }, null);
+			layout.AddRow(new NumericStepper { Value = 50 }, null);
 			layout.EndBeginVertical();
 			layout.AddRow(ListBox(), new TextArea { Text = "Text Area", Size = new Size(150, 50) }, null);
 			layout.EndBeginVertical();

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/NumericStepperSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/NumericStepperSection.cs
@@ -3,12 +3,12 @@ using Eto.Forms;
 
 namespace Eto.Test.Sections.Controls
 {
-	[Section("Controls", typeof(NumericUpDown))]
-	public class NumericUpDownSection : Panel
+	[Section("Controls", typeof(NumericStepper))]
+	public class NumericStepperSection : Panel
 	{
-		public NumericUpDownSection()
+		public NumericStepperSection()
 		{
-			var numeric = new NumericUpDown { Width = 200 };
+			var numeric = new NumericStepper { Width = 200 };
 
 			LogEvents(numeric);
 
@@ -18,7 +18,7 @@ namespace Eto.Test.Sections.Controls
 			var readOnly = new CheckBox { Text = "ReadOnly" };
 			readOnly.CheckedBinding.Bind(numeric, n => n.ReadOnly);
 
-			var minValue = new NumericUpDown { Enabled = false, Value = -1000 };
+			var minValue = new NumericStepper { Enabled = false, Value = -1000 };
 			var minBinding = minValue.ValueBinding.Bind(numeric, n => n.MinValue, DualBindingMode.Manual);
 
 			var chkMinValue = new CheckBox { Text = "MinValue" };
@@ -26,7 +26,7 @@ namespace Eto.Test.Sections.Controls
 			chkMinValue.CheckedBinding.Bind(minValue, m => m.Enabled);
 			chkMinValue.CheckedBinding.Convert(r => r == false ? double.NegativeInfinity : minValue.Value).Bind(numeric, m => m.MinValue);
 
-			var maxValue = new NumericUpDown { Enabled = false, Value = 1000 };
+			var maxValue = new NumericStepper { Enabled = false, Value = 1000 };
 			var maxBinding = maxValue.ValueBinding.Bind(numeric, (n) => n.MaxValue, DualBindingMode.Manual);
 
 			var chkMaxValue = new CheckBox { Text = "MaxValue" };
@@ -34,16 +34,16 @@ namespace Eto.Test.Sections.Controls
 			chkMaxValue.CheckedBinding.Bind(maxValue, m => m.Enabled);
 			chkMaxValue.CheckedBinding.Convert(r => r == false ? double.PositiveInfinity : maxValue.Value).Bind(numeric, m => m.MaxValue);
 
-			var decimalPlaces = new NumericUpDown { MaxValue = 15, MinValue = 0 };
+			var decimalPlaces = new NumericStepper { MaxValue = 15, MinValue = 0 };
 			var decimalBinding = decimalPlaces.ValueBinding.Convert(r => (int)r, r => r).Bind(numeric, n => n.DecimalPlaces);
 
-			var maxDecimalPlaces = new NumericUpDown { MaxValue = 15, MinValue = 0 };
+			var maxDecimalPlaces = new NumericStepper { MaxValue = 15, MinValue = 0 };
 			var maxDecimalBinding = maxDecimalPlaces.ValueBinding.Convert(r => (int)r, r => r).Bind(numeric, n => n.MaximumDecimalPlaces);
 
 			maxDecimalBinding.Changed += (sender, e) => decimalBinding.Update(BindingUpdateMode.Destination);
 			decimalBinding.Changed += (sender, e) => maxDecimalBinding.Update(BindingUpdateMode.Destination);
 
-			var increment = new NumericUpDown { MaximumDecimalPlaces = 15 };
+			var increment = new NumericStepper { MaximumDecimalPlaces = 15 };
 			increment.ValueBinding.Bind(numeric, n => n.Increment);
 
 			var options1 = new StackLayout
@@ -89,7 +89,7 @@ namespace Eto.Test.Sections.Controls
 			};
 		}
 
-		void LogEvents(NumericUpDown control)
+		void LogEvents(NumericStepper control)
 		{
 			control.ValueChanged += delegate
 			{

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/StepperSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/StepperSection.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Eto.Forms;
+namespace Eto.Test.Sections.Controls
+{
+	[Section("Controls", typeof(Stepper))]
+	public class StepperSection : Panel
+	{
+		public StepperSection()
+		{
+			var stepper = new Stepper();
+			LogEvents(stepper);
+
+			var enabledCheckBox = new CheckBox { Text = "Enabled" };
+			enabledCheckBox.CheckedBinding.Bind(stepper, s => s.Enabled);
+
+			var validDirectionsDropDown = new EnumDropDown<StepperValidDirections>();
+			validDirectionsDropDown.SelectedValueBinding.Bind(stepper, s => s.ValidDirection);
+
+			Content = new StackLayout
+			{
+				Padding = 10,
+				Spacing = 5,
+				Items =
+				{
+					"Stepper",
+					enabledCheckBox,
+					validDirectionsDropDown,
+					stepper
+				}
+			};
+		}
+
+		void LogEvents(Stepper stepper)
+		{
+			stepper.Step += (sender, e) => Log.Write(stepper, $"Step: {e.Direction}");
+		}
+	}
+}

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/TextStepperSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/TextStepperSection.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Eto.Forms;
+namespace Eto.Test.Sections.Controls
+{
+	[Section("Controls", typeof(TextStepper))]
+	public class TextStepperSection : Panel
+	{
+		public TextStepperSection()
+		{
+			var textUpDown = new TextStepper { PlaceholderText = "<multiple values>" };
+			LogEvents(textUpDown);
+
+			var enabledCheckBox = new CheckBox { Text = "Enabled" };
+			enabledCheckBox.CheckedBinding.Bind(textUpDown, c => c.Enabled);
+
+			var readOnlyCheckBox = new CheckBox { Text = "ReadOnly" };
+			readOnlyCheckBox.CheckedBinding.Bind(textUpDown, c => c.ReadOnly);
+
+			var setTextButton = new Button { Text = "Set Text" };
+			setTextButton.Click += (sender, e) => textUpDown.Text = "Some text";
+
+			var validDirectionsDropDown = new EnumDropDown<StepperValidDirections>();
+			validDirectionsDropDown.SelectedValueBinding.Bind(textUpDown, s => s.ValidDirection);
+
+			Content = new StackLayout
+			{
+				Padding = 10,
+				Spacing = 5,
+				Items =
+				{
+					enabledCheckBox,
+					TableLayout.Horizontal(2, readOnlyCheckBox, setTextButton),
+					TableLayout.Horizontal(2, "ValidDirection", validDirectionsDropDown),
+					textUpDown
+				}
+			};
+		}
+
+		void LogEvents(TextStepper textUpDown)
+		{
+			textUpDown.Step += (sender, e) => Log.Write(textUpDown, $"Step: {e.Direction}");
+			textUpDown.TextChanging += (sender, e) => Log.Write(textUpDown, $"TextChanging: {e.Text}, Current: {textUpDown.Text}");
+			textUpDown.TextChanged += (sender, e) => Log.Write(textUpDown, $"TextChanged: {textUpDown.Text}");
+}
+	}
+}

--- a/Source/Eto.Test/Eto.Test/Sections/Drawing/BrushSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Drawing/BrushSection.cs
@@ -77,7 +77,7 @@ namespace Eto.Test.Sections.Drawing
 				layout.AddSeparateRow(null, BrushControl(), UseBackgroundColorControl(), null);
 			else
 				layout.AddSeparateRow(null, BrushControl(), UseBackgroundColorControl(), WithContent(), null);
-			if (Platform.Supports<NumericUpDown>())
+			if (Platform.Supports<NumericStepper>())
 			{
 				matrixRow = layout.AddSeparateRow(null, new Label { Text = "Rot" }, RotationControl(), new Label { Text = "Sx" }, ScaleXControl(), new Label { Text = "Sy" }, ScaleYControl(), new Label { Text = "Ox" }, OffsetXControl(), new Label { Text = "Oy" }, OffsetYControl(), null);
 				matrixRow.Table.Visible = false;
@@ -165,7 +165,7 @@ namespace Eto.Test.Sections.Drawing
 
 		Control ScaleXControl()
 		{
-			var control = new NumericUpDown { MinValue = 1, MaxValue = 1000 };
+			var control = new NumericStepper { MinValue = 1, MaxValue = 1000 };
 			control.ValueBinding.Bind(() => ScaleX, v =>
 			{
 				ScaleX = (float)v;
@@ -176,7 +176,7 @@ namespace Eto.Test.Sections.Drawing
 
 		Control ScaleYControl()
 		{
-			var control = new NumericUpDown { MinValue = 1, MaxValue = 1000 };
+			var control = new NumericStepper { MinValue = 1, MaxValue = 1000 };
 			control.ValueBinding.Bind(() => ScaleY, v =>
 			{
 				ScaleY = (float)v;
@@ -187,7 +187,7 @@ namespace Eto.Test.Sections.Drawing
 
 		Control RotationControl()
 		{
-			var control = new NumericUpDown { MinValue = 0, MaxValue = 360 };
+			var control = new NumericStepper { MinValue = 0, MaxValue = 360 };
 			control.ValueBinding.Bind(() => Rotation, v =>
 			{
 				Rotation = (float)v;
@@ -198,7 +198,7 @@ namespace Eto.Test.Sections.Drawing
 
 		Control OffsetXControl()
 		{
-			var control = new NumericUpDown();
+			var control = new NumericStepper();
 			control.ValueBinding.Bind(() => OffsetX, v =>
 			{
 				OffsetX = (float)v;
@@ -209,7 +209,7 @@ namespace Eto.Test.Sections.Drawing
 
 		Control OffsetYControl()
 		{
-			var control = new NumericUpDown();
+			var control = new NumericStepper();
 			control.ValueBinding.Bind(() => OffsetY, v =>
 			{
 				OffsetY = (float)v;
@@ -245,7 +245,7 @@ namespace Eto.Test.Sections.Drawing
 
 		Control PointControl(Func<PointF> getValue, Action<PointF> setValue)
 		{
-			var xpoint = new NumericUpDown();
+			var xpoint = new NumericStepper();
 			xpoint.ValueBinding.Bind(() => getValue().X, v =>
 			{
 				var p = getValue();
@@ -254,7 +254,7 @@ namespace Eto.Test.Sections.Drawing
 				Refresh();
 			});
 
-			var ypoint = new NumericUpDown();
+			var ypoint = new NumericStepper();
 			ypoint.ValueBinding.Bind(() => getValue().Y, v =>
 			{
 				var p = getValue();
@@ -272,7 +272,7 @@ namespace Eto.Test.Sections.Drawing
 
 		Control SizeControl(Func<SizeF> getValue, Action<SizeF> setValue)
 		{
-			var xpoint = new NumericUpDown();
+			var xpoint = new NumericStepper();
 			xpoint.ValueBinding.Bind(() => getValue().Width, v =>
 			{
 				var p = getValue();
@@ -281,7 +281,7 @@ namespace Eto.Test.Sections.Drawing
 				Refresh();
 			});
 
-			var ypoint = new NumericUpDown();
+			var ypoint = new NumericStepper();
 			ypoint.ValueBinding.Bind(() => getValue().Height, v =>
 			{
 				var p = getValue();

--- a/Source/Eto.Test/Eto.Test/Sections/Drawing/GraphicsPathSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Drawing/GraphicsPathSection.cs
@@ -49,7 +49,7 @@ namespace Eto.Test.Sections.Drawing
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
 
 			layout.AddSeparateRow(null, StartFiguresControl(), CloseFiguresControl(), ConnectPathControl(), AntiAliasControl(), null);
-			if (Platform.Instance.Supports<NumericUpDown>())
+			if (Platform.Instance.Supports<NumericStepper>())
 				layout.AddSeparateRow(null, PenThicknessControl(), PenJoinControl(), PenCapControl(), null);
 			layout.AddSeparateRow(null, ShowBounds(), CurrentPoint(), null);
 			layout.BeginVertical();
@@ -91,7 +91,7 @@ namespace Eto.Test.Sections.Drawing
 
 		Control PenThicknessControl()
 		{
-			var control = new NumericUpDown { MinValue = 1, MaxValue = 100 };
+			var control = new NumericStepper { MinValue = 1, MaxValue = 100 };
 			control.ValueBinding.Bind(() => PenThickness, val => { PenThickness = (float)val; Refresh(); });
 
 			var layout = new DynamicLayout { Padding = Padding.Empty };

--- a/Source/Eto.Test/Eto.Test/Sections/Drawing/PenSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Drawing/PenSection.cs
@@ -29,7 +29,7 @@ namespace Eto.Test.Sections.Drawing
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
 
 			layout.AddSeparateRow(null, PenJoinControl(), PenCapControl(), DashStyleControl(), null);
-			if (Platform.Supports<NumericUpDown>())
+			if (Platform.Supports<NumericStepper>())
 				layout.AddSeparateRow(null, PenThicknessControl(), null);
 			layout.AddCentered(GetDrawable());
 
@@ -54,7 +54,7 @@ namespace Eto.Test.Sections.Drawing
 
 		Control PenThicknessControl()
 		{
-			var control = new NumericUpDown { MinValue = 1, MaxValue = 10 };
+			var control = new NumericStepper { MinValue = 1, MaxValue = 10 };
 			control.Bind(c => c.Value, this, r => r.PenThickness);
 			control.ValueChanged += Refresh;
 

--- a/Source/Eto.Test/Eto.Test/Sections/Printing/PrintDialogSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Printing/PrintDialogSection.cs
@@ -8,8 +8,8 @@ namespace Eto.Test.Sections.Printing
 	public class PrintDialogSection : Panel
 	{
 		PrintSettings settings = new PrintSettings();
-		NumericUpDown selectedEnd;
-		NumericUpDown maximumEnd;
+		NumericStepper selectedEnd;
+		NumericStepper maximumEnd;
 		CheckBox allowPageRange;
 		CheckBox allowSelection;
 
@@ -207,7 +207,7 @@ namespace Eto.Test.Sections.Printing
 
 		static Control Copies()
 		{
-			var control = new NumericUpDown { MinValue = 1 };
+			var control = new NumericStepper { MinValue = 1 };
 			control.ValueBinding.BindDataContext<PrintSettings>(r => r.Copies, (r, v) => r.Copies = (int)v, defaultGetValue: 1);
 			return control;
 		}
@@ -228,7 +228,7 @@ namespace Eto.Test.Sections.Printing
 
 		Control MaximumStart()
 		{
-			var control = new NumericUpDown { MinValue = 1 };
+			var control = new NumericStepper { MinValue = 1 };
 			control.DataContextChanged += delegate
 			{
 				control.Value = settings.MaximumPageRange.Start;
@@ -247,7 +247,7 @@ namespace Eto.Test.Sections.Printing
 
 		Control MaximumEnd()
 		{
-			var control = maximumEnd = new NumericUpDown { MinValue = 1 };
+			var control = maximumEnd = new NumericStepper { MinValue = 1 };
 			control.DataContextChanged += delegate
 			{
 				control.Value = settings.MaximumPageRange.End;
@@ -262,7 +262,7 @@ namespace Eto.Test.Sections.Printing
 
 		Control SelectedStart()
 		{
-			var control = new NumericUpDown { MinValue = 1 };
+			var control = new NumericStepper { MinValue = 1 };
 			control.DataContextChanged += delegate
 			{
 				control.Value = settings.SelectedPageRange.Start;
@@ -281,7 +281,7 @@ namespace Eto.Test.Sections.Printing
 
 		Control SelectedEnd()
 		{
-			var control = selectedEnd = new NumericUpDown { MinValue = 1 };
+			var control = selectedEnd = new NumericStepper { MinValue = 1 };
 			control.DataContextChanged += delegate
 			{
 				control.Value = settings.SelectedPageRange.End;

--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/NumericUpDownTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/NumericUpDownTests.cs
@@ -16,7 +16,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			TestBase.Invoke(() =>
 			{
-				var numeric = new NumericUpDown();
+				var numeric = new NumericStepper();
 				int valueChanged = 0;
 				numeric.ValueChanged += (sender, e) => valueChanged++;
 
@@ -33,7 +33,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			TestBase.Invoke(() =>
 			{
-				var numeric = new NumericUpDown();
+				var numeric = new NumericStepper();
 				int valueChanged = 0;
 				int currentValueChanged = 0;
 				numeric.ValueChanged += (sender, e) => valueChanged++;
@@ -61,7 +61,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			TestBase.Invoke(() =>
 			{
-				var numeric = new NumericUpDown();
+				var numeric = new NumericStepper();
 				int valueChanged = 0;
 				int currentValueChanged = 0;
 				numeric.ValueChanged += (sender, e) => valueChanged++;
@@ -106,7 +106,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			TestBase.Invoke(() =>
 			{
-				var numeric = new NumericUpDown();
+				var numeric = new NumericStepper();
 				int valueChanged = 0;
 				numeric.ValueChanged += (sender, e) => valueChanged++;
 
@@ -128,7 +128,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			TestBase.Invoke(() =>
 			{
-				var numeric = new NumericUpDown();
+				var numeric = new NumericStepper();
 				int valueChanged = 0;
 				numeric.ValueChanged += (sender, e) => valueChanged++;
 
@@ -148,7 +148,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			TestBase.Invoke(() =>
 			{
-				var numeric = new NumericUpDown();
+				var numeric = new NumericStepper();
 				int valueChanged = 0;
 				numeric.ValueChanged += (sender, e) => valueChanged++;
 
@@ -167,7 +167,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			TestBase.Invoke(() =>
 			{
-				var numeric = new NumericUpDown();
+				var numeric = new NumericStepper();
 				int valueChanged = 0;
 				numeric.ValueChanged += (sender, e) => valueChanged++;
 
@@ -197,7 +197,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			TestBase.Invoke(() =>
 			{
-				var numeric = new NumericUpDown();
+				var numeric = new NumericStepper();
 				int valueChanged = 0;
 				//numeric.MinimumDecimalPlaces = maxDecimalPlaces;
 				numeric.MaximumDecimalPlaces = maxDecimalPlaces;
@@ -219,7 +219,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			TestBase.Invoke(() =>
 			{
-				var numeric = new NumericUpDown();
+				var numeric = new NumericStepper();
 
 				numeric.DecimalPlaces = 3;
 				Assert.AreEqual(3, numeric.DecimalPlaces, "DecimalPlaces isn't roundtripping set values");

--- a/Source/Eto.WinForms/Eto.WinForms - net45.csproj
+++ b/Source/Eto.WinForms/Eto.WinForms - net45.csproj
@@ -84,6 +84,8 @@
     <Compile Include="Drawing\RadialGradientBrushHandler.cs" />
     <Compile Include="Drawing\SystemColorsHandler.cs" />
     <Compile Include="Forms\Cells\CustomCellHandler.cs" />
+    <Compile Include="Forms\Controls\TextStepperHandler.cs" />
+    <Compile Include="Forms\Controls\StepperHandler.cs" />
     <Compile Include="Win32.dpi.cs" />
     <Compile Include="WinConversions.cs" />
     <Compile Include="CustomControls\ExtendedDateTimePicker.cs" />
@@ -214,7 +216,7 @@
     <Compile Include="Forms\Controls\ListBoxHandler.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Forms\Controls\NumericUpDownHandler.cs">
+    <Compile Include="Forms\Controls\NumericStepperHandler.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Forms\Controls\PanelHandler.cs">

--- a/Source/Eto.WinForms/Forms/Controls/NumericStepperHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/NumericStepperHandler.cs
@@ -6,7 +6,7 @@ using System.Globalization;
 
 namespace Eto.WinForms.Forms.Controls
 {
-	public class NumericUpDownHandler : WindowsControl<swf.NumericUpDown, NumericUpDown, NumericUpDown.ICallback>, NumericUpDown.IHandler
+	public class NumericStepperHandler : WindowsControl<swf.NumericUpDown, NumericStepper, NumericStepper.ICallback>, NumericStepper.IHandler
 	{
 		public class EtoNumericUpDown : swf.NumericUpDown
 		{
@@ -25,7 +25,7 @@ namespace Eto.WinForms.Forms.Controls
 			}
 		}
 
-		public NumericUpDownHandler()
+		public NumericStepperHandler()
 		{
 			Control = new EtoNumericUpDown
 			{

--- a/Source/Eto.WinForms/Forms/Controls/StepperHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/StepperHandler.cs
@@ -1,0 +1,73 @@
+﻿using Eto.Forms;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using swf = System.Windows.Forms;
+using System.Drawing;
+using System.Reflection;
+
+namespace Eto.WinForms.Forms.Controls
+{
+	public class StepperHandler : WindowsControl<StepperHandler.EtoUpDown, Stepper, Stepper.ICallback>, Stepper.IHandler
+	{
+		public class EtoUpDown : swf.UpDownBase
+		{
+			public event EventHandler DownButtonClicked;
+			public event EventHandler UpButtonClicked;
+
+			public override void DownButton()
+			{
+				DownButtonClicked?.Invoke(this, EventArgs.Empty);
+			}
+
+			public override void UpButton()
+			{
+				UpButtonClicked?.Invoke(this, EventArgs.Empty);
+			}
+
+			protected override Size DefaultSize => new Size(18, base.DefaultSize.Height);
+
+			protected override void UpdateEditText()
+			{
+				
+			}
+		}
+
+		public StepperHandler()
+		{
+			Control = new EtoUpDown();
+			Control.InterceptArrowKeys = true;
+			Control.Padding = new swf.Padding(0);
+			Control.ReadOnly = true;
+			var upDownEdit = Control.GetType().GetField("upDownEdit", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(Control) as swf.Control;
+			//var upDownButtons = Control.GetType().GetField("upDownButtons", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(Control) as swf.Control;
+			upDownEdit.Visible = false;
+		}
+
+		public StepperValidDirections ValidDirection
+		{
+			get { return StepperValidDirections.Both; }
+			set
+			{
+			}
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Stepper.StepEvent:
+					Control.DownButtonClicked += (sender, e) => Callback.OnStep(Widget, new StepperEventArgs(StepperDirection.Down));
+					Control.UpButtonClicked += (sender, e) => Callback.OnStep(Widget, new StepperEventArgs(StepperDirection.Up));
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+
+	}
+}

--- a/Source/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
@@ -11,17 +11,6 @@ namespace Eto.WinForms.Forms.Controls
 	[DesignerCategory("Code")]
 	public class EtoTextBox : swf.TextBox
 	{
-		string watermarkText;
-		public string WatermarkText
-		{
-			get { return watermarkText; }
-			set
-			{
-				watermarkText = value;
-				Win32.SendMessage(Handle, Win32.WM.EM_SETCUEBANNER, IntPtr.Zero, watermarkText);
-			}
-		}
-
 		public event EventHandler<CancelEventArgs> Copying;
 
 		protected virtual void OnCopying(CancelEventArgs e)
@@ -60,17 +49,31 @@ namespace Eto.WinForms.Forms.Controls
 		}
 	}
 
-	public class TextBoxHandler : WindowsControl<EtoTextBox, TextBox, TextBox.ICallback>, TextBox.IHandler
+	public class TextBoxHandler : TextBoxHandler<EtoTextBox, TextBox, TextBox.ICallback>
 	{
+		public override swf.TextBox SwfTextBox => Control;
+
+		public override EtoTextBox EtoTextBox => Control;
+
 		public TextBoxHandler()
 		{
 			Control = new EtoTextBox();
 		}
+	}
 
-		public bool ShowBorder
+	public abstract class TextBoxHandler<TControl, TWidget, TCallback> : WindowsControl<TControl, TWidget, TCallback>, TextBox.IHandler
+		where TControl: swf.Control
+		where TWidget: TextBox
+		where TCallback: TextBox.ICallback
+	{
+		public abstract swf.TextBox SwfTextBox { get; }
+
+		public abstract EtoTextBox EtoTextBox { get; }
+
+		public virtual bool ShowBorder
 		{
-			get { return Control.BorderStyle != swf.BorderStyle.None; }
-			set { Control.BorderStyle = value ? swf.BorderStyle.Fixed3D : swf.BorderStyle.None; }
+			get { return SwfTextBox.BorderStyle != swf.BorderStyle.None; }
+			set { SwfTextBox.BorderStyle = value ? swf.BorderStyle.Fixed3D : swf.BorderStyle.None; }
 		}
 
 		static Func<char, bool> testIsNonWord = ch => char.IsWhiteSpace(ch) || char.IsPunctuation(ch);
@@ -92,7 +95,7 @@ namespace Eto.WinForms.Forms.Controls
 								var selection = Selection;
 								if (selection.Length() == 0)
 									selection = new Range<int>(e.KeyData == Keys.Delete ? CaretIndex : CaretIndex - 1);
-								if (selection.Start >= 0 && selection.End < Control.TextLength)
+								if (selection.Start >= 0 && selection.End < SwfTextBox.TextLength)
 								{
 									var tia = new TextChangingEventArgs(string.Empty, selection);
 									Callback.OnTextChanging(Widget, tia);
@@ -144,26 +147,29 @@ namespace Eto.WinForms.Forms.Controls
 								break;
 						}
 					};
-					Control.Cutting += (sender, e) =>
-					{
-						clipboard.Clear();
-						clipboard.Text = Control.SelectedText;
-						var tia = new TextChangingEventArgs(string.Empty, Selection);
-						Callback.OnTextChanging(Widget, tia);
-						e.Cancel = tia.Cancel;
-					};
-					Control.Pasting += (sender, e) =>
-					{
-						var tia = new TextChangingEventArgs(clipboard.Text, Selection);
-						Callback.OnTextChanging(Widget, tia);
-						e.Cancel = tia.Cancel;
-					};
 					Widget.TextInput += (sender, e) =>
 					{
 						var tia = new TextChangingEventArgs(e.Text, Selection);
 						Callback.OnTextChanging(Widget, tia);
 						e.Cancel = tia.Cancel;
 					};
+					if (EtoTextBox != null)
+					{
+						EtoTextBox.Cutting += (sender, e) =>
+						{
+							clipboard.Clear();
+							clipboard.Text = SwfTextBox.SelectedText;
+							var tia = new TextChangingEventArgs(string.Empty, Selection);
+							Callback.OnTextChanging(Widget, tia);
+							e.Cancel = tia.Cancel;
+						};
+						EtoTextBox.Pasting += (sender, e) =>
+						{
+							var tia = new TextChangingEventArgs(clipboard.Text, Selection);
+							Callback.OnTextChanging(Widget, tia);
+							e.Cancel = tia.Cancel;
+						};
+					}
 					break;
 				default:
 					base.AttachEvent(id);
@@ -171,28 +177,36 @@ namespace Eto.WinForms.Forms.Controls
 			}
 		}
 
-		public bool ReadOnly
+		public virtual bool ReadOnly
 		{
-			get { return Control.ReadOnly; }
-			set { Control.ReadOnly = value; }
+			get { return SwfTextBox.ReadOnly; }
+			set { SwfTextBox.ReadOnly = value; }
 		}
 
 		public int MaxLength
 		{
-			get { return Control.MaxLength; }
-			set { Control.MaxLength = value; }
+			get { return SwfTextBox.MaxLength; }
+			set { SwfTextBox.MaxLength = value; }
 		}
+
+		static object PlaceholderText_Key = new object();
 
 		public string PlaceholderText
 		{
-			get { return Control.WatermarkText; }
-			set { Control.WatermarkText = value; }
+			get { return Widget.Properties.Get<string>(PlaceholderText_Key); }
+			set
+			{
+				Widget.Properties.Set(PlaceholderText_Key, value, () =>
+				{
+					Win32.SendMessage(SwfTextBox.Handle, Win32.WM.EM_SETCUEBANNER, IntPtr.Zero, value);
+				});
+			}
 		}
 
 		public void SelectAll()
 		{
 			Control.Focus();
-			Control.SelectAll();
+			SwfTextBox.SelectAll();
 		}
 
 		static readonly Win32.WM[] intrinsicEvents = {
@@ -206,21 +220,21 @@ namespace Eto.WinForms.Forms.Controls
 
 		public int CaretIndex
 		{
-			get { return Control.SelectionStart; }
+			get { return SwfTextBox.SelectionStart; }
 			set
 			{
-				Control.SelectionStart = value;
-				Control.SelectionLength = 0;
+				SwfTextBox.SelectionStart = value;
+				SwfTextBox.SelectionLength = 0;
 			}
 		}
 
 		public Range<int> Selection
 		{
-			get { return new Range<int>(Control.SelectionStart, Control.SelectionStart + Control.SelectionLength - 1); }
+			get { return new Range<int>(SwfTextBox.SelectionStart, SwfTextBox.SelectionStart + SwfTextBox.SelectionLength - 1); }
 			set
 			{
-				Control.SelectionStart = value.Start;
-				Control.SelectionLength = value.Length();
+				SwfTextBox.SelectionStart = value.Start;
+				SwfTextBox.SelectionLength = value.Length();
 			}
 		}
 

--- a/Source/Eto.WinForms/Forms/Controls/TextStepperHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TextStepperHandler.cs
@@ -1,0 +1,85 @@
+﻿using Eto.Forms;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using swf = System.Windows.Forms;
+using System.Drawing;
+using System.Reflection;
+
+namespace Eto.WinForms.Forms.Controls
+{
+	public class TextStepperHandler : TextBoxHandler<TextStepperHandler.EtoUpDown, TextStepper, TextStepper.ICallback>, TextStepper.IHandler
+	{
+		public class EtoUpDown : swf.UpDownBase
+		{
+			public event EventHandler DownButtonClicked;
+			public event EventHandler UpButtonClicked;
+
+			public override void DownButton()
+			{
+				DownButtonClicked?.Invoke(this, EventArgs.Empty);
+			}
+
+			public override void UpButton()
+			{
+				UpButtonClicked?.Invoke(this, EventArgs.Empty);
+			}
+
+			protected override void UpdateEditText()
+			{
+				
+			}
+		}
+
+		public override EtoTextBox EtoTextBox => null;
+
+		public override swf.TextBox SwfTextBox => Control.GetType().GetField("upDownEdit", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(Control) as swf.TextBox;
+
+		public TextStepperHandler()
+		{
+			Control = new EtoUpDown();
+			Control.InterceptArrowKeys = false;
+		}
+
+		public StepperValidDirections ValidDirection { get; set; } = StepperValidDirections.Both;
+
+		public override bool ReadOnly
+		{
+			get { return Control.ReadOnly; }
+			set { Control.ReadOnly = value; }
+		}
+
+		public override bool ShowBorder
+		{
+			get { return Control.BorderStyle != swf.BorderStyle.None; }
+			set
+			{
+				Control.BorderStyle = value ? swf.BorderStyle.Fixed3D : swf.BorderStyle.None;
+			}
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case TextStepper.StepEvent:
+					Control.DownButtonClicked += (sender, e) =>
+					{
+						if (ValidDirection.HasFlag(StepperValidDirections.Down))
+							Callback.OnStep(Widget, new StepperEventArgs(StepperDirection.Down));
+					};
+					Control.UpButtonClicked += (sender, e) =>
+					{
+						if (ValidDirection.HasFlag(StepperValidDirections.Up))
+							Callback.OnStep(Widget, new StepperEventArgs(StepperDirection.Up));
+					};
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+	}
+}

--- a/Source/Eto.WinForms/Platform.cs
+++ b/Source/Eto.WinForms/Platform.cs
@@ -84,7 +84,7 @@ namespace Eto.WinForms
 			p.Add<Label.IHandler>(() => new LabelHandler());
 			p.Add<LinkButton.IHandler>(() => new LinkButtonHandler());
 			p.Add<ListBox.IHandler>(() => new ListBoxHandler());
-			p.Add<NumericUpDown.IHandler>(() => new NumericUpDownHandler());
+			p.Add<NumericStepper.IHandler>(() => new NumericStepperHandler());
 			p.Add<Panel.IHandler>(() => new PanelHandler());
 			p.Add<PasswordBox.IHandler>(() => new PasswordBoxHandler());
 			p.Add<ProgressBar.IHandler>(() => new ProgressBarHandler());
@@ -102,7 +102,9 @@ namespace Eto.WinForms
 			p.Add<TreeView.IHandler>(() => new TreeViewHandler());
 			p.Add<WebView.IHandler>(() => new WebViewHandler());
 			p.Add<RichTextArea.IHandler>(() => new RichTextAreaHandler());
-			
+			p.Add<Stepper.IHandler>(() => new ThemedStepperHandler());
+			p.Add<TextStepper.IHandler>(() => new TextStepperHandler());
+
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());
 			p.Add<ContextMenu.IHandler>(() => new ContextMenuHandler());

--- a/Source/Eto.WinRT/Eto.WinRT.csproj
+++ b/Source/Eto.WinRT/Eto.WinRT.csproj
@@ -269,7 +269,7 @@
     <Compile Include="Forms\Controls\ListBoxHandler.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Forms\Controls\NumericUpDownHandler.cs">
+    <Compile Include="Forms\Controls\NumericStepperHandler.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="Forms\Controls\PanelHandler.cs">

--- a/Source/Eto.WinRT/Forms/Controls/NumericStepperHandler.cs
+++ b/Source/Eto.WinRT/Forms/Controls/NumericStepperHandler.cs
@@ -8,9 +8,9 @@ using System.Text;
 
 namespace Eto.WinRT.Forms.Controls
 {
-	public class NumericUpDownHandler : WpfControl<mwc.NumericUpDown, NumericUpDown, NumericUpDown.ICallback>, NumericUpDown.IHandler
+	public class NumericStepperHandler : WpfControl<mwc.NumericUpDown, NumericStepper, NumericStepper.ICallback>, NumericStepper.IHandler
 	{
-		public NumericUpDownHandler()
+		public NumericStepperHandler()
 		{
 			Control = new mwc.NumericUpDown { ValueBarVisibility = mwc.NumericUpDownValueBarVisibility.Visible, ValueFormat = "0" };
 			Control.ValueChanged += (sender, e) => Callback.OnValueChanged(Widget, EventArgs.Empty);

--- a/Source/Eto.WinRT/Platform.cs
+++ b/Source/Eto.WinRT/Platform.cs
@@ -68,7 +68,7 @@ namespace Eto.WinRT
 			//p.Add<ImageView.IHandler>(() => new ImageViewHandler());
 			p.Add<Label.IHandler>(() => new LabelHandler());
 			//p.Add<ListBox.IHandler>(() => new ListBoxHandler());
-			p.Add<NumericUpDown.IHandler>(() => new NumericUpDownHandler());
+			p.Add<NumericStepper.IHandler>(() => new NumericStepperHandler());
 			p.Add<Panel.IHandler>(() => new PanelHandler());
 			p.Add<PasswordBox.IHandler>(() => new PasswordBoxHandler());
 			p.Add<ProgressBar.IHandler>(() => new ProgressBarHandler());

--- a/Source/Eto.Wpf/Eto.Wpf - net45.csproj
+++ b/Source/Eto.Wpf/Eto.Wpf - net45.csproj
@@ -94,6 +94,8 @@
     <Compile Include="Drawing\SystemColorsHandler.cs" />
     <Compile Include="Forms\Controls\ExpanderHandler.cs" />
     <Compile Include="Forms\Cells\CustomCellHandler.cs" />
+    <Compile Include="Forms\Controls\TextStepperHandler.cs" />
+    <Compile Include="Forms\Controls\StepperHandler.cs" />
     <Compile Include="Forms\Menu\MenuHandler.cs" />
     <Compile Include="Forms\PerMonitorDpiHelper.cs" />
     <Compile Include="Win32.dib.cs" />
@@ -155,7 +157,7 @@
     <Compile Include="Forms\Controls\ImageViewHandler.cs" />
     <Compile Include="Forms\Controls\LabelHandler.cs" />
     <Compile Include="Forms\Controls\ListBoxHandler.cs" />
-    <Compile Include="Forms\Controls\NumericUpDownHandler.cs" />
+    <Compile Include="Forms\Controls\NumericStepperHandler.cs" />
     <Compile Include="Forms\Controls\PanelHandler.cs" />
     <Compile Include="Forms\Controls\PasswordBoxHandler.cs" />
     <Compile Include="Forms\Controls\ProgressBarHandler.cs" />

--- a/Source/Eto.Wpf/Forms/Controls/NumericStepperHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/NumericStepperHandler.cs
@@ -14,7 +14,7 @@ namespace Eto.Wpf.Forms.Controls
 		public new mwc.Spinner Spinner { get { return base.Spinner; } }
 	}
 
-	public class NumericUpDownHandler : WpfControl<EtoDoubleUpDown, NumericUpDown, NumericUpDown.ICallback>, NumericUpDown.IHandler
+	public class NumericStepperHandler : WpfControl<EtoDoubleUpDown, NumericStepper, NumericStepper.ICallback>, NumericStepper.IHandler
 	{
 		double lastValue;
 
@@ -22,7 +22,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected override bool PreventUserResize { get { return true; } }
 
-		public NumericUpDownHandler()
+		public NumericStepperHandler()
 		{
 			Control = new EtoDoubleUpDown
 			{

--- a/Source/Eto.Wpf/Forms/Controls/StepperHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/StepperHandler.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using sw = System.Windows;
+using swc = System.Windows.Controls;
+using mwc = Xceed.Wpf.Toolkit;
+using Eto.Forms;
+
+namespace Eto.Wpf.Forms.Controls
+{
+	public class StepperHandler : WpfControl<mwc.ButtonSpinner, Stepper, Stepper.ICallback>, Stepper.IHandler
+	{
+		double originalWidth;
+		swc.Grid gridContent;
+
+		public StepperHandler()
+		{
+			Control = new mwc.ButtonSpinner();
+			Control.BorderThickness = new sw.Thickness(0);
+			Control.Padding = new sw.Thickness(0);
+			Control.Loaded += Control_Loaded;
+		}
+
+		void Control_Loaded(object sender, System.Windows.RoutedEventArgs e)
+		{
+			// when the control's size is set, grow the buttons instead of showing the entry area
+			var parentGrid = Control.FindChild<swc.Grid>(string.Empty);
+			if (parentGrid == null)
+				return;
+			parentGrid.ColumnDefinitions[0].Width = new sw.GridLength(0);
+			parentGrid.ColumnDefinitions[1].Width = new sw.GridLength(1, sw.GridUnitType.Star);
+
+			gridContent = parentGrid.FindChild<swc.Grid>("gridContent");
+			if (gridContent == null)
+				return;
+			gridContent.MinWidth = originalWidth = gridContent.Width;
+			gridContent.Width = double.NaN;
+		}
+
+		protected override void SetSize()
+		{
+			base.SetSize();
+			if (gridContent != null)
+			{
+				gridContent.MinWidth = double.IsNaN(PreferredSize.Width) ? originalWidth : 0;
+			}
+		}
+
+		public StepperValidDirections ValidDirection
+		{
+			get { return Control.ValidSpinDirection.ToEto(); }
+			set { Control.ValidSpinDirection = value.ToWpf(); }
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Stepper.StepEvent:
+					Control.Spin += (sender, e) => Callback.OnStep(Widget, new StepperEventArgs(e.Direction == Xceed.Wpf.Toolkit.SpinDirection.Increase ? StepperDirection.Up : StepperDirection.Down));
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+	}
+}

--- a/Source/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using sw = System.Windows;
+using swc = System.Windows.Controls;
+using mwc = Xceed.Wpf.Toolkit;
+using Eto.Forms;
+
+namespace Eto.Wpf.Forms.Controls
+{
+	public class TextStepperHandler : TextBoxHandler<mwc.ButtonSpinner, TextStepper, TextStepper.ICallback>, TextStepper.IHandler
+	{
+		public TextStepperHandler()
+		{
+			Control = new mwc.ButtonSpinner
+			{
+				Content = new mwc.WatermarkTextBox
+				{
+					BorderThickness = new sw.Thickness(0),
+					BorderBrush = null,
+					Padding = new sw.Thickness(0)
+				}
+			};
+		}
+
+		public override string PlaceholderText
+		{
+			get { return WatermarkTextBox.Watermark as string; }
+			set { WatermarkTextBox.Watermark = value; }
+		}
+
+		public StepperValidDirections ValidDirection
+		{
+			get { return Control.ValidSpinDirection.ToEto(); }
+			set { Control.ValidSpinDirection = value.ToWpf(); }
+		}
+
+		mwc.WatermarkTextBox WatermarkTextBox => (mwc.WatermarkTextBox)Control.Content;
+
+		protected override swc.TextBox TextBox => (swc.TextBox)Control.Content;
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case TextStepper.StepEvent:
+					Control.Spin += (sender, e) => Callback.OnStep(Widget, new StepperEventArgs(e.Direction == Xceed.Wpf.Toolkit.SpinDirection.Increase ? StepperDirection.Up : StepperDirection.Down));
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+	}
+}

--- a/Source/Eto.Wpf/Platform.cs
+++ b/Source/Eto.Wpf/Platform.cs
@@ -88,7 +88,7 @@ namespace Eto.Wpf
 			p.Add<Label.IHandler>(() => new LabelHandler());
 			p.Add<LinkButton.IHandler>(() => new LinkButtonHandler());
 			p.Add<ListBox.IHandler>(() => new ListBoxHandler());
-			p.Add<NumericUpDown.IHandler>(() => new NumericUpDownHandler());
+			p.Add<NumericStepper.IHandler>(() => new NumericStepperHandler());
 			p.Add<Panel.IHandler>(() => new PanelHandler());
 			p.Add<PasswordBox.IHandler>(() => new PasswordBoxHandler());
 			p.Add<ProgressBar.IHandler>(() => new ProgressBarHandler());
@@ -106,6 +106,8 @@ namespace Eto.Wpf
 			p.Add<TreeView.IHandler>(() => new TreeViewHandler());
 			//p.Add<WebView.IHandler>(()  => new WebViewHandler ());
 			p.Add<RichTextArea.IHandler>(() => new RichTextAreaHandler());
+			p.Add<Stepper.IHandler>(() => new StepperHandler());
+			p.Add<TextStepper.IHandler>(() => new TextStepperHandler());
 			
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/Source/Eto.Wpf/WpfConversions.cs
+++ b/Source/Eto.Wpf/WpfConversions.cs
@@ -9,6 +9,7 @@ using sp = System.Printing;
 using swc = System.Windows.Controls;
 using swmi = System.Windows.Media.Imaging;
 using swd = System.Windows.Documents;
+using xwt = Xceed.Wpf.Toolkit;
 using Eto.Wpf.Drawing;
 
 namespace Eto.Wpf
@@ -757,6 +758,26 @@ namespace Eto.Wpf
 				default:
 					throw new NotSupportedException();
 			}
+		}
+
+		public static StepperValidDirections ToEto(this xwt.ValidSpinDirections direction)
+		{
+			var dir = StepperValidDirections.None;
+			if (direction.HasFlag(xwt.ValidSpinDirections.Increase))
+				dir |= StepperValidDirections.Up;
+			if (direction.HasFlag(xwt.ValidSpinDirections.Decrease))
+				dir |= StepperValidDirections.Down;
+			return dir;
+		}
+
+		public static xwt.ValidSpinDirections ToWpf(this StepperValidDirections direction)
+		{
+			var dir = xwt.ValidSpinDirections.None;
+			if (direction.HasFlag(StepperValidDirections.Up))
+				dir |= xwt.ValidSpinDirections.Increase;
+			if (direction.HasFlag(StepperValidDirections.Down))
+				dir |= xwt.ValidSpinDirections.Decrease;
+			return dir;
 		}
 	}
 }

--- a/Source/Eto.Wpf/WpfExtensions.cs
+++ b/Source/Eto.Wpf/WpfExtensions.cs
@@ -38,10 +38,14 @@ namespace Eto.Wpf
 		public static T FindChild<T>(this sw.DependencyObject parent, string childName = null)
 			 where T : sw.DependencyObject
 		{
-			// Confirm parent and childName are valid. 
-			if (parent == null) return null;
+			return FindVisualChildren<T>(parent, childName).FirstOrDefault();
+		}
 
-			T foundChild = null;
+		public static IEnumerable<T> FindVisualChildren<T>(this sw.DependencyObject parent, string childName = null)
+			 where T : sw.DependencyObject
+		{
+			// Confirm parent and childName are valid. 
+			if (parent == null) yield break;
 
 			int childrenCount = swm.VisualTreeHelper.GetChildrenCount(parent);
 			for (int i = 0; i < childrenCount; i++)
@@ -52,31 +56,34 @@ namespace Eto.Wpf
 				if (childType == null)
 				{
 					// recursively drill down the tree
-					foundChild = FindChild<T>(child, childName);
-
-					// If the child is found, break so we do not overwrite the found child. 
-					if (foundChild != null) break;
+					foreach (var c in FindVisualChildren<T>(child, childName))
+					{
+						yield return c;
+					}
 				}
-				else if (!string.IsNullOrEmpty(childName))
+				else if (childName != null)
 				{
 					var frameworkElement = child as sw.FrameworkElement;
 					// If the child's name is set for search
 					if (frameworkElement != null && frameworkElement.Name == childName)
 					{
 						// if the child's name is of the request name
-						foundChild = (T)child;
-						break;
+						yield return childType;
+					}
+					else
+					{
+						foreach (var c in FindVisualChildren<T>(child, childName))
+						{
+							yield return c;
+						}
 					}
 				}
 				else
 				{
 					// child element found.
-					foundChild = (T)child;
-					break;
+					yield return childType;
 				}
 			}
-
-			return foundChild;
 		}
 
 		public static sw.Window GetParentWindow(this sw.FrameworkElement element)

--- a/Source/Eto.iOS/Eto.iOS.csproj
+++ b/Source/Eto.iOS/Eto.iOS.csproj
@@ -139,7 +139,7 @@
     <Compile Include="..\Eto.Mac\Drawing\SplineHelper.cs">
       <Link>Drawing\SplineHelper.cs</Link>
     </Compile>
-    <Compile Include="Forms\Controls\NumericUpDownHandler.cs" />
+    <Compile Include="Forms\Controls\NumericStepperHandler.cs" />
     <Compile Include="..\Eto.Mac\Drawing\TextureBrushHandler.cs">
       <Link>Drawing\TextureBrushHandler.cs</Link>
     </Compile>

--- a/Source/Eto.iOS/Forms/Controls/NumericStepperHandler.cs
+++ b/Source/Eto.iOS/Forms/Controls/NumericStepperHandler.cs
@@ -7,9 +7,9 @@ using Eto.Drawing;
 
 namespace Eto.iOS.Forms.Controls
 {
-	public class NumericUpDownHandler : IosControl<UITextField, NumericUpDown, NumericUpDown.ICallback>, NumericUpDown.IHandler
+	public class NumericStepperHandler : IosControl<UITextField, NumericStepper, NumericStepper.ICallback>, NumericStepper.IHandler
 	{
-		public NumericUpDownHandler()
+		public NumericStepperHandler()
 		{
 			Control = new UITextField();
 		}

--- a/Source/Eto.iOS/Platform.cs
+++ b/Source/Eto.iOS/Platform.cs
@@ -78,7 +78,7 @@ namespace Eto.iOS
 			p.Add<ImageView.IHandler>(() => new ImageViewHandler());
 			p.Add<Label.IHandler>(() => new LabelHandler());
 			p.Add<ListBox.IHandler>(() => new ListBoxHandler());
-			p.Add<NumericUpDown.IHandler>(() => new NumericUpDownHandler());
+			p.Add<NumericStepper.IHandler>(() => new NumericStepperHandler());
 			p.Add<Panel.IHandler>(() => new PanelHandler());
 			p.Add<PasswordBox.IHandler>(() => new PasswordBoxHandler());
 			p.Add<ProgressBar.IHandler>(() => new ProgressBarHandler());

--- a/Source/Eto/Eto - pcl.csproj
+++ b/Source/Eto/Eto - pcl.csproj
@@ -120,7 +120,7 @@
     <Compile Include="Forms\Controls\MouseEventArgs.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Forms\Controls\NumericUpDown.cs" />
+    <Compile Include="Forms\Controls\NumericStepper.cs" />
     <Compile Include="Forms\Controls\Panel.cs" />
     <Compile Include="Forms\Controls\RadioButton.cs" />
     <Compile Include="Forms\Controls\Scrollable.cs" />
@@ -333,6 +333,10 @@
     <Compile Include="Drawing\IconFrame.cs" />
     <Compile Include="Forms\AboutDialog.cs" />
     <Compile Include="Forms\ThemedControls\ThemedAboutHandler.cs" />
+    <Compile Include="Forms\Controls\Stepper.cs" />
+    <Compile Include="Forms\Controls\TextStepper.cs" />
+    <Compile Include="Forms\ThemedControls\ThemedStepperHandler.cs" />
+    <Compile Include="Forms\ThemedControls\ThemedTextStepperHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\LICENSE">

--- a/Source/Eto/Forms/BindingExtensions.cs
+++ b/Source/Eto/Forms/BindingExtensions.cs
@@ -15,7 +15,7 @@ namespace Eto.Forms
 		/// Causes the change event of the binding to occur only when the <see cref="Control.LostFocus"/> event is triggered.
 		/// </summary>
 		/// <remarks>
-		/// This is useful for text-based input controls such as the <see cref="NumericUpDown"/> when a partial input can be invalid.
+		/// This is useful for text-based input controls such as the <see cref="NumericStepper"/> when a partial input can be invalid.
 		/// The binding will only be updated when the control has lost the input focus, where by default it will be updated for every
 		/// change while the user is updating the control.
 		/// </remarks>

--- a/Source/Eto/Forms/Controls/NumericStepper.cs
+++ b/Source/Eto/Forms/Controls/NumericStepper.cs
@@ -5,13 +5,24 @@ using Eto.Drawing;
 namespace Eto.Forms
 {
 	/// <summary>
+	/// Control for the user to enter a numeric value (obsolete, use NumericStepper instead)
+	/// </summary>
+	/// <remarks>
+	/// This usually presents with a <see cref="Stepper"/> to increase/decrease the value, or a specific numeric keyboard.
+	/// </remarks>
+	[Obsolete("Since 2.4: Use NumericStepper instead")]
+	public class NumericUpDown : NumericStepper
+	{
+	}
+
+	/// <summary>
 	/// Control for the user to enter a numeric value
 	/// </summary>
 	/// <remarks>
-	/// This usually presents with a spinner to increase/decrease the value, or a specific numeric keyboard.
+	/// This usually presents with a <see cref="Stepper"/> to increase/decrease the value, or a specific numeric keyboard.
 	/// </remarks>
-	[Handler(typeof(NumericUpDown.IHandler))]
-	public class NumericUpDown : CommonControl
+	[Handler(typeof(NumericStepper.IHandler))]
+	public class NumericStepper : CommonControl
 	{
 		new IHandler Handler { get { return (IHandler)base.Handler; } }
 
@@ -31,7 +42,7 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this <see cref="Eto.Forms.NumericUpDown"/> is read only.
+		/// Gets or sets a value indicating whether this <see cref="Eto.Forms.NumericStepper"/> is read only.
 		/// </summary>
 		/// <remarks>
 		/// A read only control can copy the value and focus the control, but cannot edit or change the value.
@@ -101,7 +112,7 @@ namespace Eto.Forms
 		/// Gets or sets the number of digits to display after the decimal.
 		/// </summary>
 		/// <remarks>
-		/// The NumericUpDown control will at least show the number of fraction digits as specified by this value, padded
+		/// The NumericStepper control will at least show the number of fraction digits as specified by this value, padded
 		/// by zeros. 
 		/// The <see cref="MaximumDecimalPlaces"/> specifies the maximum number of fraction digits the control will display
 		/// if the value has a value that can be represented by more digits.
@@ -111,7 +122,7 @@ namespace Eto.Forms
 		/// This shows the effect of the <see cref="DecimalPlaces"/> and <see cref="MaximumDecimalPlaces"/> on the display 
 		/// of the control and its returned value.
 		/// <pre>
-		/// var numeric = new NumericUpDown();
+		/// var numeric = new NumericStepper();
 		/// 
 		/// numeric.DecimalPlaces = 2;
 		/// numeric.MaximumDecimalPlaces = 4;
@@ -161,11 +172,11 @@ namespace Eto.Forms
 		/// Gets the binding for the <see cref="Value"/> property.
 		/// </summary>
 		/// <value>The value binding.</value>
-		public BindableBinding<NumericUpDown, double> ValueBinding
+		public BindableBinding<NumericStepper, double> ValueBinding
 		{
 			get
 			{
-				return new BindableBinding<NumericUpDown, double>(
+				return new BindableBinding<NumericStepper, double>(
 					this, 
 					c => c.Value, 
 					(c, v) => c.Value = v, 
@@ -190,37 +201,37 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Callback interface for the <see cref="NumericUpDown"/>
+		/// Callback interface for the <see cref="NumericStepper"/>
 		/// </summary>
 		public new interface ICallback : CommonControl.ICallback
 		{
 			/// <summary>
 			/// Raises the value changed event.
 			/// </summary>
-			void OnValueChanged(NumericUpDown widget, EventArgs e);
+			void OnValueChanged(NumericStepper widget, EventArgs e);
 		}
 
 		/// <summary>
-		/// Callback implementation for handlers of the <see cref="NumericUpDown"/>
+		/// Callback implementation for handlers of the <see cref="NumericStepper"/>
 		/// </summary>
 		protected new class Callback : CommonControl.Callback, ICallback
 		{
 			/// <summary>
 			/// Raises the value changed event.
 			/// </summary>
-			public void OnValueChanged(NumericUpDown widget, EventArgs e)
+			public void OnValueChanged(NumericStepper widget, EventArgs e)
 			{
 				widget.Platform.Invoke(() => widget.OnValueChanged(e));
 			}
 		}
 
 		/// <summary>
-		/// Handler interface for the <see cref="NumericUpDown"/> control.
+		/// Handler interface for the <see cref="NumericStepper"/> control.
 		/// </summary>
 		public new interface IHandler : CommonControl.IHandler
 		{
 			/// <summary>
-			/// Gets or sets a value indicating whether this <see cref="Eto.Forms.NumericUpDown"/> is read only.
+			/// Gets or sets a value indicating whether this <see cref="Eto.Forms.NumericStepper"/> is read only.
 			/// </summary>
 			/// <remarks>
 			/// A read only control can copy the value and focus the control, but cannot edit or change the value.
@@ -259,7 +270,7 @@ namespace Eto.Forms
 			/// Gets or sets the number of digits to display after the decimal.
 			/// </summary>
 			/// <remarks>
-			/// The NumericUpDown control will at least show the number of fraction digits as specified by this value, padded
+			/// The NumericStepper control will at least show the number of fraction digits as specified by this value, padded
 			/// by zeros. 
 			/// The <see cref="MaximumDecimalPlaces"/> specifies the maximum number of fraction digits the control will display
 			/// if the value has a value that can be represented by more digits.

--- a/Source/Eto/Forms/Controls/Stepper.cs
+++ b/Source/Eto/Forms/Controls/Stepper.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.ComponentModel;
+
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Direction of the stepper when it has been clicked
+	/// </summary>
+	public enum StepperDirection
+	{
+		/// <summary>
+		/// The Up direction, which usually increases the value
+		/// </summary>
+		Up,
+		/// <summary>
+		/// The Down direction, which usually decreases the value
+		/// </summary>
+		Down
+	}
+
+	/// <summary>
+	/// Valid stepper directions for the (typically) up/down buttons
+	/// </summary>
+	/// <remarks>
+	/// Note that some platforms do not actually disable the up or down buttons, but just won't trigger the <see cref="Stepper.Step"/>
+	/// event when it is not valid.
+	/// </remarks>
+	[Flags]
+	public enum StepperValidDirections
+	{
+		/// <summary>
+		/// Neither the up or down buttons are valid
+		/// </summary>
+		None = 0,
+		/// <summary>
+		/// Specifies that the up/increase button is a valid direction for the stepper
+		/// </summary>
+		Up = 1,
+		/// <summary>
+		/// Specifies that the down/decrease button is a valid direction for the stepper
+		/// </summary>
+		Down = 2,
+		/// <summary>
+		/// Combines both the <see cref="Up"/> and <see cref="Down"/> flags.
+		/// </summary>
+		Both = Up | Down
+	}
+
+	/// <summary>
+	/// Arguments for the <see cref="Stepper"/> and <see cref="TextStepper"/> to give you the direction of the step.
+	/// </summary>
+	public class StepperEventArgs : EventArgs
+	{
+		/// <summary>
+		/// Gets the step direction, either up/increase, or down/decrease.
+		/// </summary>
+		/// <value>The step direction.</value>
+		public StepperDirection Direction { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.Forms.StepperEventArgs"/> class.
+		/// </summary>
+		/// <param name="direction">Direction of the step that the user clicked.</param>
+		public StepperEventArgs(StepperDirection direction)
+		{
+			Direction = direction;
+		}
+	}
+
+	/// <summary>
+	/// Control that allows you to "step" through values, usually presented by two buttons arranged vertically with up and down arrows.
+	/// </summary>
+	[Handler(typeof(IHandler))]
+	public class Stepper : Control
+	{
+		new IHandler Handler { get { return (IHandler)base.Handler; } }
+
+		/// <summary>
+		/// Identifier for the <see cref="Step"/> event.
+		/// </summary>
+		public const string StepEvent = "Stepper.Step";
+
+		/// <summary>
+		/// Event to handle when the user clicks on one of the step buttons, either up or down.
+		/// </summary>
+		public event EventHandler<StepperEventArgs> Step
+		{
+			add { Properties.AddHandlerEvent(StepEvent, value); }
+			remove { Properties.RemoveEvent(StepEvent, value); }
+		}
+
+		/// <summary>
+		/// Triggers the <see cref="Step"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected void OnStep(StepperEventArgs e)
+		{
+			Properties.TriggerEvent(StepEvent, this, e);
+		}
+
+		/// <summary>
+		/// Gets or sets the valid directions the stepper will allow the user to click.
+		/// </summary>
+		/// <remarks>
+		/// On some platforms, the up and/or down buttons will not appear disabled, but will not trigger any events when they are 
+		/// not set as a valid direction.
+		/// </remarks>
+		/// <value>The valid directions for the stepper.</value>
+		[DefaultValue(StepperValidDirections.Both)] 
+		public StepperValidDirections ValidDirection
+		{
+			get { return Handler.ValidDirection; }
+			set { Handler.ValidDirection = value; }
+		}
+
+		ICallback callback = new Callback();
+
+		/// <summary>
+		/// Gets the callback.
+		/// </summary>
+		/// <returns>The callback.</returns>
+		protected override object GetCallback() => callback;
+
+		/// <summary>
+		/// Callback interface for the Stepper
+		/// </summary>
+		public new interface ICallback : Control.ICallback
+		{
+			/// <summary>
+			/// Triggers the <see cref="Step"/> event.
+			/// </summary>
+			/// <param name="widget">Widget instance to trigger the event</param>
+			/// <param name="e">Event arguments</param>
+			void OnStep(Stepper widget, StepperEventArgs e);
+		}
+
+		/// <summary>
+		/// Callback implementation for the Stepper
+		/// </summary>
+		protected new class Callback : Control.Callback, ICallback
+		{
+			/// <summary>
+			/// Triggers the <see cref="Step"/> event.
+			/// </summary>
+			/// <param name="widget">Widget instance to trigger the event</param>
+			/// <param name="e">Event arguments</param>
+			public void OnStep(Stepper widget, StepperEventArgs e)
+			{
+				widget.Platform.Invoke(() => widget.OnStep(e));
+			}
+		}
+
+		/// <summary>
+		/// Handler interface for the Stepper
+		/// </summary>
+		public new interface IHandler : Control.IHandler
+		{
+			/// <summary>
+			/// Gets or sets the valid directions the stepper will allow the user to click.
+			/// </summary>
+			/// <remarks>
+			/// On some platforms, the up and/or down buttons will not appear disabled, but will not trigger any events when they are 
+			/// not set as a valid direction.
+			/// </remarks>
+			/// <value>The valid directions for the stepper.</value>
+			StepperValidDirections ValidDirection { get; set; }
+		}
+	}
+}

--- a/Source/Eto/Forms/Controls/TextStepper.cs
+++ b/Source/Eto/Forms/Controls/TextStepper.cs
@@ -1,0 +1,113 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Stepper with custom text entry field
+	/// </summary>
+	/// <remarks>
+	/// This can be used to implement a custom stepper interface that is not entirely restricted to numeric values like <see cref="NumericStepper"/>.
+	/// </remarks>
+	[Handler(typeof(IHandler))]
+	public class TextStepper : TextBox
+	{
+		new IHandler Handler { get { return (IHandler)base.Handler; } }
+
+		static TextStepper()
+		{
+			EventLookup.Register((TextStepper c) => c.OnStep(null), StepEvent);
+		}
+
+		/// <summary>
+		/// Identifier for the <see cref="Step"/> event.
+		/// </summary>
+		public const string StepEvent = "TextStepper.Step";
+
+		/// <summary>
+		/// Event to handle when the user clicks on one of the step buttons, either up or down.
+		/// </summary>
+		public event EventHandler<StepperEventArgs> Step
+		{
+			add { Properties.AddHandlerEvent(StepEvent, value); }
+			remove { Properties.RemoveEvent(StepEvent, value); }
+		}
+
+		/// <summary>
+		/// Triggers the <see cref="Step"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected void OnStep(StepperEventArgs e)
+		{
+			Properties.TriggerEvent(StepEvent, this, e);
+		}
+
+		/// <summary>
+		/// Gets or sets the valid directions the stepper will allow the user to click.
+		/// </summary>
+		/// <remarks>
+		/// On some platforms, the up and/or down buttons will not appear disabled, but will not trigger any events when they are 
+		/// not set as a valid direction.
+		/// </remarks>
+		/// <value>The valid directions for the stepper.</value>
+		[DefaultValue(StepperValidDirections.Both)] 
+		public StepperValidDirections ValidDirection
+		{
+			get { return Handler.ValidDirection; }
+			set { Handler.ValidDirection = value; }
+		}
+
+		ICallback callback = new Callback();
+
+		/// <summary>
+		/// Gets the callback.
+		/// </summary>
+		/// <returns>The callback.</returns>
+		protected override object GetCallback() => callback;
+
+		/// <summary>
+		/// Callback interface for the TextStepper
+		/// </summary>
+		public new interface ICallback : TextBox.ICallback
+		{
+			/// <summary>
+			/// Triggers the <see cref="Step"/> event.
+			/// </summary>
+			/// <param name="widget">Widget instance to trigger the event</param>
+			/// <param name="e">Event arguments</param>
+			void OnStep(TextStepper widget, StepperEventArgs e);
+		}
+
+		/// <summary>
+		/// Callback implementation for the TextStepper
+		/// </summary>
+		protected new class Callback : TextBox.Callback, ICallback
+		{
+			/// <summary>
+			/// Triggers the <see cref="Step"/> event.
+			/// </summary>
+			/// <param name="widget">Widget instance to trigger the event</param>
+			/// <param name="e">Event arguments</param>
+			public void OnStep(TextStepper widget, StepperEventArgs e)
+			{
+				widget.Platform.Invoke(() => widget.OnStep(e));
+			}
+		}
+
+		/// <summary>
+		/// Handler interface for platform implementations of the TextStepper
+		/// </summary>
+		public new interface IHandler : TextBox.IHandler
+		{
+			/// <summary>
+			/// Gets or sets the valid directions the stepper will allow the user to click.
+			/// </summary>
+			/// <remarks>
+			/// On some platforms, the up and/or down buttons will not appear disabled, but will not trigger any events when they are 
+			/// not set as a valid direction.
+			/// </remarks>
+			/// <value>The valid directions for the stepper.</value>
+			StepperValidDirections ValidDirection { get; set; }
+		}
+	}
+}

--- a/Source/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/Source/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -295,62 +295,51 @@ namespace Eto.Forms
 		/// <param name="id">Identifier of the event</param>
 		public override void AttachEvent(string id)
 		{
-			var handled = false;
-
 			switch (id)
 			{
 				case Eto.Forms.Control.KeyDownEvent:
 					Control.KeyDown += (s, e) => Callback.OnKeyDown(Widget, e);
-					handled = true;
 					break;
 				case Eto.Forms.Control.KeyUpEvent:
 					Control.KeyUp += (s, e) => Callback.OnKeyUp(Widget, e);
-					handled = true;
 					break;
 				case Eto.Forms.Control.SizeChangedEvent:
 					Control.SizeChanged += (s, e) => Callback.OnSizeChanged(Widget, e);
-					handled = true;
 					break;
 				case Eto.Forms.Control.MouseDoubleClickEvent:
 					Control.MouseDoubleClick += (s, e) => Callback.OnMouseDoubleClick(Widget, e);
-					handled = true;
 					break;
 				case Eto.Forms.Control.MouseEnterEvent:
 					Control.MouseEnter += (s, e) => Callback.OnMouseEnter(Widget, e);
-					handled = true;
 					break;
 				case Eto.Forms.Control.MouseLeaveEvent:
 					Control.MouseLeave += (s, e) => Callback.OnMouseLeave(Widget, e);
-					handled = true;
 					break;
 				case Eto.Forms.Control.MouseDownEvent:
 					Control.MouseDown += (s, e) => Callback.OnMouseDown(Widget, e);
-					handled = true;
 					break;
 				case Eto.Forms.Control.MouseUpEvent:
 					Control.MouseUp += (s, e) => Callback.OnMouseUp(Widget, e);
-					handled = true;
 					break;
 				case Eto.Forms.Control.MouseMoveEvent:
 					Control.MouseMove += (s, e) => Callback.OnMouseMove(Widget, e);
-					handled = true;
 					break;
 				case Eto.Forms.Control.MouseWheelEvent:
 					Control.MouseWheel += (s, e) => Callback.OnMouseWheel(Widget, e);
-					handled = true;
 					break;
 				case Eto.Forms.Control.GotFocusEvent:
 					Control.GotFocus += (s, e) => Callback.OnGotFocus(Widget, e);
-					handled = true;
 					break;
 				case Eto.Forms.Control.LostFocusEvent:
 					Control.LostFocus += (s, e) => Callback.OnLostFocus(Widget, e);
-					handled = true;
+					break;
+				case Eto.Forms.Control.TextInputEvent:
+					Control.TextInput += (s, e) => Callback.OnTextInput(Widget, e);
+					break;
+				default:
+					base.AttachEvent(id);
 					break;
 			}
-
-			if (!handled)
-				base.AttachEvent(id);
 		}
 
 		#endregion

--- a/Source/Eto/Forms/ThemedControls/ThemedStepperHandler.cs
+++ b/Source/Eto/Forms/ThemedControls/ThemedStepperHandler.cs
@@ -1,0 +1,148 @@
+﻿using System;
+using Eto.Drawing;
+using System.ComponentModel;
+
+namespace Eto.Forms.ThemedControls
+{
+	/// <summary>
+	/// Themed version of the <see cref="Stepper"/> control for platforms that have no support for such a control.
+	/// </summary>
+	/// <remarks>
+	/// Currently used for Gtk and WinForms.  Mac and Wpf Toolkit have controls that have this functionality.
+	/// 
+	/// To use this implementation for all platforms, add this before you start your app:
+	/// <code>
+	/// Platform.Detect.Add&gt;Stepper.IHandler&lt;(() => new Eto.Forms.ThemedControls.ThemedStepperHandler());
+	/// </code>
+	/// </remarks>
+	public class ThemedStepperHandler : ThemedControlHandler<Panel, Stepper, Stepper.ICallback>, Stepper.IHandler
+	{
+		StepperValidDirections validDirection = StepperValidDirections.Both;
+		Font font = SystemFonts.Default(4);
+		Button upButton;
+		Button downButton;
+		Orientation orientation = Orientation.Vertical;
+
+		/// <summary>
+		/// Gets or sets the text for the up/increase button
+		/// </summary>
+		public string UpText
+		{
+			get { return upButton.Text; }
+			set { upButton.Text = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the text for the down/decrease button
+		/// </summary>
+		public string DownText
+		{
+			get { return downButton.Text; }
+			set { downButton.Text = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the font for the text in the buttons
+		/// </summary>
+		public Font Font
+		{
+			get { return font; }
+			set
+			{
+				font = value;
+				upButton.Font = font;
+				downButton.Font = font;
+			}
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the ThemedStepperHandler
+		/// </summary>
+		public ThemedStepperHandler()
+		{
+			upButton = new Button { Text = "\u25B2", MinimumSize = Size.Empty, Font = font };
+			downButton = new Button { Text = "\u25BC", MinimumSize = Size.Empty, Font = font };
+
+			Control = new Panel { Height = 28, Width = 17 };
+			Setup();
+		}
+
+		/// <summary>
+		/// Gets or sets the orientation of the stepper
+		/// </summary>
+		[DefaultValue(Orientation.Vertical)]
+		public Orientation Orientation
+		{
+			get { return orientation; }
+			set
+			{
+				if (orientation != value)
+				{
+					orientation = value;
+					Setup();
+				}
+			}
+		}
+
+		void Setup()
+		{
+			if (Orientation == Orientation.Vertical)
+				Control.Content = new TableLayout(true, upButton, downButton);
+			else
+				Control.Content = TableLayout.HorizontalScaled(downButton, upButton);
+		}
+
+		/// <summary>
+		/// Gets or sets the valid directions for the stepper
+		/// </summary>
+		public StepperValidDirections ValidDirection
+		{
+			get { return validDirection; }
+			set
+			{
+				if (validDirection != value)
+				{
+					validDirection = value;
+					UpdateButtonState();
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating that the control is enabled
+		/// </summary>
+		public override bool Enabled
+		{
+			get { return base.Enabled; }
+			set
+			{
+				base.Enabled = value;
+				UpdateButtonState();
+			}
+		}
+
+		void UpdateButtonState()
+		{
+			upButton.Enabled = Enabled && validDirection.HasFlag(StepperValidDirections.Up);
+			downButton.Enabled = Enabled && validDirection.HasFlag(StepperValidDirections.Down);
+		}
+
+		/// <summary>
+		/// Attaches control events
+		/// </summary>
+		/// <param name="id">ID of the event to attach</param>
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Stepper.StepEvent:
+					upButton.Click += (sender, e) => Callback.OnStep(Widget, new StepperEventArgs(StepperDirection.Up));
+					downButton.Click += (sender, e) => Callback.OnStep(Widget, new StepperEventArgs(StepperDirection.Down));
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+	}
+}

--- a/Source/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
+++ b/Source/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
@@ -1,0 +1,192 @@
+﻿using System;
+using System.ComponentModel;
+using Eto.Drawing;
+
+namespace Eto.Forms.ThemedControls
+{
+	/// <summary>
+	/// Themed implementation of the <see cref="TextStepper"/> control composed of a <see cref="TextBox"/> and <see cref="Stepper"/>.
+	/// </summary>
+	public class ThemedTextStepperHandler : ThemedControlHandler<TableLayout, TextStepper, TextStepper.ICallback>, TextStepper.IHandler
+	{
+		readonly TextBox textBox;
+		readonly Stepper stepper;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.Forms.ThemedControls.ThemedTextStepperHandler"/> class.
+		/// </summary>
+		public ThemedTextStepperHandler()
+		{
+			textBox = new TextBox();
+			stepper = new Stepper();
+			Control = TableLayout.Horizontal(TableLayout.AutoSized(textBox, centered: true), stepper);
+			Control.EndInit();
+		}
+
+		/// <summary>
+		/// Gets or sets the index of the current insertion point.
+		/// </summary>
+		/// <remarks>
+		/// When there is selected text, this is usually the start of the selection.
+		/// </remarks>
+		/// <value>The index of the current insertion point.</value>
+		public int CaretIndex
+		{
+			get { return textBox.CaretIndex; }
+			set { textBox.CaretIndex = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the font for the text of the control
+		/// </summary>
+		/// <value>The text font.</value>
+		public Font Font
+		{
+			get { return textBox.Font; }
+			set { textBox.Font = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the maximum length of the text that can be entered in the control.
+		/// </summary>
+		/// <remarks>
+		/// This typically does not affect the value set using <see cref="TextControl.Text"/>, only the limit of what the user can 
+		/// enter into the control.
+		/// </remarks>
+		/// <value>The maximum length of the text in the control.</value>
+		public int MaxLength
+		{
+			get { return textBox.MaxLength; }
+			set { textBox.MaxLength = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the placeholder text to show as a hint of what the user should enter.
+		/// </summary>
+		/// <remarks>
+		/// Typically this will be shown when the control is blank, and will dissappear when the user enters text or if
+		/// it has an existing value.
+		/// </remarks>
+		/// <value>The placeholder text.</value>
+		public string PlaceholderText
+		{
+			get { return textBox.PlaceholderText; }
+			set { textBox.PlaceholderText = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="Eto.Forms.TextBox"/> is read only.
+		/// </summary>
+		/// <remarks>
+		/// A user can selected and copied text when the read only, however the user will not be able to change any of the text.
+		/// This differs from the <see cref="Control.Enabled"/> property, which disables all user interaction.
+		/// </remarks>
+		/// <value><c>true</c> if the control is read only; otherwise, <c>false</c>.</value>
+		public bool ReadOnly
+		{
+			get { return textBox.ReadOnly; }
+			set { textBox.ReadOnly = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the current text selection.
+		/// </summary>
+		/// <value>The text selection.</value>
+		public Range<int> Selection
+		{
+			get { return textBox.Selection; }
+			set { textBox.Selection = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether to show the control's border.
+		/// </summary>
+		/// <remarks>
+		/// This is a hint to omit the border of the control and show it as plainly as possible.
+		/// 
+		/// Typically used when you want to show the control within a cell of the <see cref="GridView"/>.
+		/// </remarks>
+		/// <value><c>true</c> to show the control border; otherwise, <c>false</c>.</value>
+		[DefaultValue(true)]
+		public bool ShowBorder
+		{
+			get { return textBox.ShowBorder; }
+			set { textBox.ShowBorder = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the text of the control.
+		/// </summary>
+		/// <value>The text content.</value>
+		public string Text
+		{
+			get { return textBox.Text; }
+			set { textBox.Text = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the color of the text.
+		/// </summary>
+		/// <remarks>
+		/// By default, the text will get a color based on the user's theme. However, this is usually black.
+		/// </remarks>
+		/// <value>The color of the text.</value>
+		public Color TextColor
+		{
+			get { return textBox.TextColor; }
+			set { textBox.TextColor = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the valid directions the stepper will allow the user to click.
+		/// </summary>
+		/// <remarks>
+		/// On some platforms, the up and/or down buttons will not appear disabled, but will not trigger any events when they are 
+		/// not set as a valid direction.
+		/// </remarks>
+		/// <value>The valid directions for the stepper.</value>
+		[DefaultValue(StepperValidDirections.Both)]
+		public StepperValidDirections ValidDirection
+		{
+			get { return stepper.ValidDirection; }
+			set { stepper.ValidDirection = value; }
+		}
+
+		/// <summary>
+		/// Selects all of the text in the control.
+		/// </summary>
+		/// <remarks>
+		/// When setting the selection, the control will be focussed and the associated keyboard may appear on mobile platforms.
+		/// </remarks>
+		public void SelectAll()
+		{
+			textBox.SelectAll();
+		}
+
+		/// <summary>
+		/// Attaches the specified event to the platform-specific control
+		/// </summary>
+		/// <remarks>Implementors should override this method to handle any events that the widget
+		/// supports. Ensure to call the base class' implementation if the event is not
+		/// one the specific widget supports, so the base class' events can be handled as well.</remarks>
+		/// <param name="id">Identifier of the event</param>
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case TextControl.TextChangedEvent:
+					textBox.TextChanged += (sender, e) => Callback.OnTextChanged(Widget, e);
+					break;
+				case TextBox.TextChangingEvent:
+					textBox.TextChanging += (sender, e) => Callback.OnTextChanging(Widget, e);
+					break;
+				case TextStepper.StepEvent:
+					stepper.Step += (sender, e) => Callback.OnStep(Widget, e);
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+	}
+}


### PR DESCRIPTION
- NumericUpDown is now marked as obsolete
- Implementations for all desktop platforms
- Themed implementations for platforms that don’t support Stepper and/or TextStepper directly