### PR TITLE
Gtk2: fix gtk splitter to work the old way as it’s causing too many crashes with Eto.Test.

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/SplitterHandler.cs
@@ -13,6 +13,32 @@ namespace Eto.GtkSharp.Forms.Controls
 		int? position;
 		double relative = double.NaN;
 		int suppressSplitterMoved;
+		bool shrinkContentsToFit = true;
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the size of the splitter will be restricted to the content size
+		/// of each panel.  This may follow standard behaviour in GTK (when false), but is not compatible behaviour with Eto's sizing model.
+		/// 
+		/// In some cases, this may cause Gtk2 to crash if there isn't enough space available for the panel content.
+		/// 
+		/// Set this to true to enable this feature, usually via a style:
+		/// <code>
+		/// Eto.Style.Add<Eto.GtkSharp.Forms.Controls.SplitterHandler>(h => h.ShrinkContentsToFit = false);
+		/// </code>
+		/// </summary>
+		/// <value><c>true</c> to shrink content to fit the size of the split pane (Eto behaviour); otherwise, <c>false</c> (GTK behaviour).</value>
+		public bool ShrinkContentsToFit
+		{
+			get { return shrinkContentsToFit; }
+			set
+			{
+				if (shrinkContentsToFit != value)
+				{
+					shrinkContentsToFit = value;
+					Create();
+				}
+			}
+		}
 
 		int GetPreferredPanelSize(int width1, int width2)
 		{
@@ -297,38 +323,42 @@ namespace Eto.GtkSharp.Forms.Controls
 		void Create()
 		{
 			Gtk.Paned old = Control;
+
 			if (orientation == Orientation.Horizontal)
 				Control = new EtoHPaned() { Handler = this };
 			else
 				Control = new EtoVPaned() { Handler = this };
 
 			Control.ShowAll();
-			Control.Realized += (sender, e) =>
-			{
-				SetInitialPosition();
-				HookEvents();
-			};
+			Control.Realized += Control_Realized;
 
 			if (container.Child != null)
 				container.Remove(container.Child);
 
 			if (old != null)
 			{
+				old.Realized -= Control_Realized;
 				var child1 = old.Child1;
 				var child2 = old.Child2;
 				old.Remove(child2);
 				old.Remove(child1);
-				Control.Pack1(child1 ?? EmptyContainer(), fixedPanel != SplitterFixedPanel.Panel1, false);
-				Control.Pack2(child2 ?? EmptyContainer(), fixedPanel != SplitterFixedPanel.Panel2, false);
+				Control.Pack1(child1 ?? EmptyContainer(), fixedPanel != SplitterFixedPanel.Panel1, ShrinkContentsToFit);
+				Control.Pack2(child2 ?? EmptyContainer(), fixedPanel != SplitterFixedPanel.Panel2, ShrinkContentsToFit);
 				old.Destroy();
 			}
 			else
 			{
-				Control.Pack1(EmptyContainer(), fixedPanel != SplitterFixedPanel.Panel1, false);
-				Control.Pack2(EmptyContainer(), fixedPanel != SplitterFixedPanel.Panel2, false);
+				Control.Pack1(EmptyContainer(), fixedPanel != SplitterFixedPanel.Panel1, ShrinkContentsToFit);
+				Control.Pack2(EmptyContainer(), fixedPanel != SplitterFixedPanel.Panel2, ShrinkContentsToFit);
 			}
 
 			container.Child = Control;
+		}
+
+		void Control_Realized(object sender, EventArgs e)
+		{
+			SetInitialPosition();
+			HookEvents();
 		}
 
 		void HookEvents()
@@ -458,7 +488,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				if (Control.Child1 != null)
 					Control.Remove(Control.Child1);
 				var widget = panel1 != null ? panel1.GetContainerWidget() : EmptyContainer();
-				Control.Pack1(widget, fixedPanel != SplitterFixedPanel.Panel1, false);
+				Control.Pack1(widget, fixedPanel != SplitterFixedPanel.Panel1, ShrinkContentsToFit);
 				if (setposition)
 					Control.Position = position.Value;
 				widget.ShowAll();
@@ -475,7 +505,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				if (Control.Child2 != null)
 					Control.Remove(Control.Child2);
 				var widget = panel2 != null ? panel2.GetContainerWidget() : EmptyContainer();
-				Control.Pack2(widget, fixedPanel != SplitterFixedPanel.Panel2, false);
+				Control.Pack2(widget, fixedPanel != SplitterFixedPanel.Panel2, ShrinkContentsToFit);
 				if (setposition)
 					Control.Position = position.Value;
 				widget.ShowAll();

--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
@@ -299,9 +299,11 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					Panel2 = new Panel { BackgroundColor = SystemColors.ControlBackground }
 				};
 				int? startingPosition = null;
+				double? startingRelativePosition = null;
 				form.Shown += (sender, e) =>
 				{
 					startingPosition = splitter.Position;
+					startingRelativePosition = splitter.RelativePosition;
 					posLabel.Text = startingPosition?.ToString();
 					if (startingPosition == 0)
 					{
@@ -320,6 +322,13 @@ namespace Eto.Test.UnitTests.Forms.Controls
 						case 0:
 							if (splitter.Position > startingPosition.Value)
 							{
+								if (splitter.RelativePosition <= startingRelativePosition.Value)
+								{
+									success = false;
+									message = "Relative position was not updated, it should be greater than the starting position";
+									form.Close();
+									return;
+								}
 								label.Text = "Now, slide to the left";
 								startingPosition = splitter.Position;
 								stage++;
@@ -328,7 +337,13 @@ namespace Eto.Test.UnitTests.Forms.Controls
 						case 1:
 							if (splitter.Position < startingPosition.Value)
 							{
-								success = true;
+								if (splitter.RelativePosition >= startingRelativePosition.Value)
+								{
+									success = false;
+									message = "Relative position was not updated, it should be less than the starting position";
+								}
+								else
+									success = true;
 								form.Close();
 							}
 							break;


### PR DESCRIPTION
- Add SplitterHandler.ShrinkContentsToFit property so you can get the new functionality with a style.
- Gtk3 will retain the new functionality as it doesn’t crash.
- Fix leak when recreating the paned control by unhooking the Realized event