### PR TITLE
Add TextAlignment/VerticalAlignment to TextBoxCell & ImageTextCell

### DIFF
--- a/Source/Eto.Gtk/Forms/Cells/ImageTextCellHandler.cs
+++ b/Source/Eto.Gtk/Forms/Cells/ImageTextCellHandler.cs
@@ -66,6 +66,30 @@ namespace Eto.GtkSharp.Forms.Cells
 		{
 			imageCell = new ImageRenderer { Handler = this };
 			Control = new Renderer { Handler = this };
+			VerticalAlignment = VerticalAlignment.Center;
+		}
+
+		public TextAlignment TextAlignment
+		{
+			get { return Control.Alignment.ToEto(); }
+			set
+			{
+				Control.Alignment = value.ToPango();
+				Control.Xalign = value.ToAlignment();
+				Column?.Control?.TreeView?.QueueDraw();
+			}
+		}
+
+		VerticalAlignment verticalAlignment = VerticalAlignment.Center;
+		public VerticalAlignment VerticalAlignment
+		{
+			get { return verticalAlignment; }
+			set
+			{
+				verticalAlignment = value;
+				Control.Yalign = value.ToAlignment();
+				Column?.Control?.TreeView?.QueueDraw();
+			}
 		}
 
 		protected override void Initialize()

--- a/Source/Eto.Gtk/Forms/Cells/TextBoxCellHandler.cs
+++ b/Source/Eto.Gtk/Forms/Cells/TextBoxCellHandler.cs
@@ -40,6 +40,7 @@ namespace Eto.GtkSharp.Forms.Cells
 		public TextBoxCellHandler()
 		{
 			Control = new Renderer { Handler = this };
+			VerticalAlignment = VerticalAlignment.Center;
 		}
 
 		protected override void Initialize()
@@ -49,6 +50,29 @@ namespace Eto.GtkSharp.Forms.Cells
 		}
 
 		protected new TextBoxCellEventConnector Connector { get { return (TextBoxCellEventConnector)base.Connector; } }
+
+		public TextAlignment TextAlignment
+		{
+			get { return Control.Alignment.ToEto(); }
+			set
+			{
+				Control.Alignment = value.ToPango();
+				Control.Xalign = value.ToAlignment();
+				Column?.Control?.TreeView?.QueueDraw();
+			}
+		}
+
+		VerticalAlignment verticalAlignment = VerticalAlignment.Center;
+		public VerticalAlignment VerticalAlignment
+		{
+			get { return verticalAlignment; }
+			set
+			{
+				verticalAlignment = value;
+				Control.Yalign = value.ToAlignment();
+				Column?.Control?.TreeView?.QueueDraw();
+			}
+		}
 
 		protected override WeakConnector CreateConnector()
 		{

--- a/Source/Eto.Gtk/Forms/Controls/LabelHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/LabelHandler.cs
@@ -71,10 +71,10 @@ namespace Eto.GtkSharp.Forms.Controls
 					Layout.GetPixelSize(out pixWidth, out pixHeight);
 					HeightRequest = pixHeight;
 					wrapWidth = width;
-					#if GTK3
+#if GTK3
 					if (Parent != null)
 						Gtk.Application.Invoke((sender, e) => Parent.QueueResize());
-					#endif
+#endif
 				}
 			}
 		}
@@ -102,33 +102,38 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 			set
 			{
-				Control.ResetWidth();
-				switch (value)
-				{
-					case WrapMode.None:
-						Control.Wrap = false;
-						Control.LineWrap = false;
-						Control.SingleLineMode = true;
-						break;
-					case WrapMode.Word:
-						Control.Wrap = true;
-						Control.Layout.Wrap = Pango.WrapMode.WordChar;
-						Control.LineWrapMode = Pango.WrapMode.WordChar;
-						Control.LineWrap = true;
-						Control.SingleLineMode = false;
-						break;
-					case WrapMode.Character:
-						Control.Wrap = true;
-						Control.Layout.Wrap = Pango.WrapMode.Char;
-						Control.LineWrapMode = Pango.WrapMode.Char;
-						Control.LineWrap = true;
-						Control.SingleLineMode = false;
-						break;
-					default:
-						throw new NotSupportedException();
-				}
-				eventBox.QueueResize();
+				SetWrap(value);
 			}
+		}
+
+		void SetWrap(WrapMode mode)
+		{
+			Control.ResetWidth();
+			switch (mode)
+			{
+				case WrapMode.None:
+					Control.Wrap = false;
+					Control.LineWrap = false;
+					Control.SingleLineMode = true;
+					break;
+				case WrapMode.Word:
+					Control.Wrap = true;
+					Control.Layout.Wrap = Pango.WrapMode.WordChar;
+					Control.LineWrapMode = Pango.WrapMode.WordChar;
+					Control.LineWrap = true;
+					Control.SingleLineMode = false;
+					break;
+				case WrapMode.Character:
+					Control.Wrap = true;
+					Control.Layout.Wrap = Pango.WrapMode.Char;
+					Control.LineWrapMode = Pango.WrapMode.Char;
+					Control.LineWrap = true;
+					Control.SingleLineMode = false;
+					break;
+				default:
+					throw new NotSupportedException();
+			}
+			eventBox.QueueResize();
 		}
 
 		public override void AttachEvent(string id)
@@ -171,34 +176,10 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		void SetAlignment()
 		{
-			float xalignment;
-			float yalignment;
-			switch (horizontalAlign)
-			{
-				default:
-					xalignment = 0F;
-					break;
-				case TextAlignment.Center:
-					xalignment = 0.5F;
-					break;
-				case TextAlignment.Right:
-					xalignment = 1F;
-					break;
-			}
-			switch (verticalAlign)
-			{
-				case VerticalAlignment.Center:
-					yalignment = 0.5F;
-					break;
-				default:
-					yalignment = 0F;
-					break;
-				case VerticalAlignment.Bottom:
-					yalignment = 1F;
-					break;
-			}
-			Control.SetAlignment(xalignment, yalignment);
+			Control.ResetWidth();
 			Control.Justify = horizontalAlign.ToGtk();
+			Control.SetAlignment(horizontalAlign.ToAlignment(), verticalAlign.ToAlignment());
+			eventBox.ResizeChildren();
 		}
 
 		public VerticalAlignment VerticalAlignment

--- a/Source/Eto.Gtk/GtkConversions.cs
+++ b/Source/Eto.Gtk/GtkConversions.cs
@@ -653,5 +653,68 @@ namespace Eto.GtkSharp
 					throw new NotSupportedException();
 			}
 		}
