### PR TITLE
Add TextBox.TextAlignment and TextStepper.ShowStepper.

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
@@ -176,8 +176,8 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public int MaxLength
 		{
-			get { return Control.MaxLength; }
-			set { Control.MaxLength = value; }
+			get { return Control.MaxLength == -1 ? 0 : Control.MaxLength; }
+			set { Control.MaxLength = value == 0 ? -1 : value; }
 		}
 
 		public string PlaceholderText
@@ -191,6 +191,8 @@ namespace Eto.GtkSharp.Forms.Controls
 				placeholderText = value;
 				if (!string.IsNullOrEmpty(placeholderText))
 					Control.ExposeEvent += Connector.HandleExposeEvent;
+				if (Widget.Loaded)
+					Invalidate();
 #else
 				placeholderText = value;
 				NativeMethods.gtk_entry_set_placeholder_text(Control, value);
@@ -247,6 +249,40 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				Control.SelectRegion(value.Start, value.End + 1);
 			}
+		}
+
+		public TextAlignment TextAlignment
+		{
+			get
+			{
+				return Control.Alignment < 0.5f ? TextAlignment.Left
+						  : Control.Alignment > 0.5f ? TextAlignment.Right
+						  : TextAlignment.Center;
+			}
+			set
+			{
+				switch (value)
+				{
+					case TextAlignment.Left:
+						Control.Alignment = 0;
+						break;
+					case TextAlignment.Center:
+						Control.Alignment = 0.5f;
+						break;
+					case TextAlignment.Right:
+						Control.Alignment = 1;
+						break;
+					default:
+						throw new NotSupportedException();
+				}
+
+			}
+		}
+
+		public override bool ShowBorder
+		{
+			get { return Control.HasFrame; }
+			set { Control.HasFrame = value; }
 		}
 	}
 }

--- a/Source/Eto.Gtk/Forms/Controls/TextStepperHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/TextStepperHandler.cs
@@ -17,7 +17,6 @@ namespace Eto.GtkSharp.Forms.Controls
 		static Gtk.Adjustment DefaultAdjustment = new Gtk.Adjustment(0, 0, 3, 1, 1, 1);
 		#endif
 		int disableNotification;
-		bool readOnly;
 
 		public TextStepperHandler()
 		{
@@ -37,21 +36,15 @@ namespace Eto.GtkSharp.Forms.Controls
 			base.Initialize();
 			Control.Output += Connector.HandleOutput;
 			Control.Input += Connector.HandleInput;
-			Widget.TextChanging += (sender, e) =>
-			{
-				e.Cancel = ReadOnly;
-			};
-			Widget.KeyDown += (sender, e) =>
-			{
-				if (e.KeyData == Keys.Up || e.KeyData == Keys.Down)
-					e.Handled = true;
-			};
+			Widget.TextChanging += (sender, e) => e.Cancel = ReadOnly;
 		}
+
+		static object ReadOnly_Key = new object();
 
 		public override bool ReadOnly
 		{
-			get { return readOnly; }
-			set { readOnly = value; }
+			get { return Widget.Properties.Get(ReadOnly_Key, false); }
+			set { Widget.Properties.Set(ReadOnly_Key, value, false); }
 		}
 
 		static object ValidDirection_Key = new object();
@@ -60,6 +53,14 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			get { return Widget.Properties.Get(ValidDirection_Key, StepperValidDirections.Both); }
 			set { Widget.Properties.Set(ValidDirection_Key, value, UpdateState, StepperValidDirections.Both); }
+		}
+
+		// not supported at the moment.  
+		// Could possibly swap out with standard Entry but could be very tricky to setup all events, properties, etc.
+		public bool ShowStepper
+		{
+			get { return true; }
+			set { }
 		}
 
 		void UpdateState()

--- a/Source/Eto.Mac/Forms/Controls/MacText.cs
+++ b/Source/Eto.Mac/Forms/Controls/MacText.cs
@@ -64,8 +64,8 @@ namespace Eto.Mac.Forms.Controls
 
 		public bool ShowBorder
 		{
-			get { return Control.Bordered; }
-			set { Control.Bordered = value; }
+			get { return Control.Bezeled; }
+			set { Control.Bezeled = value; }
 		}
 
 		TextControl.ICallback IMacText.Callback
