### PR TITLE
Alternate method to hook up properties & events

### DIFF
--- a/Source/Eto.Mac/Forms/MacBase.cs
+++ b/Source/Eto.Mac/Forms/MacBase.cs
@@ -23,6 +23,13 @@ using MonoMac.CoreAnimation;
 
 namespace Eto.Mac.Forms
 {
+	public interface IMacControlHandler2
+	{
+		NSView GetContainerControl(Widget widget);
+
+		SizeF GetPreferredSize(Widget widget, SizeF availableSize);
+	}
+
 	public interface IMacControlHandler
 	{
 		NSView ContainerControl { get; }

--- a/Source/Eto.Mac/Forms/MacControlExtensions.cs
+++ b/Source/Eto.Mac/Forms/MacControlExtensions.cs
@@ -55,6 +55,9 @@ namespace Eto.Mac.Forms
 			{
 				return mh.GetPreferredSize(availableSize);
 			}
+			var mh2 = control.GetMacControl2();
+			if (mh2 != null)
+				return mh2.GetPreferredSize(control, availableSize);
 			
 			var c = control.ControlObject as NSControl;
 			if (c != null)
@@ -89,6 +92,17 @@ namespace Eto.Mac.Forms
 			return child == null ? null : child.GetMacControl();
 		}
 
+		public static IMacControlHandler2 GetMacControl2(this Control control)
+		{
+			if (control == null)
+				return null;
+			var container = control.Handler as IMacControlHandler2;
+			if (container != null)
+				return container;
+			var child = control.ControlObject as Control;
+			return child == null ? null : child.GetMacControl2();
+		}
+
 		public static NSView GetContainerView(this Widget control)
 		{
 			if (control == null)
@@ -96,6 +110,9 @@ namespace Eto.Mac.Forms
 			var containerHandler = control.Handler as IMacControlHandler;
 			if (containerHandler != null)
 				return containerHandler.ContainerControl;
+			var containerHandler2 = control.Handler as IMacControlHandler2;
+			if (containerHandler2 != null)
+				return containerHandler2.GetContainerControl(control);
 			var childControl = control.ControlObject as Control;
 			if (childControl != null)
 				return childControl.GetContainerView();

--- a/Source/Eto.Mac/Platform.cs
+++ b/Source/Eto.Mac/Platform.cs
@@ -192,6 +192,8 @@ namespace Eto.Mac
 			// General
 			p.Add<EtoEnvironment.IHandler>(() => new EtoEnvironmentHandler());
 			p.Add<Thread.IHandler>(() => new ThreadHandler());
+
+			p.AddHandler<Stepper>(() => new StepperHandler());
 		}
 
 		public override IDisposable ThreadStart()

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/StepperSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/StepperSection.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Eto.Forms;
+
 namespace Eto.Test.Sections.Controls
 {
 	[Section("Controls", typeof(Stepper))]

--- a/Source/Eto.WinRT/Eto.WinRT.csproj
+++ b/Source/Eto.WinRT/Eto.WinRT.csproj
@@ -17,6 +17,7 @@
     <TargetPlatformVersion>8.1</TargetPlatformVersion>
     <MinimumVisualStudioVersion>12</MinimumVisualStudioVersion>
     <TargetFrameworkVersion />
+    <BaseIntermediateOutputPath>..\..\BuildOutput\obj\Eto.WinRT</BaseIntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Source/Eto/Eto - pcl.csproj
+++ b/Source/Eto/Eto - pcl.csproj
@@ -344,6 +344,7 @@
     <Compile Include="Forms\Controls\FontPicker.cs" />
     <Compile Include="Forms\ThemedControls\ThemedFontPickerHandler.cs" />
     <Compile Include="Forms\OpenWithDialog.cs" />
+    <Compile Include="Handler2.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\LICENSE">

--- a/Source/Eto/Forms/Controls/Stepper.cs
+++ b/Source/Eto/Forms/Controls/Stepper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
-
+using System.Collections.Generic;
+using System.Linq.Expressions;
 
 namespace Eto.Forms
 {
@@ -68,25 +69,13 @@ namespace Eto.Forms
 		}
 	}
 
-	/// <summary>
-	/// Control that allows you to "step" through values, usually presented by two buttons arranged vertically with up and down arrows.
-	/// </summary>
-	[Handler(typeof(IHandler))]
 	public class Stepper : Control
 	{
-		new IHandler Handler { get { return (IHandler)base.Handler; } }
+		public static DependencyEvent<Stepper, StepperEventArgs> StepEvent = new DependencyEvent<Stepper, StepperEventArgs>((c, e) => c.OnStep(e));
 
-		/// <summary>
-		/// Identifier for the <see cref="Step"/> event.
-		/// </summary>
-		public const string StepEvent = "Stepper.Step";
-
-		/// <summary>
-		/// Event to handle when the user clicks on one of the step buttons, either up or down.
-		/// </summary>
 		public event EventHandler<StepperEventArgs> Step
 		{
-			add { Properties.AddHandlerEvent(StepEvent, value); }
+			add { Properties.AddEvent(StepEvent, value); }
 			remove { Properties.RemoveEvent(StepEvent, value); }
 		}
 
@@ -94,10 +83,10 @@ namespace Eto.Forms
 		/// Triggers the <see cref="Step"/> event.
 		/// </summary>
 		/// <param name="e">Event arguments</param>
-		protected void OnStep(StepperEventArgs e)
-		{
-			Properties.TriggerEvent(StepEvent, this, e);
-		}
+		protected void OnStep(StepperEventArgs e) => Properties.TriggerEvent(StepEvent, this, e);
+
+
+		public static DependencyProperty<Stepper, StepperValidDirections> ValidDirectionProperty = new DependencyProperty<Stepper, StepperValidDirections>(StepperValidDirections.Both);
 
 		/// <summary>
 		/// Gets or sets the valid directions the stepper will allow the user to click.
@@ -110,61 +99,8 @@ namespace Eto.Forms
 		[DefaultValue(StepperValidDirections.Both)] 
 		public StepperValidDirections ValidDirection
 		{
-			get { return Handler.ValidDirection; }
-			set { Handler.ValidDirection = value; }
-		}
-
-		ICallback callback = new Callback();
-
-		/// <summary>
-		/// Gets the callback.
-		/// </summary>
-		/// <returns>The callback.</returns>
-		protected override object GetCallback() => callback;
-
-		/// <summary>
-		/// Callback interface for the Stepper
-		/// </summary>
-		public new interface ICallback : Control.ICallback
-		{
-			/// <summary>
-			/// Triggers the <see cref="Step"/> event.
-			/// </summary>
-			/// <param name="widget">Widget instance to trigger the event</param>
-			/// <param name="e">Event arguments</param>
-			void OnStep(Stepper widget, StepperEventArgs e);
-		}
-
-		/// <summary>
-		/// Callback implementation for the Stepper
-		/// </summary>
-		protected new class Callback : Control.Callback, ICallback
-		{
-			/// <summary>
-			/// Triggers the <see cref="Step"/> event.
-			/// </summary>
-			/// <param name="widget">Widget instance to trigger the event</param>
-			/// <param name="e">Event arguments</param>
-			public void OnStep(Stepper widget, StepperEventArgs e)
-			{
-				widget.Platform.Invoke(() => widget.OnStep(e));
-			}
-		}
-
-		/// <summary>
-		/// Handler interface for the Stepper
-		/// </summary>
-		public new interface IHandler : Control.IHandler
-		{
-			/// <summary>
-			/// Gets or sets the valid directions the stepper will allow the user to click.
-			/// </summary>
-			/// <remarks>
-			/// On some platforms, the up and/or down buttons will not appear disabled, but will not trigger any events when they are 
-			/// not set as a valid direction.
-			/// </remarks>
-			/// <value>The valid directions for the stepper.</value>
-			StepperValidDirections ValidDirection { get; set; }
+			get { return Properties.Get(ValidDirectionProperty); }
+			set { Properties.Set(ValidDirectionProperty, value); }
 		}
 	}
 }

