### PR TITLE
RichTextArea multilingual updates

### DIFF
--- a/Source/Eto.WinForms/Forms/Controls/TextAreaHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TextAreaHandler.cs
@@ -73,6 +73,7 @@ namespace Eto.WinForms.Forms.Controls
 				Dock = swf.DockStyle.Fill,
 				BorderStyle = swf.BorderStyle.None,
 				ScrollBars = swf.RichTextBoxScrollBars.Both,
+				LanguageOption = swf.RichTextBoxLanguageOptions.DualFont
 			};
 			container = new swf.TableLayoutPanel
 			{


### PR DESCRIPTION
Wpf: set language to the current input language, otherwise setting the selection attributes does not work when inserting text
Wpf: Use the document page padding instead of magic numbers when wrap is false, and get the ceiling of the width so it doesn’t wrap text incorrectly.
WinForms: Use DualFont language options so entering in different input languages works.