### PR TITLE
Mac: Fix FontPicker and FilePicker

### DIFF
--- a/Source/Eto.Mac/Forms/MacFileDialog.cs
+++ b/Source/Eto.Mac/Forms/MacFileDialog.cs
@@ -198,7 +198,7 @@ namespace Eto.Mac.Forms
 		public string Title
 		{
 			get { return Control.Title; }
-			set { Control.Title = value; }
+			set { Control.Title = value ?? string.Empty; }
 		}
 
 		public DialogResult ShowDialog(Window parent)

--- a/Source/Eto.Mac/Forms/SelectFolderDialogHandler.cs
+++ b/Source/Eto.Mac/Forms/SelectFolderDialogHandler.cs
@@ -43,16 +43,16 @@ namespace Eto.Mac.Forms
 				return Control.Title;
 			}
 			set {
-				Control.Title = value;
+				Control.Title = value ?? string.Empty;
 			}
 		}
 		
 		public string Directory {
 			get {
-				return Control.DirectoryUrl.Path;
+				return Control.Url?.Path ?? Control.DirectoryUrl.Path;
 			}
 			set {
-				Control.DirectoryUrl = new NSUrl(value);
+				Control.DirectoryUrl = NSUrl.FromFilename(value);
 			}
 		}
 		

--- a/Source/Eto/Forms/ThemedControls/ThemedFontPickerHandler.cs
+++ b/Source/Eto/Forms/ThemedControls/ThemedFontPickerHandler.cs
@@ -9,6 +9,7 @@ namespace Eto.Forms.ThemedControls
 	public class ThemedFontPickerHandler : ThemedControlHandler<Button, FontPicker, FontPicker.ICallback>, FontPicker.IHandler
 	{
 		private Font font;
+		private FontDialog dialog;
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="T:Eto.Forms.ThemedControls.ThemedFontPickerHandler"/> class.
@@ -42,15 +43,18 @@ namespace Eto.Forms.ThemedControls
 
 		private void Control_Click(object sender, EventArgs e)
 		{
-			var dialog = new FontDialog();
+			dialog = new FontDialog();
 			dialog.Font = font;
+			dialog.FontChanged += Dialog_FontChanged;
 
-			if (dialog.ShowDialog(Widget) == DialogResult.Ok)
-			{
-				font = dialog.Font;
-				Callback.OnValueChanged(Widget, EventArgs.Empty);
-				Refresh();
-			}
+			dialog.ShowDialog(Widget);
+		}
+
+		void Dialog_FontChanged(object sender, EventArgs e)
+		{
+			font = dialog?.Font;
+			Callback.OnValueChanged(Widget, EventArgs.Empty);
+			Refresh();
 		}
 
 		/// <summary>


### PR DESCRIPTION
- FilePicker crashes on macOS as the Folder/FileDialog.Title is set to null
- ThemedFontPickerHandler should allow for a modeless dialog by using the FontChanged event instead of the return value of ShowDialog().
- SelectFolderDialog will return the selected folder, not just the enclosing folder