### PR TITLE
Add invalidateChildren parameter to Control.Invalidate()

### DIFF
--- a/Source/Eto.Android/Forms/AndroidControl.cs
+++ b/Source/Eto.Android/Forms/AndroidControl.cs
@@ -26,12 +26,12 @@ namespace Eto.Android.Forms
 	{
 		public abstract av.View ContainerControl { get; }
 
-		public void Invalidate()
+		public void Invalidate(bool invalidateChildren)
 		{
 			throw new NotImplementedException();
 		}
 
-		public void Invalidate(Rectangle rect)
+		public void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
 			throw new NotImplementedException();
 		}

--- a/Source/Eto.Direct2D/Drawing/GraphicsHandler.cs
+++ b/Source/Eto.Direct2D/Drawing/GraphicsHandler.cs
@@ -149,7 +149,7 @@ namespace Eto.Direct2D.Drawing
 			try
 			{
 				target.Resize(drawable.ClientSize.ToDx());
-				drawable.Invalidate();
+				drawable.Invalidate(false);
 			}
 			catch (Exception ex)
 			{

--- a/Source/Eto.Direct2D/Forms/Controls/DrawableHandler.cs
+++ b/Source/Eto.Direct2D/Forms/Controls/DrawableHandler.cs
@@ -23,7 +23,7 @@ namespace Eto.Direct2D.Forms.Controls
 			{
 				backgroundColor = value.A > 0 ? new SolidBrush(value) : null;
 				if (Widget.Loaded)
-					Invalidate();
+					Invalidate(false);
 			}
 		}
 

--- a/Source/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
@@ -192,7 +192,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				if (!string.IsNullOrEmpty(placeholderText))
 					Control.ExposeEvent += Connector.HandleExposeEvent;
 				if (Widget.Loaded)
-					Invalidate();
+					Invalidate(false);
 #else
 				placeholderText = value;
 				NativeMethods.gtk_entry_set_placeholder_text(Control, value);

--- a/Source/Eto.Gtk/Forms/GtkControl.cs
+++ b/Source/Eto.Gtk/Forms/GtkControl.cs
@@ -135,12 +135,12 @@ namespace Eto.GtkSharp.Forms
 			set { Control.Name = value; }
 		}
 
-		public void Invalidate()
+		public void Invalidate(bool invalidateChildren)
 		{
 			Control.QueueDraw();
 		}
 
-		public void Invalidate(Rectangle rect)
+		public void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
 			Control.QueueDrawArea(rect.X, rect.Y, rect.Width, rect.Height);
 		}

--- a/Source/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -92,7 +92,7 @@ namespace Eto.Mac.Forms.Controls
 				{
 					backgroundColor = value;
 					backgroundBrush = backgroundColor.A > 0 ? new SolidBrush(backgroundColor) : null;
-					Invalidate();
+					Invalidate(false);
 				}
 			}
 		}
@@ -114,16 +114,16 @@ namespace Eto.Mac.Forms.Controls
 			set { Control.CanFocus = value; }
 		}
 
-		public override void Invalidate()
+		public override void Invalidate(bool invalidateChildren)
 		{
-			if (!NeedsQueue(Invalidate))
-				base.Invalidate();
+			if (!NeedsQueue(() => Invalidate(invalidateChildren)))
+				base.Invalidate(invalidateChildren);
 		}
 
-		public override void Invalidate(Rectangle rect)
+		public override void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
-			if (!NeedsQueue(() => Invalidate(rect)))
-				base.Invalidate(rect);
+			if (!NeedsQueue(() => Invalidate(rect, invalidateChildren)))
+				base.Invalidate(rect, invalidateChildren);
 		}
 
 		void DrawRegion(Rectangle rect)

--- a/Source/Eto.Mac/Forms/MacContainer.cs
+++ b/Source/Eto.Mac/Forms/MacContainer.cs
@@ -150,22 +150,28 @@ namespace Eto.Mac.Forms
 			LayoutAllChildren();
 		}
 