@@ -123,6 +123,19 @@ namespace Eto.Mac.Forms.Controls
 					InitialSelection = null;
 					editor.SelectedRange = value.ToNS();
 				}
+			}
+		}
+
+		public TextAlignment TextAlignment
+		{
+			get { return Control.Alignment.ToEto(); }
+			set
+			{
+				// need to set current editor first when the control has focus, otherwise it won't be reflected for some reason after it loses focus.
+				var editor = Control.CurrentEditor;
+				if (editor != null)
+					editor.Alignment = value.ToNS();
+				Control.Alignment = value.ToNS();
 			}
 		}
 

--- a/Source/Eto.Mac/Forms/Controls/StepperHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/StepperHandler.cs
@@ -47,7 +47,6 @@ namespace Eto.Mac.Forms.Controls
 				MinValue = 0,
 				MaxValue = 2
 			};
-			Control.SizeToFit();
 		}
 
 		static object ValidDirection_Key = new object();

--- a/Source/Eto.Mac/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/TextBoxHandler.cs
@@ -44,7 +44,7 @@ namespace Eto.Mac.Forms.Controls
 		[Export("isPartialStringValid:proposedSelectedRange:originalString:originalSelectedRange:errorDescription:")]
 		public bool IsPartialStringValid(ref NSString value, IntPtr proposedSelRange, NSString origString, NSRange origSelRange, ref IntPtr error)
 		{
-			if (Handler.MaxLength >= 0)
+			if (Handler.MaxLength > 0)
 			{
 				int size = (int)value.Length;
 				if (size > Handler.MaxLength)
@@ -69,7 +69,7 @@ namespace Eto.Mac.Forms.Controls
 		IMacText TextHandler => WeakHandler.Target as IMacText;
 		ITextBoxWithMaxLength MaxLengthHandler => WeakHandler.Target as ITextBoxWithMaxLength;
 
-		public int MaxLength { get { return MaxLengthHandler?.MaxLength ?? -1; } }
+		public int MaxLength { get { return MaxLengthHandler?.MaxLength ?? 0; } }
 
 		public EtoTextField()
 		{
@@ -104,7 +104,7 @@ namespace Eto.Mac.Forms.Controls
 	{
 		protected override void Initialize()
 		{
-			MaxLength = -1;
+			MaxLength = 0;
 			base.Initialize();
 		}
 

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/TextBoxSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/TextBoxSection.cs
@@ -8,72 +8,56 @@ namespace Eto.Test.Sections.Controls
 	{
 		public TextBoxSection()
 		{
-			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
+			var textBox = new TextBox();
+			LogEvents(textBox);
 
-			layout.AddRow(new Label { Text = "Default" }, Default());
-			layout.AddRow(new Label { Text = "Different Size" }, DifferentSize());
-			layout.AddRow(new Label { Text = "Read Only" }, ReadOnly());
-			layout.AddRow(new Label { Text = "Disabled" }, Disabled());
-			layout.AddRow(new Label { Text = "Placeholder" }, Placeholder());
-			layout.AddRow(new Label { Text = "Limit Length" }, LimitLength());
+			var placeholderText = new TextBox();
+			placeholderText.TextBinding.Bind(textBox, c => c.PlaceholderText);
 
-			// growing space at end is blank!
+			var setTextButton = new Button { Text = "Set Text" };
+			setTextButton.Click += (sender, e) => textBox.Text = "Some Text";
+
+			var selectAllButton = new Button { Text = "SelectAll" };
+			selectAllButton.Click += (sender, e) => textBox.SelectAll();
+
+			var enabledCheckBox = new CheckBox { Text = "Enabled" };
+			enabledCheckBox.CheckedBinding.Bind(textBox, c => c.Enabled);
+
+			var readOnlyCheckBox = new CheckBox { Text = "ReadOnly" };
+			readOnlyCheckBox.CheckedBinding.Bind(textBox, c => c.ReadOnly);
+
+			var alignmentDropDown = new EnumDropDown<TextAlignment>();
+			alignmentDropDown.SelectedValueBinding.Bind(textBox, c => c.TextAlignment);
+
+			var showBorderCheckBox = new CheckBox { Text = "ShowBorder" };
+			showBorderCheckBox.CheckedBinding.Bind(textBox, c => c.ShowBorder);
+
+			var maxLengthStepper = new NumericStepper { MinValue = 0 };
+			maxLengthStepper.ValueBinding.Bind(textBox, c => c.MaxLength);
+
+			var layout = new DynamicLayout { Padding = 10, DefaultSpacing = new Size(5, 5) };
+			layout.AddSeparateRow(null, enabledCheckBox, readOnlyCheckBox, showBorderCheckBox, null);
+			layout.AddSeparateRow(null, "TextAlignment", alignmentDropDown, "MaxLength", maxLengthStepper, null);
+			layout.AddSeparateRow(null, "PlaceholderText", placeholderText, null);
+			layout.AddSeparateRow(null, setTextButton, selectAllButton, null);
+			layout.Add(null);
+			layout.AddCentered(textBox);
+			layout.AddCentered(DifferentSize());
 			layout.Add(null);
 
 			Content = layout;
 		}
 
-		Control Default()
-		{
-			var control = new TextBox { Text = "Some Text" };
-			LogEvents(control);
-
-			var selectAll = new Button { Text = "Select All" };
-			selectAll.Click += (sender, e) => control.SelectAll();
-
-			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5) };
-			layout.Add(control);
-			layout.AddSeparateRow(null, selectAll, null);
-			return layout;
-		}
-
 		Control DifferentSize()
 		{
-			var control = new TextBox { Text = "Some Text", Size = new Size(100, 50) };
-			LogEvents(control);
-			return control;
-		}
-
-		Control ReadOnly()
-		{
-			var control = new TextBox { Text = "Read only text", ReadOnly = true };
-			LogEvents(control);
-			return control;
-		}
-
-		Control Disabled()
-		{
-			var control = new TextBox { Text = "Disabled Text", Enabled = false };
-			LogEvents(control);
-			return control;
-		}
-
-		Control LimitLength()
-		{
-			var control = new TextBox { Text = "Limited to 30 characters", MaxLength = 30 };
-			LogEvents(control);
-			return control;
-		}
-
-		Control Placeholder()
-		{
-			var control = new TextBox { PlaceholderText = "Some Placeholder" };
+			var control = new TextBox { Text = "Different Size (300x50)", Size = new Size(300, 50) };
 			LogEvents(control);
 			return control;
 		}
 
 		void LogEvents(TextBox control)
 		{
+			control.TextChanging += (sender, e) => Log.Write(control, $"TextChanging, Range: {e.Range}, Text: {e.Text}");
 			control.TextChanged += (sender, e) => Log.Write(control, "TextChanged, Text: {0}", control.Text);
 			control.TextInput += (sender, e) => Log.Write(control, "TextInput: {0}", e.Text);
 		}

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/TextStepperSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/TextStepperSection.cs
@@ -1,14 +1,19 @@
 ﻿using System;
 using Eto.Forms;
+using Eto.Drawing;
+
 namespace Eto.Test.Sections.Controls
 {
 	[Section("Controls", typeof(TextStepper))]
-	public class TextStepperSection : Panel
+	public class TextStepperSection : Scrollable
 	{
 		public TextStepperSection()
 		{
-			var textUpDown = new TextStepper { PlaceholderText = "<multiple values>" };
+			var textUpDown = new TextStepper();
 			LogEvents(textUpDown);
+
+			var placeholderText = new TextBox();
+			placeholderText.TextBinding.Bind(textUpDown, c => c.PlaceholderText);
 
 			var enabledCheckBox = new CheckBox { Text = "Enabled" };
 			enabledCheckBox.CheckedBinding.Bind(textUpDown, c => c.Enabled);
@@ -19,21 +24,36 @@ namespace Eto.Test.Sections.Controls
 			var setTextButton = new Button { Text = "Set Text" };
 			setTextButton.Click += (sender, e) => textUpDown.Text = "Some text";
 
-			var validDirectionsDropDown = new EnumDropDown<StepperValidDirections>();
-			validDirectionsDropDown.SelectedValueBinding.Bind(textUpDown, s => s.ValidDirection);
+			var selectAllButton = new Button { Text = "SelectAll" };
+			selectAllButton.Click += (sender, e) => textUpDown.SelectAll();
 
-			Content = new StackLayout
-			{
-				Padding = 10,
-				Spacing = 5,
-				Items =
-				{
-					enabledCheckBox,
-					TableLayout.Horizontal(2, readOnlyCheckBox, setTextButton),
-					TableLayout.Horizontal(2, "ValidDirection", validDirectionsDropDown),
-					textUpDown
-				}
-			};
+			var validDirectionsDropDown = new EnumDropDown<StepperValidDirections>();
+			validDirectionsDropDown.SelectedValueBinding.Bind(textUpDown, c => c.ValidDirection);
+
+			var alignmentDropDown = new EnumDropDown<TextAlignment>();
+			alignmentDropDown.SelectedValueBinding.Bind(textUpDown, c => c.TextAlignment);
+
+			var showStepperCheckBox = new CheckBox { Text = "ShowStepper" };
+			showStepperCheckBox.CheckedBinding.Bind(textUpDown, c => c.ShowStepper);
+
+			var showBorderCheckBox = new CheckBox { Text = "ShowBorder" };
+			showBorderCheckBox.CheckedBinding.Bind(textUpDown, c => c.ShowBorder);
+
+			var maxLengthStepper = new NumericStepper { MinValue = 0 };
+			maxLengthStepper.ValueBinding.Bind(textUpDown, c => c.MaxLength);
+
+			var layout = new DynamicLayout { Padding = 10, DefaultSpacing = new Size(5, 5) };
+			layout.AddSeparateRow(null, enabledCheckBox, readOnlyCheckBox, showStepperCheckBox, showBorderCheckBox, null);
+			layout.AddSeparateRow(null, "TextAlignment", alignmentDropDown, "MaxLength", maxLengthStepper, null);
+			layout.AddSeparateRow(null, "PlaceholderText", placeholderText, null);
+			layout.AddSeparateRow(null, setTextButton, selectAllButton, null);
+			layout.AddSeparateRow(null, "ValidDirection", validDirectionsDropDown, null);
+			layout.Add(null);
+			layout.AddCentered(textUpDown);
+			layout.AddCentered(new TextStepper { Text = "Different Size (300x-1)", Size = new Size(300, -1) });
+			layout.Add(null);
+
+			Content = layout;
 		}
 
 		void LogEvents(TextStepper textUpDown)

--- a/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Controls/TestTextBoxHandler.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Controls/TestTextBoxHandler.cs
@@ -112,6 +112,19 @@ namespace Eto.Test.UnitTests.Handlers.Controls
 				throw new NotImplementedException();
 			}
 		}
+
+		public TextAlignment TextAlignment
+		{
+			get
+			{
+				throw new NotImplementedException();
+			}
+
+			set
+			{
+				throw new NotImplementedException();
+			}
+		}
 	}
 }
 

--- a/Source/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
@@ -11,6 +11,11 @@ namespace Eto.WinForms.Forms.Controls
 	[DesignerCategory("Code")]
 	public class EtoTextBox : swf.TextBox
 	{
+		public EtoTextBox()
+		{
+			MaxLength = 0;
+		}
+
 		public event EventHandler<CancelEventArgs> Copying;
 
 		protected virtual void OnCopying(CancelEventArgs e)
@@ -73,7 +78,21 @@ namespace Eto.WinForms.Forms.Controls
 		public virtual bool ShowBorder
 		{
 			get { return SwfTextBox.BorderStyle != swf.BorderStyle.None; }
-			set { SwfTextBox.BorderStyle = value ? swf.BorderStyle.Fixed3D : swf.BorderStyle.None; }
+			set
+			{
+				SwfTextBox.BorderStyle = value ? swf.BorderStyle.Fixed3D : swf.BorderStyle.None;
+				SetPlaceholderText(); // setting border clears this out for some reason
+			}
+		}
+
+		public TextAlignment TextAlignment
+		{
+			get { return SwfTextBox.TextAlign.ToEto(); }
+			set
+			{
+				SwfTextBox.TextAlign = value.ToSWF();
+				SetPlaceholderText(); // setting text alignment clears this out for some reason
+			}
 		}
 
 		static Func<char, bool> testIsNonWord = ch => char.IsWhiteSpace(ch) || char.IsPunctuation(ch);
@@ -180,7 +199,11 @@ namespace Eto.WinForms.Forms.Controls
 		public virtual bool ReadOnly
 		{
 			get { return SwfTextBox.ReadOnly; }
-			set { SwfTextBox.ReadOnly = value; }
+			set
+			{
+				SwfTextBox.ReadOnly = value;
+				SetPlaceholderText();
+			}
 		}
 
 		public int MaxLength
@@ -196,11 +219,13 @@ namespace Eto.WinForms.Forms.Controls
 			get { return Widget.Properties.Get<string>(PlaceholderText_Key); }
 			set
 			{
-				Widget.Properties.Set(PlaceholderText_Key, value, () =>
-				{
-					Win32.SendMessage(SwfTextBox.Handle, Win32.WM.EM_SETCUEBANNER, IntPtr.Zero, value);
-				});
+				Widget.Properties.Set(PlaceholderText_Key, value, SetPlaceholderText);
 			}
+		}
+		
+		void SetPlaceholderText()
+		{
+			Win32.SendMessage(SwfTextBox.Handle, Win32.WM.EM_SETCUEBANNER, IntPtr.Zero, PlaceholderText);
 		}
 
 		public void SelectAll()

--- a/Source/Eto.WinForms/Forms/Controls/TextStepperHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TextStepperHandler.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using swf = System.Windows.Forms;
-using System.Drawing;
+using sd = System.Drawing;
 using System.Reflection;
 
 namespace Eto.WinForms.Forms.Controls
@@ -16,6 +16,25 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			public event EventHandler DownButtonClicked;
 			public event EventHandler UpButtonClicked;
+
+			static FieldInfo DefaultButtonsWidthField = typeof(swf.UpDownBase).GetField("defaultButtonsWidth", BindingFlags.Static | BindingFlags.NonPublic);
+			static FieldInfo TextBoxField = typeof(swf.UpDownBase).GetField("upDownEdit", BindingFlags.Instance | BindingFlags.NonPublic);
+			static FieldInfo UpDownButtonsField = typeof(swf.UpDownBase).GetField("upDownButtons", BindingFlags.Instance | BindingFlags.NonPublic);
+
+			public swf.TextBox TextBox => TextBoxField?.GetValue(this) as swf.TextBox;
+
+			public swf.Control UpDownButtons => UpDownButtonsField?.GetValue(this) as swf.Control;
+
+			static int DefaultButtonsWidth
+			{
+				get { return (int?)DefaultButtonsWidthField?.GetValue(null) ?? 0; }
+				set { DefaultButtonsWidthField?.SetValue(null, value); }
+			}
+
+			public EtoUpDown()
+			{
+				TextBox.MaxLength = 0;
+			}
 
 			public override void DownButton()
 			{
@@ -29,18 +48,36 @@ namespace Eto.WinForms.Forms.Controls
 
 			protected override void UpdateEditText()
 			{
-				
+			}
+
+			public override sd.Size GetPreferredSize(sd.Size proposedSize)
+			{
+				// fix preferred size from being different from actual size, which causes the control
+				// to grow/shrink each time it has a layout.. not sure why this fixes it, but oh well!
+				return SizeFromClientSize(ClientSize) + Padding.Size;
+			}
+
+			protected override void OnLayout(swf.LayoutEventArgs e)
+			{
+				if (!UpDownButtons.Visible)
+				{
+					var oldVal = DefaultButtonsWidth;
+					DefaultButtonsWidth = 0;
+					base.OnLayout(e);
+					DefaultButtonsWidth = oldVal;
+					return;
+				}
+				base.OnLayout(e);
 			}
 		}
 
 		public override EtoTextBox EtoTextBox => null;
 
-		public override swf.TextBox SwfTextBox => Control.GetType().GetField("upDownEdit", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(Control) as swf.TextBox;
+		public override swf.TextBox SwfTextBox => Control.TextBox;
 
 		public TextStepperHandler()
 		{
 			Control = new EtoUpDown();
-			Control.InterceptArrowKeys = false;
 		}
 
 		public StepperValidDirections ValidDirection { get; set; } = StepperValidDirections.Both;
@@ -57,6 +94,17 @@ namespace Eto.WinForms.Forms.Controls
 			set
 			{
 				Control.BorderStyle = value ? swf.BorderStyle.Fixed3D : swf.BorderStyle.None;
+				Control.PerformLayout();
+			}
+		}
+
+		public bool ShowStepper
+		{
+			get { return Control.UpDownButtons.Visible; }
+			set
+			{
+				Control.UpDownButtons.Visible = value;
+				Control.PerformLayout();
 			}
 		}
 

--- a/Source/Eto.WinRT/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.WinRT/Forms/Controls/TextBoxHandler.cs
@@ -4,7 +4,7 @@ using sw = Windows.UI.Xaml;
 using wf = Windows.Foundation;
 using Eto.Forms;
 using Eto.Drawing;
-using Windows.UI.Xaml;
+using wux = Windows.UI.Xaml;
 
 namespace Eto.WinRT.Forms.Controls
 {
@@ -102,7 +102,7 @@ namespace Eto.WinRT.Forms.Controls
 
 		public void SelectAll ()
 		{
-			Control.Focus (FocusState.Programmatic);
+			Control.Focus(wux.FocusState.Programmatic);
 			Control.SelectAll ();
 		}
 
@@ -131,6 +131,12 @@ namespace Eto.WinRT.Forms.Controls
 				Control.SelectionStart = value.Start;
 				Control.SelectionLength = value.Length();
 			}
+		}
+
+		public TextAlignment TextAlignment
+		{
+			get { return Control.TextAlignment.ToEto(); }
+			set { Control.TextAlignment = value.ToWpfTextAlignment(); }
 		}
 	}
 }

