### PR TITLE
Mac: Use CrashReporter when an unhandled exception occurs.

### DIFF
--- a/Source/Eto.Mac/CrashReporter.cs
+++ b/Source/Eto.Mac/CrashReporter.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace Eto.Mac
+{
+	public static class CrashReporter
+	{
+		[DllImport("libSystem.B.Dylib")]
+		static extern IntPtr dlsym(IntPtr handle, string symbol);
+
+		[DllImport("libc")]
+		static extern void signal(int sig, IntPtr handler);
+
+		[DllImport("libc")]
+		static extern void kill(int pid, int sig);
+
+		[DllImport("libc")]
+		static extern int getpid();
+
+		const int SIGSEGV = 11;
+
+		public static void Attach(AppDomain domain = null)
+		{
+			domain = domain ?? AppDomain.CurrentDomain;
+			domain.UnhandledException += CurrentDomain_UnhandledException;
+		}
+
+		static void CurrentDomain_UnhandledException(object sender, System.UnhandledExceptionEventArgs e)
+		{
+			// if we're not debugging, generate native crash reports with .NET exception info included
+			var crashReporter = dlsym(new IntPtr(-2), "__crashreporter_info__"); // -2 = auto
+			if (crashReporter != IntPtr.Zero)
+			{
+				unsafe
+				{
+					var msg = e.ExceptionObject?.ToString();
+					var ptr = (IntPtr*)crashReporter;
+					if (*ptr != IntPtr.Zero)
+					{
+						// append to existing string
+						var existingMsg = Marshal.PtrToStringAuto(*ptr);
+						if (!string.IsNullOrEmpty(existingMsg))
+							msg = existingMsg
+								+ Environment.NewLine
+								+ Environment.NewLine
+								+ msg;
+					}
+					*ptr = Marshal.StringToHGlobalAuto(msg);
+					signal(SIGSEGV, IntPtr.Zero); // replace mono's SIGSEGV handler with the system default
+					kill(getpid(), SIGSEGV); // cause a SIGSEGV
+				}
+			}
+		}
+	}
+}

--- a/Source/Eto.Mac/Eto.Mac - net45.csproj
+++ b/Source/Eto.Mac/Eto.Mac - net45.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="Drawing\IconFrameHandler.cs" />
     <Compile Include="Forms\Controls\StepperHandler.cs" />
+    <Compile Include="CrashReporter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Source/Eto.Mac/Eto.Mac64 - net45.csproj
+++ b/Source/Eto.Mac/Eto.Mac64 - net45.csproj
@@ -225,6 +225,7 @@
     <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="Drawing\IconFrameHandler.cs" />
     <Compile Include="Forms\Controls\StepperHandler.cs" />
+    <Compile Include="CrashReporter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Source/Eto.Mac/Eto.XamMac - net45.csproj
+++ b/Source/Eto.Mac/Eto.XamMac - net45.csproj
@@ -243,6 +243,7 @@
     <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="Drawing\IconFrameHandler.cs" />
     <Compile Include="Forms\Controls\StepperHandler.cs" />
+    <Compile Include="CrashReporter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/Source/Eto.Mac/Eto.XamMac2 - mobile.csproj
+++ b/Source/Eto.Mac/Eto.XamMac2 - mobile.csproj
@@ -234,6 +234,7 @@
     <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="Drawing\IconFrameHandler.cs" />
     <Compile Include="Forms\Controls\StepperHandler.cs" />
+    <Compile Include="CrashReporter.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/Source/Eto.Mac/Eto.XamMac2 - net45.csproj
+++ b/Source/Eto.Mac/Eto.XamMac2 - net45.csproj
@@ -231,6 +231,7 @@
     <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="Drawing\IconFrameHandler.cs" />
     <Compile Include="Forms\Controls\StepperHandler.cs" />
+    <Compile Include="CrashReporter.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/Source/Eto.Mac/Forms/ApplicationHandler.cs
+++ b/Source/Eto.Mac/Forms/ApplicationHandler.cs
@@ -3,6 +3,7 @@ using Eto.Forms;
 using Eto.Mac.Forms.Actions;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.InteropServices;
 
 #if XAMMAC2
 using AppKit;
@@ -47,6 +48,21 @@ namespace Eto.Mac.Forms
 		public bool AddFullScreenMenuItem { get; set; }
 
 		public bool AllowClosingMainForm { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether native macOS crash reports are generated for uncaught .NET exceptions.
+		/// </summary>
+		/// <remarks>
+		/// By default, this will be true when NOT debugging in Xamarin Studio.
+		/// 
+		/// The crash report will also include the .NET exception details, which can be extremely useful to determine 
+		/// where crashes occurred.
+		/// 
+		/// When attaching to existing applications, this is assumed to be dealt with by native code and will not be 
+		/// enabled regardless.
+		/// </remarks>
+		/// <value><c>true</c> to enable native crash reports; otherwise, <c>false</c>.</value>
+		public bool EnableNativeCrashReport { get; set; } = !System.Diagnostics.Debugger.IsAttached;
 
 		public ApplicationHandler()
 		{
@@ -166,6 +182,9 @@ namespace Eto.Mac.Forms
 		{
 			if (!attached)
 			{
+				if (EnableNativeCrashReport)
+					CrashReporter.Attach();
+
 				EtoBundle.Init();
 
 				if (Control.Delegate == null)

--- a/Source/Eto.Test/Eto.Test/MainForm.cs
+++ b/Source/Eto.Test/Eto.Test/MainForm.cs
@@ -4,6 +4,7 @@ using System.ComponentModel;
 using System.Globalization;
 using Eto.Forms;
 using Eto.Drawing;
+using System.Threading.Tasks;
 
 namespace Eto.Test
 {
@@ -192,7 +193,13 @@ namespace Eto.Test
 				var windowCommand = new Command { MenuText = "Window Command" };
 				windowCommand.Executed += (sender, e) => Log.Write(sender, "Executed");
 
-				var file = new ButtonMenuItem { Text = "&File", Items = { fileCommand } };
+				var crashCommand = new Command { MenuText = "Test Exception" };
+				crashCommand.Executed += (sender, e) =>
+				{
+					throw new InvalidOperationException("This is the exception message");
+				};
+
+				var file = new ButtonMenuItem { Text = "&File", Items = { fileCommand, crashCommand } };
 				var edit = new ButtonMenuItem { Text = "&Edit", Items = { editCommand } };
                 var view = new ButtonMenuItem { Text = "&View", Items = { viewCommand } };
 				var window = new ButtonMenuItem { Text = "&Window", Order = 1000, Items = { windowCommand } };


### PR DESCRIPTION
- Causes macOS to generate a crash report in Console, and includes the .NET stack trace.