-		public override void Invalidate()
+		public override void Invalidate(bool invalidateChildren)
 		{
-			base.Invalidate();
-			foreach (var child in Widget.VisualControls)
+			base.Invalidate(invalidateChildren);
+			if (invalidateChildren)
 			{
-				child.Invalidate();
+				foreach (var child in Widget.VisualControls)
+				{
+					child.Invalidate(invalidateChildren);
+				}
 			}
 		}
 
-		public override void Invalidate(Rectangle rect)
+		public override void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
-			base.Invalidate(rect);
-			var screenRect = Widget.RectangleToScreen(rect);
-			foreach (var child in Widget.VisualControls)
+			base.Invalidate(rect, invalidateChildren);
+			if (invalidateChildren)
 			{
-				child.Invalidate(Rectangle.Round(child.RectangleFromScreen(screenRect)));
+				var screenRect = Widget.RectangleToScreen(rect);
+				foreach (var child in Widget.VisualControls)
+				{
+					child.Invalidate(Rectangle.Round(child.RectangleFromScreen(screenRect)), invalidateChildren);
+				}
 			}
 		}
 	}

--- a/Source/Eto.Mac/Forms/MacView.cs
+++ b/Source/Eto.Mac/Forms/MacView.cs
@@ -528,12 +528,12 @@ namespace Eto.Mac.Forms
 			CreateTracking();
 		}
 
-		public virtual void Invalidate()
+		public virtual void Invalidate(bool invalidateChildren)
 		{
 			ContainerControl.NeedsDisplay = true;
 		}
 
-		public virtual void Invalidate(Rectangle rect)
+		public virtual void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
 			var region = rect.ToNS();
 			region.Y = EventControl.Frame.Height - region.Y - region.Height;

--- a/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Controls/TestControlHandler.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Controls/TestControlHandler.cs
@@ -23,12 +23,12 @@ namespace Eto.Test.UnitTests.Handlers.Controls
 			AutoSize = true;
 		}
 
-		public virtual void Invalidate()
+		public virtual void Invalidate(bool invalidateChildren)
 		{
-			Invalidate(new Rectangle(Point.Empty, Size));
+			Invalidate(new Rectangle(Point.Empty, Size), invalidateChildren);
 		}
 
-		public virtual void Invalidate(Rectangle rect)
+		public virtual void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
 		}
 
@@ -176,7 +176,7 @@ namespace Eto.Test.UnitTests.Handlers.Controls
 
 		public virtual void OnShown()
 		{
-			Invalidate();
+			Invalidate(false);
 		}
 
 		public virtual Size GetPreferredSize()

--- a/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Controls/TestDrawableHandler.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Controls/TestDrawableHandler.cs
@@ -26,7 +26,7 @@ namespace Eto.Test.UnitTests.Handlers.Controls
 		{
 		}
 
-		public override void Invalidate(Rectangle rect)
+		public override void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
 			var graphics = new Graphics(new Drawing.TestGraphicsHandler(Widget));
 			var e = new PaintEventArgs(graphics, rect);
@@ -35,7 +35,7 @@ namespace Eto.Test.UnitTests.Handlers.Controls
 
 		public void Update(Rectangle region)
 		{
-			Invalidate(region);
+			Invalidate(region, false);
 		}
 
 		public bool CanFocus

--- a/Source/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
@@ -98,9 +98,9 @@ namespace Eto.WinForms.Forms.Controls
 			}
 		}
 
-		public override void Invalidate()
+		public override void Invalidate(bool invalidateChildren)
 		{
-			base.Invalidate();
+			base.Invalidate(invalidateChildren);
 			if (this.Widget.Loaded)
 			{
 				Control.Refresh();

--- a/Source/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/Source/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -354,12 +354,12 @@ namespace Eto.WinForms.Forms
 			}
 		}
 