+
+		public static Pango.Alignment ToPango(this TextAlignment alignment)
+		{
+			switch (alignment)
+			{
+				case TextAlignment.Left:
+					return Pango.Alignment.Left;
+				case TextAlignment.Center:
+					return Pango.Alignment.Center;
+				case TextAlignment.Right:
+					return Pango.Alignment.Right;
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
+		public static float ToAlignment(this TextAlignment alignment)
+		{
+			switch (alignment)
+			{
+				case TextAlignment.Left:
+					return 0;
+				case TextAlignment.Center:
+					return 0.5f;
+				case TextAlignment.Right:
+					return 1f;
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
+		public static TextAlignment ToEto(this Pango.Alignment alignment)
+		{
+			switch (alignment)
+			{
+				case Pango.Alignment.Left:
+					return TextAlignment.Left;
+				case Pango.Alignment.Center:
+					return TextAlignment.Center;
+				case Pango.Alignment.Right:
+					return TextAlignment.Right;
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
+		public static float ToAlignment(this VerticalAlignment alignment)
+		{
+			switch (alignment)
+			{
+				case VerticalAlignment.Stretch:
+				case VerticalAlignment.Top:
+					return 0;
+				case VerticalAlignment.Center:
+					return 0.5f;
+				case VerticalAlignment.Bottom:
+					return 1f;
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
+
 	}
 }

--- a/Source/Eto.Mac/Forms/Cells/CellHandler.cs
+++ b/Source/Eto.Mac/Forms/Cells/CellHandler.cs
@@ -31,6 +31,12 @@ using CGPoint = System.Drawing.PointF;
 #endif
 #endif
 
+#if XAMMAC2
+using nnuint = System.nint;
+#else
+using nnuint = System.Int32;
+#endif
+
 namespace Eto.Mac.Forms.Cells
 {
 	public interface ICellHandler
@@ -162,6 +168,17 @@ namespace Eto.Mac.Forms.Cells
 
 		public virtual void SetForegroundColor(NSView view, Color color)
 		{
+		}
+
+		protected virtual void ReloadColumnData()
+		{
+			var handler = ColumnHandler?.DataViewHandler;
+			if (handler?.Loaded == true)
+			{
+				var column = handler.Widget.Columns.IndexOf(ColumnHandler.Widget);
+				var rows = NSIndexSet.FromNSRange(new NSRange(0, (nnuint)handler.Table.RowCount));
+				handler.Table.ReloadData(rows, new NSIndexSet(column));
+			}
 		}
 
 		public abstract NSView GetViewForItem(NSTableView tableView, NSTableColumn tableColumn, int row, NSObject obj, Func<NSObject, int, object> getItem);

--- a/Source/Eto.Mac/Forms/Controls/GridColumnHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/GridColumnHandler.cs
@@ -103,7 +103,7 @@ namespace Eto.Mac.Forms.Controls
 
 		protected override void Initialize()
 		{
-			Control.ResizingMask = NSTableColumnResizing.None;
+			Control.ResizingMask = NSTableColumnResizing.UserResizingMask;
 			Sortable = false;
 			HeaderText = string.Empty;
 			Editable = false;

--- a/Source/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
+++ b/Source/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
@@ -183,7 +183,7 @@ namespace Eto.Mac.Forms.Controls
 				var newHeight = Math.Min(imageSize.Height, bounds.Height);
 				var newWidth = imageSize.Width * newHeight / imageSize.Height;
 				size.Width += (nfloat)(newWidth + ImagePadding);
-				size.Height = (nfloat)newHeight;
+				size.Height = (nfloat)Math.Max(newHeight, size.Height);
 			}
 			size.Width = (nfloat)Math.Min(size.Width, bounds.Width);
 			return size;

--- a/Source/Eto.Mac/MacConversions.cs
+++ b/Source/Eto.Mac/MacConversions.cs
@@ -49,7 +49,7 @@ namespace Eto.Mac
 		public static Color ToEto(this NSColor color, bool calibrated = true)
 		{
 			if (color == null)
-				return Colors.Black;
+				return Colors.Transparent;
 			var colorspace = calibrated ? NSColorSpace.CalibratedRGB : NSColorSpace.DeviceRGB;
 			var converted = color.UsingColorSpace(colorspace);
 			if (converted == null)

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -27,8 +27,8 @@ namespace Eto.Test.Sections.Controls
 	[Section("Controls", typeof(GridView))]
 	public class GridViewSection : Panel
 	{
-		static readonly Image image1 = TestIcons.TestImage;
-		static readonly Image image2 = TestIcons.TestIcon;
+		static Icon image1 = new Icon(1, TestIcons.TestImage).WithSize(16, 16);
+		static Icon image2 = TestIcons.TestIcon.WithSize(16, 16);
 
 		public GridViewSection()
 		{
@@ -70,50 +70,67 @@ namespace Eto.Test.Sections.Controls
 				HorizontalContentAlignment = HorizontalAlignment.Stretch,
 				Items =
 				{
-					new StackLayout
-					{
-						Orientation = Orientation.Horizontal,
-						Spacing = 5,
-						Items =
-						{
-							null,
-							EnabledCheckBox(grid),
-							EditableCheckBox(grid),
-							AllowMultiSelectCheckBox(grid),
-							ShowHeaderCheckBox(grid),
-							GridLinesDropDown(grid),
-							null
-						}
-					},
-					new StackLayout
-					{
-						Orientation = Orientation.Horizontal,
-						Spacing = 5,
-						Items =
-						{
-							null,
-							AddItemButton(filtered),
-							CreateScrollToRow(grid),
-							CreateBeginEditButton(grid),
-							"Border",
-							CreateBorderType(grid),
-							null
-						}
-					},
-					new StackLayout
-					{
-						Orientation = Orientation.Horizontal,
-						Spacing = 5,
-						Items =
-						{
-							null,
-							ReloadDataButton(grid),
-							null
-						}
-					},
+					TableLayout.Horizontal(
+						5,
+						null,
+						EnabledCheckBox(grid),
+						EditableCheckBox(grid),
+						AllowMultiSelectCheckBox(grid),
+						ShowHeaderCheckBox(grid),
+						GridLinesDropDown(grid),
+						null
+					),
+					TableLayout.Horizontal(
+						5,
+						null,
+						AddItemButton(filtered),
+						CreateScrollToRow(grid),
+						CreateBeginEditButton(grid),
+						"Border",
+						CreateBorderType(grid),
+						null
+					),
+					TableLayout.Horizontal(
+						5,
+						null,
+						ReloadDataButton(grid),
+						null
+					),
+					TableLayout.Horizontal(
+						5,
+						null,
+						"TextBoxCell:",
+						"TextAlignment", TextAlignmentDropDown(grid),
+						"VerticalAlignment", VerticalAlignmentDropDown(grid),
+						null
+					),
 					CreateSearchBox(filtered)
 				}
 			};
+		}
+
+		Control TextAlignmentDropDown(GridView grid)
+		{
+			var control = new EnumDropDown<TextAlignment>();
+
+			var textBoxCell = grid.Columns.Select(r => r.DataCell).OfType<TextBoxCell>().First();
+			control.SelectedValueBinding.Bind(textBoxCell, c => c.TextAlignment);
+
+			var imageTextCell = grid.Columns.Select(r => r.DataCell).OfType<ImageTextCell>().First();
+			control.SelectedValueBinding.Bind(imageTextCell, c => c.TextAlignment);
+			return control;
+		}
+
+		Control VerticalAlignmentDropDown(GridView grid)
+		{
+			var control = new EnumDropDown<VerticalAlignment>();
+
+			var textBoxCell = grid.Columns.Select(r => r.DataCell).OfType<TextBoxCell>().First();
+			control.SelectedValueBinding.Bind(textBoxCell, c => c.VerticalAlignment);
+
+			var imageTextCell = grid.Columns.Select(r => r.DataCell).OfType<ImageTextCell>().First();
+			control.SelectedValueBinding.Bind(imageTextCell, c => c.VerticalAlignment);
+			return control;
 		}
 
 		ComboBoxCell MyDropDown(string bindingProperty)

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/LabelSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/LabelSection.cs
@@ -139,6 +139,16 @@ namespace Eto.Test.Sections.Controls
 			var textAlignmentDropDown = new EnumDropDown<TextAlignment>();
 			textAlignmentDropDown.SelectedValueBinding.Bind(label, l => l.TextAlignment);
 
+			var verticalAlignmentDropDown = new EnumDropDown<VerticalAlignment>();
+			verticalAlignmentDropDown.SelectedValueBinding.Bind(label, l => l.VerticalAlignment);
+
+			var testVerticalAlignment = new CheckBox { Text = "Test VerticalAlignment" };
+			testVerticalAlignment.CheckedChanged += (sender, e) => label.Height = testVerticalAlignment.Checked == true ? 200 : -1;
+			testVerticalAlignment.CheckedBinding.Bind(verticalAlignmentDropDown, c => c.Enabled, DualBindingMode.OneWayToSource);
+
+			var fontSelector = new FontPicker();
+			fontSelector.Bind(c => c.Value, label, l => l.Font);
+
 			Func<Control> spacer = () => new Panel { BackgroundColor = Colors.DarkGray, Size = new Size(10, 10) };
 
 			return new StackLayout
@@ -146,12 +156,8 @@ namespace Eto.Test.Sections.Controls
 				HorizontalContentAlignment = HorizontalAlignment.Stretch,
 				Items =
 				{
-					new StackLayoutItem(new StackLayout
-					{
-						Orientation = Orientation.Horizontal,
-						Spacing = 5,
-						Items = { "Wrap:", wrapDropDown, "TextAlignment:", textAlignmentDropDown }
-					}, HorizontalAlignment.Center),
+					TableLayout.Horizontal(5, null, "Wrap:", wrapDropDown, "Font:", fontSelector, null),
+					TableLayout.Horizontal(5, null, testVerticalAlignment, verticalAlignmentDropDown, "TextAlignment:", textAlignmentDropDown, null),
 					spacer(),
 					new TableLayout(
 						new TableRow(

--- a/Source/Eto.Test/Eto.Test/TestApplication.cs
+++ b/Source/Eto.Test/Eto.Test/TestApplication.cs
@@ -53,6 +53,7 @@ namespace Eto.Test
 			MainForm.Show();
 		}
 
+		/*
 		protected override void OnTerminating(CancelEventArgs e)
 		{
 			base.OnTerminating(e);
@@ -61,7 +62,7 @@ namespace Eto.Test
 			var result = MessageBox.Show(MainForm, "Are you sure you want to quit?", MessageBoxButtons.YesNo, MessageBoxType.Question);
 			if (result == DialogResult.No)
 				e.Cancel = true;
-		}
+		}*/
 	}
 }
 

--- a/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Cells/TestTextBoxCellHandler.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Handlers/Cells/TestTextBoxCellHandler.cs
@@ -9,5 +9,30 @@ namespace Eto.Test.UnitTests.Handlers.Cells
 {
 	public class TestTextBoxCellHandler : TestWidgetHandler, TextBoxCell.IHandler
 	{
+		public TextAlignment TextAlignment
+		{
+			get
+			{
+				throw new NotImplementedException();
+			}
+
+			set
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		public VerticalAlignment VerticalAlignment
+		{
+			get
+			{
+				throw new NotImplementedException();
+			}
+
+			set
+			{
+				throw new NotImplementedException();
+			}
+		}
 	}
 }

--- a/Source/Eto.WinForms/Forms/Cells/CellHandler.cs
+++ b/Source/Eto.WinForms/Forms/Cells/CellHandler.cs
@@ -7,6 +7,8 @@ namespace Eto.WinForms.Forms.Cells
 {
 	public interface ICellConfigHandler
 	{
+		swf.DataGridViewColumn Column { get; }
+
 		void Paint (sd.Graphics graphics, sd.Rectangle clipBounds, sd.Rectangle cellBounds, int rowIndex, swf.DataGridViewElementStates cellState, object value, object formattedValue, string errorText, swf.DataGridViewCellStyle cellStyle, swf.DataGridViewAdvancedBorderStyle advancedBorderStyle, ref swf.DataGridViewPaintParts paintParts);
 
 		int GetRowOffset (int rowIndex);
@@ -30,7 +32,22 @@ namespace Eto.WinForms.Forms.Cells
 			get { return Control; }
 		}
 
-		public ICellConfigHandler CellConfig { get; set; }
+		ICellConfigHandler _cellConfig;
+		public ICellConfigHandler CellConfig
+		{
+			get { return _cellConfig; }
+			set
+			{
+				_cellConfig = value;
+				InitializeColumn();
+			}
+		}
+
+		public swf.DataGridViewColumn Column => CellConfig?.Column;
+
+		protected virtual void InitializeColumn()
+		{
+		}
 
 		protected void PositionEditingControl (int row, ref sd.Rectangle cellClip, ref sd.Rectangle cellBounds, int customOffset = 0)
 		{

--- a/Source/Eto.WinForms/Forms/Cells/ImageTextCellHandler.cs
+++ b/Source/Eto.WinForms/Forms/Cells/ImageTextCellHandler.cs
@@ -128,6 +128,41 @@ namespace Eto.WinForms.Forms.Cells
 			get { return Control.InterpolationMode.ToEto(); }
 			set { Control.InterpolationMode = value.ToSD(); }
 		}
+
+		TextAlignment _textAlignment;
+		public TextAlignment TextAlignment
+		{
+			get { return _textAlignment; }
+			set
+			{
+				_textAlignment = value;
+				SetAlignment();
+			}
+		}
+
+		VerticalAlignment _verticalAlignment = VerticalAlignment.Center;
+		public VerticalAlignment VerticalAlignment
+		{
+			get { return _verticalAlignment; }
+			set
+			{
+				_verticalAlignment = value;
+				SetAlignment();
+			}
+		}
+
+		void SetAlignment()
+		{
+			if (Column == null)
+				return;
+			Column.DefaultCellStyle.Alignment = WinConversions.ToSWF(TextAlignment, VerticalAlignment);
+		}
+
+		protected override void InitializeColumn()
+		{
+			base.InitializeColumn();
+			SetAlignment();
+		}
 	}
 }
 

--- a/Source/Eto.WinForms/Forms/Cells/TextBoxCellHandler.cs
+++ b/Source/Eto.WinForms/Forms/Cells/TextBoxCellHandler.cs
@@ -11,32 +11,32 @@ namespace Eto.WinForms.Forms.Cells
 		{
 			public TextBoxCellHandler Handler { get; set; }
 
-			public override void PositionEditingControl (bool setLocation, bool setSize, sd.Rectangle cellBounds, sd.Rectangle cellClip, swf.DataGridViewCellStyle cellStyle, bool singleVerticalBorderAdded, bool singleHorizontalBorderAdded, bool isFirstDisplayedColumn, bool isFirstDisplayedRow)
+			public override void PositionEditingControl(bool setLocation, bool setSize, sd.Rectangle cellBounds, sd.Rectangle cellClip, swf.DataGridViewCellStyle cellStyle, bool singleVerticalBorderAdded, bool singleHorizontalBorderAdded, bool isFirstDisplayedColumn, bool isFirstDisplayedRow)
 			{
-				Handler.PositionEditingControl (RowIndex, ref cellClip, ref cellBounds);
-				base.PositionEditingControl (setLocation, setSize, cellBounds, cellClip, cellStyle, singleVerticalBorderAdded, singleHorizontalBorderAdded, isFirstDisplayedColumn, isFirstDisplayedRow);
+				Handler.PositionEditingControl(RowIndex, ref cellClip, ref cellBounds);
+				base.PositionEditingControl(setLocation, setSize, cellBounds, cellClip, cellStyle, singleVerticalBorderAdded, singleHorizontalBorderAdded, isFirstDisplayedColumn, isFirstDisplayedRow);
 			}
 
-			protected override sd.Size GetPreferredSize (sd.Graphics graphics, swf.DataGridViewCellStyle cellStyle, int rowIndex, sd.Size constraintSize)
+			protected override sd.Size GetPreferredSize(sd.Graphics graphics, swf.DataGridViewCellStyle cellStyle, int rowIndex, sd.Size constraintSize)
 			{
-				var size = base.GetPreferredSize (graphics, cellStyle, rowIndex, constraintSize);
-				size.Width += Handler.GetRowOffset (rowIndex);
+				var size = base.GetPreferredSize(graphics, cellStyle, rowIndex, constraintSize);
+				size.Width += Handler.GetRowOffset(rowIndex);
 				return size;
 			}
 
-			protected override void Paint (System.Drawing.Graphics graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, swf.DataGridViewElementStates cellState, object value, object formattedValue, string errorText, swf.DataGridViewCellStyle cellStyle, swf.DataGridViewAdvancedBorderStyle advancedBorderStyle, swf.DataGridViewPaintParts paintParts)
+			protected override void Paint(System.Drawing.Graphics graphics, System.Drawing.Rectangle clipBounds, System.Drawing.Rectangle cellBounds, int rowIndex, swf.DataGridViewElementStates cellState, object value, object formattedValue, string errorText, swf.DataGridViewCellStyle cellStyle, swf.DataGridViewAdvancedBorderStyle advancedBorderStyle, swf.DataGridViewPaintParts paintParts)
 			{
-				Handler.Paint (graphics, clipBounds, ref cellBounds, rowIndex, cellState, value, formattedValue, errorText, cellStyle, advancedBorderStyle, ref paintParts);
-				base.Paint (graphics, clipBounds, cellBounds, rowIndex, cellState, value, formattedValue, errorText, cellStyle, advancedBorderStyle, paintParts);
+				Handler.Paint(graphics, clipBounds, ref cellBounds, rowIndex, cellState, value, formattedValue, errorText, cellStyle, advancedBorderStyle, ref paintParts);
+				base.Paint(graphics, clipBounds, cellBounds, rowIndex, cellState, value, formattedValue, errorText, cellStyle, advancedBorderStyle, paintParts);
 			}
 
-			protected override void OnMouseClick (swf.DataGridViewCellMouseEventArgs e)
+			protected override void OnMouseClick(swf.DataGridViewCellMouseEventArgs e)
 			{
-				if (!Handler.MouseClick (e, e.RowIndex))
-					base.OnMouseClick (e);
+				if (!Handler.MouseClick(e, e.RowIndex))
+					base.OnMouseClick(e);
 			}
 
-			public override object Clone ()
+			public override object Clone()
 			{
 				var val = (EtoCell)base.Clone();
 				val.Handler = Handler;
@@ -45,23 +45,57 @@ namespace Eto.WinForms.Forms.Cells
 		}
 
 
-		public TextBoxCellHandler ()
+		public TextBoxCellHandler()
 		{
 			Control = new EtoCell { Handler = this };
 		}
 
-		public override void SetCellValue (object dataItem, object value)
+		public override void SetCellValue(object dataItem, object value)
 		{
-			if (Widget.Binding != null) {
-				Widget.Binding.SetValue (dataItem, Convert.ToString(value));
+			if (Widget.Binding != null)
+			{
+				Widget.Binding.SetValue(dataItem, Convert.ToString(value));
 			}
 		}
 
-		public override object GetCellValue (object dataItem)
+		public override object GetCellValue(object dataItem)
 		{
 			return Widget.Binding == null ? null : Widget.Binding.GetValue(dataItem);
 		}
 
+		TextAlignment _textAlignment;
+		public TextAlignment TextAlignment
+		{
+			get { return _textAlignment; }
+			set
+			{
+				_textAlignment = value;
+				SetAlignment();
+			}
+		}
+
+		VerticalAlignment _verticalAlignment = VerticalAlignment.Center;
+		public VerticalAlignment VerticalAlignment
+		{
+			get { return _verticalAlignment; }
+			set
+			{
+				_verticalAlignment = value;
+				SetAlignment();
+			}
+		}
+
+		void SetAlignment()
+		{
+			if (Column == null)
+				return;
+			Column.DefaultCellStyle.Alignment = WinConversions.ToSWF(TextAlignment, VerticalAlignment);
+		}
+
+		protected override void InitializeColumn()
+		{
+			base.InitializeColumn();
+			SetAlignment();
+		}
 	}
 }
-

--- a/Source/Eto.WinForms/Forms/Controls/GridColumnHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/GridColumnHandler.cs
@@ -2,6 +2,7 @@ using swf = System.Windows.Forms;
 using sd = System.Drawing;
 using Eto.Forms;
 using Eto.WinForms.Forms.Cells;
+using System;
 
 namespace Eto.WinForms.Forms.Controls
 {
@@ -73,6 +74,8 @@ namespace Eto.WinForms.Forms.Controls
 			get { return Control.Visible; }
 			set { Control.Visible = value; }
 		}
+
+		public swf.DataGridViewColumn Column => Control;
 
 		public void SetCellValue (object dataItem, object value)
 		{

--- a/Source/Eto.WinForms/WinConversions.cs
+++ b/Source/Eto.WinForms/WinConversions.cs
@@ -725,6 +725,94 @@ namespace Eto.WinForms
 			}
 		}
 
+		public static TextAlignment ToEtoTextAlignment(this swf.DataGridViewContentAlignment existing)
+		{
+			switch (existing)
+			{
+				default:
+				case swf.DataGridViewContentAlignment.NotSet:
+				case swf.DataGridViewContentAlignment.TopLeft:
+				case swf.DataGridViewContentAlignment.MiddleLeft:
+				case swf.DataGridViewContentAlignment.BottomLeft:
+					return TextAlignment.Left;
+				case swf.DataGridViewContentAlignment.TopCenter:
+				case swf.DataGridViewContentAlignment.MiddleCenter:
+				case swf.DataGridViewContentAlignment.BottomCenter:
+					return TextAlignment.Center;
+				case swf.DataGridViewContentAlignment.TopRight:
+				case swf.DataGridViewContentAlignment.MiddleRight:
+				case swf.DataGridViewContentAlignment.BottomRight:
+					return TextAlignment.Right;
+			}
+		}
+
+		public static VerticalAlignment ToEtoVerticalAlignment(this swf.DataGridViewContentAlignment existing)
+		{
+			switch (existing)
+			{
+				default:
+				case swf.DataGridViewContentAlignment.NotSet:
+				case swf.DataGridViewContentAlignment.TopLeft:
+				case swf.DataGridViewContentAlignment.MiddleLeft:
+				case swf.DataGridViewContentAlignment.BottomLeft:
+					return VerticalAlignment.Top;
+				case swf.DataGridViewContentAlignment.TopCenter:
+				case swf.DataGridViewContentAlignment.MiddleCenter:
+				case swf.DataGridViewContentAlignment.BottomCenter:
+					return VerticalAlignment.Center;
+				case swf.DataGridViewContentAlignment.TopRight:
+				case swf.DataGridViewContentAlignment.MiddleRight:
+				case swf.DataGridViewContentAlignment.BottomRight:
+					return VerticalAlignment.Bottom;
+			}
+		}
+
+		public static swf.DataGridViewContentAlignment ToSWF(TextAlignment textAlignment, VerticalAlignment verticalAlignment)
+		{
+			switch (verticalAlignment)
+			{
+				case VerticalAlignment.Stretch:
+				case VerticalAlignment.Top:
+					switch (textAlignment)
+					{
+						case TextAlignment.Left:
+							return swf.DataGridViewContentAlignment.TopLeft;
+						case TextAlignment.Center:
+							return swf.DataGridViewContentAlignment.TopCenter;
+						case TextAlignment.Right:
+							return swf.DataGridViewContentAlignment.TopRight;
+						default:
+							throw new ArgumentOutOfRangeException();
+					}
+				case VerticalAlignment.Center:
+					switch (textAlignment)
+					{
+						case TextAlignment.Left:
+							return swf.DataGridViewContentAlignment.MiddleLeft;
+						case TextAlignment.Center:
+							return swf.DataGridViewContentAlignment.MiddleCenter;
+						case TextAlignment.Right:
+							return swf.DataGridViewContentAlignment.MiddleRight;
+						default:
+							throw new ArgumentOutOfRangeException();
+					}
+				case VerticalAlignment.Bottom:
+					switch (textAlignment)
+					{
+						case TextAlignment.Left:
+							return swf.DataGridViewContentAlignment.BottomLeft;
+						case TextAlignment.Center:
+							return swf.DataGridViewContentAlignment.BottomCenter;
+						case TextAlignment.Right:
+							return swf.DataGridViewContentAlignment.BottomRight;
+						default:
+							throw new ArgumentOutOfRangeException();
+					}
+				default:
+					throw new ArgumentOutOfRangeException();
+			}
+		}
+
 		public static TextAlignment ToEto(this swf.HorizontalAlignment align)
 		{
 			switch (align)

--- a/Source/Eto.Wpf/Forms/Cells/CellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/CellHandler.cs
@@ -17,16 +17,24 @@ namespace Eto.Wpf.Forms.Cells
 		swc.DataGridColumn Control { get; }
 	}
 
+	static class CellProperties
+	{
+		public static sw.DependencyProperty ControlInitializedProperty = sw.DependencyProperty.Register("EtoControlInitialized", typeof(bool), typeof(sw.FrameworkElement), new sw.PropertyMetadata(false));
+		public static sw.DependencyProperty ControlEditInitializedProperty = sw.DependencyProperty.Register("EtoControlEditInitialized", typeof(bool), typeof(sw.FrameworkElement), new sw.PropertyMetadata(false));
+	}
+
 	public abstract class CellHandler<TControl, TWidget, TCallback> : WidgetHandler<TControl, TWidget, TCallback>, ICellHandler
 		where TControl : swc.DataGridColumn
 		where TWidget : Cell
 	{
 		public ICellContainerHandler ContainerHandler { get; set; }
 
-		swc.DataGridColumn ICellHandler.Control
-		{
-			get { return Control; }
-		}
+		public static bool IsControlInitialized(sw.DependencyObject obj) => (bool)obj.GetValue(CellProperties.ControlInitializedProperty);
+		public static void SetControlInitialized(sw.DependencyObject obj, bool value) => obj.SetValue(CellProperties.ControlInitializedProperty, value);
+		public static bool IsControlEditInitialized(sw.DependencyObject obj) => (bool)obj.GetValue(CellProperties.ControlEditInitializedProperty);
+		public static void SetControlEditInitialized(sw.DependencyObject obj, bool value) => obj.SetValue(CellProperties.ControlEditInitializedProperty, value);
+
+		swc.DataGridColumn ICellHandler.Control => Control;
 
 		public void FormatCell(sw.FrameworkElement element, swc.DataGridCell cell, object dataItem)
 		{

--- a/Source/Eto.Wpf/Forms/Cells/CheckBoxCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/CheckBoxCellHandler.cs
@@ -31,37 +31,56 @@ namespace Eto.Wpf.Forms.Cells
 
 			protected override sw.FrameworkElement GenerateElement(swc.DataGridCell cell, object dataItem)
 			{
-				var element = base.GenerateElement(cell, dataItem);
-				element.DataContextChanged += (sender, e) =>
-				{
-					var control = sender as swc.CheckBox;
-					control.IsChecked = Handler.GetValue(control.DataContext);
-					Handler.FormatCell(control, cell, control.DataContext);
-				};
+				var element = (swc.CheckBox)base.GenerateElement(cell, dataItem);
+				InitializeElement(element, cell, dataItem);
 				return Handler.SetupCell(element);
+			}
+
+			void InitializeElement(swc.CheckBox element, swc.DataGridCell cell, object dataItem)
+			{
+				if (!IsControlInitialized(element))
+				{
+					element.VerticalAlignment = sw.VerticalAlignment.Center;
+					element.DataContextChanged += (sender, e) =>
+					{
+						var control = sender as swc.CheckBox;
+						control.IsChecked = Handler.GetValue(control.DataContext);
+						Handler.FormatCell(control, cell, control.DataContext);
+					};
+					SetControlInitialized(element, true);
+				}
+				else
+				{
+					element.IsChecked = Handler.GetValue(dataItem);
+					Handler.FormatCell(element, cell, dataItem);
+				}
 			}
 
 			protected override sw.FrameworkElement GenerateEditingElement(swc.DataGridCell cell, object dataItem)
 			{
-				var element = base.GenerateEditingElement(cell, dataItem);
-				element.Name = "control";
-				element.DataContextChanged += (sender, e) =>
+				var element = (swc.CheckBox)base.GenerateEditingElement(cell, dataItem);
+				InitializeElement(element, cell, dataItem);
+				if (!IsControlEditInitialized(element))
 				{
-					var control = sender as swc.CheckBox;
-					control.IsChecked = Handler.GetValue(control.DataContext);
-					Handler.FormatCell(control, cell, control.DataContext);
-				};
+					element.Checked += (sender, e) =>
+					{
+						var control = (swc.CheckBox)sender;
+						Handler.SetValue(control.DataContext, control.IsChecked);
+					};
+					element.Unchecked += (sender, e) =>
+					{
+						var control = (swc.CheckBox)sender;
+						Handler.SetValue(control.DataContext, control.IsChecked);
+					};
+					SetControlEditInitialized(element, true);
+				}
 				return Handler.SetupCell(element);
 			}
-
 			protected override bool CommitCellEdit(sw.FrameworkElement editingElement)
 			{
-				var control = editingElement as swc.CheckBox ?? editingElement.FindChild<swc.CheckBox>("control");
-				Handler.SetValue(control.DataContext, control.IsChecked);
 				Handler.ContainerHandler.CellEdited(Handler, editingElement);
-				return true;
+				return base.CommitCellEdit(editingElement);
 			}
-
 		}
 
 		public CheckBoxCellHandler()

--- a/Source/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
@@ -72,64 +72,69 @@ namespace Eto.Wpf.Forms.Cells
 				return cachedList;
 			}
 
-			EtoBorder Create(swc.DataGridCell cell)
+			EtoBorder Create(swc.DataGridCell cell, object dataItem)
 			{
-				var control = new EtoBorder { Column = this };
-				control.Args = new WpfCellEventArgs(-1, null, CellStates.None);
-				control.DataContextChanged += (sender, e) =>
+				var control = cell.Content as EtoBorder;
+				if (control == null)
 				{
-					var ctl = sender as EtoBorder;
-					ctl.Args.SetSelected(cell.IsSelected);
-					ctl.Args.SetDataContext(ctl.DataContext);
-					var id = Handler.Callback.OnGetIdentifier(Handler.Widget, ctl.Args);
-					var child = ctl.Control;
-					if (id != ctl.Identifier || child == null)
+					control = new EtoBorder { Column = this };
+					control.Args = new WpfCellEventArgs(-1, null, CellStates.None);
+					control.DataContextChanged += (sender, e) =>
 					{
-						Stack<Control> cache;
-						if (child != null)
+						var ctl = sender as EtoBorder;
+						ctl.Args.SetSelected(cell.IsSelected);
+						ctl.Args.SetDataContext(ctl.DataContext);
+						var id = Handler.Callback.OnGetIdentifier(Handler.Widget, ctl.Args);
+						var child = ctl.Control;
+						if (id != ctl.Identifier || child == null)
 						{
+							Stack<Control> cache;
+							if (child != null)
+							{
 							// store old child into cache
 							cache = GetCached(ctl.Identifier);
-							cache.Push(child);
-						}
+								cache.Push(child);
+							}
 						// get new from cache or create if none created yet
 						cache = GetCached(id);
-						if (cache.Count > 0)
-							child = cache.Pop();
-						else
-							child = Handler.Callback.OnCreateCell(Handler.Widget, ctl.Args);
-						ctl.Control = child;
-						var handler = child.GetWpfFrameworkElement();
-						if (handler != null)
-							handler.SetScale(true, true);
-						ctl.Child = child.ToNative(true);
-					}
-					Handler.Callback.OnConfigureCell(Handler.Widget, ctl.Args, child);
+							if (cache.Count > 0)
+								child = cache.Pop();
+							else
+								child = Handler.Callback.OnCreateCell(Handler.Widget, ctl.Args);
+							ctl.Control = child;
+							var handler = child.GetWpfFrameworkElement();
+							if (handler != null)
+								handler.SetScale(true, true);
+							ctl.Child = child.ToNative(true);
+						}
+						Handler.Callback.OnConfigureCell(Handler.Widget, ctl.Args, child);
 
-					Handler.FormatCell(ctl, cell, ctl.DataContext);
-					ctl.InvalidateVisual();
-				};
-				cell.Selected += (sender, e) =>
-				{
-					control.Args.SetSelected(cell.IsSelected);
-					Handler.Callback.OnConfigureCell(Handler.Widget, control.Args, control.Control);
-				};
-				cell.Unselected += (sender, e) =>
-				{
-					control.Args.SetSelected(cell.IsSelected);
-					Handler.Callback.OnConfigureCell(Handler.Widget, control.Args, control.Control);
-				};
+						Handler.FormatCell(ctl, cell, ctl.DataContext);
+						ctl.InvalidateVisual();
+					};
+					cell.Selected += (sender, e) =>
+					{
+						control.Args.SetSelected(cell.IsSelected);
+						Handler.Callback.OnConfigureCell(Handler.Widget, control.Args, control.Control);
+					};
+					cell.Unselected += (sender, e) =>
+					{
+						control.Args.SetSelected(cell.IsSelected);
+						Handler.Callback.OnConfigureCell(Handler.Widget, control.Args, control.Control);
+					};
+				}
+				control.DataContext = dataItem;
 				return control;
 			}
 
 			protected override sw.FrameworkElement GenerateElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell));
+				return Handler.SetupCell(Create(cell, dataItem));
 			}
 
 			protected override sw.FrameworkElement GenerateEditingElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell));