--- a/Source/Eto/Forms/ThemedControls/ThemedStepperHandler.cs
+++ b/Source/Eto/Forms/ThemedControls/ThemedStepperHandler.cs
@@ -135,14 +135,28 @@ namespace Eto.Forms.ThemedControls
 		{
 			switch (id)
 			{
-				case Stepper.StepEvent:
-					upButton.Click += (sender, e) => Callback.OnStep(Widget, new StepperEventArgs(StepperDirection.Up));
-					downButton.Click += (sender, e) => Callback.OnStep(Widget, new StepperEventArgs(StepperDirection.Down));
-					break;
+				/*case Stepper.StepEvent:
+					upButton.Click += (sender, e) => Stepper.StepEvent.Callback(Widget, new StepperEventArgs(StepperDirection.Up));
+					downButton.Click += (sender, e) => Stepper.StepEvent.Callback(Widget, new StepperEventArgs(StepperDirection.Down));
+					break;*/
 				default:
 					base.AttachEvent(id);
 					break;
 			}
+		}
+
+		public override Action<Stepper> GetEvent(object evt)
+		{
+			if (evt == Stepper.StepEvent)
+				return StepEventHandler;
+			return base.GetEvent(evt);
+		}
+
+		static void StepEventHandler(Stepper c)
+		{
+			var h = c.Handler as ThemedStepperHandler;
+			h.upButton.Click += (sender, e) => Stepper.StepEvent.Raise(c, new StepperEventArgs(StepperDirection.Up));
+			h.downButton.Click += (sender, e) => Stepper.StepEvent.Raise(c, new StepperEventArgs(StepperDirection.Down));
 		}
 	}
 }

