### PR TITLE
Add DropDown.ItemImageBinding

### DIFF
--- a/Source/Eto.Gtk/Drawing/IconHandler.cs
+++ b/Source/Eto.Gtk/Drawing/IconHandler.cs
@@ -176,7 +176,14 @@ namespace Eto.GtkSharp.Drawing
 			{
 				Control.AddSource(new Gtk.IconSource { Pixbuf = frame.Bitmap.ToGdk() });
 			}
-			Pixbuf = this.frames.First(r => r.Scale == 1).Bitmap.ToGdk();
+			Pixbuf = this.frames.FirstOrDefault(r => r.Scale == 1)?.Bitmap.ToGdk();
+			if (Pixbuf == null)
+			{
+				var frame = this.frames.OrderBy(r => r.Scale).Last();
+				Pixbuf = frame.Bitmap.ToGdk();
+
+				Pixbuf = Widget.GetFrame(1).Bitmap.ToGdk().ScaleSimple(frame.Size.Width, frame.Size.Height, Gdk.InterpType.Bilinear);
+			}
 		}
 
 		public IEnumerable<IconFrame> Frames

--- a/Source/Eto.Gtk/Forms/Controls/DropDownHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/DropDownHandler.cs
@@ -13,8 +13,11 @@ namespace Eto.GtkSharp.Forms.Controls
 	{
 		protected override void Create()
 		{
-			listStore = new Gtk.ListStore(typeof(string));
+			listStore = new Gtk.ListStore(typeof(string), typeof(Gdk.Pixbuf));
 			Control = new Gtk.ComboBox(listStore);
+			var imageCell = new Gtk.CellRendererPixbuf();
+			Control.PackStart(imageCell, false);
+			Control.SetAttributes(imageCell, "pixbuf", 1);
 			text = new Gtk.CellRendererText();
 			Control.PackStart(text, false);
 			Control.SetAttributes(text, "text", 0);
@@ -139,15 +142,21 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public override void AddItem(object item)
 			{
-				var binding = Handler.Widget.ItemTextBinding;
-				Handler.listStore.AppendValues(binding.GetValue(item));
+				Handler.listStore.AppendValues(GetValues(item));
 				Handler.Control.QueueResize();
+			}
+
+			object[] GetValues(object dataItem)
+			{
+				return new object[] {
+					Handler.Widget.ItemTextBinding?.GetValue(dataItem) ?? string.Empty,
+					(object)Handler.Widget.ItemImageBinding?.GetValue(dataItem).ToGdk() ?? GLib.Value.Empty
+				};
 			}
 
 			public override void InsertItem(int index, object item)
 			{
-				var binding = Handler.Widget.ItemTextBinding;
-				Handler.listStore.InsertWithValues(index, binding.GetValue(item));
+				Handler.listStore.InsertWithValues(index, GetValues(item));
 				Handler.Control.QueueResize();
 			}
 

--- a/Source/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
@@ -29,7 +29,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			scroll.ShadowType = Gtk.ShadowType.In;
 			Control = new Gtk.TreeView(new Gtk.TreeModelAdapter(model));
 			Size = new Size(80, 80);
-			//tree.FixedHeightMode = true;
+			Control.FixedHeightMode = false;
 			Control.ShowExpanders = false;
 			scroll.Add(Control);
 
@@ -123,19 +123,9 @@ namespace Eto.GtkSharp.Forms.Controls
 			switch (column)
 			{
 				case 0:
-					return new GLib.Value(Widget.ItemTextBinding.GetValue(item));
+					return new GLib.Value(Widget.ItemTextBinding?.GetValue(item) ?? string.Empty);
 				case 1:
-					if (Widget.ItemImageBinding != null)
-					{
-						var img = Widget.ItemImageBinding.GetValue(item);
-						if (img != null)
-						{
-							var imgHandler = img.Handler as IGtkPixbuf;
-							if (imgHandler != null)
-								return new GLib.Value(imgHandler.GetPixbuf(MaxImageSize));
-						}
-					}
-					return new GLib.Value((Gdk.Pixbuf)null);
+					return new GLib.Value(Widget.ItemImageBinding?.GetValue(item).ToGdk());
 				default:
 					throw new InvalidOperationException();
 			}

--- a/Source/Eto.Gtk/GtkConversions.cs
+++ b/Source/Eto.Gtk/GtkConversions.cs
@@ -426,8 +426,12 @@ namespace Eto.GtkSharp
 
 		public static Gdk.Pixbuf ToGdk(this Image image)
 		{
-			var handler = image.Handler as IGtkPixbuf;
-			return handler != null ? handler.Pixbuf : null;
+			return (image?.Handler as IGtkPixbuf)?.Pixbuf;
+		}
+
+		public static Gdk.Pixbuf ToGdk(this Image image, Size maxSize, Gdk.InterpType interpolation = Gdk.InterpType.Bilinear, bool shrink = false)
+		{
+			return (image?.Handler as IGtkPixbuf)?.GetPixbuf(maxSize, interpolation, shrink);
 		}
 
 		public static void SetCairoSurface(this Image image, Cairo.Context context, float x, float y)

--- a/Source/Eto.Mac/Forms/Controls/DropDownHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/DropDownHandler.cs
@@ -153,13 +153,19 @@ namespace Eto.Mac.Forms.Controls
 				return (int)Handler.Control.Menu.IndexOf(binding.GetValue(item));
 			}
 
+			NSMenuItem CreateItem(object dataItem)
+			{
+				var item = new NSMenuItem(Handler.Widget.ItemTextBinding?.GetValue(dataItem) ?? string.Empty);
+				item.Image = Handler.Widget.ItemImageBinding?.GetValue(dataItem).ToNS();
+				return item;
+			}
+
 			public override void AddRange(IEnumerable<object> items)
 			{
 				var oldIndex = Handler.Control.IndexOfSelectedItem;
-				var binding = Handler.Widget.ItemTextBinding;
-				foreach (var item in items.Select(r => binding.GetValue(r)))
+				foreach (var item in items)
 				{
-					Handler.Control.Menu.AddItem(new NSMenuItem(item));
+					Handler.Control.Menu.AddItem(CreateItem(item));
 				}
 				if (oldIndex == -1)
 					Handler.Control.SelectItem(-1);
@@ -169,8 +175,7 @@ namespace Eto.Mac.Forms.Controls
 			public override void AddItem(object item)
 			{
 				var oldIndex = Handler.Control.IndexOfSelectedItem;
-				var binding = Handler.Widget.ItemTextBinding;
-				Handler.Control.Menu.AddItem(new NSMenuItem(Convert.ToString(binding.GetValue(item))));
+				Handler.Control.Menu.AddItem(CreateItem(item));
 				if (oldIndex == -1)
 					Handler.Control.SelectItem(-1);
 				Handler.LayoutIfNeeded();
@@ -179,8 +184,7 @@ namespace Eto.Mac.Forms.Controls
 			public override void InsertItem(int index, object item)
 			{
 				var oldIndex = Handler.Control.IndexOfSelectedItem;
-				var binding = Handler.Widget.ItemTextBinding;
-				Handler.Control.Menu.InsertItem(new NSMenuItem(Convert.ToString(binding.GetValue(item))), index);
+				Handler.Control.Menu.InsertItem(CreateItem(item), index);
 				if (oldIndex == -1)
 					Handler.Control.SelectItem(-1);
 				Handler.LayoutIfNeeded();

--- a/Source/Eto.Mac/Forms/Controls/ListBoxHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/ListBoxHandler.cs
@@ -107,6 +107,11 @@ namespace Eto.Mac.Forms.Controls
 			{
 				Handler.Callback.OnSelectedIndexChanged(Handler.Widget, EventArgs.Empty);
 			}
+
+			public override nfloat GetRowHeight(NSTableView tableView, nint row)
+			{
+				return Handler.Control.GetCell(0, row).CellSize.Height;
+			}
 		}
 
 		public class EtoListBoxTableView : NSTableView, IMacControl

--- a/Source/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
+++ b/Source/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
@@ -183,9 +183,8 @@ namespace Eto.Mac.Forms.Controls
 			{
 				var ctl = ControlView as NSTableView;
 				var imageSize = data.Image.Size;
-				var newHeight = Math.Min(imageSize.Height, ctl != null ? ctl.RowHeight : bounds.Height);
-				var newWidth = imageSize.Width * newHeight / imageSize.Height;
-				size.Width += (nfloat)(newWidth + ImagePadding);
+				size.Height = (nfloat)Math.Max(imageSize.Height, size.Height);
+				size.Width += (nfloat)(imageSize.Width + ImagePadding);
 			}
 			size.Width = (nfloat)Math.Min(size.Width, bounds.Width);
 			return size;

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/DropDownSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/DropDownSection.cs
@@ -7,15 +7,13 @@ namespace Eto.Test.Sections.Controls
 	[Section("Controls", typeof(DropDown))]
 	public class DropDownSection : Scrollable
 	{
+		bool AddWithImages { get; set; }
+
 		public DropDownSection()
 		{
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
 
 			layout.AddRow("Default", Default(), null);
-
-			layout.AddRow("With Items", TableLayout.AutoSized(Items()));
-
-			layout.AddRow("Disabled", TableLayout.AutoSized(Disabled()));
 
 			layout.AddRow("Set Initial Value", TableLayout.AutoSized(SetInitialValue()));
 
@@ -33,20 +31,41 @@ namespace Eto.Test.Sections.Controls
 
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5) };
 			layout.Add(TableLayout.AutoSized(control));
-			layout.BeginVertical();
-			layout.AddRow(null, AddRowsButton(control), RemoveRowsButton(control), ClearButton(control), SetSelected(control), ClearSelected(control), null);
-			layout.EndVertical();
+			layout.AddSeparateRow(null, AddRowsButton(control), AddWithImagesCheckBox(), RemoveRowsButton(control), ClearButton(control), null);
+			layout.AddSeparateRow(null, EnabledCheckBox(control), SetSelected(control), ClearSelected(control), null);
 
 			return layout;
 		}
 
+		Control EnabledCheckBox(DropDown list)
+		{
+			var control = new CheckBox { Text = "Enabled" };
+			control.CheckedBinding.Bind(list, l => l.Enabled);
+			return control;
+		}
+
+		Control AddWithImagesCheckBox()
+		{
+			var control = new CheckBox { Text = "Add with images" };
+			control.CheckedBinding.Bind(this, l => l.AddWithImages);
+			return control;
+		}
+
+
 		Control AddRowsButton(DropDown list)
 		{
 			var control = new Button { Text = "Add Rows" };
-			control.Click += delegate
+			control.Click += (sender, e) =>
 			{
+				var image1 = TestIcons.Logo.WithSize(32, 32);
+				var image2 = TestIcons.TestIcon.WithSize(16, 16);
 				for (int i = 0; i < 10; i++)
-					list.Items.Add(new ListItem { Text = "Item " + list.Items.Count });
+				{
+					if (AddWithImages)
+						list.Items.Add(new ImageListItem { Text = "Item " + list.Items.Count, Image = i % 2 == 0 ? image1 : image2 });
+					else
+						list.Items.Add(new ListItem { Text = "Item " + list.Items.Count });
+				}
 			};
 			return control;
 		}

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/ListBoxSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/ListBoxSection.cs
@@ -80,7 +80,10 @@ namespace Eto.Test.Sections.Controls
 
 		class VirtualList : IList, IEnumerable<object>
 		{
-			Icon image = TestIcons.TestIcon;
+			Icon image1 = TestIcons.TestIcon.WithSize(32, 32);
+			Icon image2 = TestIcons.Logo.WithSize(16, 16);
+
+			public bool UseVariableImages { get; set; }
 
 			public int Count
 			{
@@ -89,7 +92,15 @@ namespace Eto.Test.Sections.Controls
 
 			public object this[int index]
 			{
-				get { return new ImageListItem { Text = "Item " + index, Image = image }; }
+				get
+				{
+					var item = new ImageListItem { Text = "Item " + index };
+					if (UseVariableImages)
+						item.Image = index % 2 == 0 ? image1 : image2;
+					else
+						item.Image = image1;
+					return item;
+				}
 				set { }
 			}
 
@@ -155,7 +166,22 @@ namespace Eto.Test.Sections.Controls
 			LogEvents(control);
 
 			control.DataStore = new VirtualList();
-			return control;
+
+			var useVariableImages = new CheckBox { Text = "Use Variable Image Sizes" };
+			useVariableImages.CheckedChanged += (sender, e) =>
+			{
+				control.DataStore = new VirtualList { UseVariableImages = useVariableImages.Checked ?? false };
+			};
+
+			return new StackLayout
+			{
+				HorizontalContentAlignment = HorizontalAlignment.Stretch,
+				Items =
+				{
+					TableLayout.Horizontal(useVariableImages, null),
+					control
+				}
+			};
 		}
 
 		Control WithContextMenu()

--- a/Source/Eto.Test/Eto.Test/TestIcons.cs
+++ b/Source/Eto.Test/Eto.Test/TestIcons.cs
@@ -26,7 +26,7 @@ namespace Eto.Test
 			get { return Bitmap.FromResource("Eto.Test.Images.Textures.gif"); }
 		}
 
-		public static Image Logo
+		public static Icon Logo
 		{
 			get { return Icon.FromResource("Eto.Test.Images.Logo.png"); }
 		}

--- a/Source/Eto.WinForms/Forms/Controls/DropDownHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/DropDownHandler.cs
@@ -12,6 +12,20 @@ namespace Eto.WinForms.Forms.Controls
 	{
 
 	}
+	class EtoComboBoxItem
+	{
+		DropDown DropDown { get; set; }
+		public object Value { get; set; }
+		public Image Image => DropDown.ItemImageBinding?.GetValue(Value);
+
+		public override string ToString() => DropDown.ItemTextBinding?.GetValue(Value);
+
+		public EtoComboBoxItem(DropDown dropDown, object value)
+		{
+			DropDown = dropDown;
+			Value = value;
+		}
+	}
 
 	public class EtoComboBox : swf.ComboBox
 	{
@@ -22,6 +36,23 @@ namespace Eto.WinForms.Forms.Controls
 		}
 
 		public sd.Size MinSize { get; set; }
+
+		/*
+		protected override void OnMeasureItem(swf.MeasureItemEventArgs e)
+		{
+			base.OnMeasureItem(e);
+			using (var g = CreateGraphics())
+			{
+				//foreach (object item in Items)
+				{
+					var font = Font;
+					var text = GetItemText(e.Index);
+					var itemSize = swf.TextRenderer.MeasureText(g, text, font);
+					e.ItemWidth = (int)itemSize.Width;
+					e.ItemHeight = (int)itemSize.Height;
+				}
+			}
+		}*/
 
 		public override sd.Size GetPreferredSize(sd.Size proposedSize)
 		{
@@ -35,6 +66,9 @@ namespace Eto.WinForms.Forms.Controls
 					{
 						var text = GetItemText(item);
 						var itemSize = swf.TextRenderer.MeasureText(g, text, font);
+						var image = (item as EtoComboBoxItem)?.Image;
+						if (image != null)
+							itemSize.Width += 18;
 						size.Width = Math.Max(size.Width, (int) itemSize.Width);
 						size.Height = Math.Max(size.Height, (int) itemSize.Height);
 					}
@@ -79,10 +113,21 @@ namespace Eto.WinForms.Forms.Controls
 
 			if (e.Index >= 0)
 			{
-				string text = Items[e.Index].ToString();
+				var item = Items[e.Index];
+				var bounds = e.Bounds;
+				var image = (item as EtoComboBoxItem)?.Image;
+
+				if (image != null)
+				{
+					e.Graphics.DrawImage(image.ToSD(new Size(16, 16)), bounds.X, bounds.Y, 16, 16);
+					bounds.X += 18;
+					bounds.Width -= 18;
+				}
+
+				string text = item?.ToString();
 
 				// Determine the forecolor based on whether or not the item is selected    
-				swf.TextRenderer.DrawText(e.Graphics, text, Font, e.Bounds, ForeColor, swf.TextFormatFlags.Left);
+				swf.TextRenderer.DrawText(e.Graphics, text, Font, bounds, ForeColor, swf.TextFormatFlags.Left);
 			}
 
 			e.DrawFocusRectangle();
@@ -144,6 +189,7 @@ namespace Eto.WinForms.Forms.Controls
 			Control = (TControl)new EtoComboBox
 			{
 				DropDownStyle = swf.ComboBoxStyle.DropDownList,
+				DrawMode = swf.DrawMode.OwnerDrawFixed,
 				AutoSize = true,
 				Size = new sd.Size(20, 0)
 			};
@@ -171,43 +217,26 @@ namespace Eto.WinForms.Forms.Controls
 			set { Control.SelectedIndex = value; }
 		}
 
-		class Item
-		{
-			public IIndirectBinding<string> Binding { get; set; }
-			public object Value { get; set; }
-			public override string ToString()
-			{
-				return Binding.GetValue(Value);
-			}
-			public Item(IIndirectBinding<string> binding, object value)
-			{
-				Binding = binding;
-				Value = value;
-			}
-		}
-
 		class CollectionHandler : EnumerableChangedHandler<object>
 		{
 			public DropDownHandler<TControl, TWidget, TCallback> Handler { get; set; }
 
 			public override void AddRange(IEnumerable<object> items)
 			{
-				var binding = Handler.Widget.ItemTextBinding;
-				Handler.Control.Items.AddRange(items.Select(r => (object)new Item(binding, r)).ToArray());
+				var widget = Handler.Widget;
+				Handler.Control.Items.AddRange(items.Select(r => (object)new EtoComboBoxItem(widget, r)).ToArray());
 				Handler.UpdateSizes();
 			}
 
 			public override void AddItem(object item)
 			{
-				var binding = Handler.Widget.ItemTextBinding;
-				Handler.Control.Items.Add(new Item(binding, item));
+				Handler.Control.Items.Add(new EtoComboBoxItem(Handler.Widget, item));
 				Handler.UpdateSizes();
 			}
 
 			public override void InsertItem(int index, object item)
 			{
-				var binding = Handler.Widget.ItemTextBinding;
-				Handler.Control.Items.Insert(index, new Item(binding, item));
+				Handler.Control.Items.Insert(index, new EtoComboBoxItem(Handler.Widget, item));
 				Handler.UpdateSizes();
 			}
 

--- a/Source/Eto.WinForms/WinConversions.cs
+++ b/Source/Eto.WinForms/WinConversions.cs
@@ -323,6 +323,14 @@ namespace Eto.WinForms
 			return h.GetImageWithSize(size);
 		}
 
+		public static sd.Image ToSD(this Image image, Size? size)
+		{
+			if (image == null)
+				return null;
+			var h = (IWindowsImageSource)image.Handler;
+			return h.GetImageWithSize(size);
+		}
+
 		public static sd.Font ToSD(this Font font)
 		{
 			if (font == null)

--- a/Source/Eto.Wpf/Drawing/BitmapHandler.cs
+++ b/Source/Eto.Wpf/Drawing/BitmapHandler.cs
@@ -93,7 +93,7 @@ namespace Eto.Wpf.Drawing
 
 		public void Create(Image image, int width, int height, ImageInterpolation interpolation)
 		{
-			var source = image.ToWpfScale(1, new Size(width, height));
+			var source = image.ToWpf(1, new Size(width, height));
 			// use drawing group to allow for better quality scaling
 			var group = new swm.DrawingGroup();
 			swm.RenderOptions.SetBitmapScalingMode(group, interpolation.ToWpf());
@@ -225,7 +225,7 @@ namespace Eto.Wpf.Drawing
 			frozenControl = Control.GetAsFrozen() as swmi.BitmapSource;
 		}
 
-		public swmi.BitmapSource GetImageClosestToSize(int? width)
+		public swmi.BitmapSource GetImageClosestToSize(float scale, Size? fittingSize)
 		{
 			return FrozenControl;
 		}

--- a/Source/Eto.Wpf/Drawing/GraphicsHandler.cs
+++ b/Source/Eto.Wpf/Drawing/GraphicsHandler.cs
@@ -84,7 +84,7 @@ namespace Eto.Wpf.Drawing
 			drawingVisual = new swm.DrawingVisual();
 			visual = drawingVisual;
 			Control = drawingVisual.RenderOpen();
-			Control.DrawImage(image.ToWpf(), bounds);
+			Control.DrawImage(image.ToWpf(1), bounds);
         }
 
 		protected override void Initialize()
@@ -257,7 +257,7 @@ namespace Eto.Wpf.Drawing
 		public void DrawImage(Image image, float x, float y, float width, float height)
 		{
 			SetOffset(true);
-			var src = image.ToWpfScale((float)DPI, new Size((int)width, (int)height));
+			var src = image.ToWpf((float)DPI, new Size((int)width, (int)height));
 			var size = new SizeF((float)src.PixelWidth, (float)src.PixelHeight) / (float)DPI;
 
 			if ((ImageInterpolation == ImageInterpolation.High || ImageInterpolation == ImageInterpolation.Default)
@@ -275,7 +275,7 @@ namespace Eto.Wpf.Drawing
 		public void DrawImage(Image image, RectangleF source, RectangleF destination)
 		{
 			SetOffset(true);
-			var src = image.ToWpfScale((float)DPI);
+			var src = image.ToWpf((float)DPI);
             Control.PushClip(new swm.RectangleGeometry(destination.ToWpf()));
             bool scale = source.Size != destination.Size;
             bool translate = source.X > 0 || source.Y > 0;

--- a/Source/Eto.Wpf/Drawing/IconHandler.cs
+++ b/Source/Eto.Wpf/Drawing/IconHandler.cs
@@ -14,22 +14,22 @@ namespace Eto.Wpf.Drawing
 {
 	public interface IWpfImage
 	{
-		swmi.BitmapSource GetImageClosestToSize (int? width);
+		swmi.BitmapSource GetImageClosestToSize(float scale, Size? fittingSize);
 	}
 
 	public class IconHandler : WidgetHandler<swmi.BitmapFrame, Icon>, Icon.IHandler, IWpfImage
 	{
 		List<IconFrame> frames;
 
-		public IconHandler ()
+		public IconHandler()
 		{
 		}
 
-		public IconHandler (sd.Icon icon)
+		public IconHandler(sd.Icon icon)
 		{
-			var rect = new sw.Int32Rect (0, 0, icon.Width, icon.Height);
-			var img = swi.Imaging.CreateBitmapSourceFromHIcon (icon.Handle, rect, swmi.BitmapSizeOptions.FromEmptyOptions ());
-			Control = swmi.BitmapFrame.Create (img);
+			var rect = new sw.Int32Rect(0, 0, icon.Width, icon.Height);
+			var img = swi.Imaging.CreateBitmapSourceFromHIcon(icon.Handle, rect, swmi.BitmapSizeOptions.FromEmptyOptions());
+			Control = swmi.BitmapFrame.Create(img);
 			using (var ms = new MemoryStream())
 			{
 				icon.Save(ms);
@@ -38,32 +38,33 @@ namespace Eto.Wpf.Drawing
 			}
 		}
 
-		public IconHandler (swmi.BitmapFrame control)
+		public IconHandler(swmi.BitmapFrame control)
 		{
 			this.Control = control;
 		}
 
-		public static void CopyStream (Stream input, Stream output)
+		public static void CopyStream(Stream input, Stream output)
 		{
 			var buffer = new byte[32768];
 			int read;
-			while ((read = input.Read (buffer, 0, buffer.Length)) > 0) {
-				output.Write (buffer, 0, read);
+			while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
+			{
+				output.Write(buffer, 0, read);
 			}
 		}
 
-		public static MemoryStream CreateStream (Stream input)
+		public static MemoryStream CreateStream(Stream input)
 		{
-			var ms = new MemoryStream ();
-			CopyStream (input, ms);
+			var ms = new MemoryStream();
+			CopyStream(input, ms);
 			ms.Position = 0;
 			return ms;
 		}
 
 		public void Create(Stream stream)
 		{
-			var ms = CreateStream (stream);
-			Control = swmi.BitmapFrame.Create (ms);
+			var ms = CreateStream(stream);
+			Control = swmi.BitmapFrame.Create(ms);
 			ms.Position = 0;
 			SetFrames(ms);
 		}
@@ -72,8 +73,8 @@ namespace Eto.Wpf.Drawing
 		{
 			using (var stream = File.OpenRead(fileName))
 			{
-				var ms = CreateStream (stream);
-				Control = swmi.BitmapFrame.Create (ms);
+				var ms = CreateStream(stream);
+				Control = swmi.BitmapFrame.Create(ms);
 				ms.Position = 0;
 				SetFrames(ms);
 			}
@@ -95,101 +96,121 @@ namespace Eto.Wpf.Drawing
 			{
 				if (size != null)
 					return size.Value;
-				var largest = GetLargestIcon ();
-				return new Size ((int)largest.Bitmap.Width, (int)largest.Bitmap.Height);
+				var largest = GetLargestIcon();
+				return new Size((int)largest.Bitmap.Width, (int)largest.Bitmap.Height);
 			}
 		}
 
-		public IEnumerable<IconFrame> Frames
-		{
-			get
-			{
-				return frames;
-			}
-		}
+		public IEnumerable<IconFrame> Frames => frames;
 
-		public IconFrame GetLargestIcon ()
+		IconFrame GetLargestIcon()
 		{
 			var curicon = frames[0];
-			foreach (var icon in frames) {
+			foreach (var icon in frames)
+			{
 				if (icon.PixelSize.Width > curicon.PixelSize.Width)
 					curicon = icon;
 			}
 			return curicon;
 		}
 
-		public swmi.BitmapSource GetImageClosestToSize (int? width)
+		static swmi.BitmapFrame Resize(swmi.BitmapSource image, float scale, int width, int height, swm.BitmapScalingMode scalingMode)
 		{
+			var group = new swm.DrawingGroup();
+			swm.RenderOptions.SetBitmapScalingMode(group, scalingMode);
+			group.Children.Add(new swm.ImageDrawing(image, new sw.Rect(0, 0, width, height)));
+			var targetVisual = new swm.DrawingVisual();
+			var targetContext = targetVisual.RenderOpen();
+			targetContext.DrawDrawing(group);
+			width = (int)Math.Round(width * scale);
+			height = (int)Math.Round(height * scale);
+			var target = new swmi.RenderTargetBitmap(width, height, 96 * scale, 96 * scale, swm.PixelFormats.Default);
+			targetContext.Close();
+			target.Render(targetVisual);
+			return swmi.BitmapFrame.Create(target);
+		}
+
+		public swmi.BitmapSource GetImageClosestToSize(float scale, Size? fittingSize)
+		{
+			var size = fittingSize ?? Size;
+			var frame = Widget.GetFrame(scale, size);
+			var wpfBitmap = frame.ToWpf(scale);
+			if (wpfBitmap.Width == size.Width && wpfBitmap.Height == size.Height)
+				return wpfBitmap;
+
+			return Resize(wpfBitmap, scale, size.Width, size.Height, swm.BitmapScalingMode.Linear);
+			/*
 			if (width == null)
-				return GetLargestIcon ().ToWpf();
+				return GetLargestIcon().ToWpf();
 			var curicon = frames[0];
 			if ((int)curicon.PixelSize.Width == width.Value)
 				return curicon.ToWpf();
-			foreach (var icon in frames) {
+			foreach (var icon in frames)
+			{
 				if (icon.PixelSize.Width > width && icon.PixelSize.Width - width.Value < curicon.PixelSize.Width - width.Value)
 					curicon = icon;
 			}
-			return GetLargestIcon ().ToWpf();
+			return GetLargestIcon().ToWpf();*/
 		}
 
 		const int sICONDIR = 6;            // sizeof(ICONDIR) 
 		const int sICONDIRENTRY = 16;      // sizeof(ICONDIRENTRY)
 
-		public swmi.BitmapSource[] SplitIcon (swmi.BitmapFrame icon, MemoryStream input)
+		public swmi.BitmapSource[] SplitIcon(swmi.BitmapFrame icon, MemoryStream input)
 		{
-			if (icon == null) {
-				throw new ArgumentNullException ("icon");
+			if (icon == null)
+			{
+				throw new ArgumentNullException("icon");
 			}
 
 			// Get multiple .ico file image.
 			byte[] srcBuf = input.ToArray();
 
-			var splitIcons = new List<swmi.BitmapSource> ();
-			int count = BitConverter.ToInt16 (srcBuf, 4); // ICONDIR.idCount
+			var splitIcons = new List<swmi.BitmapSource>();
+			int count = BitConverter.ToInt16(srcBuf, 4); // ICONDIR.idCount
 
-			for (int i = 0; i < count; i++) {
-				using (var destStream = new MemoryStream ())
-				using (var writer = new BinaryWriter (destStream)) {
+			for (int i = 0; i < count; i++)
+			{
+				using (var destStream = new MemoryStream())
+				using (var writer = new BinaryWriter(destStream))
+				{
 					// Copy ICONDIR and ICONDIRENTRY.
 					int pos = 0;
-					writer.Write (srcBuf, pos, sICONDIR - 2);
-					writer.Write ((short)1);    // ICONDIR.idCount == 1;
+					writer.Write(srcBuf, pos, sICONDIR - 2);
+					writer.Write((short)1);    // ICONDIR.idCount == 1;
 
 					pos += sICONDIR;
 					pos += sICONDIRENTRY * i;
 
-					writer.Write (srcBuf, pos, sICONDIRENTRY - 4); // write out icon info (minus old offset)
-					writer.Write (sICONDIR + sICONDIRENTRY);    // write offset of icon data
+					writer.Write(srcBuf, pos, sICONDIRENTRY - 4); // write out icon info (minus old offset)
+					writer.Write(sICONDIR + sICONDIRENTRY);    // write offset of icon data
 					pos += 8;
 
 					// Copy picture and mask data.
-					int imgSize = BitConverter.ToInt32 (srcBuf, pos);       // ICONDIRENTRY.dwBytesInRes
+					int imgSize = BitConverter.ToInt32(srcBuf, pos);       // ICONDIRENTRY.dwBytesInRes
 					pos += 4;
-					int imgOffset = BitConverter.ToInt32 (srcBuf, pos);    // ICONDIRENTRY.dwImageOffset
+					int imgOffset = BitConverter.ToInt32(srcBuf, pos);    // ICONDIRENTRY.dwImageOffset
 					if (imgOffset + imgSize > srcBuf.Length)
 						throw new InvalidDataException(string.Format(CultureInfo.CurrentCulture, "Icon not a valid format"));
-					writer.Write (srcBuf, imgOffset, imgSize);
-					writer.Flush ();
+					writer.Write(srcBuf, imgOffset, imgSize);
+					writer.Flush();
 
 					// Create new icon.
-					destStream.Seek (0, SeekOrigin.Begin);
-					splitIcons.Add (swmi.BitmapFrame.Create (destStream));
+					destStream.Seek(0, SeekOrigin.Begin);
+					splitIcons.Add(swmi.BitmapFrame.Create(destStream));
 				}
 			}
 
-			return splitIcons.ToArray ();
-		}
-
-		public swmi.BitmapSource GetImageWithSize (int? size)
-		{
-			return size != null ? GetImageClosestToSize(size.Value) : Control;
+			return splitIcons.ToArray();
 		}
 
 		public void Create(IEnumerable<IconFrame> frames)
 		{
 			this.frames = new List<IconFrame>(frames);
 			var scale = 1;
-			var largest = frames.OrderBy(r => r.PixelSize.Width * r.PixelSize.Height).LastOrDefault(r => r.Scale == scale) ?? GetLargestIcon();
+			var largest = this.frames.OrderBy(r => r.PixelSize.Width * r.PixelSize.Height).LastOrDefault(r => r.Scale == scale);
+			if (largest == null)
+				largest = GetLargestIcon();
 			size = Size.Ceiling((SizeF)largest.PixelSize / largest.Scale);
 		}
 	}

--- a/Source/Eto.Wpf/Drawing/IndexedBitmapHandler.cs
+++ b/Source/Eto.Wpf/Drawing/IndexedBitmapHandler.cs
@@ -107,7 +107,7 @@ namespace Eto.Wpf.Drawing
 			get; private set;
 		}
 
-		public swmi.BitmapSource GetImageClosestToSize (int? width)
+		public swmi.BitmapSource GetImageClosestToSize(float scale, Size? fittingSize)
 		{
 			return Control;
 		}

--- a/Source/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
@@ -17,7 +17,7 @@ namespace Eto.Wpf.Forms.Cells
 			{
 				var image = Widget.ImageBinding.GetValue(dataItem) as Image;
 				if (image != null)
-					return ((IWpfImage)image.Handler).GetImageClosestToSize(16);
+					return image.ToWpf();
 			}
 			return null;
 		}

--- a/Source/Eto.Wpf/Forms/Cells/ImageViewCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/ImageViewCellHandler.cs
@@ -10,14 +10,12 @@ namespace Eto.Wpf.Forms.Cells
 {
 	public class ImageViewCellHandler : CellHandler<ImageViewCellHandler.Column, ImageViewCell, ImageViewCell.ICallback>, ImageViewCell.IHandler
 	{
-		public static int ImageSize = 16;
-
 		object GetValue (object dataItem)
 		{
 			if (Widget.Binding != null) {
 				var image = Widget.Binding.GetValue (dataItem) as Image;
 				if (image != null)
-					return ((IWpfImage)image.Handler).GetImageClosestToSize (ImageSize);
+					return image.ToWpf();
 			}
 			return null;
 		}

--- a/Source/Eto.Wpf/Forms/Controls/ButtonHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ButtonHandler.cs
@@ -139,7 +139,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		void SetImage()
 		{
-			swcimage.Source = Image.ToWpfScale(ParentScale);
+			swcimage.Source = Image.ToWpf(ParentScale);
 		}
 #endif
 

--- a/Source/Eto.Wpf/Forms/Controls/DropDownHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/DropDownHandler.cs
@@ -75,9 +75,9 @@ namespace Eto.Wpf.Forms.Controls
 			selected = null;
 		}
 
-		protected override sw.Size MeasureOverride(sw.Size constraint)
+		sw.Size FindMaxSize(sw.Size constraint)
 		{
-			var size = Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+			var size = base.MeasureOverride(constraint);
 			var popup = GetTemplateChild("PART_Popup") as swc.Primitives.Popup;
 			if (popup == null)
 				return size;
@@ -98,6 +98,11 @@ namespace Eto.Wpf.Forms.Controls
 			if (!double.IsNaN(constraint.Width))
 				size.Width = Math.Min(size.Width, constraint.Width);
 			return size;
+		}
+
+		protected override sw.Size MeasureOverride(sw.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, FindMaxSize) ?? FindMaxSize(constraint);
 		}
 	}
 
@@ -176,7 +181,7 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			Control.ItemTemplate = new sw.DataTemplate
 			{
-				VisualTree = new WpfTextBindingBlock(() => Widget.ItemTextBinding, setMargin: false)
+				VisualTree = new WpfImageTextBindingBlock(() => Widget.ItemTextBinding, () => Widget.ItemImageBinding, false)
 			};
 		}
 

--- a/Source/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
@@ -37,7 +37,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		void SetSource()
 		{
-			Control.Source = image.ToWpfScale(ParentScale, UserPreferredSize.ToEtoSize());
+			Control.Source = image.ToWpf(ParentScale, UserPreferredSize.ToEtoSize());
 		}
 
 		public Image Image

--- a/Source/Eto.Wpf/Forms/Controls/TabPageHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TabPageHandler.cs
@@ -50,8 +50,21 @@ namespace Eto.Wpf.Forms.Controls
 			set
 			{
 				image = value;
-				headerImage.Source = image != null ? ((IWpfImage)image.Handler).GetImageClosestToSize(16) : null;
+				SetSource();
 			}
+		}
+
+		void SetSource()
+		{
+			headerImage.Source = image.ToWpf(ParentScale);
+		}
+
+		protected override bool NeedsPixelSizeNotifications => true;
+
+		protected override void OnLogicalPixelSizeChanged()
+		{
+			base.OnLogicalPixelSizeChanged();
+			SetSource();
 		}
 
 		public override Size ClientSize

--- a/Source/Eto.Wpf/Forms/Controls/WpfListItemHelper.cs
+++ b/Source/Eto.Wpf/Forms/Controls/WpfListItemHelper.cs
@@ -29,7 +29,7 @@ namespace Eto.Wpf.Forms.Controls
 			Binding = binding;
 			SetBinding(swc.TextBlock.TextProperty, new sw.Data.Binding { Converter = this });
 			if (setMargin)
-				SetValue(sw.FrameworkElement.MarginProperty, new sw.Thickness(2));
+				SetValue(sw.FrameworkElement.MarginProperty, new sw.Thickness(2,0, 2, 0));
 		}
 
 		public object Convert(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)
@@ -51,10 +51,8 @@ namespace Eto.Wpf.Forms.Controls
 			: base(typeof(swc.Image))
 		{
 			Binding = binding;
-			SetValue(sw.FrameworkElement.MaxHeightProperty, 16.0);
-			SetValue(sw.FrameworkElement.MaxWidthProperty, 16.0);
 			SetValue(swc.Image.StretchDirectionProperty, swc.StretchDirection.DownOnly);
-			SetValue(sw.FrameworkElement.MarginProperty, new sw.Thickness(0, 2, 2, 2));
+			SetValue(sw.FrameworkElement.MarginProperty, new sw.Thickness(0, 0, 2, 0));
 			SetBinding(swc.Image.SourceProperty, new sw.Data.Binding { Converter = this });
 		}
 
@@ -63,7 +61,7 @@ namespace Eto.Wpf.Forms.Controls
 			var binding = Binding();
 			if (binding == null)
 				return null;
-			return binding.GetValue(value).ToWpf(16);
+			return binding.GetValue(value).ToWpf();
 		}
 
 		public object ConvertBack(object value, Type targetType, object parameter, System.Globalization.CultureInfo culture)

--- a/Source/Eto.Wpf/Forms/ToolBar/ButtonToolItemHandler.cs
+++ b/Source/Eto.Wpf/Forms/ToolBar/ButtonToolItemHandler.cs
@@ -45,7 +45,7 @@ namespace Eto.Wpf.Forms.ToolBar
 			set
 			{
 				image = value;
-				swcImage.Source = image.ToWpfScale(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
+				swcImage.Source = image.ToWpf(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/ToolBar/CheckToolItemHandler.cs
+++ b/Source/Eto.Wpf/Forms/ToolBar/CheckToolItemHandler.cs
@@ -58,7 +58,7 @@ namespace Eto.Wpf.Forms.ToolBar
 			set
 			{
 				image = value;
-				swcImage.Source = image.ToWpfScale(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
+				swcImage.Source = image.ToWpf(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/ToolBar/RadioToolItemHandler.cs
+++ b/Source/Eto.Wpf/Forms/ToolBar/RadioToolItemHandler.cs
@@ -80,7 +80,7 @@ namespace Eto.Wpf.Forms.ToolBar
 			set
 			{
 				image = value;
-				swcImage.Source = image.ToWpfScale(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
+				swcImage.Source = image.ToWpf(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -531,6 +531,8 @@ namespace Eto.Wpf.Forms
 		void Control_Loaded(object sender, sw.RoutedEventArgs e)
 		{
 			SetSize();
+			if (NeedsPixelSizeNotifications && Win32.PerMonitorDpiSupported)
+				OnLogicalPixelSizeChanged();
 		}
 
 		public virtual void OnPreLoad(EventArgs e)
@@ -545,7 +547,6 @@ namespace Eto.Wpf.Forms
 				if (parent != null)
 				{
 					parent.LogicalPixelSizeChanged += Parent_PixelSizeChanged;
-					OnLogicalPixelSizeChanged();
 				}
 			}
 		}

--- a/Source/Eto.Wpf/WpfConversions.cs
+++ b/Source/Eto.Wpf/WpfConversions.cs
@@ -350,53 +350,30 @@ namespace Eto.Wpf
 			return new Bitmap(new BitmapHandler(bitmap));
 		}
 
-		public static swmi.BitmapSource ToWpf(this Image image, int? size = null)
+		public static swmi.BitmapSource ToWpf(this Image image, float? scale = null, Size? fittingSize = null)
 		{
 			if (image == null)
 				return null;
 			var imageHandler = image.Handler as IWpfImage;
 			if (imageHandler != null)
-				return imageHandler.GetImageClosestToSize(size);
+				return imageHandler.GetImageClosestToSize(scale ?? Screen.PrimaryScreen.LogicalPixelSize, fittingSize);
 			return image.ControlObject as swmi.BitmapSource;
 		}
 
-		public static swmi.BitmapSource ToWpf(this IconFrame image, int? size = null)
+		public static swmi.BitmapSource ToWpf(this IconFrame image, float? scale = null, Size? fittingSize = null)
 		{
-			return ((Bitmap)image?.ControlObject).ToWpf();
+			return ((Bitmap)image?.ControlObject).ToWpf(scale, fittingSize);
 		}
 
-		public static swmi.BitmapSource ToWpfScale(this Image image, float scale, Size? fittingSize = null)
+		public static swc.Image ToWpfImage(this Image image, float? scale = null, Size? fittingSize = null)
 		{
-			var icon = image as Icon;
-			if (icon != null)
-				return icon.GetFrame(scale, fittingSize).ToWpf();
-			else
-				return image.ToWpf();
-		}
-
-		public static swc.Image ToWpfImage(this Image image, float scale, Size? fittingSize = null)
-		{
-			var source = image.ToWpfScale(scale, fittingSize);
+			var source = image.ToWpf(scale, fittingSize);
 			if (source == null)
 				return null;
 			var swcImage = new swc.Image { Source = source };
 			if (fittingSize != null)
 			{
 				swcImage.SetMaxSize(fittingSize.Value);
-			}
-			return swcImage;
-		}
-
-		public static swc.Image ToWpfImage(this Image image, int? size = null)
-		{
-			var source = image.ToWpf(size);
-			if (source == null)
-				return null;
-			var swcImage = new swc.Image { Source = source };
-			if (size != null)
-			{
-				swcImage.MaxWidth = size.Value;
-				swcImage.MaxHeight = size.Value;
 			}
 			return swcImage;
 		}

--- a/Source/Eto/Drawing/Icon.cs
+++ b/Source/Eto/Drawing/Icon.cs
@@ -273,6 +273,44 @@ namespace Eto.Drawing
 		}
 
 		/// <summary>
+		/// Gets a copy of this Icon with frames scaled to draw within the specified fitting size.
+		/// </summary>
+		/// <remarks>
+		/// This is useful when you want to draw an Icon at a different size than the default size. 
+		/// Note that the <paramref name="fittingSize"/> specifies the maxiumum drawing size of the Icon, but will not
+		/// change the aspect of each frame's bitmap.  For example, if an existing frame is 128x128, and you specify 16x32,
+		/// then the resulting frame will draw at 16x16.
+		/// </remarks>
+		/// <returns>A new icon that will draw within the fitting size.</returns>
+		/// <param name="fittingSize">The maximum size to draw the Icon.</param>
+		public Icon WithSize(Size fittingSize)
+		{
+			var frames = Frames.Select(frame =>
+			{
+				var scale = Math.Max((float)frame.PixelSize.Width / (float)fittingSize.Width, (float)frame.PixelSize.Height / (float)fittingSize.Height);
+				return new IconFrame(scale, frame.Bitmap);
+			});
+			return new Icon(frames);
+		}
+
+		/// <summary>
+		/// Gets a copy of this Icon with frames scaled to draw within the specified fitting size.
+		/// </summary>
+		/// <remarks>
+		/// This is useful when you want to draw an Icon at a different size than the default size. 
+		/// Note that the <paramref name="width"/> and <paramref name="height"/> specifies the maxiumum drawing size of the Icon, but will not
+		/// change the aspect of each frame's bitmap.  For example, if an existing frame is 128x128, and you specify 16x32,
+		/// then the resulting frame will draw at 16x16.
+		/// </remarks>
+		/// <returns>A new icon that will draw within the fitting size.</returns>
+		/// <param name="width">Maxiumum drawing width for the new icon.</param>
+		/// <param name="height">Maxiumum drawing height for the new icon.</param>
+		public Icon WithSize(int width, int height)
+		{
+			return WithSize(new Size(width, height));
+		}
+
+		/// <summary>
 		/// Gets the definition for each frame in this icon.
 		/// </summary>
 		/// <value>The frames of the icon.</value>

--- a/Source/Eto/Forms/Controls/DropDown.cs
+++ b/Source/Eto/Forms/Controls/DropDown.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using Eto.Drawing;
 
 namespace Eto.Forms
 {
@@ -9,7 +10,26 @@ namespace Eto.Forms
 	[Handler(typeof(DropDown.IHandler))]
 	public class DropDown : ListControl
 	{
-		new IHandler Handler { get { return (IHandler)base.Handler; } }
+		new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.Forms.DropDown"/> class.
+		/// </summary>
+		public DropDown()
+		{
+			ItemImageBinding = new ListItemImageBinding();
+		}
+
+		/// <summary>
+		/// Gets or sets the binding to get the image for each item. 
+		/// </summary>
+		/// <remarks>
+		/// By default this looks for the "Image" property of the item, and also works if you use <see cref="ImageListItem"/>.
+		/// 
+		/// This will be ignored when creating a <see cref="ComboBox"/>, and is only supported with the <see cref="DropDown"/> directly.
+		/// </remarks>
+		/// <value>The binding to get the image for each item.</value>
+		public IIndirectBinding<Image> ItemImageBinding { get; set; }
 
 		/// <summary>
 		/// Gets or sets a value indicating whether to show the control's border.

--- a/Source/Eto/Forms/Controls/ListControl.cs
+++ b/Source/Eto/Forms/Controls/ListControl.cs
@@ -78,7 +78,22 @@ namespace Eto.Forms
 			else
 				base.InternalSetValue(dataItem, value);
 		}
+	}
 
+	class ListItemImageBinding : PropertyBinding<Image>
+	{
+		public ListItemImageBinding()
+			: base("Image")
+		{
+		}
+
+		protected override Image InternalGetValue(object dataItem)
+		{
+			var item = dataItem as IImageListItem;
+			if (item != null)
+				return item.Image;
+			return base.InternalGetValue(dataItem);
+		}
 	}
 
 	class ListItemKeyBinding : PropertyBinding<string>


### PR DESCRIPTION
- Allows adding images to a DropDown using ImageListItem or your own custom POCO and binding.  Fixes #61
- ListBox now allows for differently sized images (not just 16 logical pixels high)
- Supports differently sized images (except WinForms), and macOS does not grow the control height so it overflows out of the control when selected.
- Wpf: streamline conversion of image to wpf
- Added Icon.WithSize() to return a copy of the Icon that will render at the specified logical size