+				return Handler.SetupCell(Create(cell, dataItem));
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/Cells/DrawableCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/DrawableCellHandler.cs
@@ -39,37 +39,42 @@ namespace Eto.Wpf.Forms.Cells
 		{
 			public DrawableCellHandler Handler { get; set; }
 
-			EtoCanvas Create(swc.DataGridCell cell)
+			EtoCanvas Create(swc.DataGridCell cell, object dataItem)
 			{
-				var control = new EtoCanvas { Column = this };
-				control.DataContextChanged += (sender, e) =>
+				var control = cell.Content as EtoCanvas;
+				if (control == null)
 				{
-					var ctl = sender as EtoCanvas;
-					ctl.IsSelected = cell.IsSelected;
-					Handler.FormatCell(ctl, cell, ctl.DataContext);
-					ctl.InvalidateVisual();
-				};
-				cell.Selected += (sender, e) =>
-				{
-					control.IsSelected = cell.IsSelected;
-					control.InvalidateVisual();
-				};
-				cell.Unselected += (sender, e) =>
-				{
-					control.IsSelected = cell.IsSelected;
-					control.InvalidateVisual();
-				};
+					control = new EtoCanvas { Column = this };
+					control.DataContextChanged += (sender, e) =>
+					{
+						var ctl = sender as EtoCanvas;
+						ctl.IsSelected = cell.IsSelected;
+						Handler.FormatCell(ctl, cell, ctl.DataContext);
+						ctl.InvalidateVisual();
+					};
+					cell.Selected += (sender, e) =>
+					{
+						control.IsSelected = cell.IsSelected;
+						control.InvalidateVisual();
+					};
+					cell.Unselected += (sender, e) =>
+					{
+						control.IsSelected = cell.IsSelected;
+						control.InvalidateVisual();
+					};
+				}
+				control.DataContext = dataItem;
 				return control;
 			}
 
 			protected override sw.FrameworkElement GenerateElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell));
