### PR TITLE
Wpf: Ensure proper sizing rules are followed for all controls

### DIFF
--- a/Source/Eto.WinRT/Forms/Controls/DateTimePickerHandler.cs
+++ b/Source/Eto.WinRT/Forms/Controls/DateTimePickerHandler.cs
@@ -18,7 +18,7 @@ namespace Eto.WinRT.Forms.Controls
 	{
 		DateTimePickerMode mode;
 
-		protected override Size DefaultSize { get { return new Size(mode == DateTimePickerMode.DateTime ? 180 : 120, -1); } }
+		protected override wf.Size DefaultSize => new wf.Size(mode == DateTimePickerMode.DateTime ? 180 : 120, double.NaN);
 
 		public override wf.Size GetPreferredSize(wf.Size constraint)
 		{

--- a/Source/Eto.WinRT/Forms/Controls/PasswordBoxHandler.cs
+++ b/Source/Eto.WinRT/Forms/Controls/PasswordBoxHandler.cs
@@ -15,7 +15,7 @@ namespace Eto.WinRT.Forms.Controls
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	public class PasswordBoxHandler : WpfControl<swc.PasswordBox, PasswordBox, PasswordBox.ICallback>, PasswordBox.IHandler
 	{
-		protected override Size DefaultSize { get { return new Size(80, -1); } }
+		protected override wf.Size DefaultSize => new wf.Size(80, double.NaN);
 
 		public PasswordBoxHandler()
 		{

--- a/Source/Eto.WinRT/Forms/Controls/ProgressBarHandler.cs
+++ b/Source/Eto.WinRT/Forms/Controls/ProgressBarHandler.cs
@@ -1,5 +1,6 @@
 using sw = Windows.UI.Xaml;
 using swc = Windows.UI.Xaml.Controls;
+using wf = Windows.Foundation;
 using Eto.Forms;
 using Eto.Drawing;
 
@@ -13,7 +14,7 @@ namespace Eto.WinRT.Forms.Controls
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	public class ProgressBarHandler : WpfControl<swc.ProgressBar, ProgressBar, ProgressBar.ICallback>, ProgressBar.IHandler
 	{
-		protected override Size DefaultSize { get { return new Size(-1, 22); } }
+		protected override wf.Size DefaultSize => new wf.Size(double.NaN, 22);
 
 		public ProgressBarHandler()
 		{

--- a/Source/Eto.WinRT/Forms/Controls/TextAreaHandler.cs
+++ b/Source/Eto.WinRT/Forms/Controls/TextAreaHandler.cs
@@ -16,7 +16,7 @@ namespace Eto.WinRT.Forms.Controls
 	public class TextAreaHandler : WpfControl<swc.TextBox, TextArea, TextArea.ICallback>, TextArea.IHandler
 	{
 		int? lastCaretIndex;
-		protected override Size DefaultSize { get { return new Size(100, 60); } }
+		protected override wf.Size DefaultSize => new wf.Size(100, 60);
 
 		public TextAreaHandler()
 		{

--- a/Source/Eto.WinRT/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.WinRT/Forms/Controls/TextBoxHandler.cs
@@ -17,7 +17,7 @@ namespace Eto.WinRT.Forms.Controls
 	public class TextBoxHandler : WpfControl<swc.TextBox, TextBox, TextBox.ICallback>, TextBox.IHandler
 	{
 		bool textChanging;
-		protected override Size DefaultSize { get { return new Size(80, -1); } }
+		protected override wf.Size DefaultSize => new wf.Size(80, double.NaN);
 
 		public TextBoxHandler ()
 		{

--- a/Source/Eto.WinRT/Forms/WpfContainer.cs
+++ b/Source/Eto.WinRT/Forms/WpfContainer.cs
@@ -1,5 +1,6 @@
 using swc = Windows.UI.Xaml.Controls;
 using sw = Windows.UI.Xaml;
+using wf = Windows.Foundation;
 using Eto.Forms;
 using Eto.Drawing;
 
@@ -27,7 +28,7 @@ namespace Eto.WinRT.Forms
 
 		public bool RecurseToChildren { get { return true; } }
 
-		protected override Size DefaultSize { get { return minimumSize; } }
+		protected override wf.Size DefaultSize => minimumSize.ToWpf();
 
 		public abstract void Remove(sw.FrameworkElement child);
 

--- a/Source/Eto.WinRT/Forms/WpfFrameworkElement.cs
+++ b/Source/Eto.WinRT/Forms/WpfFrameworkElement.cs
@@ -98,7 +98,7 @@ namespace Eto.WinRT.Forms
 
 		protected wf.Size PreferredSize { get { return preferredSize; } set { preferredSize = value; } }
 
-		protected virtual Size DefaultSize { get { return Size.Empty; } }
+		protected virtual wf.Size DefaultSize { get { return new wf.Size(double.NaN, double.NaN); } }
 
 		public abstract Color BackgroundColor { get; set; }
 

--- a/Source/Eto.Wpf/CustomControls/MultiSizeImage.cs
+++ b/Source/Eto.Wpf/CustomControls/MultiSizeImage.cs
@@ -5,6 +5,7 @@ using System.Windows.Controls;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
+using Eto.Wpf.Forms;
 
 namespace Eto.Wpf.CustomControls
 {
@@ -22,7 +23,7 @@ namespace Eto.Wpf.CustomControls
 	/// 
 	/// <para>Written by Isak Savo - isak.savo@gmail.com, (c) 2011-2012. Licensed under the Code Project  </para>
 	/// </remarks>
-	public class MultiSizeImage : Image
+	public class MultiSizeImage : Image, IEtoWpfControl
 	{
 		Brush background;
 		bool useSmallestSpace;
@@ -52,6 +53,8 @@ namespace Eto.Wpf.CustomControls
 				}
 			}
 		}
+
+		public IWpfFrameworkElement Handler { get; set; }
 
 		static MultiSizeImage()
 		{
@@ -94,7 +97,7 @@ namespace Eto.Wpf.CustomControls
 
 		protected override Size MeasureOverride(Size constraint)
 		{
-			return MeasureArrangeHelper(constraint);
+			return Handler?.MeasureOverride(constraint, MeasureArrangeHelper) ?? MeasureArrangeHelper(constraint);
 		}
 
 		static bool IsZero(double value)

--- a/Source/Eto.Wpf/Eto.Wpf - net45.csproj
+++ b/Source/Eto.Wpf/Eto.Wpf - net45.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Forms\Cells\CustomCellHandler.cs" />
     <Compile Include="Forms\Controls\TextStepperHandler.cs" />
     <Compile Include="Forms\Controls\StepperHandler.cs" />
+    <Compile Include="Forms\EtoBorder.cs" />
     <Compile Include="Forms\Menu\MenuHandler.cs" />
     <Compile Include="Forms\PerMonitorDpiHelper.cs" />
     <Compile Include="Win32.dib.cs" />

--- a/Source/Eto.Wpf/Forms/Controls/ButtonHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ButtonHandler.cs
@@ -4,6 +4,7 @@ using Eto.Drawing;
 #if WINRT
 using sw = Windows.UI.Xaml;
 using swc = Windows.UI.Xaml.Controls;
+using wf = Windows.Foundation;
 
 using WpfLabel = Windows.UI.Xaml.Controls.TextBlock;
 using EtoImage = Windows.UI.Xaml.Controls.Image;
@@ -12,6 +13,7 @@ namespace Eto.WinRT.Forms.Controls
 #else
 using sw = System.Windows;
 using swc = System.Windows.Controls;
+using wf = System.Windows;
 
 using WpfLabel = System.Windows.Controls.Label;
 
@@ -55,7 +57,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		public static Size DefaultMinimumSize = new Size(80, 23);
 
-		protected override Size DefaultSize { get { return MinimumSize; } }
+		protected override wf.Size DefaultSize => MinimumSize.ToWpf();
 
 		public ButtonHandler()
 		{

--- a/Source/Eto.Wpf/Forms/Controls/CalendarHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/CalendarHandler.cs
@@ -4,16 +4,28 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using swc = System.Windows.Controls;
+using System.Windows;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoCalendar : swc.Calendar, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override Size MeasureOverride(Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
 	public class CalendarHandler : WpfControl<swc.Calendar, Calendar, Calendar.ICallback>, Calendar.IHandler
 	{
 		int suppressChanged;
 		public CalendarHandler()
 		{
-			Control = new swc.Calendar
+			Control = new EtoCalendar
 			{
+				Handler = this,
 				SelectedDate = DateTime.Today
 			};
 		}

--- a/Source/Eto.Wpf/Forms/Controls/CheckBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/CheckBoxHandler.cs
@@ -24,7 +24,7 @@ namespace Eto.Wpf.Forms.Controls
 			Control.Checked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 			Control.Unchecked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 			Control.Indeterminate += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
-			border = new swc.Border { Child = Control };
+			border = new EtoBorder { Handler = this, Child = Control };
 		}
 
 		public override Eto.Drawing.Color BackgroundColor

--- a/Source/Eto.Wpf/Forms/Controls/ColorPickerHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ColorPickerHandler.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using Eto.Drawing;
 using xwt = Xceed.Wpf.Toolkit;
+using sw = System.Windows;
 using swc = System.Windows.Controls;
 using swm = System.Windows.Media;
 using Eto.Forms;
@@ -11,17 +12,28 @@ using System.ComponentModel;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoColorPicker : xwt.ColorPicker, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
 	public class ColorPickerHandler : WpfControl<xwt.ColorPicker, ColorPicker, ColorPicker.ICallback>, ColorPicker.IHandler
 	{
 		static DependencyPropertyDescriptor dpdIsOpen = DependencyPropertyDescriptor.FromProperty(xwt.ColorPicker.IsOpenProperty, typeof(xwt.ColorPicker));
-		protected override Size DefaultSize { get { return new Size(60, -1); } }
+		protected override sw.Size DefaultSize => new sw.Size(60, double.NaN);
 
 		protected override bool PreventUserResize { get { return true; } }
 
 		public ColorPickerHandler()
 		{
-			Control = new xwt.ColorPicker
+			Control = new EtoColorPicker
 			{
+				Handler = this,
 				Focusable = true,
 				IsTabStop = true,
 				UsingAlphaChannel = false,

--- a/Source/Eto.Wpf/Forms/Controls/ComboBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ComboBoxHandler.cs
@@ -12,7 +12,7 @@ namespace Eto.Wpf.Forms.Controls
 		bool textChanging;
 		string lastText;
 
-		protected override Size DefaultSize { get { return new Size(100, -1); } }
+		protected override sw.Size DefaultSize => new sw.Size(100, double.NaN);
 
 		protected override bool PreventUserResize { get { return true; } }
 

--- a/Source/Eto.Wpf/Forms/Controls/DateTimePickerHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/DateTimePickerHandler.cs
@@ -17,13 +17,13 @@ namespace Eto.Wpf.Forms.Controls
 
 		DateTimePickerMode mode;
 
-		protected override Size DefaultSize { get { return new Size(mode == DateTimePickerMode.DateTime ? 180 : 120, -1); } }
+		protected override sw.Size DefaultSize => new sw.Size(mode == DateTimePickerMode.DateTime ? 180 : 120, double.NaN);
 
 		protected override bool PreventUserResize { get { return true; } }
 
 		public DateTimePickerHandler()
 		{
-			Control = new swc.Border { Focusable = false };
+			Control = new EtoBorder { Handler = this, Focusable = false };
 			Mode = DateTimePickerMode.Date;
 		}
 

--- a/Source/Eto.Wpf/Forms/Controls/DrawableHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/DrawableHandler.cs
@@ -87,10 +87,14 @@ namespace Eto.Wpf.Forms.Controls
 				if (content != null)
 				{
 					content.Measure(constraint);
-					return content.DesiredSize;
+					return Handler.MeasureOverride(constraint, c => {
+						base.MeasureOverride(c);
+						return content.DesiredSize;
+						});
 				}
-				return base.MeasureOverride(constraint);
+				return Handler.MeasureOverride(constraint, base.MeasureOverride);
 			}
+
 			protected override sw.Size ArrangeOverride(sw.Size arrangeSize)
 			{
 				base.ArrangeOverride(arrangeSize);
@@ -477,6 +481,7 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			this.content = content;
 			Control.Children.Add(content);
+			ContainerControl.InvalidateMeasure();
 		}
 
 		public override Color BackgroundColor

--- a/Source/Eto.Wpf/Forms/Controls/DropDownHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/DropDownHandler.cs
@@ -15,7 +15,7 @@ namespace Eto.Wpf.Forms.Controls
 	{
 	}
 
-	public class EtoComboBox : swc.ComboBox
+	public class EtoComboBox : swc.ComboBox, IEtoWpfControl
 	{
 		int? selected;
 
@@ -51,6 +51,8 @@ namespace Eto.Wpf.Forms.Controls
 			get { return GetTemplateChild("PART_EditableTextBox") as swc.TextBox; }
 		}
 
+		public IWpfFrameworkElement Handler { get; set; }
+
 		protected override void OnSelectionChanged(swc.SelectionChangedEventArgs e)
 		{
 			if (selected == null)
@@ -75,7 +77,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected override sw.Size MeasureOverride(sw.Size constraint)
 		{
-			var size = base.MeasureOverride(constraint);
+			var size = Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
 			var popup = GetTemplateChild("PART_Popup") as swc.Primitives.Popup;
 			if (popup == null)
 				return size;
@@ -110,6 +112,7 @@ namespace Eto.Wpf.Forms.Controls
 		public DropDownHandler()
 		{
 			Control = (TControl)new EtoComboBox();
+			Control.Handler = this;
 			Control.SelectionChanged += (sender, e) => Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
 			CreateTemplate();
 		}

--- a/Source/Eto.Wpf/Forms/Controls/ExpanderHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ExpanderHandler.cs
@@ -7,11 +7,21 @@ using System.ComponentModel;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoExpander : swc.Expander, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
 	public class ExpanderHandler : WpfPanel<swc.Expander, Expander, Expander.ICallback>, Expander.IHandler
 	{
 		public ExpanderHandler()
 		{
-			Control = new swc.Expander();
+			Control = new EtoExpander { Handler = this };
 		}
 
 		protected override void Initialize()
@@ -39,11 +49,6 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				Widget.Properties.Set(Header_Key, value, () => Control.Header = value.ToNative());
 			}
-		}
-
-		protected override bool UseContentSize
-		{
-			get { return false; }
 		}
 
 		public override void SetContainerContent(sw.FrameworkElement content)

--- a/Source/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -16,19 +16,26 @@ namespace Eto.Wpf.Forms.Controls
 {
 	public class EtoDataGrid : swc.DataGrid
 	{
+		public IWpfFrameworkElement Handler { get; set; }
+
 		public new void BeginUpdateSelectedItems()
 		{
 			base.BeginUpdateSelectedItems();
 		}
+
 		public new void EndUpdateSelectedItems()
 		{
 			base.EndUpdateSelectedItems();
 		}
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
 	}
 
 
-	public abstract class GridHandler<TControl, TWidget, TCallback> : WpfControl<TControl, TWidget, TCallback>, Grid.IHandler, IGridHandler
-		where TControl : EtoDataGrid
+	public abstract class GridHandler<TWidget, TCallback> : WpfControl<EtoDataGrid, TWidget, TCallback>, Grid.IHandler, IGridHandler
 		where TWidget : Grid
 		where TCallback : Grid.ICallback
 	{
@@ -37,10 +44,13 @@ namespace Eto.Wpf.Forms.Controls
 		protected bool SkipSelectionChanged { get; set; }
 		protected swc.DataGridColumn CurrentColumn { get; set; }
 
+		protected override sw.Size DefaultSize => new sw.Size(100, 100);
+
 		protected GridHandler()
 		{
-			Control = (TControl)new EtoDataGrid
+			Control = new EtoDataGrid
 			{
+				Handler = this,
 				HeadersVisibility = swc.DataGridHeadersVisibility.Column,
 				AutoGenerateColumns = false,
 				CanUserDeleteRows = false,
@@ -163,7 +173,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected class ColumnCollection : EnumerableChangedHandler<GridColumn, GridColumnCollection>
 		{
-			public GridHandler<TControl, TWidget, TCallback> Handler { get; set; }
+			public GridHandler<TWidget, TCallback> Handler { get; set; }
 
 			public override void AddItem(GridColumn item)
 			{

--- a/Source/Eto.Wpf/Forms/Controls/GridViewHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/GridViewHandler.cs
@@ -7,7 +7,7 @@ using System.Linq;
 
 namespace Eto.Wpf.Forms.Controls
 {
-	public class GridViewHandler : GridHandler<EtoDataGrid, GridView, GridView.ICallback>, GridView.IHandler
+	public class GridViewHandler : GridHandler<GridView, GridView.ICallback>, GridView.IHandler
 	{
 		IEnumerable<object> store;
 

--- a/Source/Eto.Wpf/Forms/Controls/GroupBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/GroupBoxHandler.cs
@@ -4,9 +4,20 @@ using swd = System.Windows.Data;
 using Eto.Forms;
 using Eto.Drawing;
 using Eto.Wpf.Drawing;
+using System;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoGroupBox : swc.GroupBox, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
 	public class GroupBoxHandler : WpfPanel<swc.GroupBox, GroupBox, GroupBox.ICallback>, GroupBox.IHandler
 	{
 		Font font;
@@ -15,11 +26,9 @@ namespace Eto.Wpf.Forms.Controls
 
 		public GroupBoxHandler()
 		{
-			Control = new swc.GroupBox();
+			Control = new EtoGroupBox { Handler = this };
 			Header = new swc.Label { Content = new swc.AccessText() };
 		}
-
-		protected override bool UseContentSize => false;
 
 		public override void SetContainerContent(sw.FrameworkElement content)
 		{

--- a/Source/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
@@ -21,6 +21,7 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			Control = new CustomControls.MultiSizeImage
 			{
+				Handler = this,
 				UseSmallestSpace = true,
 				Stretch = swm.Stretch.Uniform,
 				StretchDirection = swc.StretchDirection.Both
@@ -36,7 +37,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		void SetSource()
 		{
-			Control.Source = image.ToWpfScale(ParentScale, PreferredSize.ToEtoSize());
+			Control.Source = image.ToWpfScale(ParentScale, UserPreferredSize.ToEtoSize());
 		}
 
 		public Image Image
@@ -46,12 +47,12 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				image = value;
 				var size = image != null ? image.Size : Eto.Drawing.Size.Empty;
-				var ps = PreferredSize;
+				var ps = UserPreferredSize;
 				if (double.IsNaN(ps.Width))
 					ps.Width = size.Width;
 				if (double.IsNaN(ps.Height))
 					ps.Height = size.Height;
-				PreferredSize = ps;
+				UserPreferredSize = ps;
 				SetSource();
 			}
 		}

--- a/Source/Eto.Wpf/Forms/Controls/LabelHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/LabelHandler.cs
@@ -8,28 +8,29 @@ using sw = System.Windows;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoLabel : swc.Label
+	{
+		public LabelHandler Handler { get; set; }
+		protected override void OnAccessKey(swi.AccessKeyEventArgs e)
+		{
+			// move focus to the next control after the label
+			var tRequest = new swi.TraversalRequest(swi.FocusNavigationDirection.Next);
+			MoveFocus(tRequest);
+		}
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			var size = Handler.MeasureOverride(constraint, base.MeasureOverride);
+			size.Width += 1;
+			return size;
+		}
+	}
+
 	public class LabelHandler : WpfControl<swc.Label, Label, Label.ICallback>, Label.IHandler
 	{
 		readonly swc.AccessText accessText;
 		sw.Size? previousRenderSize;
 		string text;
-
-		public class EtoLabel : swc.Label
-		{
-			protected override void OnAccessKey(swi.AccessKeyEventArgs e)
-			{
-				// move focus to the next control after the label
-				var tRequest = new swi.TraversalRequest(swi.FocusNavigationDirection.Next);
-				MoveFocus(tRequest);
-			}
-
-			protected override sw.Size MeasureOverride(sw.Size constraint)
-			{
-				var size = base.MeasureOverride(constraint);
-				size.Width += 1;
-				return size;
-			}
-		}
 
 		protected override void SetDecorations(sw.TextDecorationCollection decorations)
 		{
@@ -41,6 +42,7 @@ namespace Eto.Wpf.Forms.Controls
 			accessText = new swc.AccessText();
 			Control = new EtoLabel
 			{
+				Handler = this,
 				Padding = new sw.Thickness(0),
 				Content = accessText
 			};

--- a/Source/Eto.Wpf/Forms/Controls/ListBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ListBoxHandler.cs
@@ -7,23 +7,34 @@ using swd = System.Windows.Data;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using Eto.Drawing;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoListBox : swc.ListBox, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
 	public class ListBoxHandler : WpfControl<swc.ListBox, ListBox, ListBox.ICallback>, ListBox.IHandler
 	{
 		IEnumerable<object> store;
 		ContextMenu contextMenu;
 
-		public override sw.Size GetPreferredSize(sw.Size constraint)
-		{
-			return base.GetPreferredSize(sw.Size.Empty);
-		}
+		protected override sw.Size DefaultSize => new sw.Size(100, 120);
 
 		public ListBoxHandler()
 		{
-			Control = new swc.ListBox();
-			Control.HorizontalAlignment = sw.HorizontalAlignment.Stretch;
+			Control = new EtoListBox
+			{
+				HorizontalAlignment = sw.HorizontalAlignment.Stretch,
+				Handler = this
+			};
 			//Control.DisplayMemberPath = "Text";
 			var template = new sw.DataTemplate();
 

--- a/Source/Eto.Wpf/Forms/Controls/NumericStepperHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/NumericStepperHandler.cs
@@ -8,17 +8,24 @@ using System.Text;
 
 namespace Eto.Wpf.Forms.Controls
 {
-	public class EtoDoubleUpDown : mwc.DoubleUpDown
+	public class EtoDoubleUpDown : mwc.DoubleUpDown, IEtoWpfControl
 	{
 		public new swc.TextBox TextBox { get { return base.TextBox; } }
 		public new mwc.Spinner Spinner { get { return base.Spinner; } }
+
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
 	}
 
 	public class NumericStepperHandler : WpfControl<EtoDoubleUpDown, NumericStepper, NumericStepper.ICallback>, NumericStepper.IHandler
 	{
 		double lastValue;
 
-		protected override Size DefaultSize { get { return new Size(80, -1); } }
+		protected override sw.Size DefaultSize => new sw.Size(80, double.NaN);
 
 		protected override bool PreventUserResize { get { return true; } }
 
@@ -26,6 +33,7 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			Control = new EtoDoubleUpDown
 			{
+				Handler = this,
 				FormatString = "0",
 				Value = 0
 			};

--- a/Source/Eto.Wpf/Forms/Controls/PanelHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/PanelHandler.cs
@@ -10,8 +10,9 @@ namespace Eto.Wpf.Forms.Controls
 	{
 		public PanelHandler ()
 		{
-			Control = new swc.Border
+			Control = new EtoBorder
 			{
+				Handler = this,
 				Focusable = false,
 				Background = swm.Brushes.Transparent // to get mouse events
 			};

--- a/Source/Eto.Wpf/Forms/Controls/PasswordBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/PasswordBoxHandler.cs
@@ -8,13 +8,18 @@ namespace Eto.Wpf.Forms.Controls
 {
 	public class PasswordBoxHandler : WpfControl<swc.PasswordBox, PasswordBox, PasswordBox.ICallback>, PasswordBox.IHandler
 	{
-		protected override Size DefaultSize { get { return new Size(80, -1); } }
+		swc.Border border;
+
+		public override sw.FrameworkElement ContainerControl => border;
+
+		protected override sw.Size DefaultSize => new sw.Size(80, double.NaN);
 
 		protected override bool PreventUserResize { get { return true; } }
 
 		public PasswordBoxHandler()
 		{
 			Control = new swc.PasswordBox();
+			border = new EtoBorder { Handler = this, Child = Control };
 		}
 
 		public override bool UseMousePreview { get { return true; } }

--- a/Source/Eto.Wpf/Forms/Controls/ProgressBarHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ProgressBarHandler.cs
@@ -2,16 +2,29 @@ using sw = System.Windows;
 using swc = System.Windows.Controls;
 using Eto.Forms;
 using Eto.Drawing;
+using System;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoProgressBar : swc.ProgressBar, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ??base.MeasureOverride(constraint);
+		}
+	}
+
 	public class ProgressBarHandler : WpfControl<swc.ProgressBar, ProgressBar, ProgressBar.ICallback>, ProgressBar.IHandler
 	{
-		protected override Size DefaultSize { get { return new Size(-1, 22); } }
+		protected override sw.Size DefaultSize => new sw.Size(double.NaN, 22);
 
 		public ProgressBarHandler()
 		{
-			Control = new swc.ProgressBar {
+			Control = new EtoProgressBar
+			{
+				Handler = this,
 				Minimum = 0,
 				Maximum = 100,
 			};

--- a/Source/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
@@ -29,7 +29,7 @@ namespace Eto.Wpf.Forms.Controls
 			Control.Loaded += Control_Loaded;
 			Control.Checked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 			Control.Unchecked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
-			border = new swc.Border { Child = Control };
+			border = new EtoBorder { Handler = this, Child = Control };
 		}
 
 		void Control_Loaded(object sender, sw.RoutedEventArgs e)

--- a/Source/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
@@ -16,7 +16,16 @@ using System.IO;
 
 namespace Eto.Wpf.Forms.Controls
 {
-	public class RichTextAreaHandler : TextAreaHandler<swc.RichTextBox, RichTextArea, RichTextArea.ICallback>, RichTextArea.IHandler, ITextBuffer
+	public class EtoRichTextBox : swc.RichTextBox, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+	public class RichTextAreaHandler : TextAreaHandler<EtoRichTextBox, RichTextArea, RichTextArea.ICallback>, RichTextArea.IHandler, ITextBuffer
 	{
 		LanguageChangedListener _languageChangedListener;
 

--- a/Source/Eto.Wpf/Forms/Controls/SliderHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/SliderHandler.cs
@@ -5,18 +5,28 @@ using Eto.Forms;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoSlider : swc.Slider, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ??base.MeasureOverride(constraint);
+		}
+	}
+
 	public class SliderHandler : WpfControl<swc.Slider, Slider, Slider.ICallback>, Slider.IHandler
 	{
 		public SliderHandler ()
 		{
-			Control = new swc.Slider {
+			Control = new EtoSlider
+			{
+				Handler = this,
 				Minimum = 0,
 				Maximum = 100,
 				TickPlacement = swc.Primitives.TickPlacement.BottomRight
 			};
-			Control.ValueChanged += delegate {
-				Callback.OnValueChanged(Widget, EventArgs.Empty);
-			};
+			Control.ValueChanged += (sender, e) => Callback.OnValueChanged(Widget, EventArgs.Empty);
 		}
 
 		public override bool UseMousePreview { get { return true; } }

--- a/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/SplitterHandler.cs
@@ -9,6 +9,16 @@ using System.ComponentModel;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoGrid : swc.Grid, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
 	public class SplitterHandler : WpfContainer<swc.Grid, Splitter, Splitter.ICallback>, Splitter.IHandler
 	{
 		readonly swc.GridSplitter splitter;
@@ -27,7 +37,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		public SplitterHandler()
 		{
-			Control = new swc.Grid();
+			Control = new EtoGrid { Handler = this };
 			Control.ColumnDefinitions.Add(new swc.ColumnDefinition());
 			Control.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = sw.GridLength.Auto });
 			Control.ColumnDefinitions.Add(new swc.ColumnDefinition());
@@ -374,7 +384,7 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			if (desired)
 			{
-				var size = PreferredSize;
+				var size = UserPreferredSize;
 				var pick = Orientation == Orientation.Horizontal ? size.Width : size.Height;
 				if (pick >= 0)
 					return pick - splitterWidth;

--- a/Source/Eto.Wpf/Forms/Controls/StepperHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/StepperHandler.cs
@@ -44,7 +44,7 @@ namespace Eto.Wpf.Forms.Controls
 			base.SetSize();
 			if (gridContent != null)
 			{
-				gridContent.MinWidth = double.IsNaN(PreferredSize.Width) ? originalWidth : 0;
+				gridContent.MinWidth = double.IsNaN(UserPreferredSize.Width) ? originalWidth : 0;
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/Controls/SwfWebViewHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/SwfWebViewHandler.cs
@@ -33,11 +33,7 @@ namespace Eto.Wpf.Forms.Controls
 			get { return (SHDocVw.WebBrowser_V1)Browser.ActiveXInstance; }
 		}
 
-		public override sw.Size GetPreferredSize(sw.Size constraint)
-		{
-			var size = base.GetPreferredSize(constraint);
-			return new sw.Size(Math.Min(size.Width, 100), Math.Min(size.Height, 100));
-		}
+		protected override sw.Size DefaultSize => new sw.Size(100, 100);
 
 		public void AttachEvent(SHDocVw.WebBrowser_V1 control, string handler)
 		{

--- a/Source/Eto.Wpf/Forms/Controls/TabControlHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TabControlHandler.cs
@@ -9,40 +9,42 @@ using Eto.Wpf.CustomControls;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoTabControl : swc.TabControl, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			var desired = Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+			// once loaded, act as normal
+			if (IsLoaded)
+				return desired;
+
+			// not loaded yet, let's calculate size based on all tabs
+			var size = new sw.Size(0, 0);
+			var selectedSize = new sw.Size(0, 0);
+			var selected = SelectedItem as swc.TabItem;
+
+			foreach (var tab in Items.Cast<swc.TabItem>())
+			{
+				var tabContent = tab.Content as sw.FrameworkElement;
+				if (tabContent == null)
+					continue;
+				tabContent.Measure(constraint);
+				var tabSize = tabContent.DesiredSize;
+				if (tab == selected)
+					selectedSize = tabSize;
+				size = size.Max(tabSize);
+			}
+			// calculate size of the border around the content based on selected tab's content size
+			var borderSize = desired.Subtract(selectedSize);
+			// return max height with border
+			return size.Add(borderSize);
+		}
+	}
+
 	public class TabControlHandler : WpfContainer<swc.TabControl, TabControl, TabControl.ICallback>, TabControl.IHandler
 	{
-		class EtoTabControl : swc.TabControl
-		{
-			protected override sw.Size MeasureOverride(sw.Size constraint)
-			{
-				// once loaded, act as normal
-				if (IsLoaded)
-					return base.MeasureOverride(constraint);
-
-				// not loaded yet, let's calculate size based on all tabs
-				var size = new sw.Size(0, 0);
-				var selectedSize = new sw.Size(0, 0);
-				var selected = SelectedItem as swc.TabItem;
-
-				foreach (var tab in Items.Cast<swc.TabItem>())
-				{
-					var tabContent = tab.Content as sw.FrameworkElement;
-					if (tabContent == null)
-						continue;
-					tabContent.Measure(constraint);
-					var tabSize = tabContent.DesiredSize;
-					if (tab == selected)
-						selectedSize = tabSize;
-                    size = size.Max(tabSize);
-				}
-				var baseSize = base.MeasureOverride(constraint);
-				// calculate size of the border around the content based on selected tab's content size
-				var borderSize = baseSize.Subtract(selectedSize);
-                // return max height with border
-                return size.Add(borderSize);
-			}
-		}
-
 		bool disableSelectedIndexChanged;
 		public TabControlHandler()
 		{

--- a/Source/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
@@ -6,7 +6,17 @@ using Eto.Drawing;
 
 namespace Eto.Wpf.Forms.Controls
 {
-	public class TextAreaHandler : TextAreaHandler<swc.TextBox, TextArea, TextArea.ICallback>
+	public class EtoTextBox : swc.TextBox, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
+	public class TextAreaHandler : TextAreaHandler<EtoTextBox, TextArea, TextArea.ICallback>
 	{
 		public override string Text
 		{
@@ -71,11 +81,11 @@ namespace Eto.Wpf.Forms.Controls
 	}
 
 	public abstract class TextAreaHandler<TControl, TWidget, TCallback> : WpfControl<TControl, TWidget, TCallback>, TextArea.IHandler
-		where TControl : swc.Primitives.TextBoxBase, new()
+		where TControl : swc.Primitives.TextBoxBase, IEtoWpfControl, new()
 		where TWidget : TextArea
 		where TCallback : TextArea.ICallback
 	{
-		protected override Size DefaultSize { get { return new Size(100, 60); } }
+		protected override sw.Size DefaultSize => new sw.Size(100, 60);
 
 		protected override bool PreventUserResize { get { return true; } }
 
@@ -86,15 +96,16 @@ namespace Eto.Wpf.Forms.Controls
 				AcceptsReturn = true,
 				AcceptsTab = true,
 				HorizontalScrollBarVisibility = swc.ScrollBarVisibility.Auto,
-				VerticalScrollBarVisibility = swc.ScrollBarVisibility.Auto
+				VerticalScrollBarVisibility = swc.ScrollBarVisibility.Auto,
+				Handler = this
 			};
 			Wrap = true;
 		}
 
-
-		public override sw.Size GetPreferredSize(sw.Size constraint)
+		public override sw.Size MeasureOverride(sw.Size constraint, Func<sw.Size, sw.Size> measure)
 		{
-			return base.GetPreferredSize(WpfConversions.ZeroSize);
+			var size = base.MeasureOverride(constraint, measure);
+			return size;
 		}
 
 		public override bool UseMousePreview { get { return true; } }

--- a/Source/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -9,13 +9,23 @@ using Eto.Drawing;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoWatermarkTextBox : mwc.WatermarkTextBox, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
 	public class TextBoxHandler : TextBoxHandler<mwc.WatermarkTextBox, TextBox, TextBox.ICallback>, TextBox.IHandler
 	{
 		protected override swc.TextBox TextBox => Control;
 
 		public TextBoxHandler()
 		{
-			Control = new mwc.WatermarkTextBox();
+			Control = new EtoWatermarkTextBox { Handler = this };
 		}
 
 		public override string PlaceholderText
@@ -31,7 +41,7 @@ namespace Eto.Wpf.Forms.Controls
 		where TWidget : TextBox
 		where TCallback: TextBox.ICallback
 	{
-		protected override Size DefaultSize { get { return new Size(100, -1); } }
+		protected override sw.Size DefaultSize => new sw.Size(100, double.NaN);
 
 		protected override bool PreventUserResize { get { return true; } }
 
@@ -71,11 +81,6 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			TextBox.SelectAll();
 			TextBox.GotKeyboardFocus -= Control_GotKeyboardFocus;
-		}
-
-		public override sw.Size GetPreferredSize(sw.Size constraint)
-		{
-			return base.GetPreferredSize(new sw.Size(0, double.PositiveInfinity));
 		}
 
 		public override bool UseMousePreview { get { return true; } }

--- a/Source/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
@@ -10,12 +10,23 @@ using Eto.Forms;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	public class EtoButtonSpinner : mwc.ButtonSpinner, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
 	public class TextStepperHandler : TextBoxHandler<mwc.ButtonSpinner, TextStepper, TextStepper.ICallback>, TextStepper.IHandler
 	{
 		public TextStepperHandler()
 		{
-			Control = new mwc.ButtonSpinner
+			Control = new EtoButtonSpinner
 			{
+				Handler = this,
 				Content = new mwc.WatermarkTextBox
 				{
 					BorderThickness = new sw.Thickness(0),

--- a/Source/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -9,7 +9,7 @@ using Eto.Wpf.CustomControls.TreeGridView;
 
 namespace Eto.Wpf.Forms.Controls
 {
-	public class TreeGridViewHandler : GridHandler<EtoDataGrid, TreeGridView, TreeGridView.ICallback>, TreeGridView.IHandler, ITreeHandler
+	public class TreeGridViewHandler : GridHandler<TreeGridView, TreeGridView.ICallback>, TreeGridView.IHandler, ITreeHandler
 	{
 		TreeController controller;
 		ITreeGridItem lastSelected;

--- a/Source/Eto.Wpf/Forms/Controls/TreeViewHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TreeViewHandler.cs
@@ -15,7 +15,7 @@ using System.Threading.Tasks;
 
 namespace Eto.Wpf.Forms.Controls
 {
-	public class TreeViewHandler : WpfControl<SelectableTreeView, TreeView, TreeView.ICallback>, TreeView.IHandler
+	public class TreeViewHandler : WpfControl<TreeViewHandler.EtoTreeView, TreeView, TreeView.ICallback>, TreeView.IHandler
 	{
 		ContextMenu contextMenu;
 		ITreeStore topNode;
@@ -26,6 +26,8 @@ namespace Eto.Wpf.Forms.Controls
 		// use two templates to refresh individual items by changing its template (hack? yes, fast? yes)
 		sw.HierarchicalDataTemplate template1;
 		sw.HierarchicalDataTemplate template2;
+
+		protected override sw.Size DefaultSize => new sw.Size(100, 100);
 
 		public class EtoTreeViewItem : swc.TreeViewItem, INotifyPropertyChanged
 		{
@@ -215,6 +217,13 @@ namespace Eto.Wpf.Forms.Controls
 			protected override bool IsItemItsOwnContainerOverride(object item)
 			{
 				return item is EtoTreeViewItem;
+			}
+
+			protected override sw.Size MeasureOverride(sw.Size availableSize)
+			{
+				if (IsLoaded)
+					availableSize = availableSize.IfInfinity(Handler.UserPreferredSize.IfNaN(Handler.DefaultSize));
+				return Handler?.MeasureOverride(availableSize, base.MeasureOverride) ?? base.MeasureOverride(availableSize);
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/EtoBorder.cs
+++ b/Source/Eto.Wpf/Forms/EtoBorder.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using sw = System.Windows;
+using swc = System.Windows.Controls;
+using swm = System.Windows.Media;
+
+namespace Eto.Wpf.Forms
+{
+	/// <summary>
+	/// Shared class to use as a container that properly handles measurement for Eto sizing rules
+	/// </summary>
+	/// <remarks>
+	/// This should only be used if it is set to the <see cref="WpfFrameworkElement{TControl, TWidget, TCallback}.ContainerControl"/>.
+	/// </remarks>
+	public class EtoBorder : swc.Border
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
+}

--- a/Source/Eto.Wpf/Forms/PixelLayoutHandler.cs
+++ b/Source/Eto.Wpf/Forms/PixelLayoutHandler.cs
@@ -8,24 +8,28 @@ namespace Eto.Wpf.Forms
 {
 	public class PixelLayoutHandler : WpfLayout<swc.Canvas, PixelLayout, PixelLayout.ICallback>, PixelLayout.IHandler
 	{
-		public override sw.Size GetPreferredSize(sw.Size constraint)
+		public class EtoCanvas : swc.Canvas
 		{
-			var size = new sw.Size();
-			foreach (var control in Widget.VisualControls)
+			protected override sw.Size MeasureOverride(sw.Size constraint)
 			{
-				var container = control.GetContainerControl();
-				var preferredSize = control.GetPreferredSize(constraint);
-				var left = swc.Canvas.GetLeft(container) + preferredSize.Width;
-				var top = swc.Canvas.GetTop(container) + preferredSize.Height;
-				if (size.Width < left) size.Width = left;
-				if (size.Height < top) size.Height = top;
+				var size = new sw.Size();
+				
+				foreach (sw.UIElement control in Children)
+				{
+					control.Measure(constraint);
+					var preferredSize = control.DesiredSize;
+					var left = GetLeft(control) + preferredSize.Width;
+					var top = GetTop(control) + preferredSize.Height;
+					if (size.Width < left) size.Width = left;
+					if (size.Height < top) size.Height = top;
+				}
+				return size;
 			}
-			return size;
 		}
 
 		public PixelLayoutHandler()
 		{
-			Control = new swc.Canvas
+			Control = new EtoCanvas
 			{
 				SnapsToDevicePixels = true
 			};
@@ -91,6 +95,7 @@ namespace Eto.Wpf.Forms
 
 		public override void UpdatePreferredSize()
 		{
+			Control.InvalidateMeasure();
 			if (suspended == 0 && Widget.Loaded)
 				base.UpdatePreferredSize();
 		}

--- a/Source/Eto.Wpf/Forms/ToolBar/ButtonToolItemHandler.cs
+++ b/Source/Eto.Wpf/Forms/ToolBar/ButtonToolItemHandler.cs
@@ -45,7 +45,7 @@ namespace Eto.Wpf.Forms.ToolBar
 			set
 			{
 				image = value;
-				swcImage.Source = image.ToWpfScale(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize());
+				swcImage.Source = image.ToWpfScale(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/ToolBar/CheckToolItemHandler.cs
+++ b/Source/Eto.Wpf/Forms/ToolBar/CheckToolItemHandler.cs
@@ -58,7 +58,7 @@ namespace Eto.Wpf.Forms.ToolBar
 			set
 			{
 				image = value;
-				swcImage.Source = image.ToWpfScale(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize());
+				swcImage.Source = image.ToWpfScale(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/ToolBar/RadioToolItemHandler.cs
+++ b/Source/Eto.Wpf/Forms/ToolBar/RadioToolItemHandler.cs
@@ -80,7 +80,7 @@ namespace Eto.Wpf.Forms.ToolBar
 			set
 			{
 				image = value;
-				swcImage.Source = image.ToWpfScale(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize());
+				swcImage.Source = image.ToWpfScale(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/WpfContainer.cs
+++ b/Source/Eto.Wpf/Forms/WpfContainer.cs
@@ -21,7 +21,7 @@ namespace Eto.Wpf.Forms
 
 		public bool RecurseToChildren { get { return true; } }
 
-		protected override Size DefaultSize { get { return minimumSize; } }
+		protected override sw.Size DefaultSize => minimumSize.ToWpf();
 
 		public abstract void Remove(sw.FrameworkElement child);
 

--- a/Source/Eto.Wpf/Forms/WpfPanel.cs
+++ b/Source/Eto.Wpf/Forms/WpfPanel.cs
@@ -17,8 +17,6 @@ namespace Eto.Wpf.Forms
 		readonly swc.Border border;
 		Size? clientSize;
 
-		protected virtual bool UseContentSize => false;
-
 		public override Size ClientSize
 		{
 			get
@@ -50,30 +48,6 @@ namespace Eto.Wpf.Forms
 			{
 				contentHandler.SetScale(xscale, yscale);
 			}
-		}
-
-		public override sw.Size GetPreferredSize(sw.Size constraint)
-		{
-			var size = PreferredSize;
-            var margin = ContainerControl.Margin.Size();
-            if (double.IsNaN(size.Width) || double.IsNaN(size.Height))
-            {
-                sw.Size baseSize;
-                if (UseContentSize)
-				{
-                    var padding = border.Padding.Size();
-                    var childConstraint = constraint.Subtract(padding).Subtract(margin);
-					baseSize = content.GetPreferredSize(childConstraint);
-                    baseSize = baseSize.Add(padding); // we add margin back at end
-				}
-                else
-                    baseSize = base.GetPreferredSize(constraint).Subtract(margin);
-
-                size = size.IfNaN(baseSize);
-            }
-            size = size.Max(ContainerControl.GetMinSize());
-            size = size.Add(margin);
-            return size;
 		}
 
 		ContextMenu contextMenu;

--- a/Source/Eto.Wpf/Forms/WpfWindow.cs
+++ b/Source/Eto.Wpf/Forms/WpfWindow.cs
@@ -209,8 +209,8 @@ namespace Eto.Wpf.Forms
 		protected override void SetSize()
 		{
 			// don't set the minimum size of a window, just the preferred size
-			ContainerControl.Width = PreferredSize.Width;
-			ContainerControl.Height = PreferredSize.Height;
+			ContainerControl.Width = UserPreferredSize.Width;
+			ContainerControl.Height = UserPreferredSize.Height;
 			SetMinimumSize();
 		}
 

--- a/Source/Eto.Wpf/WpfConversions.cs
+++ b/Source/Eto.Wpf/WpfConversions.cs
@@ -20,7 +20,8 @@ namespace Eto.Wpf
 
 		public static readonly sw.Size PositiveInfinitySize = new sw.Size(double.PositiveInfinity, double.PositiveInfinity);
 		public static readonly sw.Size ZeroSize = new sw.Size(0, 0);
-		
+		public static readonly sw.Size NaNSize = new sw.Size(double.NaN, double.NaN);
+
 		public static swm.Color ToWpf(this Color value)
 		{
 
@@ -309,9 +310,9 @@ namespace Eto.Wpf
 			element.MaxHeight = size.Height == -1 ? double.NaN : size.Height;
 		}
 
-		public static Size GetMaxSize(this sw.FrameworkElement element)
+		public static sw.Size GetMaxSize(this sw.FrameworkElement element)
 		{
-			return new Size((int)(double.IsNaN(element.MaxWidth) ? 0 : element.MaxWidth), (int)(double.IsNaN(element.MaxHeight) ? 0 : element.MaxHeight));
+			return new sw.Size(element.MaxWidth, element.MaxHeight);
 		}
 
 		public static void SetSize(this sw.FrameworkElement element, sw.Size size)

--- a/Source/Eto.Wpf/WpfExtensions.cs
+++ b/Source/Eto.Wpf/WpfExtensions.cs
@@ -182,7 +182,18 @@ namespace Eto.Wpf
             return new sw.Rect(x, y, width, height);
         }
 
-        public static sw.Size IfNaN(this sw.Size size1, sw.Size size2)
+		public static sw.Size IfInfinity(this sw.Size size1, sw.Size size2)
+		{
+			if (double.IsInfinity(size1.Width))
+				size1.Width = size2.Width;
+
+			if (double.IsInfinity(size1.Height))
+				size1.Height = size2.Height;
+			return size1;
+		}
+
+
+		public static sw.Size IfNaN(this sw.Size size1, sw.Size size2)
         {
             if (double.IsNaN(size1.Width))
                 size1.Width = size2.Width;
@@ -201,7 +212,25 @@ namespace Eto.Wpf
             return size;
         }
 
-        public static sw.Size Add(this sw.Size size1, sw.Size size2)
+		public static sw.Size ZeroIfInfinity(this sw.Size size)
+		{
+			if (double.IsInfinity(size.Width))
+				size.Width = 0;
+			if (double.IsInfinity(size.Height))
+				size.Height = 0;
+			return size;
+		}
+
+		public static sw.Size InfinityIfNan(this sw.Size size)
+		{
+			if (double.IsNaN(size.Width))
+				size.Width = double.PositiveInfinity;
+			if (double.IsNaN(size.Height))
+				size.Height = double.PositiveInfinity;
+			return size;
+		}
+
+		public static sw.Size Add(this sw.Size size1, sw.Size size2)
 		{
 			return new sw.Size(size1.Width + size2.Width, size1.Height + size2.Height);
 		}


### PR DESCRIPTION
This simplifies the eto sizing rules for WPF by ensuring each container control overrides MeasureOveride() to provide custom logic. With this, we no longer need to manually calculate the scroll size for the Scrollable which was riddled with bugs.

This also fixes numerous issues where WPF wouldn’t respect the size set of a control in certain circumstances, which happened quite a bit after turning off the UseContentSize for all controls.