--- a/Source/Eto/Handler2.cs
+++ b/Source/Eto/Handler2.cs
@@ -1,0 +1,199 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+
+namespace Eto
+{
+	public class DependencyProperty<TControl, TValue>
+	{
+		internal object EventKey = new object();
+
+		public TValue DefaultValue { get; set; }
+
+		public DependencyProperty()
+		{
+		}
+
+		public DependencyProperty(TValue defaultValue)
+		{
+			DefaultValue = defaultValue;
+		}
+
+		public bool IsSupported
+		{
+			get
+			{
+				var h = Platform.Instance.CreateShared(typeof(TControl)) as IHandler2;
+				return h.SupportsProperty(this);
+			}
+		}
+	}
+
+	public class DependencyEvent<TControl, TArgs>
+		where TArgs : EventArgs
+	{
+		Action<TControl, TArgs> _callback;
+		Expression<Action<TControl, TArgs>> _callbackExpression;
+		Action<TControl, TArgs> Callback => _callback ?? (_callback = _callbackExpression.Compile());
+
+		string _id;
+		public string ID => _id ?? (_id = Guid.NewGuid().ToString());
+
+		public DependencyEvent(Expression<Action<TControl, TArgs>> callback)
+		{
+			_callbackExpression = callback;
+			EventLookup.Register(callback, this);
+		}
+
+		public void Raise(TControl widget, TArgs e)
+		{
+			var callback = Callback;
+			if (callback != null)
+			{
+				using ((widget as Widget)?.Platform.Context)
+					callback(widget, e);
+			}
+		}
+
+		internal void Attach(TControl widget)
+		{
+			((IHandler2)(widget as Widget).Handler).AttachEvent(widget, this);
+		}
+
+		public bool IsSupported
+		{
+			get
+			{
+				var h = Platform.Instance.CreateShared(typeof(TControl)) as IHandler2;
+				return h?.SupportsEvent(this) ?? false;
+			}
+		}
+
+	}
+
+	public interface IHandler2
+	{
+		void Initialize(object widget);
+		void AttachEvent(object widget, object evt);
+		bool TryGetValue(object widget, object prop, out object value);
+		bool TrySetValue(object widget, object prop, object value);
+		bool SupportsEvent(object evt);
+		bool SupportsProperty(object prop);
+	}
+
+	public class WidgetHandler2<TWidget, TControl> : WidgetHandler2<TWidget>
+		where TWidget : Widget
+		where TControl : new()
+	{
+		static object CtlProp = new object();
+
+		public override void Initialize(TWidget widget)
+		{
+			base.Initialize(widget);
+			SetControl(widget, new TControl());
+		}
+
+		public static TControl GetControl(TWidget widget)
+		{
+			return widget.Properties.Get<TControl>(CtlProp);
+		}
+		public static void SetControl(TWidget widget, TControl value)
+		{
+			widget.Properties.Set(CtlProp, value);
+		}
+	}
+
+	public class WidgetHandler2<TWidget> : IHandler2
+	{
+		public virtual void Initialize(TWidget widget)
+		{
+		}
+
+		public virtual Action<TWidget> GetEvent(object evt)
+		{
+			return null;
+		}
+
+		public virtual Func<TWidget, object> GetProperty(object property)
+		{
+			return null;
+		}
+
+		public virtual Action<TWidget, object> SetProperty(object property)
+		{
+			return null;
+		}
+
+		static Dictionary<object, Action<TWidget>> s_events;
+		static Dictionary<object, Action<TWidget>> events => s_events ?? (s_events = new Dictionary<object, Action<TWidget>>());
+		static Dictionary<object, Func<TWidget, object>> s_getprops;
+		static Dictionary<object, Func<TWidget, object>> getprops => s_getprops ?? (s_getprops = new Dictionary<object, Func<TWidget, object>>());
+		static Dictionary<object, Action<TWidget, object>> s_setprops;
+		static Dictionary<object, Action<TWidget, object>> setprops => s_setprops ?? (s_setprops = new Dictionary<object, Action<TWidget, object>>());
+
+
+		void IHandler2.AttachEvent(object widget, object evt) => GetAttachEvent(evt)?.Invoke((TWidget)widget);
+
+		Action<TWidget> GetAttachEvent(object evt)
+		{
+			Action<TWidget> del;
+			if (events.TryGetValue(evt, out del))
+				return del;
+
+			del = GetEvent(evt);
+			events.Add(evt, del);
+			return del;
+		}
+
+		bool IHandler2.SupportsEvent(object evt) => GetAttachEvent(evt) != null;
+
+		bool IHandler2.SupportsProperty(object prop) => GetSetProperty(prop) != null || GetGetProperty(prop) != null;
+
+		bool IHandler2.TryGetValue(object widget, object prop, out object value)
+		{
+			var getDelegate = GetProperty(prop);
+			if (getDelegate != null)
+			{
+				value = getDelegate((TWidget)widget);
+				return true;
+			}
+			value = null;
+			return false;
+		}
+
+		bool IHandler2.TrySetValue(object widget, object prop, object value)
+		{
+			var setDelegate = SetProperty(prop);
+			if (setDelegate != null)
+			{
+				setDelegate((TWidget)widget, value);
+				return true;
+			}
+			return false;
+		}
+
+		Action<TWidget, object> GetSetProperty(object prop)
+		{
+			Action<TWidget, object> del;
+			if (setprops.TryGetValue(prop, out del))
+				return del;
+
+			del = SetProperty(prop);
+			setprops.Add(prop, del);
+			return del;
+		}
+
+		Func<TWidget, object> GetGetProperty(object prop)
+		{
+			Func<TWidget, object> del;
+			if (getprops.TryGetValue(prop, out del))
+				return del;
+
+			del = GetProperty(prop);
+			getprops.Add(prop, del);
+			return del;
+		}
+
+		void IHandler2.Initialize(object widget) => Initialize((TWidget)widget);
+	}
+}