+				return Handler.SetupCell(Create(cell, dataItem));
 			}
 
 			protected override sw.FrameworkElement GenerateEditingElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell));
+				return Handler.SetupCell(Create(cell, dataItem));
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
@@ -6,11 +6,24 @@ using swd = System.Windows.Data;
 using swm = System.Windows.Media;
 using Eto.Wpf.Drawing;
 using Eto.Drawing;
+using System.ComponentModel;
 
 namespace Eto.Wpf.Forms.Cells
 {
 	public class ImageTextCellHandler : CellHandler<ImageTextCellHandler.Column, ImageTextCell, ImageTextCell.ICallback>, ImageTextCell.IHandler
 	{
+		public TextAlignment TextAlignment
+		{
+			get { return Control.TextAlignment.ToEto(); }
+			set { Control.TextAlignment = value.ToWpfTextAlignment(); }
+		}
+
+		public VerticalAlignment VerticalAlignment
+		{
+			get { return Control.VerticalAlignment.ToEto(); }
+			set { Control.VerticalAlignment = value.ToWpf(); }
+		}
+
 		object GetImageValue(object dataItem)
 		{
 			if (Widget.ImageBinding != null)
@@ -35,11 +48,36 @@ namespace Eto.Wpf.Forms.Cells
 			}
 		}
 
-		public class Column : swc.DataGridTextColumn
+		public class Column : swc.DataGridTextColumn, INotifyPropertyChanged
 		{
 			public ImageTextCellHandler Handler { get; set; }
 
+			sw.TextAlignment _textAlignment;
+			public sw.TextAlignment TextAlignment
+			{
+				get { return _textAlignment; }
+				set
+				{
+					_textAlignment = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TextAlignment)));
+				}
+			}
+
+			sw.VerticalAlignment _verticalAlignment = sw.VerticalAlignment.Center;
+			public sw.VerticalAlignment VerticalAlignment
+			{
+				get { return _verticalAlignment; }
+				set
+				{
+					_verticalAlignment = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(VerticalAlignment)));
+				}
+			}
+
 			swm.BitmapScalingMode scalingMode;
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
 			public swm.BitmapScalingMode ScalingMode
 			{
 				get { return scalingMode; }
@@ -61,7 +99,7 @@ namespace Eto.Wpf.Forms.Cells
 
 			swc.Image CreateImage()
 			{
-				var image = new swc.Image { MaxWidth = 16, MaxHeight = 16, StretchDirection = swc.StretchDirection.DownOnly, Margin = new sw.Thickness(0, 2, 2, 2) };
+				var image = new swc.Image { StretchDirection = swc.StretchDirection.DownOnly, Margin = new sw.Thickness(0, 2, 2, 2) };
 				swm.RenderOptions.SetBitmapScalingMode(image, ScalingMode);
 				image.DataContextChanged += (sender, e) =>
 				{
@@ -73,18 +111,33 @@ namespace Eto.Wpf.Forms.Cells
 
 			sw.FrameworkElement SetupCell(sw.FrameworkElement element)
 			{
-				var container = new swc.StackPanel { Orientation = swc.Orientation.Horizontal };
+				element.HorizontalAlignment = sw.HorizontalAlignment.Stretch;
+				var container = new swc.DockPanel();
 				container.Children.Add(CreateImage());
 				container.Children.Add(element);
 				return Handler.SetupCell(container);
 			}
 
+			swd.Binding CreateBinding(string property)
+			{
+				var binding = new swd.Binding();
+				binding.Source = this;
+				binding.Path = new sw.PropertyPath(property);
+				binding.Mode = swd.BindingMode.OneWay;
+				binding.UpdateSourceTrigger = swd.UpdateSourceTrigger.PropertyChanged;
+				return binding;
+			}
+
 			protected override sw.FrameworkElement GenerateElement(swc.DataGridCell cell, object dataItem)
 			{
-				var element = base.GenerateElement(cell, dataItem);
+				var element = (swc.TextBlock)base.GenerateElement(cell, dataItem);
+				element.SetBinding(swc.TextBlock.TextAlignmentProperty, CreateBinding(nameof(TextAlignment)));
+				element.SetBinding(swc.TextBlock.VerticalAlignmentProperty, CreateBinding(nameof(VerticalAlignment)));
+				element.Text = Handler.GetTextValue(dataItem);
+				Handler.FormatCell(element, cell, dataItem);
 				element.DataContextChanged += (sender, e) =>
 				{
-					var control = sender as swc.TextBlock;
+					var control = (swc.TextBlock)sender;
 					control.Text = Handler.GetTextValue(control.DataContext);
 					Handler.FormatCell(control, cell, control.DataContext);
 				};
@@ -100,7 +153,11 @@ namespace Eto.Wpf.Forms.Cells
 			protected override sw.FrameworkElement GenerateEditingElement(swc.DataGridCell cell, object dataItem)
 			{
 				var element = (swc.TextBox)base.GenerateEditingElement(cell, dataItem);
+				element.SetBinding(swc.TextBlock.TextAlignmentProperty, CreateBinding(nameof(TextAlignment)));
+				element.SetBinding(swc.TextBlock.VerticalAlignmentProperty, CreateBinding(nameof(VerticalAlignment)));
 				element.Name = "control";
+				element.Text = Handler.GetTextValue(dataItem);
+				Handler.FormatCell(element, cell, dataItem);
 				element.DataContextChanged += (sender, e) =>
 				{
 					var control = sender as swc.TextBox;

--- a/Source/Eto.Wpf/Forms/Cells/ImageViewCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/ImageViewCellHandler.cs
@@ -46,7 +46,7 @@ namespace Eto.Wpf.Forms.Cells
 
 			swc.Image Image (swc.DataGridCell cell)
 			{
-				var image = new swc.Image { MaxWidth = 16, MaxHeight = 16, StretchDirection = swc.StretchDirection.DownOnly, Margin = new sw.Thickness (0, 2, 2, 2) };
+				var image = new swc.Image { StretchDirection = swc.StretchDirection.DownOnly, Margin = new sw.Thickness (0, 2, 2, 2) };
 				swm.RenderOptions.SetBitmapScalingMode(image, ScalingMode);
 				image.DataContextChanged += (sender, e) =>
 				{

--- a/Source/Eto.Wpf/Forms/Cells/TextBoxCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/TextBoxCellHandler.cs
@@ -4,11 +4,24 @@ using swc = System.Windows.Controls;
 using swd = System.Windows.Data;
 using sw = System.Windows;
 using swm = System.Windows.Media;
+using System.ComponentModel;
 
 namespace Eto.Wpf.Forms.Cells
 {
-	public class TextBoxCellHandler : CellHandler<swc.DataGridTextColumn, TextBoxCell, TextBoxCell.ICallback>, TextBoxCell.IHandler
+	public class TextBoxCellHandler : CellHandler<TextBoxCellHandler.Column, TextBoxCell, TextBoxCell.ICallback>, TextBoxCell.IHandler
 	{
+		public TextAlignment TextAlignment
+		{
+			get { return Control.TextAlignment.ToEto(); }
+			set { Control.TextAlignment = value.ToWpfTextAlignment(); }
+		}
+
+		public VerticalAlignment VerticalAlignment
+		{
+			get { return Control.VerticalAlignment.ToEto(); }
+			set { Control.VerticalAlignment = value.ToWpf(); }
+		}
+
 		string GetValue(object dataItem)
 		{
 			if (Widget.Binding != null)
@@ -26,16 +39,55 @@ namespace Eto.Wpf.Forms.Cells
 			}
 		}
 
-		class Column : swc.DataGridTextColumn
+		public class Column : swc.DataGridTextColumn, INotifyPropertyChanged
 		{
 			public TextBoxCellHandler Handler { get; set; }
 
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			sw.TextAlignment _textAlignment;
+			public sw.TextAlignment TextAlignment
+			{
+				get { return _textAlignment; }
+				set
+				{
+					_textAlignment = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(TextAlignment)));
+				}
+			}
+
+			sw.VerticalAlignment _verticalAlignment = sw.VerticalAlignment.Center;
+			public sw.VerticalAlignment VerticalAlignment
+			{
+				get { return _verticalAlignment; }
+				set
+				{
+					_verticalAlignment = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(VerticalAlignment)));
+				}
+			}
+
+			swd.Binding CreateBinding(string property)
+			{
+				var binding = new swd.Binding();
+				binding.Source = this;
+				binding.Path = new sw.PropertyPath(property);
+				binding.Mode = swd.BindingMode.OneWay;
+				binding.UpdateSourceTrigger = swd.UpdateSourceTrigger.PropertyChanged;
+				return binding;
+			}
+
 			protected override sw.FrameworkElement GenerateElement(swc.DataGridCell cell, object dataItem)
 			{
-				var element = base.GenerateElement(cell, dataItem);
+				var element = (swc.TextBlock)base.GenerateElement(cell, dataItem);
+				element.SetBinding(swc.TextBlock.TextAlignmentProperty, CreateBinding(nameof(TextAlignment)));
+				element.SetBinding(swc.TextBlock.VerticalAlignmentProperty, CreateBinding(nameof(VerticalAlignment)));
+				element.Text = Handler.GetValue(dataItem);
+				Handler.FormatCell(element, cell, dataItem);
+
 				element.DataContextChanged += (sender, e) =>
 				{
-					var control = sender as swc.TextBlock;
+					var control = (swc.TextBlock)sender;
 					control.Text = Handler.GetValue(control.DataContext);
 					Handler.FormatCell(control, cell, control.DataContext);
 				};
@@ -46,6 +98,11 @@ namespace Eto.Wpf.Forms.Cells
 			{
 				var element = (swc.TextBox)base.GenerateEditingElement(cell, dataItem);
 				element.Name = "control";
+				element.SetBinding(swc.TextBlock.TextAlignmentProperty, CreateBinding(nameof(TextAlignment)));
+				element.SetBinding(swc.TextBlock.VerticalAlignmentProperty, CreateBinding(nameof(VerticalAlignment)));
+				element.Text = Handler.GetValue(dataItem);
+				Handler.FormatCell(element, cell, dataItem);
+
 				element.DataContextChanged += (sender, e) =>
 				{
 					var control = sender as swc.TextBox;

--- a/Source/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -338,9 +338,7 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				get
 				{
-					if (font == null)
-						font = new Font(new FontHandler(Cell));
-					return font;
+					return font ?? (font = Cell.GetEtoFont());
 				}
 				set
 				{
@@ -353,12 +351,11 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				get
 				{
-					var brush = Cell.Background as swm.SolidColorBrush;
-					return brush != null ? brush.Color.ToEto() : Colors.White;
+					return Cell.Background.ToEtoColor();
 				}
 				set
 				{
-					Cell.Background = new swm.SolidColorBrush(value.ToWpf());
+					Cell.Background = value.ToWpfBrush(Cell.Background);
 				}
 			}
 
@@ -366,12 +363,11 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				get
 				{
-					var brush = Cell.Foreground as swm.SolidColorBrush;
-					return brush != null ? brush.Color.ToEto() : Colors.Black;
+					return Cell.Foreground.ToEtoColor();
 				}
 				set
 				{
-					Cell.Foreground = new swm.SolidColorBrush(value.ToWpf());
+					Cell.Foreground = value.ToWpfBrush(Cell.Foreground);
 				}
 			}
 		}

--- a/Source/Eto.Wpf/WpfConversions.cs
+++ b/Source/Eto.Wpf/WpfConversions.cs
@@ -654,6 +654,11 @@ namespace Eto.Wpf
 			}
 		}
 
+		public static Font GetEtoFont(this swc.Control control)
+		{
+			return new Font(new FontHandler(control));
+		}
+
 		public static Font SetEtoFont(this swc.Control control, Font font, Action<sw.TextDecorationCollection> setDecorations = null)
 		{
 			if (control == null) return font;

--- a/Source/Eto.iOS/Forms/Cells/ImageTextCellHandler.cs
+++ b/Source/Eto.iOS/Forms/Cells/ImageTextCellHandler.cs
@@ -10,6 +10,7 @@ namespace Eto.iOS.Forms.Cells
 	{
 		public override void Configure(object dataItem, NSCell cell)
 		{
+			cell.TextLabel.TextAlignment = TextAlignment.ToUI();
 			if (Widget.TextBinding != null)
 			{
 				var val = Widget.TextBinding.GetValue(dataItem);
@@ -29,5 +30,9 @@ namespace Eto.iOS.Forms.Cells
 
 		// TODO
 		public ImageInterpolation ImageInterpolation { get; set; }
+
+		public TextAlignment TextAlignment { get; set; }
+
+		public VerticalAlignment VerticalAlignment { get; set; }
 	}
 }

--- a/Source/Eto.iOS/Forms/Cells/TextBoxCellHandler.cs
+++ b/Source/Eto.iOS/Forms/Cells/TextBoxCellHandler.cs
@@ -11,8 +11,13 @@ namespace Eto.iOS.Forms.Cells
 		{
 		}
 
+		public TextAlignment TextAlignment { get; set; }
+
+		public VerticalAlignment VerticalAlignment { get; set; }
+
 		public override void Configure (object dataItem, NSCell cell)
 		{
+			cell.TextLabel.TextAlignment = TextAlignment.ToUI();
 			if (Widget.Binding != null) {
 				var val = Widget.Binding.GetValue (dataItem);
 				cell.TextLabel.Text = Convert.ToString (val);

--- a/Source/Eto/Drawing/Bitmap.cs
+++ b/Source/Eto/Drawing/Bitmap.cs
@@ -390,6 +390,39 @@ namespace Eto.Drawing
 			}
 		}
 
+		/// <summary>
+		/// Gets an Icon representation of this Bitmap scaled to draw within the specified fitting size.
+		/// </summary>
+		/// <remarks>
+		/// This is useful when you want to draw the image at a different size than the default size without resizing the image.
+		/// Note that the <paramref name="width"/> and <paramref name="height"/> specifies the maxiumum drawing size of the Icon, but will not
+		/// change the aspect of each frame's bitmap.  For example, if an existing frame is 128x128, and you specify 16x32,
+		/// then the resulting frame will draw at 16x16.
+		/// </remarks>
+		/// <returns>A new icon that will draw within the fitting size.</returns>
+		/// <param name="width">Maxiumum drawing width for the new icon.</param>
+		/// <param name="height">Maxiumum drawing height for the new icon.</param>
+		public Icon WithSize(int width, int height)
+		{
+			return new Icon(1, this).WithSize(width, height);
+		}
+
+		/// <summary>
+		/// Gets an Icon representation of this Bitmap scaled to draw within the specified fitting size.
+		/// </summary>
+		/// <remarks>
+		/// This is useful when you want to draw the image at a different size than the default size without resizing the image.
+		/// Note that the <paramref name="fittingSize"/> specifies the maxiumum drawing size of the Icon, but will not
+		/// change the aspect of each frame's bitmap.  For example, if an existing frame is 128x128, and you specify 16x32,
+		/// then the resulting frame will draw at 16x16.
+		/// </remarks>
+		/// <returns>A new icon that will draw within the fitting size.</returns>
+		/// <param name="fittingSize">The maximum size to draw the Icon.</param>
+		public Icon WithSize(Size fittingSize)
+		{
+			return new Icon(1, this).WithSize(fittingSize);
+		}
+
 		#region Handler
 
 		/// <summary>

--- a/Source/Eto/Forms/Cells/ImageTextCell.cs
+++ b/Source/Eto/Forms/Cells/ImageTextCell.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using Eto.Drawing;
 
 
@@ -10,7 +11,28 @@ namespace Eto.Forms
 	[Handler(typeof(ImageTextCell.IHandler))]
 	public class ImageTextCell : Cell
 	{
-		new IHandler Handler { get { return (IHandler)base.Handler; } }
+		new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Gets or sets the horizontal alignment of the text within the cell.
+		/// </summary>
+		/// <value>The text alignment.</value>
+		public TextAlignment TextAlignment
+		{
+			get { return Handler.TextAlignment; }
+			set { Handler.TextAlignment = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the vertical alignment of the text within the cell.
+		/// </summary>
+		/// <value>The vertical text alignment.</value>
+		[DefaultValue(VerticalAlignment.Center)]
+		public VerticalAlignment VerticalAlignment
+		{
+			get { return Handler.VerticalAlignment; }
+			set { Handler.VerticalAlignment = value; }
+		}
 
 		/// <summary>
 		/// Gets or sets the binding of the image to display for the cell.
@@ -73,6 +95,18 @@ namespace Eto.Forms
 			/// </summary>
 			/// <value>The image interpolation.</value>
 			ImageInterpolation ImageInterpolation { get; set; }
+
+			/// <summary>
+			/// Gets or sets the horizontal alignment of the text within the cell.
+			/// </summary>
+			/// <value>The text alignment.</value>
+			TextAlignment TextAlignment { get; set; }
+
+			/// <summary>
+			/// Gets or sets the vertical alignment of the text within the cell.
+			/// </summary>
+			/// <value>The vertical text alignment.</value>
+			VerticalAlignment VerticalAlignment { get; set; }
 		}
 	}
 }

--- a/Source/Eto/Forms/Cells/TextBoxCell.cs
+++ b/Source/Eto/Forms/Cells/TextBoxCell.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.ComponentModel;
 
 namespace Eto.Forms
 {
@@ -9,6 +9,29 @@ namespace Eto.Forms
 	[Handler(typeof(IHandler))]
 	public class TextBoxCell : SingleValueCell<string>
 	{
+		new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Gets or sets the horizontal alignment of the text within the cell.
+		/// </summary>
+		/// <value>The text alignment.</value>
+		public TextAlignment TextAlignment
+		{
+			get { return Handler.TextAlignment; }
+			set { Handler.TextAlignment = value; }
+		}
+
+		/// <summary>
+		/// Gets or sets the vertical alignment of the text within the cell.
+		/// </summary>
+		/// <value>The vertical text alignment.</value>
+		[DefaultValue(VerticalAlignment.Center)]
+		public VerticalAlignment VerticalAlignment
+		{
+			get { return Handler.VerticalAlignment; }
+			set { Handler.VerticalAlignment = value; }
+		}
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Eto.Forms.TextBoxCell"/> class binding to the specified <paramref name="column"/>.
 		/// </summary>
@@ -39,6 +62,17 @@ namespace Eto.Forms
 		/// </summary>
 		public new interface IHandler : SingleValueCell<string>.IHandler
 		{
+			/// <summary>
+			/// Gets or sets the horizontal alignment of the text within the cell.
+			/// </summary>
+			/// <value>The text alignment.</value>
+			TextAlignment TextAlignment { get; set; }
+
+			/// <summary>
+			/// Gets or sets the vertical alignment of the text within the cell.
+			/// </summary>
+			/// <value>The vertical text alignment.</value>
+			VerticalAlignment VerticalAlignment { get; set; }
 		}
 	}
 }


### PR DESCRIPTION
- Default vertical alignment of text in GridView/TreeGridView is now centered.
- Add tests for setting alignment on a Label after control is created, and fix minor bugs on all platforms.
- Mac: Fixes resizing a Label when it has a background color.
- Wpf: Fix CheckBoxCell firing events more than once.
- Wpf: CheckBoxCell now allows checking immeditately.
- Add Bitmap.WithSize() to get an Icon that will draw the bitmap with the specified size without scaling.
- Remove message box when closing Eto.Test, Xamarin Studio no longer terminates the app when restarting so it is truly annoying.