-		public void Invalidate()
+		public void Invalidate(bool invalidateChildren)
 		{
 			throw new NotImplementedException();
 		}
 
-		public void Invalidate(Eto.Drawing.Rectangle rect)
+		public void Invalidate(Eto.Drawing.Rectangle rect, bool invalidateChildren)
 		{
 			throw new NotImplementedException();
 		}

--- a/Source/Eto.WinForms/Forms/WindowsControl.cs
+++ b/Source/Eto.WinForms/Forms/WindowsControl.cs
@@ -520,14 +520,14 @@ namespace Eto.WinForms.Forms
 			}
 		}
 
-		public virtual void Invalidate()
+		public virtual void Invalidate(bool invalidateChildren)
 		{
-			Control.Invalidate(true);
+			Control.Invalidate(invalidateChildren);
 		}
 
-		public virtual void Invalidate(Rectangle rect)
+		public virtual void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
-			Control.Invalidate(rect.ToSD(), true);
+			Control.Invalidate(rect.ToSD(), invalidateChildren);
 		}
 
 		public virtual Color BackgroundColor

--- a/Source/Eto.WinRT/Forms/Controls/DrawableHandler.cs
+++ b/Source/Eto.WinRT/Forms/Controls/DrawableHandler.cs
@@ -265,7 +265,7 @@ namespace Eto.WinRT.Forms.Controls
 		{
 			SetMaxTiles();
 			UpdateTiles(true);
-			Invalidate();
+			Invalidate(false);
 		}
 
 		void SetMaxTiles()
@@ -338,7 +338,7 @@ namespace Eto.WinRT.Forms.Controls
 			{
 				Control.Width = Widget.Size.Width;
 				Control.Height = Widget.Size.Height;
-				Invalidate(); 
+				Invalidate(false);
 				return;
 			}
 
@@ -454,7 +454,7 @@ namespace Eto.WinRT.Forms.Controls
 #endif
 		}
 
-		public override void Invalidate()
+		public override void Invalidate(bool invalidateChildren)
 		{
 			if (tiled)
 			{
@@ -474,7 +474,7 @@ namespace Eto.WinRT.Forms.Controls
 			}
 		}
 
-		public override void Invalidate(Rectangle rect)
+		public override void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
 			if (tiled)
 			{
@@ -485,12 +485,12 @@ namespace Eto.WinRT.Forms.Controls
 				}
 			}
 			else
-				base.Invalidate(rect);
+				base.Invalidate(rect, invalidateChildren);
 		}
 
 		public void Update(Rectangle rect)
 		{
-			Invalidate(rect);
+			Invalidate(rect, false);
 		}
 
 		public bool CanFocus

--- a/Source/Eto.WinRT/Forms/Controls/ScrollableHandler.cs
+++ b/Source/Eto.WinRT/Forms/Controls/ScrollableHandler.cs
@@ -224,21 +224,27 @@ namespace Eto.WinRT.Forms.Controls
 			}
 		}
 
-		public override void Invalidate()
+		public override void Invalidate(bool invalidateChildren)
 		{
-			base.Invalidate();
-			foreach (var control in Widget.Children)
+			base.Invalidate(invalidateChildren);
+			if (invalidateChildren)
 			{
-				control.Invalidate();
+				foreach (var control in Widget.VisualChildren)
+				{
+					control.Invalidate(invalidateChildren);
+				}
 			}
 		}
 
-		public override void Invalidate(Rectangle rect)
+		public override void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
-			base.Invalidate(rect);
-			foreach (var control in Widget.Children)
+			base.Invalidate(rect, invalidateChildren);
+			if (invalidateChildren)
 			{
-				control.Invalidate(rect);
+				foreach (var control in Widget.VisualChildren)
+				{
+					control.Invalidate(rect, invalidateChildren);
+				}
 			}
 		}
 

