### PR TITLE
Mac: Update Splitter position when a panel is replaced.

### DIFF
--- a/Source/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -400,6 +400,8 @@ namespace Eto.Mac.Forms.Controls
 					var view = value.GetContainerView();
 					Control.ReplaceSubviewWith(Control.Subviews[0], view ?? new NSView());
 					panel1 = value;
+					if (Widget.Loaded)
+						UpdatePosition();
 				}
 			}
 		}
@@ -414,6 +416,8 @@ namespace Eto.Mac.Forms.Controls
 					var view = value.GetContainerView();
 					Control.ReplaceSubviewWith(Control.Subviews[1], view ?? new NSView());
 					panel2 = value;
+					if (Widget.Loaded)
+						UpdatePosition();
 				}
 			}
 		}


### PR DESCRIPTION
This ensures if it’s set to a control with Visible = false, or null, then it will collapse the splitter.

Fixes #500