--- a/Source/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -37,12 +37,24 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected abstract swc.TextBox TextBox { get; }
 
-		static sw.Thickness DefaultBorderThickness = new mwc.DateTimePicker().BorderThickness;
+		protected virtual swc.Control BorderControl => TextBox;
 
 		public override bool ShowBorder
 		{
-			get { return !TextBox.BorderThickness.ToEto().IsZero; }
-			set { TextBox.BorderThickness = value ? DefaultBorderThickness : new sw.Thickness(0); }
+			get { return BorderControl.ReadLocalValue(swc.Control.BorderThicknessProperty) == sw.DependencyProperty.UnsetValue; }
+			set
+			{
+				if (value)
+					BorderControl.ClearValue(swc.Control.BorderThicknessProperty);
+				else
+					BorderControl.BorderThickness = new sw.Thickness(0);
+			}
+		}
+
+		public TextAlignment TextAlignment
+		{
+			get { return TextBox.TextAlignment.ToEto(); }
+			set { TextBox.TextAlignment = value.ToWpfTextAlignment(); }
 		}
 
 		public TextBoxHandler ()

--- a/Source/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
@@ -20,8 +20,8 @@ namespace Eto.Wpf.Forms.Controls
 				{
 					BorderThickness = new sw.Thickness(0),
 					BorderBrush = null,
-					Padding = new sw.Thickness(0)
-				}
+					Padding = new sw.Thickness(0),
+				},
 			};
 		}
 
