### PR TITLE
Fix some TreeGridView bugs:

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/GtkTreeModel.cs
+++ b/Source/Eto.Gtk/Forms/Controls/GtkTreeModel.cs
@@ -93,7 +93,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				var found = false;
 				for (int i = 0; i < items.Count; i++)
 				{
-					if (object.ReferenceEquals(items[i], item))
+					if (ReferenceEquals(items[i], item))
 					{
 						path.PrependIndex(i);
 						item = parent;
@@ -182,7 +182,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			if (path == null)
 				throw new ArgumentNullException("path");
-			
+
 			var item = GetItemAtPath(path);
 			if (item != null)
 			{
@@ -368,10 +368,12 @@ namespace Eto.GtkSharp.Forms.Controls
 				}
 				else
 					indices = new[] { n };
-				
-				var item = store[n];
-				child = GetIterFromItem(item, indices);
-				return true;
+				if (n < store.Count)
+				{
+					var item = store[n];
+					child = GetIterFromItem(item, indices);
+					return true;
+				}
 			}
 
 			child = Gtk.TreeIter.Zero;

--- a/Source/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
+++ b/Source/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
@@ -97,9 +97,7 @@ namespace Eto.Mac.Forms.Controls
 		NSColor groupColor = NSColor.FromCalibratedRgba(0x6F / (float)0xFF, 0x7E / (float)0xFF, 0x8B / (float)0xFF, 1.0F);
 		//light shade: NSColor.FromCalibratedRgba (0x82 / (float)0xFF, 0x90 / (float)0xFF, 0x9D / (float)0xFF, 1.0F);
 		
-		static readonly IntPtr selDrawInRectFromRectOperationFractionRespectFlippedHints = Selector.GetHandle("drawInRect:fromRect:operation:fraction:respectFlipped:hints:");
 
-		
 		public MacImageListItemCell()
 		{
 		}
@@ -181,10 +179,11 @@ namespace Eto.Mac.Forms.Controls
 			var data = ObjectValue as MacImageData;
 			if (data != null && data.Image != null)
 			{
-				var ctl = ControlView as NSTableView;
 				var imageSize = data.Image.Size;
-				size.Height = (nfloat)Math.Max(imageSize.Height, size.Height);
-				size.Width += (nfloat)(imageSize.Width + ImagePadding);
+				var newHeight = Math.Min(imageSize.Height, bounds.Height);
+				var newWidth = imageSize.Width * newHeight / imageSize.Height;
+				size.Width += (nfloat)(newWidth + ImagePadding);
+				size.Height = (nfloat)newHeight;
 			}
 			size.Width = (nfloat)Math.Min(size.Width, bounds.Width);
 			return size;
@@ -220,17 +219,7 @@ namespace Eto.Mac.Forms.Controls
 
 						context.ImageInterpolation = ImageInterpolation;
 
-						if (data.Image.RespondsToSelector(new Selector(selDrawInRectFromRectOperationFractionRespectFlippedHints)))
-							// 10.6+
-							data.Image.Draw(imageRect, new CGRect(CGPoint.Empty, data.Image.Size), NSCompositingOperation.SourceOver, alpha, true, null);
-						else
-						{
-							// 10.5-
-							#pragma warning disable 618
-							data.Image.Flipped = ControlView.IsFlipped; 
-							#pragma warning restore 618
-							data.Image.Draw(imageRect, new CGRect(CGPoint.Empty, data.Image.Size), NSCompositingOperation.SourceOver, alpha);
-						}
+						data.Image.Draw(imageRect, new CGRect(CGPoint.Empty, data.Image.Size), NSCompositingOperation.SourceOver, alpha, true, null);
 						frame.Width -= newWidth + ImagePadding;
 						frame.X += newWidth + ImagePadding;
 					}

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
@@ -2,6 +2,7 @@ using System;
 using System.Linq;
 using Eto.Forms;
 using Eto.Drawing;
+using System.Collections.Generic;
 
 namespace Eto.Test.Sections.Controls
 {
@@ -114,15 +115,41 @@ namespace Eto.Test.Sections.Controls
 			var control = new Button { Text = "Remove" };
 			control.Click += (sender, e) =>
 			{
-				var item = grid.SelectedItem as TreeGridItem;
-				if (item != null)
+				if (grid.AllowMultipleSelection)
 				{
-					var parent = item.Parent as TreeGridItem;
-					parent.Children.Remove(item);
-					if (parent.Parent == null)
+					var parents = new List<ITreeGridItem>();
+					bool reloadData = false;
+					foreach (var item in grid.SelectedItems.OfType<ITreeGridItem>().ToList())
+					{
+						var parent = item.Parent as TreeGridItem;
+						parent.Children.Remove(item);
+						if (parent.Parent == null)
+							reloadData = true;
+						if (!parents.Contains(parent))
+							parents.Add(parent);
+					}
+					if (reloadData)
 						grid.ReloadData();
 					else
-						grid.ReloadItem(parent);
+					{
+						foreach (var parent in parents)
+						{
+							grid.ReloadItem(parent);
+						}
+					}
+				}
+				else
+				{
+					var item = grid.SelectedItem as TreeGridItem;
+					if (item != null)
+					{
+						var parent = item.Parent as TreeGridItem;
+						parent.Children.Remove(item);
+						if (parent.Parent == null)
+							grid.ReloadData();
+						else
+							grid.ReloadItem(parent);
+					}
 				}
 			};
 			return control;

--- a/Source/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
@@ -27,6 +27,8 @@ namespace Eto.WinForms.Forms.Controls
 
 		protected override object GetItemAtRow(int row)
 		{
+			if (row >= controller.Count)
+				return null;
 			return controller[row];
 		}
 
@@ -122,6 +124,8 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			get
 			{
+				if (Control.SelectedRows.Count == 0)
+					return null;
 				var index = Control.SelectedRows.OfType<swf.DataGridViewRow>().Select(r => r.Index).FirstOrDefault();
 				return controller[index];
 			}
@@ -346,12 +350,27 @@ namespace Eto.WinForms.Forms.Controls
 
 		public void ReloadData()
 		{
+			var selectedItems = SelectedItems.OfType<ITreeGridItem>().ToList();
+			SupressSelectionChanged++;
 			controller.ReloadData();
+			Control.ClearSelection();
+			bool selectionChanged = false;
+			foreach (var selectedItem in selectedItems)
+			{
+				var row = controller.IndexOf(selectedItem);
+				if (row >= 0)
+					Control.Rows[row].Selected = true;
+				else
+					selectionChanged = true;
+			}
+			if (selectionChanged)
+				Callback.OnSelectionChanged(Widget, EventArgs.Empty);
+			SupressSelectionChanged--;
 		}
 
 		public void ReloadItem(ITreeGridItem item)
 		{
-			controller.ReloadData();
+			ReloadData();
 		}
 
 		public ITreeGridItem GetCellAt(PointF location, out int column)


### PR DESCRIPTION
- Gtk: When removing all children from an expanded row it would get into an invalid state. Fixes #681
- Gtk: Properly expand child items when a node is expanded.
- Mac: Fix showing text in ImageTextCell when image is larger than the row height.
- WinForms: Fix keeping (proper) selection when refreshing and some crashing bugs.
- TreeGridViewSection now tests removing multiple children when enabled.