### PR TITLE
TreeGridView updates

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -21,6 +21,8 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		protected Dictionary<int, int> ColumnMap { get { return columnMap; } }
 
+		public override Gtk.Widget EventControl => Tree;
+
 		protected GridHandler()
 		{
 			Control = new Gtk.ScrolledWindow
@@ -451,6 +453,12 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
+		static readonly object Border_Key = new object();
+		public BorderType Border
+		{
+			get { return Widget.Properties.Get(Border_Key, BorderType.Bezel); }
+			set { Widget.Properties.Set(Border_Key, value, () => Control.ShadowType = value.ToGtk(), BorderType.Bezel); }
+		}
 	}
 }
 

--- a/Source/Eto.Gtk/Forms/Controls/GtkTreeModel.cs
+++ b/Source/Eto.Gtk/Forms/Controls/GtkTreeModel.cs
@@ -107,6 +107,32 @@ namespace Eto.GtkSharp.Forms.Controls
 			return path;
 		}
 
+		public Gtk.TreeIter? GetIterFromItem(TItem item, bool expandedOnly = false)
+		{
+			var indicies = new List<int>();
+			var parents = GetParents(item);
+			foreach (var parent in parents)
+			{
+				if (expandedOnly && !parent.Expanded)
+					return null;
+				var items = (TStore)(object)parent;
+				var found = false;
+				for (int i = 0; i < items.Count; i++)
+				{
+					if (ReferenceEquals(items[i], item))
+					{
+						indicies.Insert(0, i);
+						item = parent;
+						found = true;
+						break;
+					}
+				}
+				if (!found)
+					return null;
+			}
+			return GetIterFromItem(item, indicies.ToArray());
+		}
+
 		public Gtk.TreeIter GetIterFromItem(TItem item, Gtk.TreePath path)
 		{
 			return GetIterFromItem(item, path.Indices);
@@ -165,6 +191,14 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 			iter = Gtk.TreeIter.Zero;
 			return false;
+		}
+
+		public int[] GetIndices(Gtk.TreeIter iter)
+		{
+			if (iter.UserData == IntPtr.Zero)
+				return new int[0];
+			var node = GetNodeAtIter(iter);
+			return node.Indices;
 		}
 
 		public Gtk.TreePath GetPath(Gtk.TreeIter iter)
