### PR TITLE
Fix setting Parent of Panel.Content

### DIFF
--- a/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
+++ b/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
@@ -135,6 +135,7 @@
     <Compile Include="UnitTests\Drawing\MatrixTests.cs" />
     <Compile Include="UnitTests\Forms\Controls\ComboBoxTests.cs" />
     <Compile Include="UnitTests\Forms\Controls\NumericUpDownTests.cs" />
+    <Compile Include="UnitTests\Forms\Controls\PanelTests.cs" />
     <Compile Include="UnitTests\Forms\Controls\SplitterTests.cs" />
     <Compile Include="UnitTests\Forms\GridViewUtils.cs" />
     <Compile Include="UnitTests\Forms\RangeTests.cs" />

--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/PanelTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/PanelTests.cs
@@ -1,0 +1,37 @@
+﻿using Eto.Forms;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	[TestFixture]
+	public class PanelTests : TestBase
+	{
+		[Test]
+		public void ParentShouldBeSet()
+		{
+			Invoke(() =>
+			{
+				var panel1 = new Panel { ID = "panel1" };
+				var panel2 = new Panel { ID = "panel2" };
+				var label = new Label { Text = "Label" };
+
+				panel1.Content = label;
+				Assert.AreSame(panel1, label.Parent, "#1");
+				Assert.AreSame(panel1, label.VisualParent, "#2");
+
+				panel1.Content = null;
+				Assert.AreSame(null, label.Parent, "#2");
+				Assert.AreSame(null, label.VisualParent, "#3");
+
+				panel2.Content = label;
+				Assert.AreSame(panel2, label.Parent, "#3");
+				Assert.AreSame(panel2, label.VisualParent, "#4");
+			});
+		}
+	}
+}

--- a/Source/Eto/Forms/Container.cs
+++ b/Source/Eto/Forms/Container.cs
@@ -264,7 +264,7 @@ namespace Eto.Forms
 		/// <param name="child">Child to remove from this container</param>
 		protected void RemoveParent(Control child)
 		{
-			if (child != null && !ReferenceEquals(child.VisualParent, null))
+			if (!ReferenceEquals(child, null) && !ReferenceEquals(child.VisualParent, null))
 			{
 #if DEBUG
 				if (!ReferenceEquals(child.VisualParent, this))
@@ -275,7 +275,7 @@ namespace Eto.Forms
 					child.TriggerUnLoad(EventArgs.Empty);
 				}
 				child.VisualParent = null;
-				if (child.LogicalParent == this)
+				if (ReferenceEquals(child.LogicalParent, this))
 					child.LogicalParent = null;
 			}
 		}
@@ -295,7 +295,7 @@ namespace Eto.Forms
 		/// <param name="child">Child to set the logical parent to this container.</param>
 		protected void SetLogicalParent(Control child)
 		{
-			if (child == null)
+			if (ReferenceEquals(child, null))
 				return;
 			child.LogicalParent = this;
 		}
@@ -311,7 +311,7 @@ namespace Eto.Forms
 		/// <param name="child">Child to remove from this container as the logical parent.</param>
 		protected void RemoveLogicalParent(Control child)
 		{
-			if (child == null)
+			if (ReferenceEquals(child, null))
 				return;
 			if (!ReferenceEquals(child.LogicalParent, this))
 			{
@@ -335,19 +335,28 @@ namespace Eto.Forms
 		/// <param name="previousChild">Previous child that the new child is replacing.</param>
 		protected void SetParent(Control child, Action assign = null, Control previousChild = null)
 		{
-			if (previousChild != null && !ReferenceEquals(previousChild.VisualParent, null) && (!ReferenceEquals(previousChild, child) || !ReferenceEquals(child.VisualParent, this)))
+			if (!ReferenceEquals(previousChild, null) && !ReferenceEquals(previousChild, child))
 			{
 #if DEBUG
 				if (!ReferenceEquals(previousChild.VisualParent, this))
-					throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "The child control is not a child of this container. Ensure you only remove children that you own."));
+					throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "The previous child control is not a child of this container. Ensure you only remove children that you own."));
 #endif
-				if (previousChild.Loaded)
+
+				if (!ReferenceEquals(previousChild.VisualParent, null))
 				{
-					previousChild.TriggerUnLoad(EventArgs.Empty);
+					if (previousChild.Loaded)
+					{
+						previousChild.TriggerUnLoad(EventArgs.Empty);
+					}
+					previousChild.VisualParent = null;
 				}
-				previousChild.VisualParent = null;
+
+				if (ReferenceEquals(previousChild.LogicalParent, this))
+				{
+					previousChild.LogicalParent = null;
+				}
 			}
-			if (child != null && !ReferenceEquals(child.VisualParent, this))
+			if (!ReferenceEquals(child, null) && !ReferenceEquals(child.VisualParent, this))
 			{
 				// Detach so parent can remove from controls collection if necessary.
 				// prevents UnLoad from being called more than once when containers think a control is still a child

--- a/Source/Eto/Widget.cs
+++ b/Source/Eto/Widget.cs
@@ -432,6 +432,18 @@ namespace Eto
 			System.Diagnostics.Debug.WriteLine ("{0}: {1}", disposing ? "Dispose" : "GC", GetType().Name);
 			#endif
 		}
+
+		/// <summary>
+		/// Gets a string that represents the current object with its ID if specified.
+		/// </summary>
+		/// <returns>A string value indicating the type and ID (if specified) of this widget.</returns>
+		public override string ToString()
+		{
+			if (!string.IsNullOrEmpty(ID))
+				return $"{base.ToString()} ({ID})";
+			else
+				return base.ToString();
+		}
 	}
 }
 


### PR DESCRIPTION
- Removing the content of a Panel didn’t unset the LogicalParent properly if it was the current container.
- Add ID to the ToString() of a Widget to more easily debug things.
- Simplify logic of SetParent() slightly, as Detatch() will take care of checking a few things.
- Add tests

Fixes #682