@@ -37,9 +37,17 @@ namespace Eto.Wpf.Forms.Controls
 			set { Control.ValidSpinDirection = value.ToWpf(); }
 		}
 
+		public bool ShowStepper
+		{
+			get { return Control.ShowButtonSpinner; }
+			set { Control.ShowButtonSpinner = value; }
+		}
+
 		mwc.WatermarkTextBox WatermarkTextBox => (mwc.WatermarkTextBox)Control.Content;
 
 		protected override swc.TextBox TextBox => (swc.TextBox)Control.Content;
+
+		protected override swc.Control BorderControl => Control;
 
 		public override void AttachEvent(string id)
 		{

--- a/Source/Eto.Wpf/WpfConversions.cs
+++ b/Source/Eto.Wpf/WpfConversions.cs
@@ -611,6 +611,23 @@ namespace Eto.Wpf
 			}
 		}
 
+		public static TextAlignment ToEto(this sw.TextAlignment align)
+		{
+			switch (align)
+			{
+				case sw.TextAlignment.Left:
+					return TextAlignment.Left;
+				case sw.TextAlignment.Right:
+					return TextAlignment.Right;
+				case sw.TextAlignment.Center:
+					return TextAlignment.Center;
+				case sw.TextAlignment.Justify:
+					return TextAlignment.Left;
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
 		public static sw.TextAlignment ToWpfTextAlignment(this TextAlignment align)
 		{
 			switch (align)

--- a/Source/Eto.iOS/Forms/Controls/SearchBoxHandler.cs
+++ b/Source/Eto.iOS/Forms/Controls/SearchBoxHandler.cs
@@ -84,6 +84,12 @@ namespace Eto.iOS.Forms.Controls
 			get { throw new NotImplementedException(); }
 			set { throw new NotImplementedException(); }
 		}
+
+		public TextAlignment TextAlignment
+		{
+			get { throw new NotImplementedException(); }
+			set { throw new NotImplementedException(); }
+		}
 	}
 }
 

