### PR TITLE
Fix label alignment in StackLayout when it is recreated.

### DIFF
--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Layout/StackLayoutTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Layout/StackLayoutTests.cs
@@ -78,11 +78,11 @@ namespace Eto.Test.UnitTests.Forms.Layout
 			}, () =>
 			{
 				Assert.AreSame(stack, child?.Parent);
-				Assert.IsNotNull(child.VisualParent); 
+				Assert.IsNotNull(child.VisualParent);
 				// StackLayout uses TableLayout internally to align controls
 				// this will be changed when StackLayout does not depend on TableLayout
 				Assert.AreNotSame(stack, child.VisualParent);
-				Assert.IsInstanceOf<TableLayout>(child.VisualParent); 
+				Assert.IsInstanceOf<TableLayout>(child.VisualParent);
 			});
 		}
 
@@ -136,6 +136,41 @@ namespace Eto.Test.UnitTests.Forms.Layout
 				Assert.IsNull(child.VisualParent);
 				Assert.IsNull(child.Parent);
 			});
+		}
+
+		[Test, ManualTest]
+		public void UpdateShouldKeepAlignment()
+		{
+			ManualForm(
+				"Label should stay centered vertically after clicking the button",
+				form =>
+				{
+					StackLayout content = null;
+					Action command = () =>
+					{
+						if (content == null)
+							return;
+						content.Items[1] = new ComboBox { Items = { "Zus", "Wim", "Jet" }, SelectedIndex = 1 };
+					};
+
+					return content = new StackLayout
+					{
+						VerticalContentAlignment = VerticalAlignment.Center,
+						Orientation = Orientation.Horizontal,
+						Height = 100, // so we can exaggerate the issue
+						Items =
+						{
+							"Hello",
+							new ComboBox { Items = { "Aap", "Noot", "Mies" }, SelectedIndex = 1 },
+							"There",
+							new Button
+							{
+								Text = "Click",
+								Command = new RelayCommand(command)
+							}
+						}
+					};
+				});
 		}
 	}
 }

--- a/Source/Eto.Test/Eto.Test/UnitTests/TestBase.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/TestBase.cs
@@ -241,6 +241,58 @@ namespace Eto.Test.UnitTests
 			);
 		}
 
+		public static void ManualForm(string description, Func<Form, Control> init)
+		{
+			Exception exception = null;
+			Form(form =>
+			{
+				try
+				{
+					var c = init(form);
+
+					var failButton = new Button { Text = "Fail" };
+					failButton.Click += (sender, e) =>
+					{
+						try
+						{
+							Assert.Fail(description);
+						}
+						catch (Exception ex)
+						{
+							exception = ex;
+						}
+						finally
+						{
+							form.Close();
+						}
+					};
+
+					var passButton = new Button { Text = "Pass" };
+					passButton.Click += (sender, e) => form.Close();
+
+					form.Content = new StackLayout
+					{
+						Padding = 10,
+						Spacing = 10,
+						Items =
+					{
+						new StackLayoutItem(c, HorizontalAlignment.Stretch, true),
+						description,
+						new StackLayoutItem(TableLayout.Horizontal(2, failButton, passButton), HorizontalAlignment.Center)
+					}
+					};
+				}
+				catch (Exception ex)
+				{
+					exception = ex;
+				}
+
+			}, timeout: -1);
+
+			if (exception != null)
+				ExceptionDispatchInfo.Capture(exception).Throw();
+		}
+
 		/// <summary>
 		/// Test operations on a form once it is shown
 		/// </summary>

--- a/Source/Eto/Forms/Layout/StackLayout.cs
+++ b/Source/Eto/Forms/Layout/StackLayout.cs
@@ -390,40 +390,37 @@ namespace Eto.Forms
 			items = new StackLayoutItemCollection { Parent = this };
 		}
 