--- a/Source/Eto.WinRT/Forms/WpfContainer.cs
+++ b/Source/Eto.WinRT/Forms/WpfContainer.cs
@@ -55,21 +55,27 @@ namespace Eto.WinRT.Forms
 				parent.UpdatePreferredSize();
 		}
 
-		public override void Invalidate()
+		public override void Invalidate(bool invalidateChildren)
 		{
-			base.Invalidate();
-			foreach (var control in Widget.Children)
+			base.Invalidate(invalidateChildren);
+			if (invalidateChildren)
 			{
-				control.Invalidate();
+				foreach (var control in Widget.VisualControls)
+				{
+					control.Invalidate(invalidateChildren);
+				}
 			}
 		}
 
-		public override void Invalidate(Rectangle rect)
+		public override void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
-			base.Invalidate(rect);
-			foreach (var control in Widget.Children)
+			base.Invalidate(rect, invalidateChildren);
+			if (invalidateChildren)
 			{
-				control.Invalidate(rect);
+				foreach (var control in Widget.VisualControls)
+				{
+					control.Invalidate(rect, invalidateChildren);
+				}
 			}
 		}
 	}

--- a/Source/Eto.WinRT/Forms/WpfFrameworkElement.cs
+++ b/Source/Eto.WinRT/Forms/WpfFrameworkElement.cs
@@ -222,12 +222,12 @@ namespace Eto.WinRT.Forms
 #endif
 		}
 
-		public virtual void Invalidate()
+		public virtual void Invalidate(bool invalidateChildren)
 		{
 			InvalidateControlVisual();
 		}
 
-		public virtual void Invalidate(Rectangle rect)
+		public virtual void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
 			InvalidateControlVisual();
 		}

--- a/Source/Eto.Wpf/Forms/Controls/DrawableHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/DrawableHandler.cs
@@ -146,7 +146,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected override void OnLogicalPixelSizeChanged()
 		{
-			Invalidate();
+			Invalidate(false);
 		}
 
 		public override void OnUnLoad(EventArgs e)
@@ -188,7 +188,7 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			SetMaxTiles();
 			UpdateTiles(true);
-			Invalidate();
+			Invalidate(false);
 			content.Width = e.NewSize.Width;
 			content.Height = e.NewSize.Height;
 		}
@@ -356,12 +356,12 @@ namespace Eto.Wpf.Forms.Controls
 			UpdateTiles();
 		}
 
-		public override void Invalidate()
+		public override void Invalidate(bool invalidateChildren)
 		{
 			if (!Control.IsLoaded)
 			{
 				if (Widget.Loaded)
-					Application.Instance.AsyncInvoke(Invalidate);
+					Application.Instance.AsyncInvoke(() => Invalidate(invalidateChildren));
 				return;
 			}
 			if (tiled)
@@ -379,16 +379,16 @@ namespace Eto.Wpf.Forms.Controls
 					unusedTiles.AddRange(invalidateTiles);
 					invalidateTiles.Clear();
 				}
-				base.Invalidate();
+				base.Invalidate(invalidateChildren);
 			}
 		}
 
-		public override void Invalidate(Rectangle rect)
+		public override void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
 			if (!Control.IsLoaded)
 			{
 				if (Widget.Loaded)
-					Application.Instance.AsyncInvoke(() => Invalidate(rect));
+					Application.Instance.AsyncInvoke(() => Invalidate(rect, invalidateChildren));
 				return;
 			}
 			if (tiled)
@@ -403,7 +403,7 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				if (((rect.Width * rect.Height) / (Control.ActualWidth * Control.ActualHeight)) > 0.9)
 				{
-					Invalidate();
+					Invalidate(false);
 					return;
 				}
 
@@ -453,12 +453,12 @@ namespace Eto.Wpf.Forms.Controls
 				}
 			}
 			else
-				base.Invalidate(rect);
+				base.Invalidate(rect, invalidateChildren);
 		}
 
 		public void Update(Rectangle rect)
 		{
-			Invalidate(rect);
+			Invalidate(rect, false);
 		}
 
 		public bool CanFocus