--- a/Source/Eto.iOS/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.iOS/Forms/Controls/TextBoxHandler.cs
@@ -134,6 +134,12 @@ namespace Eto.iOS.Forms.Controls
 			get { return Control.BorderStyle != UITextBorderStyle.None; }
 			set { Control.BorderStyle = value ? UITextBorderStyle.RoundedRect : UITextBorderStyle.None; }
 		}
+
+		public TextAlignment TextAlignment
+		{
+			get { return Control.TextAlignment.ToEto(); }
+			set { Control.TextAlignment = value.ToUI(); }
+		}
 	}
 }
 

--- a/Source/Eto/Forms/Controls/TextBox.cs
+++ b/Source/Eto/Forms/Controls/TextBox.cs
@@ -59,7 +59,7 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Gets or sets the maximum length of the text that can be entered in the control.
+		/// Gets or sets the maximum length of the text that can be entered in the control, 0 for no limit.
 		/// </summary>
 		/// <remarks>
 		/// This typically does not affect the value set using <see cref="TextControl.Text"/>, only the limit of what the user can 
@@ -69,7 +69,12 @@ namespace Eto.Forms
 		public int MaxLength
 		{
 			get { return Handler.MaxLength; }
-			set { Handler.MaxLength = value; }
+			set
+			{
+				if (value < 0)
+					throw new ArgumentOutOfRangeException(nameof(value), "MaxLength must be greater or equal to zero.");
+				Handler.MaxLength = value;
+			}
 		}
 
 		/// <summary>