-		void UpdateLabelItem(StackLayoutItem item)
+		VerticalAlignment GetVerticalAlign(StackLayoutItem item)
 		{
-			if (!AlignLabels)
-				return;
+			var align = item.VerticalAlignment ?? VerticalContentAlignment;
 			var label = item.Control as Label;
-			if (label != null)
+			if (!AlignLabels || label == null)
+				return align;
+			label.VerticalAlignment = align;
+			return VerticalAlignment.Stretch;
+		}
+
+		HorizontalAlignment GetHorizontalAlign(StackLayoutItem item)
+		{
+			var align = item.HorizontalAlignment ?? HorizontalContentAlignment;
+			var label = item.Control as Label;
+			if (!AlignLabels || label == null)
+				return align;
+			switch (align)
 			{
-				switch (Orientation)
-				{
-					case Orientation.Horizontal:
-						label.VerticalAlignment = item.VerticalAlignment ?? VerticalContentAlignment;
-						item.VerticalAlignment = VerticalAlignment.Stretch;
-						break;
-					case Orientation.Vertical:
-						switch (item.HorizontalAlignment ?? HorizontalContentAlignment)
-						{
-							case HorizontalAlignment.Left:
-								label.TextAlignment = TextAlignment.Left;
-								break;
-							case HorizontalAlignment.Center:
-								label.TextAlignment = TextAlignment.Center;
-								break;
-							case HorizontalAlignment.Right:
-								label.TextAlignment = TextAlignment.Right;
-								break;
-							default:
-								return;
-						}
-						item.HorizontalAlignment = HorizontalAlignment.Stretch;
-						break;
-					default:
-						throw new ArgumentOutOfRangeException();
-				}
+				case HorizontalAlignment.Left:
+					label.TextAlignment = TextAlignment.Left;
+					break;
+				case HorizontalAlignment.Center:
+					label.TextAlignment = TextAlignment.Center;
+					break;
+				case HorizontalAlignment.Right:
+					label.TextAlignment = TextAlignment.Right;
+					break;
+				default:
+					return align;
 			}
+			return HorizontalAlignment.Stretch;
 		}
 
 		/// <summary>
@@ -487,7 +484,6 @@ namespace Eto.Forms
 			table.Spacing = new Size(Spacing, Spacing);
 
 			bool filled = false;
-			Action<StackLayoutItem> itemAdding = UpdateLabelItem;
 			var expandItem = new StackLayoutItem { Expand = true };
 			switch (Orientation)
 			{
@@ -496,11 +492,11 @@ namespace Eto.Forms
 					for (int i = 0; i < items.Count; i++)
 					{
 						var item = items[i] ?? expandItem;
-						itemAdding(item);
+						var align = GetVerticalAlign(item);
 						var control = item.Control;
 						filled |= item.Expand;
 						var cell = new TableCell { ScaleWidth = item.Expand };
-						switch (item.VerticalAlignment ?? VerticalContentAlignment)
+						switch (align)
 						{
 							case VerticalAlignment.Top:
 								cell.Control = new TableLayout(control, null);
@@ -527,11 +523,11 @@ namespace Eto.Forms
 					for (int i = 0; i < items.Count; i++)
 					{
 						var item = items[i] ?? expandItem;
-						itemAdding(item);
+						var align = GetHorizontalAlign(item);
 						var control = item.Control;
 						filled |= item.Expand;
 						var vrow = new TableRow { ScaleHeight = item.Expand };
-						switch (item.HorizontalAlignment ?? HorizontalContentAlignment)
+						switch (align)
 						{
 							case HorizontalAlignment.Left:
 								vrow.Cells.Add(TableLayout.Horizontal(control, null));
@@ -561,4 +557,3 @@ namespace Eto.Forms
 		}
 	}
 }
-

--- a/Source/Eto/Forms/RelayCommand.cs
+++ b/Source/Eto/Forms/RelayCommand.cs
@@ -8,6 +8,39 @@ namespace Eto.Forms
 	/// <summary>
 	/// Command to relay execution and execute state to delegates
 	/// </summary>
+	public class RelayCommand : RelayCommand<object>
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.RelayCommand"/> class.
+		/// </summary>
+		/// <remarks>
+		/// The <see cref="RelayCommand{T}.CanExecute"/> will always return true.
+		/// </remarks>
+		/// <param name="execute">Delegate to execute the command.</param>
+		public RelayCommand(Action execute)
+			: base((obj) => execute())
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.RelayCommand"/> class.
+		/// </summary>
+		/// <remarks>
+		/// This constructor allows you to specify whether the command can be executed.
+		/// If the state of the <paramref name="canExecute"/> delegate changes, you can call <see cref="RelayCommand{T}.UpdateCanExecute"/>
+		/// to tell the control that is bound to this command to call the delegate again.
+		/// </remarks>
+		/// <param name="execute">Delegate to execute the command.</param>
+		/// <param name="canExecute">Delegate to determine the state of whether the command can be executed.</param>
+		public RelayCommand(Action execute, Func<bool> canExecute)
+			: base((obj) => execute(), (obj) => canExecute())
+		{
+		}
+	}
+
+	/// <summary>
+	/// Command to relay execution and execute state to delegates
+	/// </summary>
 	public class RelayCommand<T> : ICommand
 	{
 		readonly Action<T> execute;


### PR DESCRIPTION
- No longer update StackLayoutItem alignment after aligning the label so it remains the same value.
- Added manual test for StackLayout to reproduce the issue.
- Added TestBase.ManualForm with pass/fail buttons to make it easier to create more manual tests.
- Also added non-generic RelayCommand which I’ve been meaning to add for a while to make it easier to create a command that does not need a parameter.