### PR TITLE
[Gtk] Fix TreeGridView Multiselect

### DIFF
--- a/Source/Eto.Gtk/Forms/GtkControl.cs
+++ b/Source/Eto.Gtk/Forms/GtkControl.cs
@@ -451,7 +451,7 @@ namespace Eto.GtkSharp.Forms
 			}
 
 			[GLib.ConnectBefore]
-			public void HandleButtonPressEvent(object sender, Gtk.ButtonPressEventArgs args)
+			public virtual void HandleButtonPressEvent(object sender, Gtk.ButtonPressEventArgs args)
 			{
 				var p = new PointF((float)args.Event.X, (float)args.Event.Y);
 				Keys modifiers = args.Event.State.ToEtoKey();


### PR DESCRIPTION
In short, Gtk default treeview multiselect is extremely broken since right click does the same things as left click so you actually need a bit of code to make it act like the VisualStudio/XamarinStudio/MonoDevelop solution explorer treeview acts.