@@ -100,6 +105,16 @@ namespace Eto.Forms
 		{
 			get { return Handler.ShowBorder; }
 			set { Handler.ShowBorder = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the alignment of the text in the entry box.
+		/// </summary>
+		/// <value>The text alignment.</value>
+		public TextAlignment TextAlignment
+		{
+			get { return Handler.TextAlignment; }
+			set { Handler.TextAlignment = value; }
 		}
 
 		/// <summary>
@@ -231,6 +246,12 @@ namespace Eto.Forms
 			/// </remarks>
 			/// <value><c>true</c> to show the control border; otherwise, <c>false</c>.</value>
 			bool ShowBorder { get; set; }
+
+			/// <summary>
+			/// Gets or sets the alignment of the text in the entry box.
+			/// </summary>
+			/// <value>The text alignment.</value>
+			TextAlignment TextAlignment { get; set; }
 		}
 
 		#region Callback

--- a/Source/Eto/Forms/Controls/TextStepper.cs
+++ b/Source/Eto/Forms/Controls/TextStepper.cs
@@ -57,6 +57,20 @@ namespace Eto.Forms
 			set { Handler.ValidDirection = value; }
 		}
 
+		/// <summary>
+		/// Gets or sets a value indicating whether the Stepper will be shown.
+		/// </summary>
+		/// <remarks>
+		/// This is a hint only, some platforms (currently Gtk) may ignore this setting.
+		/// </remarks>
+		/// <value><c>true</c> to show the stepper (default); otherwise, <c>false</c>.</value>
+		[DefaultValue(true)]
+		public bool ShowStepper
+		{
+			get { return Handler.ShowStepper; }
+			set { Handler.ShowStepper = value; }
+		}
+
 		ICallback callback = new Callback();
 
 		/// <summary>