@@ -266,24 +300,24 @@ namespace Eto.GtkSharp.Forms.Controls
 		public bool IterChildren(out Gtk.TreeIter child, Gtk.TreeIter parent)
 		{
 			TStore store;
-			Gtk.TreePath path;
+			int[] indices;
 			if (parent.UserData == IntPtr.Zero)
 			{
 				var h = Handler;
 				store = h != null ? h.DataStore : null;
-				path = new Gtk.TreePath();
+				indices = new[] { 0 };
 			}
 			else
 			{
 				var node = GetNodeAtIter(parent);
-				path = new Gtk.TreePath(node.Indices);
+				indices = new int[node.Indices.Length + 1];
+				Array.Copy(node.Indices, indices, node.Indices.Length);
 				store = (TStore)(object)node.Item;
 			}
-			path.AppendIndex(0);
 
 			if (store != null && store.Count > 0)
 			{
-				child = GetIterFromItem(store[0], path);
+				child = GetIterFromItem(store[0], indices);
 				return true;
 			}
 			child = Gtk.TreeIter.Zero;
@@ -324,10 +358,19 @@ namespace Eto.GtkSharp.Forms.Controls
 			var store = GetStore(parent);
 			if (store != null)
 			{
-				var path = GetPath(parent).Copy();
-				path.AppendIndex(n);
+				int[] indices;
+				if (parent.UserData != IntPtr.Zero)
+				{
+					var parentIndices = GetNodeAtIter(parent).Indices;
+					indices = new int[parentIndices.Length + 1];
+					Array.Copy(parentIndices, indices, parentIndices.Length);
+					indices[indices.Length - 1] = n;
+				}
+				else
+					indices = new[] { n };
+				
 				var item = store[n];
-				child = GetIterFromItem(item, path);
+				child = GetIterFromItem(item, indices);
 				return true;
 			}
 

--- a/Source/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
@@ -3,6 +3,7 @@ using Eto.Forms;
 using System.Collections.Generic;
 using Eto.GtkSharp.Forms.Cells;
 using System.Linq;
+using Eto.Drawing;
 
 namespace Eto.GtkSharp.Forms.Controls
 {
@@ -14,6 +15,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		CollectionHandler collection;
 		bool? selectCollapsingItem;
 		ITreeGridItem lastSelected;
+		int suppressExpandCollapseEvents;
 
 		protected override void Initialize()
 		{
@@ -36,8 +38,10 @@ namespace Eto.GtkSharp.Forms.Controls
 			WeakReference handler;
 			public TreeGridViewHandler Handler { get { return (TreeGridViewHandler)handler.Target; } set { handler = new WeakReference(value); } }
 
-			void ExpandItems(ITreeGridStore<ITreeGridItem> store, Gtk.TreePath path)
+			public void ExpandItems(ITreeGridStore<ITreeGridItem> store, Gtk.TreePath path)
 			{
+				if (store == null)
+					return;
 				for (int i = 0; i < store.Count; i++)
 				{
 					var item = store[i];
@@ -51,7 +55,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				}
 			}
 
-			void ExpandItems()
+			public void ExpandItems()
 			{
 				var store = Handler.collection.Collection;
 				var path = new Gtk.TreePath();
@@ -109,6 +113,8 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			get
 			{
+				if (AllowMultipleSelection)
+					return SelectedItems.FirstOrDefault() as ITreeGridItem;
 				Gtk.TreeIter iter;
 				return Tree.Selection.GetSelected(out iter) ? model.GetItemAtIter(iter) : null;
 			}
@@ -167,12 +173,9 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
-		protected new TreeGridViewConnector Connector { get { return (TreeGridViewConnector)base.Connector; } }
+		protected new TreeGridViewConnector Connector => (TreeGridViewConnector)base.Connector;
 
-		protected override WeakConnector CreateConnector()
-		{
-			return new TreeGridViewConnector();
-		}
+		protected override WeakConnector CreateConnector() => new TreeGridViewConnector();
 
 		protected class TreeGridViewConnector : GridConnector
 		{
@@ -181,6 +184,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleTestExpandRow(object o, Gtk.TestExpandRowArgs args)
 			{
 				var h = Handler;
+				if (h.suppressExpandCollapseEvents > 0)
+					return;
 				var e = new TreeGridViewItemCancelEventArgs(h.GetItem(args.Path) as ITreeGridItem);
 				h.Callback.OnExpanding(h.Widget, e);
 				args.RetVal = e.Cancel;
@@ -189,6 +194,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleRowExpanded(object o, Gtk.RowExpandedArgs args)
 			{
 				var h = Handler;
+				if (h.suppressExpandCollapseEvents > 0)
+					return;
 				var e = new TreeGridViewItemEventArgs(h.GetItem(args.Path) as ITreeGridItem);
 				e.Item.Expanded = true;
 				h.Callback.OnExpanded(h.Widget, e);
@@ -197,6 +204,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleTestCollapseRow(object o, Gtk.TestCollapseRowArgs args)
 			{
 				var h = Handler;
+				if (h.suppressExpandCollapseEvents > 0)
+					return;
 				var e = new TreeGridViewItemCancelEventArgs(h.GetItem(args.Path) as ITreeGridItem);
 				h.Callback.OnCollapsing(h.Widget, e);
 				args.RetVal = e.Cancel;
@@ -210,6 +219,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleRowCollapsed(object o, Gtk.RowCollapsedArgs args)
 			{
 				var h = Handler;
+				if (h.suppressExpandCollapseEvents > 0)
+					return;
 				var e = new TreeGridViewItemEventArgs(h.GetItem(args.Path) as ITreeGridItem);
 				e.Item.Expanded = false;
 				h.Callback.OnCollapsed(h.Widget, e);
@@ -412,31 +423,103 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			int rows = upToIndex == -1 ? model.IterNChildren(parent) : upToIndex;
 			int count = 0;
+			var path = model.GetPath(parent);
+			path.AppendIndex(0);
 			for (int i = 0; i < rows; i++)
 			{
 				Gtk.TreeIter iter;
-				if (model.IterNthChild(out iter, parent, i))
+				if (Tree.GetRowExpanded(path))
 				{
-					var childPath = model.GetPath(iter);
-					
-					if (Tree.GetRowExpanded(childPath))
+					if (model.IterNthChild(out iter, parent, i))
 					{
 						count += GetCount(iter, -1);
 					}
 				}
+				path.Next();
 				count++;
 			}
 			return count;
 		}
 
-		public override IEnumerable<int> SelectedRows
+		public void ReloadData()
 		{
-			get
+			// save selected items
+			var items = SelectedItems.ToArray();
+			// save scroll state
+			var hscrollbar = Control.HScrollbar as Gtk.HScrollbar;
+			var vscrollbar = Control.VScrollbar as Gtk.VScrollbar;
+			var hscroll = hscrollbar?.Value;
+			var vscroll = vscrollbar?.Value;
+
+			// reload data and expand items
+			suppressExpandCollapseEvents++;
+			UpdateModel();
+			collection.ExpandItems();
+			suppressExpandCollapseEvents--;
+
+			// restore selection
+			SkipSelectedChange = true;
+			bool selectionChanged = false;
+			Tree.Selection.UnselectAll();
+			foreach (var item in items.OfType<ITreeGridItem>())
 			{
-				var rows = Tree.Selection.GetSelectedRows();
-				foreach (var row in rows)
-					yield return GetRowIndexOfPath(row);
+				var iter = model.GetIterFromItem(item, true);
+				if (iter != null)
+					Tree.Selection.SelectIter(iter.Value);
+				else
+					selectionChanged = true;
 			}
+			if (selectionChanged)
+			{
+				Callback.OnSelectionChanged(Widget, EventArgs.Empty);
+			}
+			SkipSelectedChange = false;
+			if (hscroll != null)
+				vscrollbar.Value = hscroll.Value;
+			if (vscroll != null)
+				vscrollbar.Value = vscroll.Value;
 		}
+
+		public void ReloadItem(ITreeGridItem item)
+		{
+			var tree = Tree;
+			var path = model.GetPathFromItem(item);
+			if (path != null && path.Depth > 0 && !object.ReferenceEquals(item, collection.Collection))
+			{
+				Gtk.TreeIter iter;
+				tree.Model.GetIter(out iter, path);
+				tree.Model.EmitRowChanged(path, iter);
+				tree.Model.EmitRowHasChildToggled(path, iter);
+				suppressExpandCollapseEvents++;
+				if (item.Expanded)
+				{
+					tree.CollapseRow(path);
+					tree.ExpandRow(path, false);
+					collection.ExpandItems((ITreeGridStore<ITreeGridItem>)item, path);
+				}
+				else
+					tree.CollapseRow(path);
+				suppressExpandCollapseEvents--;
+			}
+			else
+				ReloadData();
+		}
+
+		public ITreeGridItem GetCellAt(PointF location, out int column)
+		{
+			Gtk.TreePath path;
+			Gtk.TreeViewColumn col;
+			if (Tree.GetPathAtPos((int)location.X, (int)location.Y, out path, out col))
+			{
+				column = GetColumnOfItem(col);
+				return model.GetItemAtPath(path);
+			}
+			column = -1;
+			return null;
+		}
+
+		public override IEnumerable<int> SelectedRows => Tree.Selection.GetSelectedRows().Select(GetRowIndexOfPath);
+
+		public IEnumerable<object> SelectedItems => Tree.Selection.GetSelectedRows().Select(GetItem);
 	}
 }

--- a/Source/Eto.Gtk/Forms/GtkControl.cs
+++ b/Source/Eto.Gtk/Forms/GtkControl.cs
@@ -465,8 +465,8 @@ namespace Eto.GtkSharp.Forms
 				{
 					Handler.Callback.OnMouseDoubleClick(Handler.Widget, mouseArgs);
 				}
-				if (!mouseArgs.Handled && Handler.Control.CanFocus && !Handler.Control.HasFocus)
-					Handler.Control.GrabFocus();
+				if (!mouseArgs.Handled && Handler.EventControl.CanFocus && !Handler.EventControl.HasFocus)
+					Handler.EventControl.GrabFocus();
 				args.RetVal = mouseArgs.Handled;
 			}
 

--- a/Source/Eto.Gtk/GtkConversions.cs
+++ b/Source/Eto.Gtk/GtkConversions.cs
@@ -634,5 +634,20 @@ namespace Eto.GtkSharp
 					throw new NotSupportedException();
 			}
 		}
+
+		public static Gtk.ShadowType ToGtk(this BorderType border)
+		{
+			switch (border)
+			{
+				case BorderType.Bezel:
+					return Gtk.ShadowType.In;
+				case BorderType.Line:
+					return Gtk.ShadowType.In;
+				case BorderType.None:
+					return Gtk.ShadowType.None;
+				default:
+					throw new NotSupportedException();
+			}
+		}
 	}
 }

--- a/Source/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -418,6 +418,16 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
+		public BorderType Border
+		{
+			get { return ScrollView.BorderType.ToEto(); }
+			set
+			{
+				ScrollView.BorderType = value.ToNS();
+				LayoutIfNeeded();
+			}
+		}
+
 		public void SelectAll()
 		{
 			Control.SelectAll(Control);

--- a/Source/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -68,15 +68,27 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void MouseDown(NSEvent theEvent)
 			{
-				var point = ConvertPointFromView(theEvent.LocationInWindow, null);
-
-				int rowIndex;
-				if ((rowIndex = (int)GetRow(point)) >= 0)
+				var handler = Handler;
+				if (handler != null)
 				{
-					int columnIndex = (int)GetColumn(point);
-					var item = Handler.GetItem(rowIndex);
-					var column = columnIndex == -1 || columnIndex > Handler.Widget.Columns.Count ? null : Handler.Widget.Columns[columnIndex];
-					Handler.Callback.OnCellClick(Handler.Widget, new GridViewCellEventArgs(column, rowIndex, columnIndex, item));
+					var args = MacConversions.GetMouseEvent(handler.ContainerControl, theEvent, false);
+					if (theEvent.ClickCount >= 2)
+						handler.Callback.OnMouseDoubleClick(handler.Widget, args);
+					else
+						handler.Callback.OnMouseDown(handler.Widget, args);
+					if (args.Handled)
+						return;
+
+					var point = ConvertPointFromView(theEvent.LocationInWindow, null);
+
+					int rowIndex;
+					if ((rowIndex = (int)GetRow(point)) >= 0)
+					{
+						int columnIndex = (int)GetColumn(point);
+						var item = handler.GetItem(rowIndex);
+						var column = columnIndex == -1 || columnIndex > handler.Widget.Columns.Count ? null : handler.Widget.Columns[columnIndex];
+						handler.Callback.OnCellClick(handler.Widget, new GridViewCellEventArgs(column, rowIndex, columnIndex, item));
+					}
 				}
 
 				base.MouseDown(theEvent);

--- a/Source/Eto.Mac/Forms/Controls/ScrollableHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/ScrollableHandler.cs
@@ -144,36 +144,10 @@ namespace Eto.Mac.Forms.Controls
 
 		public BorderType Border
 		{
-			get
-			{
-				switch (Control.BorderType)
-				{
-					case NSBorderType.BezelBorder:
-						return BorderType.Bezel;
-					case NSBorderType.LineBorder:
-						return BorderType.Line;
-					case NSBorderType.NoBorder:
-						return BorderType.None;
-					default:
-						throw new NotSupportedException();
-				}
-			}
+			get { return Control.BorderType.ToEto(); }
 			set
 			{
-				switch (value)
-				{
-					case BorderType.Bezel:
-						Control.BorderType = NSBorderType.BezelBorder;
-						break;
-					case BorderType.Line:
-						Control.BorderType = NSBorderType.LineBorder;
-						break;
-					case BorderType.None:
-						Control.BorderType = NSBorderType.NoBorder;
-						break;
-					default:
-						throw new NotSupportedException();
-				}
+				Control.BorderType = value.ToNS();
 				LayoutIfNeeded();
 			}
 		}

--- a/Source/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -3,7 +3,7 @@ using Eto.Forms;
 using System.Collections.Generic;
 using System.Linq;
 using Eto.Mac.Forms.Cells;
-
+using Eto.Drawing;
 
 #if XAMMAC2
 using AppKit;
@@ -35,10 +35,13 @@ using CGPoint = System.Drawing.PointF;
 
 #if XAMMAC
 using nnint = System.Int32;
+using nnint2 = System.Int32;
 #elif Mac64
 using nnint = System.UInt64;
+using nnint2 = System.Int64;
 #else
 using nnint = System.UInt32;
+using nnint2 = System.Int32;
 #endif
 
 namespace Eto.Mac.Forms.Controls
@@ -46,44 +49,49 @@ namespace Eto.Mac.Forms.Controls
 	public class TreeGridViewHandler : GridHandler<NSOutlineView, TreeGridView, TreeGridView.ICallback>, TreeGridView.IHandler, IDataViewHandler
 	{
 		ITreeGridStore<ITreeGridItem> store;
-		readonly Dictionary<ITreeGridItem, EtoTreeItem> cachedItems = new Dictionary<ITreeGridItem, EtoTreeItem> ();
-		readonly Dictionary<int, EtoTreeItem> topitems = new Dictionary<int, EtoTreeItem> ();
+		readonly Dictionary<ITreeGridItem, EtoTreeItem> cachedItems = new Dictionary<ITreeGridItem, EtoTreeItem>();
+		readonly Dictionary<int, EtoTreeItem> topitems = new Dictionary<int, EtoTreeItem>();
+		int suppressExpandCollapseEvents;
+		int skipSelectionChanged;
 
 		public class EtoTreeItem : NSObject
 		{
 			Dictionary<int, EtoTreeItem> items;
-			
-			public EtoTreeItem ()
+
+			public EtoTreeItem()
 			{
 			}
-			
-			public EtoTreeItem (IntPtr ptr)
+
+			public EtoTreeItem(IntPtr ptr)
 				: base(ptr)
 			{
 			}
-			
-			public EtoTreeItem (EtoTreeItem value)
+
+			public EtoTreeItem(EtoTreeItem value)
 			{
 				this.Item = value.Item;
 				this.items = value.items;
 			}
 
 			public ITreeGridItem Item { get; set; }
-			
-			public Dictionary<int, EtoTreeItem> Items {
-				get {
+
+			public Dictionary<int, EtoTreeItem> Items
+			{
+				get
+				{
 					if (items == null)
-						items = new Dictionary<int, EtoTreeItem> ();
+						items = new Dictionary<int, EtoTreeItem>();
 					return items;
 				}
 			}
 		}
 
-		bool ChildIsSelected (ITreeGridItem item)
+		bool ChildIsSelected(ITreeGridItem item)
 		{
 			var node = SelectedItem;
-			
-			while (node != null) {
+
+			while (node != null)
+			{
 				if (node == item)
 					return true;
 				node = node.Parent;
@@ -98,77 +106,101 @@ namespace Eto.Mac.Forms.Controls
 
 			bool? collapsedItemIsSelected;
 			ITreeGridItem lastSelected;
-			bool skipSelectionChanged;
-			
-			public override void SelectionDidChange (NSNotification notification)
+
+			public override void SelectionDidChange(NSNotification notification)
 			{
-				if (!skipSelectionChanged) {
-					Handler.Callback.OnSelectionChanged(Handler.Widget, EventArgs.Empty);
-					var item = Handler.SelectedItem;
-					if (!object.ReferenceEquals (item, lastSelected)) {
-						Handler.Callback.OnSelectedItemChanged(Handler.Widget, EventArgs.Empty);
-						lastSelected = item;
-					}
+				var h = Handler;
+				if (h.skipSelectionChanged > 0)
+					return;
+
+				h.Callback.OnSelectionChanged(h.Widget, EventArgs.Empty);
+				var item = h.SelectedItem;
+				if (!ReferenceEquals(item, lastSelected))
+				{
+					h.Callback.OnSelectedItemChanged(h.Widget, EventArgs.Empty);
+					lastSelected = item;
 				}
 			}
-			
-			public override void ItemDidCollapse (NSNotification notification)
+
+			public override void ItemDidCollapse(NSNotification notification)
 			{
-				var myitem = notification.UserInfo [(NSString)"NSObject"] as EtoTreeItem;
-				if (myitem != null) {
+				var h = Handler;
+				if (h.suppressExpandCollapseEvents > 0)
+					return;
+				var myitem = notification.UserInfo[(NSString)"NSObject"] as EtoTreeItem;
+				if (myitem != null)
+				{
 					myitem.Item.Expanded = false;
-					Handler.Callback.OnCollapsed(Handler.Widget, new TreeGridViewItemEventArgs (myitem.Item));
-					if (collapsedItemIsSelected == true) {
-						Handler.SelectedItem = myitem.Item;
+					h.Callback.OnCollapsed(h.Widget, new TreeGridViewItemEventArgs(myitem.Item));
+					if (collapsedItemIsSelected == true)
+					{
+						h.SelectedItem = myitem.Item;
 						collapsedItemIsSelected = null;
-						skipSelectionChanged = false;
+						h.skipSelectionChanged = 0;
 					}
 				}
 			}
-			
-			public override bool ShouldExpandItem (NSOutlineView outlineView, NSObject item)
+
+			public override bool ShouldExpandItem(NSOutlineView outlineView, NSObject item)
 			{
+				var h = Handler;
+				if (h.suppressExpandCollapseEvents > 0)
+					return true;
 				var myitem = item as EtoTreeItem;
-				if (myitem != null) {
-					var args = new TreeGridViewItemCancelEventArgs (myitem.Item);
-					Handler.Callback.OnExpanding(Handler.Widget, args);
+				if (myitem != null)
+				{
+					var args = new TreeGridViewItemCancelEventArgs(myitem.Item);
+					h.Callback.OnExpanding(h.Widget, args);
 					return !args.Cancel;
 				}
 				return true;
 			}
-			
-			public override bool ShouldCollapseItem (NSOutlineView outlineView, NSObject item)
+
+			public override bool ShouldCollapseItem(NSOutlineView outlineView, NSObject item)
 			{
+				var h = Handler;
+				if (h.suppressExpandCollapseEvents > 0)
+					return true;
 				var myitem = item as EtoTreeItem;
-				if (myitem != null) {
-					var args = new TreeGridViewItemCancelEventArgs (myitem.Item);
-					Handler.Callback.OnCollapsing(Handler.Widget, args);
-					if (!args.Cancel && !Handler.AllowMultipleSelection) {
-						collapsedItemIsSelected = Handler.ChildIsSelected (myitem.Item);
-						skipSelectionChanged = collapsedItemIsSelected ?? false;
+				if (myitem != null)
+				{
+					var args = new TreeGridViewItemCancelEventArgs(myitem.Item);
+					h.Callback.OnCollapsing(h.Widget, args);
+					if (!args.Cancel && !h.AllowMultipleSelection)
+					{
+						collapsedItemIsSelected = h.ChildIsSelected(myitem.Item);
+						if (collapsedItemIsSelected == true)
+							h.skipSelectionChanged = 1;
 					}
-					else 
+					else
 						collapsedItemIsSelected = null;
 					return !args.Cancel;
 				}
 				collapsedItemIsSelected = null;
 				return true;
 			}
-			
-			public override void ItemDidExpand (NSNotification notification)
+
+			public override void ItemDidExpand(NSNotification notification)
 			{
-				var myitem = notification.UserInfo [(NSString)"NSObject"] as EtoTreeItem;
-				if (myitem != null) {
+				var h = Handler;
+				if (h.suppressExpandCollapseEvents > 0)
+					return;
+				var myitem = notification.UserInfo[(NSString)"NSObject"] as EtoTreeItem;
+				if (myitem != null)
+				{
 					myitem.Item.Expanded = true;
-					Handler.Callback.OnExpanded(Handler.Widget, new TreeGridViewItemEventArgs (myitem.Item));
-					Handler.AutoSizeColumns();
+					h.suppressExpandCollapseEvents++;
+					h.ExpandItems(myitem);
+					h.suppressExpandCollapseEvents--;
+					h.Callback.OnExpanded(h.Widget, new TreeGridViewItemEventArgs(myitem.Item));
+					h.AutoSizeColumns();
 				}
 			}
-			
-			public override void DidClickTableColumn (NSOutlineView outlineView, NSTableColumn tableColumn)
+
+			public override void DidClickTableColumn(NSOutlineView outlineView, NSTableColumn tableColumn)
 			{
-				var column = Handler.GetColumn (tableColumn);
-				Handler.Callback.OnColumnHeaderClick(Handler.Widget, new GridColumnEventArgs (column.Widget));
+				var column = Handler.GetColumn(tableColumn);
+				Handler.Callback.OnColumnHeaderClick(Handler.Widget, new GridColumnEventArgs(column.Widget));
 			}
 
 			public override NSView GetView(NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item)
@@ -185,61 +217,65 @@ namespace Eto.Mac.Forms.Controls
 				return outlineView.MakeView(tableColumn.Identifier, this);
 			}
 		}
-			
+
 		public class EtoDataSource : NSOutlineViewDataSource
 		{
 			WeakReference handler;
 			public TreeGridViewHandler Handler { get { return (TreeGridViewHandler)handler.Target; } set { handler = new WeakReference(value); } }
 
-			public override NSObject GetObjectValue (NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item)
+			public override NSObject GetObjectValue(NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item)
 			{
-				var colHandler = Handler.GetColumn (tableColumn);
-				if (colHandler != null) {
+				var colHandler = Handler.GetColumn(tableColumn);
+				if (colHandler != null)
+				{
 					var myitem = (EtoTreeItem)item;
-					return colHandler.GetObjectValue (myitem.Item);
+					return colHandler.GetObjectValue(myitem.Item);
 				}
 				return null;
 			}
-			
-			public override void SetObjectValue (NSOutlineView outlineView, NSObject theObject, NSTableColumn tableColumn, NSObject item)
+
+			public override void SetObjectValue(NSOutlineView outlineView, NSObject theObject, NSTableColumn tableColumn, NSObject item)
 			{
-				var colHandler = Handler.GetColumn (tableColumn);
-				if (colHandler != null) {
+				var colHandler = Handler.GetColumn(tableColumn);
+				if (colHandler != null)
+				{
 					var myitem = (EtoTreeItem)item;
-					colHandler.SetObjectValue (myitem.Item, theObject);
+					colHandler.SetObjectValue(myitem.Item, theObject);
 				}
 			}
-			
-			public override bool ItemExpandable (NSOutlineView outlineView, NSObject item)
+
+			public override bool ItemExpandable(NSOutlineView outlineView, NSObject item)
 			{
 				var myitem = item as EtoTreeItem;
 				return myitem != null && myitem.Item.Expandable;
 			}
-			
-			public override NSObject GetChild (NSOutlineView outlineView, nint childIndex, NSObject item)
+
+			public override NSObject GetChild(NSOutlineView outlineView, nint childIndex, NSObject item)
 			{
 				Dictionary<int, EtoTreeItem> items;
 				var myitem = item as EtoTreeItem;
 				items = myitem == null ? Handler.topitems : myitem.Items;
-				
+
 				EtoTreeItem etoItem;
-				if (!items.TryGetValue((int)childIndex, out etoItem)) {
+				if (!items.TryGetValue((int)childIndex, out etoItem))
+				{
+
 					var parentItem = myitem != null ? (ITreeGridStore<ITreeGridItem>)myitem.Item : Handler.store;
-					etoItem = new EtoTreeItem{ Item = parentItem [(int)childIndex] };
-					Handler.cachedItems.Add (etoItem.Item, etoItem);
+					etoItem = new EtoTreeItem { Item = parentItem[(int)childIndex] };
+					Handler.cachedItems[etoItem.Item] = etoItem;
 					items.Add((int)childIndex, etoItem);
 				}
 				return etoItem;
 			}
-			
-			public override nint GetChildrenCount (NSOutlineView outlineView, NSObject item)
+
+			public override nint GetChildrenCount(NSOutlineView outlineView, NSObject item)
 			{
 				if (Handler.store == null)
 					return 0;
-				
+
 				if (item == null)
 					return Handler.store.Count;
-				
+
 				var myitem = item as EtoTreeItem;
 				return ((ITreeGridStore<ITreeGridItem>)myitem.Item).Count;
 			}
@@ -249,25 +285,41 @@ namespace Eto.Mac.Forms.Controls
 		{
 			public WeakReference WeakHandler { get; set; }
 
-			public object Handler
-			{ 
-				get { return WeakHandler.Target; }
-				set { WeakHandler = new WeakReference(value); } 
+			public TreeGridViewHandler Handler
+			{
+				get { return WeakHandler.Target as TreeGridViewHandler; }
+				set { WeakHandler = new WeakReference(value); }
 			}
 
 			public override void MouseDown(NSEvent theEvent)
 			{
-				var point = ConvertPointFromView(theEvent.LocationInWindow, null);
-
-				int rowIndex = (int)GetRow(point);
-				if (rowIndex >= 0)
+				var handler = Handler;
+				if (handler != null)
 				{
-					int columnIndex = (int)GetColumn(point);
-					var item = (Handler as TreeGridViewHandler).GetItem(rowIndex);
-					var column = columnIndex == -1 || columnIndex > (Handler as TreeGridViewHandler).Widget.Columns.Count ? null : (Handler as TreeGridViewHandler).Widget.Columns[columnIndex];
-					(Handler as TreeGridViewHandler).Callback.OnCellClick((Handler as TreeGridViewHandler).Widget, new GridViewCellEventArgs(column, rowIndex, columnIndex, item));
-				}
+					var args = MacConversions.GetMouseEvent(handler.ContainerControl, theEvent, false);
+					if (theEvent.ClickCount >= 2)
+						handler.Callback.OnMouseDoubleClick(handler.Widget, args);
+					else
+						handler.Callback.OnMouseDown(handler.Widget, args);
+					if (args.Handled)
+						return;
 
+					var point = ConvertPointFromView(theEvent.LocationInWindow, null);
+					int rowIndex = (int)GetRow(point);
+					if (rowIndex >= 0)
+					{
+						int columnIndex = (int)GetColumn(point);
+						var item = handler.GetItem(rowIndex);
+						var column = columnIndex == -1 || columnIndex > handler.Widget.Columns.Count ? null : handler.Widget.Columns[columnIndex];
+						handler.Callback.OnCellClick(handler.Widget, new GridViewCellEventArgs(column, rowIndex, columnIndex, item));
+					}
+					base.MouseDown(theEvent);
+
+					// NSOutlineView uses an event loop and MouseUp() does not get called
+					handler.Callback.OnMouseUp(handler.Widget, args);
+
+					return;
+				}
 				base.MouseDown(theEvent);
 			}
 
@@ -283,29 +335,31 @@ namespace Eto.Mac.Forms.Controls
 				ColumnAutoresizingStyle = NSTableViewColumnAutoresizingStyle.None;
 			}
 		}
-		
-		public override object EventObject {
+
+		public override object EventObject
+		{
 			get { return Control; }
 		}
-		
-		public override void AttachEvent (string id)
+
+		public override void AttachEvent(string id)
 		{
-			switch (id) {
-			case TreeGridView.ExpandedEvent:
-			case TreeGridView.ExpandingEvent:
-			case TreeGridView.CollapsedEvent:
-			case TreeGridView.CollapsingEvent:
-			case TreeGridView.SelectedItemChangedEvent:
-			case Grid.SelectionChangedEvent:
-			case Grid.ColumnHeaderClickEvent:
-				// handled in delegate
-				break;
-			case Grid.CellClickEvent:
-				// Handled in EtoOutlineView
-				break;
-			default:
-				base.AttachEvent (id);
-				break;
+			switch (id)
+			{
+				case TreeGridView.ExpandedEvent:
+				case TreeGridView.ExpandingEvent:
+				case TreeGridView.CollapsedEvent:
+				case TreeGridView.CollapsingEvent:
+				case TreeGridView.SelectedItemChangedEvent:
+				case Grid.SelectionChangedEvent:
+				case Grid.ColumnHeaderClickEvent:
+					// handled in delegate
+					break;
+				case Grid.CellClickEvent:
+					// Handled in EtoOutlineView
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
 			}
 		}
 
@@ -314,87 +368,96 @@ namespace Eto.Mac.Forms.Controls
 			return new EtoOutlineView(this);
 		}
 
-		public ITreeGridStore<ITreeGridItem> DataStore {
+		public ITreeGridStore<ITreeGridItem> DataStore
+		{
 			get { return store; }
-			set {
+			set
+			{
 				store = value;
-				topitems.Clear ();
-				cachedItems.Clear ();
-				Control.ReloadData ();
-				ExpandItems (null);
+				topitems.Clear();
+				cachedItems.Clear();
+				Control.ReloadData();
+				ExpandItems(null);
 				if (Widget.Loaded)
-					AutoSizeColumns ();
+					AutoSizeColumns();
 			}
 		}
 
-		static IEnumerable<ITreeGridItem> GetParents (ITreeGridItem item)
+		static IEnumerable<ITreeGridItem> GetParents(ITreeGridItem item)
 		{
 			var parent = item.Parent;
-			while (parent != null) {
+			while (parent != null)
+			{
 				yield return parent;
 				parent = parent.Parent;
 			}
 		}
 
-		EtoTreeItem GetCachedItem (ITreeGridItem item)
+		EtoTreeItem GetCachedItem(ITreeGridItem item)
 		{
 			EtoTreeItem myitem;
 			return cachedItems.TryGetValue(item, out myitem) ? myitem : null;
 		}
 
-		int CountRows (ITreeGridItem item)
+		int CountRows(ITreeGridItem item)
 		{
 			if (!item.Expanded)
 				return 0;
 
 			var rows = 0;
 			var container = item as IDataStore<ITreeGridItem>;
-			if (container != null) {
+			if (container != null)
+			{
 				rows += container.Count;
 				for (int i = 0; i < container.Count; i++)
 				{
-					rows += CountRows (container[i]);
+					rows += CountRows(container[i]);
 				}
 			}
 			return rows;
 		}
 
-		int FindRow (IDataStore<ITreeGridItem> container, ITreeGridItem item)
+		int FindRow(IDataStore<ITreeGridItem> container, ITreeGridItem item)
 		{
 			int row = 0;
-			for (int i = 0; i < container.Count; i++) {
-				var current = container [i];
-				if (object.ReferenceEquals (current, item)) {
+			for (int i = 0; i < container.Count; i++)
+			{
+				var current = container[i];
+				if (object.ReferenceEquals(current, item))
+				{
 					return row;
 				}
-				row ++;
-				row += CountRows (current);
+				row++;
+				row += CountRows(current);
 			}
 			return -1;
 		}
-		
-		int? ExpandToItem (ITreeGridItem item)
+
+		int? ExpandToItem(ITreeGridItem item)
 		{
-			var parents = GetParents (item).Reverse ();
+			var parents = GetParents(item).Reverse();
 			IDataStore<ITreeGridItem> lastParent = null;
 			var row = 0;
-			foreach (var parent in parents) {
-				if (lastParent != null) {
-					var foundRow = FindRow (lastParent, parent);
+			foreach (var parent in parents)
+			{
+				if (lastParent != null)
+				{
+					var foundRow = FindRow(lastParent, parent);
 					if (foundRow == -1)
 						return null;
 					row += foundRow;
-					var foundItem = Control.ItemAtRow (row) as EtoTreeItem;
+					var foundItem = Control.ItemAtRow(row) as EtoTreeItem;
 					if (foundItem == null)
 						return null;
-					Control.ExpandItem (foundItem);
+					Control.ExpandItem(foundItem);
 					foundItem.Item.Expanded = true;
-					row ++;
+					row++;
 				}
 				lastParent = parent as IDataStore<ITreeGridItem>;
 			}
-			if (lastParent != null) {
-				var foundRow = FindRow (lastParent, item);
+			if (lastParent != null)
+			{
+				var foundRow = FindRow(lastParent, item);
 				if (foundRow == -1)
 					return null;
 
@@ -403,63 +466,71 @@ namespace Eto.Mac.Forms.Controls
 			return null;
 		}
 
-		public ITreeGridItem SelectedItem {
-			get {
+		public ITreeGridItem SelectedItem
+		{
+			get
+			{
 				var row = Control.SelectedRow;
 				if (row == -1)
 					return null;
 				var myitem = (EtoTreeItem)Control.ItemAtRow(row);
 				return myitem.Item;
 			}
-			set {
+			set
+			{
 				if (value == null)
 					Control.DeselectAll(Control);
 				else {
-					
+
 					EtoTreeItem myitem;
-					if (cachedItems.TryGetValue (value, out myitem)) {
-						var cachedRow = Control.RowForItem (myitem);
-						if (cachedRow >= 0) {
-							Control.ScrollRowToVisible (cachedRow);
-							Control.SelectRow ((nnint)cachedRow, false);
+					if (cachedItems.TryGetValue(value, out myitem))
+					{
+						var cachedRow = Control.RowForItem(myitem);
+						if (cachedRow >= 0)
+						{
+							Control.ScrollRowToVisible(cachedRow);
+							Control.SelectRow((nnint)cachedRow, false);
 							return;
 						}
 					}
 
-					var row = ExpandToItem (value);
-					if (row != null) {
-						Control.ScrollRowToVisible (row.Value);
-						Control.SelectRow ((nnint)row.Value, false);
+					var row = ExpandToItem(value);
+					if (row != null)
+					{
+						Control.ScrollRowToVisible(row.Value);
+						Control.SelectRow((nnint)row.Value, false);
 					}
 				}
 			}
 		}
-		
-		void ExpandItems (NSObject parent)
+
+		void ExpandItems(NSObject parent)
 		{
 			var ds = (EtoDataSource)Control.DataSource;
-			var count = ds.GetChildrenCount (Control, parent);
-			for (int i=0; i<count; i++) {
-				
-				var item = ds.GetChild (Control, i, parent) as EtoTreeItem;
-				if (item != null && item.Item.Expanded) {
-					Control.ExpandItem (item);
-					ExpandItems (item);
+			var count = ds.GetChildrenCount(Control, parent);
+			for (int i = 0; i < count; i++)
+			{
+				var item = ds.GetChild(Control, i, parent) as EtoTreeItem;
+				if (item != null && item.Item.Expanded)
+				{
+					Control.ExpandItem(item);
+					ExpandItems(item);
 				}
 			}
 		}
-		
-		protected override void PreUpdateColumn (int index)
+
+		protected override void PreUpdateColumn(int index)
 		{
-			base.PreUpdateColumn (index);
+			base.PreUpdateColumn(index);
 			if (index == 0)
 				Control.OutlineTableColumn = null;
 		}
-		
-		protected override void UpdateColumns ()
+
+		protected override void UpdateColumns()
 		{
-			base.UpdateColumns ();
-			if (Control.OutlineTableColumn == null) {
+			base.UpdateColumns();
+			if (Control.OutlineTableColumn == null)
+			{
 				if (Widget.Columns.Count > 0)
 					Control.OutlineTableColumn = ((GridColumnHandler)Widget.Columns[0].Handler).Control;
 			}
@@ -467,10 +538,132 @@ namespace Eto.Mac.Forms.Controls
 				Control.OutlineTableColumn = null;
 		}
 
-		public override object GetItem (int row)
+		public override object GetItem(int row)
 		{
 			var item = Control.ItemAtRow(row) as EtoTreeItem;
 			return item != null ? item.Item : null;
+		}
+
+		public void ReloadData()
+		{
+			skipSelectionChanged++;
+			suppressExpandCollapseEvents++;
+			var selection = SelectedItems.ToList();
+
+			var contentView = ScrollView.ContentView;
+			var loc = contentView.Bounds.Location;
+			if (!Control.IsFlipped)
+				loc.Y = Control.Frame.Height - contentView.Frame.Height - loc.Y;
+
+			topitems.Clear();
+			cachedItems.Clear();
+			Control.ReloadData();
+			ExpandItems(null);
+
+			if (Control.IsFlipped)
+				contentView.ScrollToPoint(loc);
+			else
+				contentView.ScrollToPoint(new CGPoint(loc.X, Control.Frame.Height - contentView.Frame.Height - loc.Y));
+
+			bool isSelectionChanged = false;
+			foreach (var sel in selection)
+			{
+				var row = Control.RowForItem(GetCachedItem(sel as ITreeGridItem));
+				if (row >= 0)
+					Control.SelectRow((nnint)row, true);
+				else
+					isSelectionChanged = true;
+			}
+
+			ScrollView.ReflectScrolledClipView(contentView);
+			suppressExpandCollapseEvents--;
+			skipSelectionChanged--;
+
+			if (isSelectionChanged)
+			{
+				Callback.OnSelectionChanged(Widget, EventArgs.Empty);
+			}
+		}
+
+		public IEnumerable<object> SelectedItems
+		{
+			get
+			{
+				foreach (var row in Control.SelectedRows)
+				{
+					var item = Control.ItemAtRow((nnint2)row) as EtoTreeItem;
+					if (item != null)
+						yield return item.Item;
+				}
+			}
+		}
+
+		public void ReloadItem(ITreeGridItem item)
+		{
+			EtoTreeItem myitem;
+			if (cachedItems.TryGetValue(item, out myitem))
+			{
+				skipSelectionChanged++;
+				suppressExpandCollapseEvents++;
+				var selectedItem = SelectedItem;
+				var selection = SelectedItems.ToList();
+				var row = Control.RowForItem(myitem);
+				if (row >= 0)
+					topitems.Remove((int)row);
+				myitem.Items.Clear();
+
+				Control.ReloadItem(myitem, true);
+				SetItemExpansion(myitem);
+				ExpandItems(myitem);
+				AutoSizeColumns();
+				var isSelectionChanged = false;
+				foreach (var sel in selection)
+				{
+					row = Control.RowForItem(GetCachedItem(sel as ITreeGridItem));
+					if (row >= 0)
+						Control.SelectRow((nnint)row, true);
+					else
+						isSelectionChanged = true;
+				}
+				skipSelectionChanged--;
+				suppressExpandCollapseEvents--;
+				if (isSelectionChanged)
+				{
+					Callback.OnSelectionChanged(Widget, EventArgs.Empty);
+					if (!ReferenceEquals(selectedItem , SelectedItem))
+						Callback.OnSelectedItemChanged(Widget, EventArgs.Empty);
+				}
+			}
+			else
+				ReloadData();
+		}
+
+		void SetItemExpansion(NSObject parent)
+		{
+			suppressExpandCollapseEvents++;
+			var item = parent as EtoTreeItem;
+			if (item != null && item.Item.Expandable && item.Item.Expanded != Control.IsItemExpanded(item))
+			{
+				if (item.Item.Expanded)
+					Control.ExpandItem(item);
+				else
+					Control.CollapseItem(item, false);
+			}
+			suppressExpandCollapseEvents--;
+		}
+	
+		public ITreeGridItem GetCellAt(PointF location, out int column)
+		{
+			location += ScrollView.ContentView.Bounds.Location.ToEto();
+			column = (int)Control.GetColumn(location.ToNS());
+			var row = Control.GetRow(location.ToNS());
+			if (row >= 0)
+			{
+				var item = Control.ItemAtRow(row) as EtoTreeItem;
+				if (item != null)
+					return item.Item;
+			}
+			return null;
 		}
 	}
 }

--- a/Source/Eto.Mac/MacConversions.cs
+++ b/Source/Eto.Mac/MacConversions.cs
@@ -226,7 +226,7 @@ namespace Eto.Mac
 			if (size != null)
 			{
 				var mainScale = Screen.PrimaryScreen.RealScale;
-				var scales = new [] { 1f, 2f }; // generate both retina and non-retina representations
+				var scales = new[] { 1f, 2f }; // generate both retina and non-retina representations
 				var sz = (float)Math.Ceiling(size.Value / mainScale);
 				var rep = nsimage.BestRepresentation(new CGRect(0, 0, sz, sz), null, null);
 				sz = size.Value;
@@ -438,12 +438,42 @@ namespace Eto.Mac
 					throw new NotSupportedException();
 			}
 		}
-		
+
 		public static NSFont ToNS(this Font font)
 		{
 			if (font == null)
 				return null;
 			return ((FontHandler)font.Handler).Control;
+		}
+
+		public static BorderType ToEto(this NSBorderType border)
+		{
+			switch (border)
+			{
+				case NSBorderType.BezelBorder:
+					return BorderType.Bezel;
+				case NSBorderType.LineBorder:
+					return BorderType.Line;
+				case NSBorderType.NoBorder:
+					return BorderType.None;
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
+		public static NSBorderType ToNS(this BorderType border)
+		{
+			switch (border)
+			{
+				case BorderType.Bezel:
+					return NSBorderType.BezelBorder;
+				case BorderType.Line:
+					return NSBorderType.LineBorder;
+				case BorderType.None:
+					return NSBorderType.NoBorder;
+				default:
+					throw new NotSupportedException();
+			}
 		}
 	}
 }

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -85,7 +85,7 @@ namespace Eto.Test.Sections.Controls
 							null
 						}
 					},
-					new StackLayout 
+					new StackLayout
 					{
 						Orientation = Orientation.Horizontal,
 						Spacing = 5,
@@ -95,6 +95,19 @@ namespace Eto.Test.Sections.Controls
 							AddItemButton(filtered),
 							CreateScrollToRow(grid),
 							CreateBeginEditButton(grid),
+							"Border",
+							CreateBorderType(grid),
+							null
+						}
+					},
+					new StackLayout
+					{
+						Orientation = Orientation.Horizontal,
+						Spacing = 5,
+						Items =
+						{
+							null,
+							ReloadDataButton(grid),
 							null
 						}
 					},
@@ -127,6 +140,13 @@ namespace Eto.Test.Sections.Controls
 		{
 			var control = new CheckBox { Text = "ShowHeader" };
 			control.CheckedBinding.Bind(grid, r => r.ShowHeader);
+			return control;
+		}
+
+		Control ReloadDataButton(GridView grid)
+		{
+			var control = new Button { Text = "ReloadData" };
+			control.Click += (sender, e) => grid.ReloadData(grid.SelectedRows);
 			return control;
 		}
 
@@ -186,6 +206,13 @@ namespace Eto.Test.Sections.Controls
 				};
 			};
 			return filterText;
+		}
+
+		Control CreateBorderType(GridView grid)
+		{
+			var borderType = new EnumDropDown<BorderType>();
+			borderType.SelectedValueBinding.Bind(grid, g => g.Border);
+			return borderType;
 		}
 
 		class MyCustomCell : CustomCell

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
@@ -9,63 +9,173 @@ namespace Eto.Test.Sections.Controls
 	public class TreeGridViewSection : Scrollable
 	{
 		int expanded;
-		CheckBox allowCollapsing;
-		CheckBox allowExpanding;
-		static Image Image = TestIcons.TestIcon;
+		readonly CheckBox allowCollapsing;
+		readonly CheckBox allowExpanding;
+		readonly TreeGridView grid;
+		int newItemCount;
+		static readonly Image Image = TestIcons.TestIcon;
+		Label hoverNodeLabel;
+		bool cancelLabelEdit;
 
 		public TreeGridViewSection()
 		{
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
+			grid = ImagesAndMenu();
 
-			layout.BeginHorizontal();
-			layout.Add(new Label());
-			layout.BeginVertical();
-			layout.BeginHorizontal();
-			layout.Add(null);
-			layout.Add(allowExpanding = new CheckBox { Text = "Allow Expanding", Checked = true });
-			layout.Add(allowCollapsing = new CheckBox { Text = "Allow Collapsing", Checked = true });
-			layout.Add(null);
-			layout.EndHorizontal();
-			layout.EndVertical();
-			layout.EndHorizontal();
+			layout.AddSeparateRow(
+				null,
+				allowExpanding = new CheckBox { Text = "Allow Expanding", Checked = true },
+				allowCollapsing = new CheckBox { Text = "Allow Collapsing", Checked = true },
+				ShowHeaderCheckBox(grid),
+				null
+			);
+			layout.AddSeparateRow(null, InsertButton(), AddChildButton(), RemoveButton(), ExpandButton(), CollapseButton(), null);
+			layout.AddSeparateRow(null, EnabledCheck(), AllowMultipleSelect(), "Border", CreateBorderType(grid), null);
+			layout.AddSeparateRow(null, ReloadDataButton(grid), null);
 
-			layout.AddRow(new Label { Text = "Simple" }, Default());
-
-			layout.AddRow(new Label { Text = "With Images\n&& Context Menu" }, ImagesAndMenu());
-			layout.AddRow(new Label { Text = "Disabled" }, Disabled());
-
-			layout.Add(null, false, true);
+			layout.Add(grid, yscale: true);
+			layout.Add(HoverNodeLabel());
 
 			Content = layout;
 		}
 
-		TreeGridItem CreateSimpleTreeItem(int level, string name)
+		Control ShowHeaderCheckBox(TreeGridView grid)
 		{
-			var item = new TreeGridItem
-			{
-				Expanded = expanded++ % 2 == 0
-			};
-			item.Values = new object[] { "col 0 - " + name };
-			if (level < 4)
-			{
-				for (int i = 0; i < 4; i++)
-				{
-					item.Children.Add(CreateSimpleTreeItem(level + 1, name + " " + i));
-				}
-			}
-			return item;
+			var control = new CheckBox { Text = "ShowHeader" };
+			control.CheckedBinding.Bind(grid, g => g.ShowHeader);
+			return control;
 		}
 
-		Control Default()
+		Control ReloadDataButton(TreeGridView grid)
 		{
-			var control = new TreeGridView
+			var control = new Button { Text = "ReloadData" };
+			control.Click += (sender, e) => grid.ReloadData();
+			return control;
+		}
+
+		Control CreateBorderType(TreeGridView grid)
+		{
+			var borderType = new EnumDropDown<BorderType>();
+			borderType.SelectedValueBinding.Bind(grid, g => g.Border);
+			return borderType;
+		}
+
+		Control HoverNodeLabel()
+		{
+			hoverNodeLabel = new Label();
+
+			grid.MouseMove += (sender, e) =>
 			{
-				Size = new Size(100, 150),
-				ShowHeader = false
+				var cell = grid.GetCellAt(e.Location);
+				if (cell != null)
+					hoverNodeLabel.Text = $"Item under mouse: {((TreeGridItem)cell.Item)?.Values[1] ?? "(no item)"}, Column: {cell.Column?.HeaderText ?? "(no column)"}";
 			};
-			control.Columns.Add(new GridColumn { DataCell = new TextBoxCell(0) });
-			control.DataStore = CreateSimpleTreeItem(0, "");
-			LogEvents(control);
+
+			return hoverNodeLabel;
+		}
+
+		Control InsertButton()
+		{
+			var control = new Button { Text = "Insert" };
+			control.Click += (sender, e) =>
+			{
+				var item = grid.SelectedItem as TreeGridItem;
+				var parent = (item?.Parent ?? (ITreeGridItem)grid.DataStore) as TreeGridItem;
+				if (parent != null)
+				{
+					var index = item != null ? parent.Children.IndexOf(item) : 0;
+					parent.Children.Insert(index, CreateComplexTreeItem(0, "New Item " + newItemCount++, null));
+					if (item != null)
+						grid.ReloadItem(parent);
+					else
+						grid.ReloadData();
+				}
+			};
+			return control;
+		}
+
+		Control AddChildButton()
+		{
+			var control = new Button { Text = "Add Child" };
+			control.Click += (sender, e) =>
+			{
+				var item = grid.SelectedItem as TreeGridItem;
+				if (item != null)
+				{
+					item.Children.Add(CreateComplexTreeItem(0, "New Item " + newItemCount++, null));
+					grid.ReloadItem(item);
+				}
+			};
+			return control;
+		}
+
+		Control RemoveButton()
+		{
+			var control = new Button { Text = "Remove" };
+			control.Click += (sender, e) =>
+			{
+				var item = grid.SelectedItem as TreeGridItem;
+				if (item != null)
+				{
+					var parent = item.Parent as TreeGridItem;
+					parent.Children.Remove(item);
+					if (parent.Parent == null)
+						grid.ReloadData();
+					else
+						grid.ReloadItem(parent);
+				}
+			};
+			return control;
+		}
+
+		Control ExpandButton()
+		{
+			var control = new Button { Text = "Expand" };
+			control.Click += (sender, e) =>
+			{
+				var item = grid.SelectedItem;
+				if (item != null)
+				{
+					item.Expanded = true;
+					grid.ReloadItem(item);
+				}
+			};
+			return control;
+		}
+
+		Control CollapseButton()
+		{
+			var control = new Button { Text = "Collapse" };
+			control.Click += (sender, e) =>
+			{
+				var item = grid.SelectedItem;
+				if (item != null)
+				{
+					item.Expanded = false;
+					grid.ReloadItem(item);
+				}
+			};
+			return control;
+		}
+
+		Control CancelLabelEdit()
+		{
+			var control = new CheckBox { Text = "Cancel Edit" };
+			control.CheckedChanged += (sender, e) => cancelLabelEdit = control.Checked ?? false;
+			return control;
+		}
+
+		Control EnabledCheck()
+		{
+			var control = new CheckBox { Text = "Enabled", Checked = grid.Enabled };
+			control.CheckedChanged += (sender, e) => grid.Enabled = control.Checked ?? false;
+			return control;
+		}
+
+		Control AllowMultipleSelect()
+		{
+			var control = new CheckBox { Text = "AllowMultipleSelection" };
+			control.CheckedBinding.Bind(grid, t => t.AllowMultipleSelection);
 			return control;
 		}
 
@@ -86,7 +196,7 @@ namespace Eto.Test.Sections.Controls
 			return item;
 		}
 
-		Control ImagesAndMenu()
+		TreeGridView ImagesAndMenu()
 		{
 			var control = new TreeGridView
 			{
@@ -117,18 +227,12 @@ namespace Eto.Test.Sections.Controls
 			return control;
 		}
 
-		Control Disabled()
-		{
-			var control = ImagesAndMenu();
-			control.Enabled = false;
-			return control;
-		}
-
 		string GetDescription(ITreeGridItem item)
 		{
 			var treeItem = item as TreeGridItem;
 			if (treeItem != null)
-				return Convert.ToString(string.Join(", ", treeItem.Values.Select(r => Convert.ToString(r))));
+				return Convert.ToString(treeItem.Values[1]);
+				//return Convert.ToString(string.Join(", ", treeItem.Values.Select(r => Convert.ToString(r))));
 			return Convert.ToString(item);
 		}
 
@@ -141,6 +245,7 @@ namespace Eto.Test.Sections.Controls
 			control.SelectionChanged += delegate
 			{
 				Log.Write(control, "SelectionChanged, Rows: {0}", string.Join(", ", control.SelectedRows.Select(r => r.ToString())));
+				Log.Write(control, "\t Items: {0}", string.Join(", ", control.SelectedItems.OfType<TreeGridItem>().Select(r => GetDescription(r))));
 			};
 			control.SelectedItemChanged += delegate
 			{
@@ -165,19 +270,37 @@ namespace Eto.Test.Sections.Controls
 			{
 				Log.Write(control, "Collapsed, Item: {0}", GetDescription(e.Item));
 			};
-			control.ColumnHeaderClick += delegate(object sender, GridColumnEventArgs e)
+			control.ColumnHeaderClick += delegate (object sender, GridColumnEventArgs e)
 			{
-				Log.Write(control, "Column Header Clicked: {0}", e.Column);
+				Log.Write(control, "ColumnHeaderClick: {0}", e.Column);
 			};
 
 			control.CellClick += (sender, e) =>
 			{
-				Log.Write(control, "Cell Clicked, Row: {0}, Column: {1}, Item: {2}, ColInfo: {3}", e.Row, e.Column, e.Item, e.GridColumn);
+				Log.Write(control, "CellClick, Row: {0}, Column: {1}, Item: {2}, ColInfo: {3}", e.Row, e.Column, e.Item, e.GridColumn);
 			};
 
 			control.CellDoubleClick += (sender, e) =>
 			{
-				Log.Write(control, "Cell Double Clicked, Row: {0}, Column: {1}, Item: {2}, ColInfo: {3}", e.Row, e.Column, e.Item, e.GridColumn);
+				Log.Write(control, "CellDoubleClick, Row: {0}, Column: {1}, Item: {2}, ColInfo: {3}", e.Row, e.Column, e.Item, e.GridColumn);
+			};
+
+			control.MouseDown += (sender, e) =>
+			{
+				var cell = control.GetCellAt(e.Location);
+				Log.Write(control, $"MouseDown, Cell Column: {cell.Column?.HeaderText}, Item: {GetDescription(cell.Item as ITreeGridItem)}");
+			};
+
+			control.MouseUp += (sender, e) =>
+			{
+				var cell = control.GetCellAt(e.Location);
+				Log.Write(control, $"MouseUp, Cell Column: {cell.Column?.HeaderText}, Item: {GetDescription(cell.Item as ITreeGridItem)}");
+			};
+
+			control.MouseDoubleClick += (sender, e) =>
+			{
+				var cell = control.GetCellAt(e.Location);
+				Log.Write(control, $"MouseDoubleClick, Cell Column: {cell.Column?.HeaderText}, Item: {GetDescription(cell.Item as ITreeGridItem)}");
 			};
 		}
 	}

--- a/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Controls/TestGridViewHandler.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Controls/TestGridViewHandler.cs
@@ -204,6 +204,19 @@ namespace Eto.Test.UnitTests.Handlers.Controls
 
 		public GridLines GridLines { get; set; }
 
+		public BorderType Border
+		{
+			get
+			{
+				throw new NotImplementedException();
+			}
+
+			set
+			{
+				throw new NotImplementedException();
+			}
+		}
+
 		public void ReloadData(IEnumerable<int> rows)
 		{
 			throw new NotImplementedException();

--- a/Source/Eto.WinForms/CustomControls/TreeController.cs
+++ b/Source/Eto.WinForms/CustomControls/TreeController.cs
@@ -71,18 +71,34 @@ namespace Eto.CustomControls
 				sections.Clear ();
 			Store = store;
 
-			if (Store != null) {
-				for (int row = 0; row < Store.Count; row++) {
+			ResetSections();
+			ResetCollection ();
+		}
+
+		void ResetSections()
+		{
+			Sections.Clear();
+			if (Store != null)
+			{
+				for (int row = 0; row < Store.Count; row++)
+				{
 					var item = Store[row];
-					if (item.Expanded) {
+					if (item.Expanded)
+					{
 						var children = (ITreeGridStore<ITreeGridItem>)item;
 						var section = new TreeController { StartRow = row, Handler = Handler, parent = this };
-						section.InitializeItems (children);
-						Sections.Add (section);
+						section.InitializeItems(children);
+						Sections.Add(section);
 					}
 				}
 			}
-			ResetCollection ();
+		}
+
+		public void ReloadData()
+		{
+			ClearCache();
+			ResetSections();
+			ResetCollection();
 		}
 
 		void ClearCache ()
@@ -95,12 +111,12 @@ namespace Eto.CustomControls
 		{
 			if (cache.ContainsValue(item))
 			{
-				var found = cache.First(r => object.ReferenceEquals(item, r.Value));
+				var found = cache.First(r => ReferenceEquals(item, r.Value));
 				return found.Key;
 			}
 			for (int i = 0; i < Count; i++)
 			{
-				if (object.ReferenceEquals(this[i], item))
+				if (ReferenceEquals(this[i], item))
 					return i;
 			}
 			return -1;
@@ -257,7 +273,8 @@ namespace Eto.CustomControls
 			ITreeGridStore<ITreeGridItem> children = null;
 			if (sections == null || sections.Count == 0) {
 				children = (ITreeGridStore<ITreeGridItem>)Store [row];
-				var childController = new TreeController { StartRow = row, Store = children, Handler = Handler, parent = this };
+				var childController = new TreeController { StartRow = row, Handler = Handler, parent = this };
+				childController.InitializeItems(children);
 				Sections.Add (childController);
 			}
 			else {
@@ -278,7 +295,8 @@ namespace Eto.CustomControls
 				}
 				if (addTop && row < Store.Count) {
 					children = (ITreeGridStore<ITreeGridItem>)Store [row];
-					var childController = new TreeController { StartRow = row, Store = children, Handler = Handler, parent = this };
+					var childController = new TreeController { StartRow = row, Handler = Handler, parent = this };
+					childController.InitializeItems(children);
 					Sections.Add (childController);
 				}
 			}

--- a/Source/Eto.WinForms/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/GridHandler.cs
@@ -448,6 +448,12 @@ namespace Eto.WinForms.Forms.Controls
 			}
 		}
 
+		public BorderType Border
+		{
+			get { return Control.BorderStyle.ToEto(); }
+			set { Control.BorderStyle = value.ToSWF(); }
+		}
+
 		public void ReloadData(IEnumerable<int> rows)
 		{
 			Control.Refresh();

--- a/Source/Eto.WinForms/Forms/Controls/ScrollableHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/ScrollableHandler.cs
@@ -127,38 +127,11 @@ namespace Eto.WinForms.Forms.Controls
 
 		public BorderType Border
 		{
-			get
-			{
-				switch (Control.BorderStyle)
-				{
-					case swf.BorderStyle.FixedSingle:
-						return BorderType.Line;
-					case swf.BorderStyle.None:
-						return BorderType.None;
-					case swf.BorderStyle.Fixed3D:
-						return BorderType.Bezel;
-					default:
-						throw new NotSupportedException();
-				}
-			}
+			get { return Control.BorderStyle.ToEto(); }
 			set
 			{
-				switch (value)
-				{
-					case BorderType.Bezel:
-						Control.BorderStyle = swf.BorderStyle.Fixed3D;
-						break;
-					case BorderType.Line:
-						Control.BorderStyle = swf.BorderStyle.FixedSingle;
-						break;
-					case BorderType.None:
-						Control.BorderStyle = swf.BorderStyle.None;
-						break;
-					default:
-						throw new NotSupportedException();
-				}
+				Control.BorderStyle = value.ToSWF();
                 UpdateScrollSizes();
-
             }
 		}
 

--- a/Source/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
@@ -33,7 +33,7 @@ namespace Eto.WinForms.Forms.Controls
 		public TreeGridViewHandler()
 		{
 			controller = new TreeController { Handler = this };
-			controller.CollectionChanged += HandleCollectionChanged;
+			controller.CollectionChanged += (sender, e) => UpdateCollection();
 		}
 
 		public override void OnLoad(EventArgs e)
@@ -108,10 +108,10 @@ namespace Eto.WinForms.Forms.Controls
 			}
 		}
 
-		void HandleCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		void UpdateCollection()
 		{
 			Control.RowCount = controller.Count;
-			if (this.Widget.Loaded)
+			if (Widget.Loaded)
 			{
 				Control.Refresh();
 				AutoSizeColumns();
@@ -136,6 +136,17 @@ namespace Eto.WinForms.Forms.Controls
 				}
 				else
 					Control.ClearSelection();
+			}
+		}
+
+		public IEnumerable<object> SelectedItems
+		{
+			get
+			{
+				foreach (swf.DataGridViewRow row in Control.SelectedRows)
+				{
+					yield return GetItemAtRow(row.Index);
+				}
 			}
 		}
 
@@ -331,6 +342,25 @@ namespace Eto.WinForms.Forms.Controls
 
 		void ITreeHandler.PostResetTree()
 		{
+		}
+
+		public void ReloadData()
+		{
+			controller.ReloadData();
+		}
+
+		public void ReloadItem(ITreeGridItem item)
+		{
+			controller.ReloadData();
+		}
+
+		public ITreeGridItem GetCellAt(PointF location, out int column)
+		{
+			var result = Control.HitTest((int)location.X, (int)location.Y);
+			column = result.ColumnIndex;
+			if (result.RowIndex == -1)
+				return null;
+			return GetItemAtRow(result.RowIndex) as ITreeGridItem;
 		}
 	}
 }

--- a/Source/Eto.WinForms/WinConversions.cs
+++ b/Source/Eto.WinForms/WinConversions.cs
@@ -782,5 +782,35 @@ namespace Eto.WinForms
 				return null;
 			return new Screen(new ScreenHandler(screen));
 		}
+
+		public static BorderType ToEto(this swf.BorderStyle border)
+		{
+			switch (border)
+			{
+				case swf.BorderStyle.FixedSingle:
+					return BorderType.Line;
+				case swf.BorderStyle.None:
+					return BorderType.None;
+				case swf.BorderStyle.Fixed3D:
+					return BorderType.Bezel;
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
+		public static swf.BorderStyle ToSWF(this BorderType border)
+		{
+			switch (border)
+			{
+				case BorderType.Bezel:
+					return swf.BorderStyle.Fixed3D;
+				case BorderType.Line:
+					return swf.BorderStyle.FixedSingle;
+				case BorderType.None:
+					return swf.BorderStyle.None;
+				default:
+					throw new NotSupportedException();
+			}
+		}
 	}
 }

--- a/Source/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -45,6 +45,8 @@ namespace Eto.Wpf.Forms.Controls
 		protected swc.DataGridColumn CurrentColumn { get; set; }
 
 		protected override sw.Size DefaultSize => new sw.Size(100, 100);
+		public override bool UseMousePreview => true;
+		public override bool UseKeyPreview => true;
 
 		protected GridHandler()
 		{
@@ -493,6 +495,14 @@ namespace Eto.Wpf.Forms.Controls
 						break;
 				}
 			}
+		}
+
+		static object Border_Key = new object();
+
+		public BorderType Border
+		{
+			get { return Widget.Properties.Get(Border_Key, BorderType.Bezel); }
+			set { Widget.Properties.Set(Border, value, () => Control.SetEtoBorderType(value)); }
 		}
 
 		public void ReloadData(IEnumerable<int> rows)

--- a/Source/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
@@ -9,7 +9,6 @@ namespace Eto.Wpf.Forms.Controls
 {
 	public class ScrollableHandler : WpfPanel<swc.Border, Scrollable, Scrollable.ICallback>, Scrollable.IHandler
 	{
-		BorderType borderType;
 		bool expandContentWidth = true;
 		bool expandContentHeight = true;
 		readonly EtoScrollViewer scroller;
@@ -75,7 +74,7 @@ namespace Eto.Wpf.Forms.Controls
 			scroller.Loaded += HandleSizeChanged;
 
 			Control.Child = scroller;
-			this.Border = BorderType.Bezel;
+			Control.SetEtoBorderType(BorderType.Bezel);
 		}
 
 		public override void OnLoad(EventArgs e)
@@ -143,30 +142,12 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
+		static object Border_Key = new object();
+
 		public BorderType Border
 		{
-			get { return borderType; }
-			set
-			{
-				borderType = value;
-				switch (value)
-				{
-					case BorderType.Bezel:
-						Control.BorderBrush = sw.SystemColors.ControlDarkDarkBrush;
-						Control.BorderThickness = new sw.Thickness(1);
-						break;
-					case BorderType.Line:
-						Control.BorderBrush = sw.SystemColors.ControlDarkDarkBrush;
-						Control.BorderThickness = new sw.Thickness(1);
-						break;
-					case BorderType.None:
-						Control.BorderBrush = null;
-                        Control.BorderThickness = new sw.Thickness(0);
-                        break;
-					default:
-						throw new NotSupportedException();
-				}
-			}
+			get { return Widget.Properties.Get(Border_Key, BorderType.Bezel); }
+			set { Widget.Properties.Set(Border_Key, value, () => Control.SetEtoBorderType(value)); }
 		}
 
 		public override Size ClientSize

--- a/Source/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -6,6 +6,9 @@ using swm = System.Windows.Media;
 using Eto.Forms;
 using Eto.CustomControls;
 using Eto.Wpf.CustomControls.TreeGridView;
+using Eto.Drawing;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Eto.Wpf.Forms.Controls
 {
@@ -100,6 +103,8 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
+		public IEnumerable<object> SelectedItems => Control.SelectedItems.OfType<object>();
+
 		public override sw.FrameworkElement SetupCell(IGridColumnHandler column, sw.FrameworkElement defaultContent)
 		{
 			if (object.ReferenceEquals(column, Columns.Collection[0].Handler))
@@ -117,6 +122,36 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			RestoreFocus();
 			SkipSelectionChanged = false;
+		}
+
+		public void ReloadData()
+		{
+			controller.ReloadData();
+		}
+
+		public void ReloadItem(ITreeGridItem item)
+		{
+			controller.ReloadData();
+		}
+
+		public ITreeGridItem GetCellAt(PointF location, out int column)
+		{
+			var hitTestResult = swm.VisualTreeHelper.HitTest(Control, location.ToWpf())?.VisualHit;
+			if (hitTestResult == null)
+			{
+				column = -1;
+				return null;
+			}
+			var dataGridCell = hitTestResult.GetVisualParent<swc.DataGridCell>();
+			column = dataGridCell?.Column != null ? Control.Columns.IndexOf(dataGridCell.Column) : -1;
+
+			var dataGridRow = hitTestResult.GetVisualParent<swc.DataGridRow>();
+			if (dataGridRow != null)
+			{
+				int row = dataGridRow.GetIndex();
+				return GetItemAtRow(row) as ITreeGridItem;
+			}
+			return null;
 		}
 	}
 }

--- a/Source/Eto.Wpf/WpfConversions.cs
+++ b/Source/Eto.Wpf/WpfConversions.cs
@@ -24,7 +24,6 @@ namespace Eto.Wpf
 
 		public static swm.Color ToWpf(this Color value)
 		{
-
 			return swm.Color.FromArgb((byte)(value.A * byte.MaxValue), (byte)(value.R * byte.MaxValue), (byte)(value.G * byte.MaxValue), (byte)(value.B * byte.MaxValue));
 		}
 
@@ -78,20 +77,20 @@ namespace Eto.Wpf
 
 		public static sw.Rect ToWpf(this Rectangle value)
 		{
-            value.Normalize();
+			value.Normalize();
 			return new sw.Rect(value.X, value.Y, value.Width, value.Height);
 		}
 
 		public static sw.Int32Rect ToWpfInt32(this Rectangle value)
 		{
-            value.Normalize();
-            return new sw.Int32Rect(value.X, value.Y, value.Width, value.Height);
+			value.Normalize();
+			return new sw.Int32Rect(value.X, value.Y, value.Width, value.Height);
 		}
 
 		public static sw.Rect ToWpf(this RectangleF value)
 		{
-            value.Normalize();
-            return new sw.Rect(value.X, value.Y, value.Width, value.Height);
+			value.Normalize();
+			return new sw.Rect(value.X, value.Y, value.Width, value.Height);
 		}
 
 		public static SizeF ToEto(this sw.Size value)
@@ -286,19 +285,19 @@ namespace Eto.Wpf
 			}
 		}
 
-        public static Size GetSize(this sw.FrameworkElement element)
-        {
-            if (!double.IsNaN(element.ActualWidth) && !double.IsNaN(element.ActualHeight))
-                return new Size((int)element.ActualWidth, (int)element.ActualHeight);
-            return new Size((int)(double.IsNaN(element.Width) ? -1 : element.Width), (int)(double.IsNaN(element.Height) ? -1 : element.Height));
-        }
+		public static Size GetSize(this sw.FrameworkElement element)
+		{
+			if (!double.IsNaN(element.ActualWidth) && !double.IsNaN(element.ActualHeight))
+				return new Size((int)element.ActualWidth, (int)element.ActualHeight);
+			return new Size((int)(double.IsNaN(element.Width) ? -1 : element.Width), (int)(double.IsNaN(element.Height) ? -1 : element.Height));
+		}
 
-        public static sw.Size GetMinSize(this sw.FrameworkElement element)
-        {
-            return new sw.Size(element.MinWidth, element.MinHeight);
-        }
+		public static sw.Size GetMinSize(this sw.FrameworkElement element)
+		{
+			return new sw.Size(element.MinWidth, element.MinHeight);
+		}
 
-        public static void SetSize(this sw.FrameworkElement element, Size size)
+		public static void SetSize(this sw.FrameworkElement element, Size size)
 		{
 			element.Width = size.Width == -1 ? double.NaN : size.Width;
 			element.Height = size.Height == -1 ? double.NaN : size.Height;
@@ -796,6 +795,50 @@ namespace Eto.Wpf
 			if (direction.HasFlag(StepperValidDirections.Down))
 				dir |= xwt.ValidSpinDirections.Decrease;
 			return dir;
+		}
+
+		public static void SetEtoBorderType(this swc.Border control, BorderType value, Func<swm.Brush> getBezelBrush = null)
+		{
+			switch (value)
+			{
+				case BorderType.Bezel:
+					control.BorderBrush = getBezelBrush?.Invoke() ?? sw.SystemColors.ControlDarkBrush;
+					control.BorderThickness = new sw.Thickness(1);
+					break;
+				case BorderType.Line:
+					control.BorderBrush = sw.SystemColors.ControlDarkDarkBrush;
+					control.BorderThickness = new sw.Thickness(1);
+					break;
+				case BorderType.None:
+					control.BorderBrush = null;
+					control.BorderThickness = new sw.Thickness(0);
+					break;
+				default:
+					throw new NotSupportedException();
+
+			}
+		}
+
+		public static void SetEtoBorderType(this swc.Control control, BorderType value, Func<swm.Brush> getBezelBrush = null)
+		{
+			switch (value)
+			{
+				case BorderType.Bezel:
+					control.BorderBrush = getBezelBrush?.Invoke() ?? sw.SystemColors.ControlDarkBrush;
+					control.BorderThickness = new sw.Thickness(1);
+					break;
+				case BorderType.Line:
+					control.BorderBrush = sw.SystemColors.ControlDarkDarkBrush;
+					control.BorderThickness = new sw.Thickness(1);
+					break;
+				case BorderType.None:
+					control.BorderBrush = null;
+					control.BorderThickness = new sw.Thickness(0);
+					break;
+				default:
+					throw new NotSupportedException();
+
+			}
 		}
 	}
 }

--- a/Source/Eto/Forms/Controls/Grid.cs
+++ b/Source/Eto/Forms/Controls/Grid.cs
@@ -441,6 +441,16 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Gets or sets the border type
+		/// </summary>
+		/// <value>The border.</value>
+		public BorderType Border
+		{
+			get { return Handler.Border; }
+			set { Handler.Border = value; }
+		}
+
+		/// <summary>
 		/// Selects the row to the specified <paramref name="row"/>, clearing other selections
 		/// </summary>
 		/// <param name="row">Row to select</param>
@@ -652,6 +662,12 @@ namespace Eto.Forms
 			/// </summary>
 			/// <value>The grid line style.</value>
 			GridLines GridLines { get; set; }
+
+			/// <summary>
+			/// Gets or sets the border type
+			/// </summary>
+			/// <value>The border.</value>
+			BorderType Border { get; set; }
 
 			/// <summary>
 			/// Selects the row to the specified <paramref name="row"/>, clearing other selections

--- a/Source/Eto/Forms/Controls/TreeGridView.cs
+++ b/Source/Eto/Forms/Controls/TreeGridView.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using Eto.Drawing;
 
 namespace Eto.Forms
 {
@@ -51,6 +52,30 @@ namespace Eto.Forms
 		public TreeGridViewItemCancelEventArgs(ITreeGridItem item)
 		{
 			this.Item = item;
+		}
+	}
+
+	/// <summary>
+	/// Information of a cell in the <see cref="TreeGridView"/>
+	/// </summary>
+	public class TreeGridCell
+	{
+		/// <summary>
+		/// Gets the item associated with the row of the cell.
+		/// </summary>
+		/// <value>The row item.</value>
+		public object Item { get; }
+
+		/// <summary>
+		/// Gets the column of the cell, or null
+		/// </summary>
+		/// <value>The column.</value>
+		public GridColumn Column { get; }
+
+		internal TreeGridCell(object item, GridColumn column)
+		{
+			Item = item;
+			Column = column;
 		}
 	}
 
@@ -239,15 +264,7 @@ namespace Eto.Forms
 		/// <value>The selected items.</value>
 		public override IEnumerable<object> SelectedItems
 		{
-			get
-			{
-				if (DataStore == null)
-					yield break;
-				foreach (var row in SelectedRows)
-				{
-					yield return DataStore[row];
-				}
-			}
+			get { return Handler.SelectedItems; }
 		}
 
 		/// <summary>
@@ -259,6 +276,39 @@ namespace Eto.Forms
 			get { return Handler.ContextMenu; }
 			set { Handler.ContextMenu = value; }
 		}
+
+		/// <summary>
+		/// Refreshes the data, keeping the selection
+		/// </summary>
+		public void ReloadData()
+		{
+			Handler.ReloadData();
+		}
+
+		/// <summary>
+		/// Refreshes the specified item and all its children, keeping the selection if not part of the refreshed nodes
+		/// </summary>
+		/// <param name="item">Item to refresh</param>
+		public void ReloadItem(ITreeGridItem item)
+		{
+			Handler.ReloadItem(item);
+		}
+
+		/// <summary>
+		/// Gets the node at a specified point from the origin of the control
+		/// </summary>
+		/// <remarks>
+		/// Useful for determining which node is under the mouse cursor.
+		/// </remarks>
+		/// <returns>The item from the data store that is displayed at the specified location</returns>
+		/// <param name="point">Point to find the node</param>
+		public TreeGridCell GetCellAt(PointF point)
+		{
+			int column;
+			var item = Handler.GetCellAt(point, out column);
+			return new TreeGridCell(item, column >= 0 ? Columns[column] : null);
+		}
+
 
 		static readonly object callback = new Callback();
 
@@ -380,6 +430,31 @@ namespace Eto.Forms
 			/// </summary>
 			/// <value>The selected item.</value>
 			ITreeGridItem SelectedItem { get; set; }
+
+			/// <summary>
+			/// Gets an enumeration of the currently selected items
+			/// </summary>
+			/// <value>The selected items.</value>
+			IEnumerable<object> SelectedItems { get; }
+
+			/// <summary>
+			/// Refreshes the data, keeping the selection
+			/// </summary>
+			void ReloadData();
+
+			/// <summary>
+			/// Refreshes the specified item and all its children, keeping the selection if not part of the refreshed nodes
+			/// </summary>
+			/// <param name="item">Item to refresh</param>
+			void ReloadItem(ITreeGridItem item);
+
+			/// <summary>
+			/// Gets the item and column of a location in the control.
+			/// </summary>
+			/// <returns>The item from the data store that is displayed at the specified location</returns>
+			/// <param name="location">Point to find the node</param>
+			/// <param name="column">Column at the location, or -1 if no column (e.g. at the end of the row)</param>
+			ITreeGridItem GetCellAt(PointF location, out int column);
 		}
 	}
 }


### PR DESCRIPTION
This is a work in progress, and will hopefully fix a ton of issues with the TreeGridView.  Not full MVVM yet, but one step closer to getting that implemented.

It adds some apis:
- `TreeGridView.GetCellAt(PointF location)` - get the column & item at a specified point
- `TreeGridView.ReloadData()` - reload all data, keeping selection
- `TreeGridView.ReloadItem(ITreeGridItem item)` - reload the specified item and its children (helps with #493, but still not a full fix yet)
- `Grid.Border` - specify the type of border, or none (similar to Scrollable)

Fixes some things:
- Make mouse up/down events consistent and usable, combined with `GetCellAt()` should be very useful
- Fix `TreeGridView.SelectedItems` when allowing multiple selection (#451)
- Performance issues on some platforms
- Expanding children (if Expanded = true) when the parent node is expanded