--- a/Source/Eto/Platform.cs
+++ b/Source/Eto/Platform.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.Threading;
 using Eto.Drawing;
+using Eto.Forms;
 
 namespace Eto
 {
@@ -429,6 +430,11 @@ namespace Eto
 			Add(typeof(T), instantiator);
 		}
 
+		public void Add<T>(Func<IHandler2> instantiator)
+		{
+			Add(typeof(T), instantiator);
+		}
+
 		/// <summary>
 		/// Add the specified type and instantiator.
 		/// </summary>
@@ -446,20 +452,7 @@ namespace Eto
 		/// Find the delegate to create instances of the specified <paramref name="type"/>
 		/// </summary>
 		/// <param name="type">Type of the handler interface to get the instantiator for (usually derived from <see cref="Widget.IHandler"/> or another type)</param>
-		public Func<object> Find(Type type)
-		{
-			Func<object> activator;
-			if (instantiatorMap.TryGetValue(type, out activator))
-				return activator;
-
-			var handler = type.GetCustomAttribute<HandlerAttribute>(true);
-			if (handler != null && instantiatorMap.TryGetValue(handler.Type, out activator))
-			{
-				instantiatorMap.Add(type, activator);
-				return activator;
-			}
-			return null;
-		}
+		public Func<object> Find(Type type) => FindHandler(type)?.Instantiator;
 
 		/// <summary>
 		/// Finds the delegate to create instances of the specified type