@@ -108,6 +122,15 @@ namespace Eto.Forms
 			/// </remarks>
 			/// <value>The valid directions for the stepper.</value>
 			StepperValidDirections ValidDirection { get; set; }
+
+			/// <summary>
+			/// Gets or sets a value indicating whether the Stepper will be shown.
+			/// </summary>
+			/// <remarks>
+			/// This is a hint only, some platforms (currently Gtk) may ignore this setting.
+			/// </remarks>
+			/// <value><c>true</c> to show the stepper (default); otherwise, <c>false</c>.</value>
+			bool ShowStepper { get; set; }
 		}
 	}
 }

--- a/Source/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
+++ b/Source/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
@@ -19,8 +19,33 @@ namespace Eto.Forms.ThemedControls
 		{
 			textBox = new TextBox();
 			stepper = new Stepper();
-			Control = TableLayout.Horizontal(TableLayout.AutoSized(textBox, centered: true), stepper);
+			Control = TableLayout.Horizontal(
+				new TableCell(new TableLayout(null, textBox, null), true),
+				stepper
+			);
 			Control.EndInit();
+
+			textBox.KeyDown += TextBox_KeyDown;
+		}
+
+		void TextBox_KeyDown(object sender, KeyEventArgs e)
+		{
+			if (e.KeyData == Keys.Up)
+			{
+				if (ValidDirection.HasFlag(StepperValidDirections.Up))
+				{
+					Callback.OnStep(Widget, new StepperEventArgs(StepperDirection.Up));
+					e.Handled = true;
+				}
+			}
+			else if (e.KeyData == Keys.Down)
+			{
+				if (ValidDirection.HasFlag(StepperValidDirections.Down))
+				{
+					Callback.OnStep(Widget, new StepperEventArgs(StepperDirection.Down));
+					e.Handled = true;
+				}
+			}
 		}
 
 		/// <summary>
