### PR TITLE
Wpf Splitter fixes

### DIFF
--- a/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
@@ -87,6 +87,9 @@ namespace Eto.Wpf.Forms.Controls
 
 		void SetInitialPosition()
 		{
+			panel1Visible = panel1?.Visible ?? false;
+			panel2Visible = panel2?.Visible ?? false;
+
 			// controls should be stretched to fit panels
 			SetStretch(panel1);
 			SetStretch(panel2);
@@ -554,9 +557,10 @@ namespace Eto.Wpf.Forms.Controls
 					SetStretch(panel1);
 					if (Widget.Loaded)
 						control.SetScale(true, true);
+
 					pane1.Children.Add(control.ContainerControl);
-					panel1Visible = panel1.Visible;
 					dpdVisibility.AddValueChanged(control.ContainerControl, HandlePanel1IsVisibleChanged);
+					HandlePanelVisibleChanged(ref panel1Visible, panel1);
 				}
 			}
 		}
@@ -581,9 +585,9 @@ namespace Eto.Wpf.Forms.Controls
 					if (Widget.Loaded)
 						control.SetScale(true, true);
 					pane2.Children.Add(control.ContainerControl);
-					panel2Visible = panel2.Visible;
 
 					dpdVisibility.AddValueChanged(control.ContainerControl, HandlePanel2IsVisibleChanged);
+					HandlePanelVisibleChanged(ref panel2Visible, panel2);
 				}
 			}
 		}
@@ -599,7 +603,7 @@ namespace Eto.Wpf.Forms.Controls
 		}
 
 		void HandlePanelVisibleChanged(ref bool isVisible, Control panel)
-		{ 
+		{
 			if ((Control.IsLoaded || WasLoaded) && isVisible != panel.Visible)
 			{
 				isVisible = panel.Visible;

--- a/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -278,10 +278,10 @@ namespace Eto.Wpf.Forms
 
 		public bool Visible
 		{
-			get { return Control.Visibility != sw.Visibility.Collapsed; }
+			get { return ContainerControl.Visibility != sw.Visibility.Collapsed; }
 			set
 			{
-				Control.Visibility = (value) ? sw.Visibility.Visible : sw.Visibility.Collapsed;
+				ContainerControl.Visibility = (value) ? sw.Visibility.Visible : sw.Visibility.Collapsed;
                 UpdatePreferredSize();
             }
         }


### PR DESCRIPTION
- Fix setting new panel content with splitter if previous control was not visible
- Fix Control.Visible to use the ContainerControl to set visibility, which is only different on certain controls (e.g. TableLayout)
- Fix setting visibility of a panel before it is loaded

Fixes #644