@@ -487,6 +480,14 @@ namespace Eto
 				handlerMap.Add(type, info);
 				return info;
 			}
+
+			if (instantiatorMap.TryGetValue(type, out activator))
+			{
+				info = new HandlerInfo(true, activator);
+				handlerMap.Add(type, info);
+				return info;
+			}
+
 			return null;
 		}
 

--- a/Source/Eto/Widget.cs
+++ b/Source/Eto/Widget.cs
@@ -5,6 +5,7 @@
 using System;
 using System.Globalization;
 using System.Linq.Expressions;
+using Eto.Forms;
 
 namespace Eto
 {
@@ -82,6 +83,8 @@ namespace Eto
 		/// Gets the platform-specific handler for this widget
 		/// </summary>
 		public object Handler { get; internal set; }
+
+		public IHandler2 Handler2 => Handler as IHandler2;
 
 		/// <summary>
 		/// Gets the native platform-specific handle for integration purposes
@@ -261,9 +264,8 @@ namespace Eto
 		/// </remarks>
 		protected void Initialize()
 		{
-			var handler = WidgetHandler;
-			if (handler != null)
-				handler.Initialize();
+			WidgetHandler?.Initialize();
+			Handler2?.Initialize(this);
 			EventLookup.HookupEvents(this);
 			Platform.Instance.TriggerWidgetCreated(new WidgetCreatedEventArgs(this));
 		}


### PR DESCRIPTION
This is an experimental feature, trying to simplify the creation of new controls.  In most cases this may even eliminate the need to declare an IHandler interface for the control.

This will probably be done for the 3.x series (which is a ways off)

### Benefits:
1. If done properly, we can make it so only a single handler instance is created for ALL child objects instead of one per object reducing the number of instantiated objects substantially
2. Simplifies not only the declaration of the control but could also simplify platform implementations by eliminating the need for the `Connector` in GTK (due to using static methods to wire up event handlers)
3. Removes the need for the (excessive) amount of code required for `ICallback`/`Callback` implementations
4. Removes the need for `EventManager.Register()` in the static constructors
5. Removes the need for `IHandler` in cases where there are no methods and only properties and/or events.
6. Change is good

### Drawbacks:
1. Completely breaks any custom handlers, custom controls, or styles for native controls done through the handler
2. If more properties are stored in the `Widget.Properties`, accessing them may be slower (though this can be mitigated by pushing more functionality into subclasses of the native controls)
2. Change is bad

### Incomplete:
- [ ] Need to figure out how to style native controls, e.g. `Style.Add<SomeHandler>(h => h.Control.NativeProperty = blah);` won't work
- [ ] Other stuff I haven't thought of yet