@@ -161,6 +186,31 @@ namespace Eto.Forms.ThemedControls
 		public void SelectAll()
 		{
 			textBox.SelectAll();
+		}
+
+		/// <summary>
+		/// Gets or sets the alignment of the text in the entry box.
+		/// </summary>
+		/// <value>The text alignment.</value>
+		public TextAlignment TextAlignment
+		{
+			get { return textBox.TextAlignment; }
+			set { textBox.TextAlignment = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="Eto.Forms.Control"/> is visible to the user.
+		/// </summary>
+		/// <remarks>
+		/// When the visibility of a control is set to false, it will still occupy space in the layout, but not be shown.
+		/// The only exception is for controls like the <see cref="Splitter"/>, which will hide a pane if the visibility
+		/// of one of the panels is changed.
+		/// </remarks>
+		/// <value><c>true</c> if visible; otherwise, <c>false</c>.</value>
+		public bool ShowStepper
+		{
+			get { return stepper.Visible; }
+			set { stepper.Visible = value; }
 		}
 
 		/// <summary>


### PR DESCRIPTION
- Gtk: TextStepper now uses default behaviour of responding to up/down keystrokes
- TextBox.MaxLength now normalized across platforms.  0 = unlimited, which is now default. -1 will throw an exception.
- TextBox.ShowBorder now works correctly on all platforms