### PR TITLE
More RichTextArea updates

### DIFF
--- a/Source/Eto.Test/Eto.Test/Sections/Controls/RichTextAreaSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/RichTextAreaSection.cs
@@ -18,10 +18,14 @@ namespace Eto.Test.Sections.Controls
 		{
 			var richText = new RichTextArea();
 			richText.Size = new Size(-1, 300);
+			//richText.Font = new Font("Arial", 10);
+
+			var buffer = richText.Buffer;
+
+			/**/
 			richText.Text = LoremText;
 
 			var range = new Range<int>(6, 10);
-			var buffer = richText.Buffer;
 			buffer.SetFont(range, Fonts.Cursive(20, FontStyle.Bold, FontDecoration.Underline));
 			buffer.SetForeground(range, Colors.Blue);
 			buffer.SetBackground(range, Colors.Yellow);
@@ -32,6 +36,8 @@ namespace Eto.Test.Sections.Controls
 			buffer.SetStrikethrough(new Range<int>(28, 38), true);
 
 			richText.CaretIndex = LoremText.Length - 1;
+			/**/
+
 
 			richText.SelectionChanged += (sender, e) =>
 			{

--- a/Source/Eto.Wpf/Drawing/FontHandler.cs
+++ b/Source/Eto.Wpf/Drawing/FontHandler.cs
@@ -149,7 +149,7 @@ namespace Eto.Wpf.Drawing
 		{
 			var wpfFamily = range.GetPropertyValue(swd.TextElement.FontFamilyProperty) as swm.FontFamily ?? swd.TextElement.GetFontFamily(control);
 			this.Family = new FontFamily(new FontFamilyHandler(wpfFamily));
-			this.Size = PixelsToPoints(range.GetPropertyValue(swd.TextElement.FontSizeProperty) as double? ?? swd.TextElement.GetFontSize(control), control);
+			Size = PixelsToPoints(range.GetPropertyValue(swd.TextElement.FontSizeProperty) as double? ?? swd.TextElement.GetFontSize(control));
 			this.WpfFontStyle = range.GetPropertyValue(swd.TextElement.FontStyleProperty) as sw.FontStyle? ?? swd.TextElement.GetFontStyle(control);
 			this.WpfFontWeight = range.GetPropertyValue(swd.TextElement.FontWeightProperty) as sw.FontWeight? ?? swd.TextElement.GetFontWeight(control);
 			var decorations = range.GetPropertyValue(swd.Inline.TextDecorationsProperty) as sw.TextDecorationCollection;

--- a/Source/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
@@ -120,23 +120,12 @@ namespace Eto.Wpf.Forms.Controls
 			base.Dispose(disposing);
 		}
 
-		swd.TextRange ContentRange
-		{
-			get { return new swd.TextRange(Control.Document.ContentStart, Control.Document.ContentEnd); }
-		}
+		swd.TextRange ContentRange => new swd.TextRange(Control.Document.ContentStart, Control.Document.ContentEnd);
 
 		public override string Text
 		{
-			get
-			{
-				var doc = Control.Document;
-				return ContentRange.Text;
-			}
-			set
-			{
-				var doc = Control.Document;
-				ContentRange.Text = value ?? string.Empty;
-			}
+			get { return ContentRange.Text; }
+			set { ContentRange.Text = value ?? string.Empty; }
 		}
 
 		bool wrap = true;
@@ -581,7 +570,6 @@ namespace Eto.Wpf.Forms.Controls
 
 	static class FlowDocumentExtensions
 	{
-		static readonly Type[] runAndParagraphTypes = new Type[] { typeof(swd.Run), typeof(swd.Paragraph) };
 		static IEnumerable<swd.TextElement> GetRunsAndParagraphs(swd.FlowDocument doc)
 		{
 			for (var position = doc.ContentStart;
@@ -590,8 +578,9 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				if (position.GetPointerContext(swd.LogicalDirection.Forward) == swd.TextPointerContext.ElementEnd)
 				{
-					if (runAndParagraphTypes.Any(r => r.IsInstanceOfType(position.Parent)))
-						yield return position.Parent as swd.TextElement;
+					var parent = position.Parent;
+					if (parent is swd.Run || parent is swd.Paragraph || parent is swd.LineBreak)
+						yield return parent as swd.TextElement;
 				}
 			}
 		}
@@ -619,17 +608,21 @@ namespace Eto.Wpf.Forms.Controls
 			if (doc == null)
 				throw new ArgumentNullException("doc");
 
+			
+			var runsAndParagraphs = GetRunsAndParagraphs(doc).ToList();
 			var output = new swm.FormattedText(
-			  GetText(doc),
+			  GetText(runsAndParagraphs),
 			  CultureInfo.CurrentCulture,
 			  doc.FlowDirection,
 			  new swm.Typeface(doc.FontFamily, doc.FontStyle, doc.FontWeight, doc.FontStretch),
 			  doc.FontSize,
-			  doc.Foreground);
+			  doc.Foreground,
+			  null,
+			  swm.TextOptions.GetTextFormattingMode(doc));
 
 			int offset = 0;
 
-			foreach (var el in GetRunsAndParagraphs(doc))
+			foreach (var el in runsAndParagraphs)
 			{
 				var run = el as swd.Run;
 
@@ -646,11 +639,9 @@ namespace Eto.Wpf.Forms.Controls
 					output.SetTextDecorations(run.TextDecorations, offset, count);
 
 					offset += count;
+					continue;
 				}
-				else
-				{
-					offset += Environment.NewLine.Length;
-				}
+				offset += Environment.NewLine.Length;
 			}
 
 			return output;
@@ -668,14 +659,20 @@ namespace Eto.Wpf.Forms.Controls
 			return sb.ToString();
 		}
 
-		public static string GetText(this swd.FlowDocument doc)
+		public static string GetText(this IEnumerable<swd.TextElement> runsAndParagraphs)
 		{
 			var sb = new StringBuilder();
 
-			foreach (var el in GetRunsAndParagraphs(doc))
+			foreach (var el in runsAndParagraphs)
 			{
 				var run = el as swd.Run;
-				sb.Append(run == null ? Environment.NewLine : run.Text);
+				if (run != null)
+				{
+					sb.Append(run.Text);
+					continue;
+				}
+				if (el is swd.Paragraph || el is swd.LineBreak)
+					sb.AppendLine();
 			}
 			return sb.ToString();
 		}


### PR DESCRIPTION
Wpf: RichTextArea.SelectionFont now returns correct font size in high dpi.
Wpf: Use TextFormattingMode of document to calculate width when wrap is false
Wpf: Optimize getting width of text by reducing allocations for lambda