### PR TITLE
Wpf: Fix setting scale of a tab control when inserted at runtime.

### DIFF
--- a/Source/Eto.Wpf/Forms/Controls/TabControlHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TabControlHandler.cs
@@ -87,6 +87,8 @@ namespace Eto.Wpf.Forms.Controls
 				Control.Items.Add(page.ControlObject);
 			else
 				Control.Items.Insert(index, page.ControlObject);
+			if (Widget.Loaded)
+				page.GetWpfFrameworkElement()?.SetScale(XScale, YScale);
 			if (Control.Items.Count == 1)
 				SelectedIndex = 0;
 		}


### PR DESCRIPTION
Fixes Splitter > Dynamic splitter creation test.