--- a/Source/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -381,20 +381,20 @@ namespace Eto.Wpf.Forms.Controls
 			RestoreColumnFocus();
 		}
 
-		public override void Invalidate()
+		public override void Invalidate(bool invalidateChildren)
 		{
 			SaveColumnFocus();
 			Control.Items.Refresh();
 			RestoreColumnFocus();
-			base.Invalidate();
+			base.Invalidate(invalidateChildren);
 		}
 
-		public override void Invalidate(Rectangle rect)
+		public override void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
 			SaveColumnFocus();
 			Control.Items.Refresh();
 			RestoreColumnFocus();
-			base.Invalidate(rect);
+			base.Invalidate(rect, invalidateChildren);
 		}
 
 		public virtual void FormatCell(IGridColumnHandler column, ICellHandler cell, sw.FrameworkElement element, swc.DataGridCell gridcell, object dataItem)

--- a/Source/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
@@ -239,24 +239,6 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
-		public override void Invalidate()
-		{
-			base.Invalidate();
-			foreach (var control in Widget.VisualChildren)
-			{
-				control.Invalidate();
-			}
-		}
-
-		public override void Invalidate(Rectangle rect)
-		{
-			base.Invalidate(rect);
-			foreach (var control in Widget.VisualChildren)
-			{
-				control.Invalidate(rect);
-			}
-		}
-
 		public float MaximumZoom { get { return 1f; } set { } }
 
 		public float MinimumZoom { get { return 1f; } set { } }

--- a/Source/Eto.Wpf/Forms/WpfContainer.cs
+++ b/Source/Eto.Wpf/Forms/WpfContainer.cs
@@ -41,21 +41,27 @@ namespace Eto.Wpf.Forms
 			}
 		}
 
-		public override void Invalidate()
+		public override void Invalidate(bool invalidateChildren)
 		{
-			base.Invalidate();
-			foreach (var control in Widget.VisualChildren)
+			base.Invalidate(invalidateChildren);
+			if (invalidateChildren)
 			{
-				control.Invalidate();
+				foreach (var control in Widget.VisualControls)
+				{
+					control.Invalidate(invalidateChildren);
+				}
 			}
 		}
 
-		public override void Invalidate(Rectangle rect)
+		public override void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
-			base.Invalidate(rect);
-			foreach (var control in Widget.VisualChildren)
+			base.Invalidate(rect, invalidateChildren);
+			if (invalidateChildren)
 			{
-				control.Invalidate(rect);
+				foreach (var control in Widget.VisualControls)
+				{
+					control.Invalidate(rect, invalidateChildren);
+				}
 			}
 		}
 	}

--- a/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -233,12 +233,12 @@ namespace Eto.Wpf.Forms
 			set { Control.ToolTip = value; }
 		}
 
-		public virtual void Invalidate()
+		public virtual void Invalidate(bool invalidateChildren)
 		{
 			Control.InvalidateVisual();
 		}
 
-		public virtual void Invalidate(Rectangle rect)
+		public virtual void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
 			Control.InvalidateVisual();
 		}

--- a/Source/Eto.iOS/Forms/IosView.cs
+++ b/Source/Eto.iOS/Forms/IosView.cs
@@ -221,12 +221,12 @@ namespace Eto.iOS.Forms
 			}
 		}
 
-		public virtual void Invalidate()
+		public virtual void Invalidate(bool invalidateChildren)
 		{
 			EventControl.SetNeedsDisplay();
 		}
 
-		public virtual void Invalidate(Rectangle rect)
+		public virtual void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
 			EventControl.SetNeedsDisplayInRect(rect.ToNS());
 		}

