### PR TITLE
Fix Gtk2 build warning on windows

### DIFF
--- a/Source/Eto.Test/Eto.Test.Gtk2/Eto.Test.Gtk2 - net45.csproj
+++ b/Source/Eto.Test/Eto.Test.Gtk2/Eto.Test.Gtk2 - net45.csproj
@@ -10,6 +10,7 @@
     <ApplicationIcon>..\Eto.Test\Images\TestIcon.ico</ApplicationIcon>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <AssemblyName>Eto.Test.Gtk2</AssemblyName>
+	<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
- Gtk for .NET installer on windows packages Mono.Cairo 4.0, but gtk-sharp, etc all reference Mono.Cairo 2.0.