--- a/Source/Eto/Forms/Controls/Control.cs
+++ b/Source/Eto/Forms/Controls/Control.cs
@@ -564,14 +564,38 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Queues a repaint of the entire control on the screen
+		/// Queues a repaint of the entire control on the screen and any of its children.
 		/// </summary>
 		/// <remarks>
 		/// This is only useful when the control is visible.
 		/// </remarks>
 		public void Invalidate()
 		{
-			Handler.Invalidate();
+			Handler.Invalidate(true);
+		}
+
+		/// <summary>
+		/// Queues a repaint of the entire control on the screen
+		/// </summary>
+		/// <remarks>
+		/// This is only useful when the control is visible.
+		/// </remarks>
+		/// <param name="invalidateChildren"><c>True</c> to invalidate all children, <c>false</c> to only invalidate the container</param>
+		public void Invalidate(bool invalidateChildren)
+		{
+			Handler.Invalidate(invalidateChildren);
+		}
+
+		/// <summary>
+		/// Queues a repaint of the specified <paramref name="rect"/> of the control and any children.
+		/// </summary>
+		/// <remarks>
+		/// This is only useful when the control is visible.
+		/// </remarks>
+		/// <param name="rect">Rectangle to repaint</param>
+		public void Invalidate(Rectangle rect)
+		{
+			Handler.Invalidate(rect, true);
 		}
 
 		/// <summary>
@@ -581,9 +605,10 @@ namespace Eto.Forms
 		/// This is only useful when the control is visible.
 		/// </remarks>
 		/// <param name="rect">Rectangle to repaint</param>
-		public void Invalidate(Rectangle rect)
+		/// <param name="invalidateChildren"><c>True</c> to invalidate all children, <c>false</c> to only invalidate the container</param>
+		public void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
-			Handler.Invalidate(rect);
+			Handler.Invalidate(rect, invalidateChildren);
 		}
 
 		/// <summary>
@@ -1301,7 +1326,8 @@ namespace Eto.Forms
 			/// <remarks>
 			/// This is only useful when the control is visible.
 			/// </remarks>
-			void Invalidate();
+			/// <param name="invalidateChildren"><c>True</c> to invalidate all children, <c>false</c> to only invalidate the container</param>
+			void Invalidate(bool invalidateChildren);
 
 			/// <summary>
 			/// Queues a repaint of the specified <paramref name="rect"/> of the control
@@ -1310,7 +1336,8 @@ namespace Eto.Forms
 			/// This is only useful when the control is visible.
 			/// </remarks>
 			/// <param name="rect">Rectangle to repaint</param>
-			void Invalidate(Rectangle rect);
+			/// <param name="invalidateChildren"><c>True</c> to invalidate all children, <c>false</c> to only invalidate the container</param>
+			void Invalidate(Rectangle rect, bool invalidateChildren);
 
 			/// <summary>
 			/// Suspends the layout of child controls

--- a/Source/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/Source/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -69,9 +69,10 @@ namespace Eto.Forms
 		/// Queues a repaint of the entire control on the screen
 		/// </summary>
 		/// <remarks>This is only useful when the control is visible.</remarks>
-		public virtual void Invalidate()
+		/// <param name="invalidateChildren"><c>True</c> to invalidate all children, <c>false</c> to only invalidate the container</param>
+		public virtual void Invalidate(bool invalidateChildren)
 		{
-			Control.Invalidate();
+			Control.Invalidate(invalidateChildren);
 		}
 
 		/// <summary>
@@ -81,9 +82,10 @@ namespace Eto.Forms
 		/// This is only useful when the control is visible.
 		/// </remarks>
 		/// <param name="rect">Rectangle to repaint</param>
-		public virtual void Invalidate(Rectangle rect)
+		/// <param name="invalidateChildren"><c>True</c> to invalidate all children, <c>false</c> to only invalidate the container</param>
+		public virtual void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
-			Control.Invalidate(rect);
+			Control.Invalidate(rect, invalidateChildren);
 		}
 
 		/// <summary>


### PR DESCRIPTION
- By default, all children are invalidated which can be overly CPU intensive.  Passing false will only invalidate the immediate control/container for cases where that is necessary.