### PR TITLE
Wpf: Change screen/mouse position to logical coordinates.

### DIFF
--- a/Source/Eto.WinForms/Win32.cs
+++ b/Source/Eto.WinForms/Win32.cs
@@ -15,8 +15,10 @@ namespace Eto
 			public int top;
 			public int right;
 			public int bottom;
+			public int width => right - left;
+			public int height => bottom - top;
 		}
-        
+
 		[Flags]
 		public enum SWP : uint
 		{
@@ -149,7 +151,8 @@ namespace Eto
 			ECM_FIRST = 0x1500,
 			EM_SETCUEBANNER = ECM_FIRST + 1,
 
-			DPICHANGED = 0x02E0
+			DPICHANGED = 0x02E0,
+			NCCREATE = 0x0081
 		}
 
 		public static ushort LOWORD(IntPtr word)

--- a/Source/Eto.WinForms/Win32.dpi.cs
+++ b/Source/Eto.WinForms/Win32.dpi.cs
@@ -5,6 +5,13 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
+using swf = System.Windows.Forms;
+using sd = System.Drawing;
+#if WPF
+using Eto.Wpf.Forms;
+#elif WINFORMS
+using Eto.WinForms.Forms;
+#endif
 
 namespace Eto
 {
@@ -60,6 +67,128 @@ namespace Eto
 			return dpiX;
 		}
 
+		static swf.Screen FindLeftScreen(this swf.Screen screen) =>
+			swf.Screen.AllScreens
+			.Where(r => r.Bounds.X >= 0 && r.Bounds.Right == screen.Bounds.X)
+			.OrderBy(r => r.GetDpi())
+			.FirstOrDefault();
+
+		static swf.Screen FindRightScreen(this swf.Screen screen) => 
+			swf.Screen.AllScreens
+			.Where(r => r.Bounds.X < 0 && r.Bounds.X == screen.Bounds.Right)
+			.OrderBy(r => r.GetDpi())
+			.FirstOrDefault();
+
+		static swf.Screen FindTopScreen(this swf.Screen screen) =>
+			swf.Screen.AllScreens
+			.Where(r => r.Bounds.Y >= 0 && r.Bounds.Bottom == screen.Bounds.Y)
+			.OrderBy(r => r.GetDpi())
+			.FirstOrDefault();
+
+		static swf.Screen FindBottomScreen(this swf.Screen screen) =>
+			swf.Screen.AllScreens
+			.Where(r => r.Bounds.Y < 0 && r.Bounds.Y == screen.Bounds.Bottom)
+			.OrderBy(r => r.GetDpi())
+			.FirstOrDefault();
+
+		public static Eto.Drawing.Point LogicalToScreen(this Eto.Drawing.PointF point)
+		{
+			var screen = Eto.Forms.Screen.FromPoint(point);
+			var sdscreen = ScreenHandler.GetControl(screen);
+			var pixelSize = sdscreen.GetLogicalPixelSize();
+			var location = sdscreen.Bounds.Location;
+			var screenBounds = screen.Bounds;
+
+			var x = location.X + (point.X - screenBounds.X) * pixelSize;
+			var y = location.Y + (point.Y - screenBounds.Y) * pixelSize;
+
+			return Drawing.Point.Round(new Drawing.PointF(x, y));
+		}
+
+		public static Eto.Drawing.PointF ScreenToLogical(this Eto.Drawing.Point point, swf.Screen sdscreen = null)
+		{
+			return ScreenToLogical(point.ToSD(), sdscreen);
+		}
+
+		public static Eto.Drawing.PointF ScreenToLogical(this sd.Point point, swf.Screen sdscreen = null)
+		{
+			sdscreen = sdscreen ?? swf.Screen.FromPoint(point);
+			var location = sdscreen.GetLogicalLocation();
+			var pixelSize = sdscreen.GetLogicalPixelSize();
+
+			var x = location.X + (point.X - sdscreen.Bounds.X) / pixelSize;
+			var y = location.Y + (point.Y - sdscreen.Bounds.Y) / pixelSize;
+
+			return new Drawing.PointF(x, y);
+		}
+
+		public static Eto.Drawing.RectangleF ScreenToLogical(this Eto.Drawing.Rectangle rect) => ScreenToLogical(rect.ToSD());
+
+		public static Eto.Drawing.RectangleF ScreenToLogical(this sd.Rectangle rect)
+		{
+			var screen = swf.Screen.FromPoint(new sd.Point(rect.X + rect.Width / 2, rect.Y + rect.Height / 2));
+			var location = screen.GetLogicalLocation();
+			var pixelSize = screen.GetLogicalPixelSize();
+			return new Eto.Drawing.RectangleF(
+				location.X + (rect.X - screen.Bounds.X) / pixelSize,
+				location.Y + (rect.Y - screen.Bounds.Y) / pixelSize,
+				rect.Width / pixelSize,
+				rect.Height / pixelSize
+				);
+		}
+
+		public static float GetMaxLogicalPixelSize() => swf.Screen.AllScreens.Max(r => r.GetLogicalPixelSize());
+
+		public static Eto.Drawing.RectangleF GetLogicalBounds(this swf.Screen screen)
+		{
+			return new Eto.Drawing.RectangleF(GetLogicalLocation(screen), GetLogicalSize(screen));
+		}
+
+		public static Eto.Drawing.PointF GetLogicalLocation(this swf.Screen screen)
+		{
+			var bounds = screen.Bounds;
+			float x, y;
+			if (bounds.X > 0)
+			{
+				var left = screen.FindLeftScreen();
+				if (left != null)
+					x = GetLogicalLocation(left).X + GetLogicalSize(left).Width;
+				else
+					x = bounds.X / GetMaxLogicalPixelSize();
+			}
+			else if (bounds.X < 0)
+			{
+				var right = screen.FindRightScreen();
+				if (right != null)
+					x = GetLogicalLocation(right).X - GetLogicalSize(screen).Width;
+				else
+					x = bounds.X / screen.GetLogicalPixelSize();
+			}
+			else x = bounds.X;
+			if (bounds.Y > 0)
+			{
+				var top = screen.FindTopScreen();
+				if (top != null)
+					y = GetLogicalLocation(top).Y + GetLogicalSize(top).Height;
+				else
+					y = bounds.Y / GetMaxLogicalPixelSize();
+			}
+			else if (bounds.Y < 0)
+			{
+				var bottom = screen.FindBottomScreen();
+				if (bottom != null)
+					y = GetLogicalLocation(bottom).Y - GetLogicalSize(screen).Height;
+				else
+					y = bounds.Y / screen.GetLogicalPixelSize();
+			}
+			else y = bounds.Y;
+			return new Eto.Drawing.PointF(x, y);
+		}
+
+		public static Eto.Drawing.SizeF GetLogicalSize(this swf.Screen screen) => (Eto.Drawing.SizeF)screen.Bounds.Size.ToEto() / screen.GetLogicalPixelSize();
+
+		public static float GetLogicalPixelSize(this swf.Screen screen) => GetDpi(screen) / 96f;
+
 		public static uint GetDpi(this System.Windows.Forms.Screen screen)
 		{
 			if (!MonitorDpiSupported)
@@ -82,7 +211,6 @@ namespace Eto
 		[DllImport("User32.dll")]
 		public static extern IntPtr MonitorFromPoint(System.Drawing.Point pt, MONITOR dwFlags);
 
-
 		[DllImport("user32.dll")]
 		public static extern IntPtr MonitorFromWindow(IntPtr hwnd, MONITOR flags);
 
@@ -94,5 +222,8 @@ namespace Eto
 
 		[DllImport("shcore.dll")]
 		public static extern uint GetProcessDpiAwareness(IntPtr handle, out PROCESS_DPI_AWARENESS awareness);
+
+		[DllImport("User32.dll")]
+		public static extern bool EnableNonClientDpiScaling(IntPtr hwnd);
 	}
 }

--- a/Source/Eto.Wpf/Forms/MouseHandler.cs
+++ b/Source/Eto.Wpf/Forms/MouseHandler.cs
@@ -17,8 +17,8 @@ namespace Eto.Wpf.Forms
 
 		public PointF Position
 		{
-			get { return swf.Control.MousePosition.ToEto(); }
-			set { swf.Cursor.Position = Point.Round(value).ToSD(); }
+			get { return swf.Control.MousePosition.ScreenToLogical(); }
+			set { swf.Cursor.Position = Point.Round(value.LogicalToScreen()).ToSD(); }
 		}
 
 		public MouseButtons Buttons

--- a/Source/Eto.Wpf/Forms/PerMonitorDpiHelper.cs
+++ b/Source/Eto.Wpf/Forms/PerMonitorDpiHelper.cs
@@ -131,7 +131,7 @@ namespace Eto.Wpf.Forms
 			}
 			HwndSource.AddHook(HwndHook);
 			hwnd = new WindowInteropHelper(window).Handle;
-			if (hwnd != IntPtr.Zero)
+			if (!BuiltInPerMonitorSupported && hwnd != IntPtr.Zero)
 				SetScale(Win32.GetWindowDpi(hwnd));
 		}
 
@@ -143,7 +143,12 @@ namespace Eto.Wpf.Forms
 
 		IntPtr HwndHook(IntPtr hwnd, int message, IntPtr wparam, IntPtr lparam, ref bool handled)
 		{
-			if (message == (int)Win32.WM.DPICHANGED)
+			/* Doesn't work
+			if (message == (int)Win32.WM.NCCREATE)
+			{
+				Win32.EnableNonClientDpiScaling(hwnd);
+			}*/
+			if (!BuiltInPerMonitorSupported && message == (int)Win32.WM.DPICHANGED)
 			{
 				var rect = (Win32.RECT)Marshal.PtrToStructure(lparam, typeof(Win32.RECT));
 				SetScale(Win32.HIWORD(wparam));

--- a/Source/Eto.Wpf/Forms/ScreenHandler.cs
+++ b/Source/Eto.Wpf/Forms/ScreenHandler.cs
@@ -5,6 +5,7 @@ using sd = System.Drawing;
 using swm = System.Windows.Media;
 using swf = System.Windows.Forms;
 using Eto.Drawing;
+using System.Linq;
 
 namespace Eto.Wpf.Forms
 {
@@ -13,9 +14,9 @@ namespace Eto.Wpf.Forms
 		float? realScale;
 		sw.Window window;
 
-		public ScreenHandler(sw.Window window)
+		public ScreenHandler(sw.Window window, swf.Screen screen)
 		{
-			Control = GetCurrentScreen(window);
+			Control = screen;
 			this.window = window;
 		}
 
@@ -46,45 +47,16 @@ namespace Eto.Wpf.Forms
 			return realScale ?? 1f;
 		}
 
-		static swf.Screen GetCurrentScreen(sw.Window window)
-		{
-			var centerPoint = new sd.Point((int)(window.Left + window.ActualWidth / 2), (int)(window.Top + window.ActualHeight / 2));
-			foreach (var s in swf.Screen.AllScreens)
-			{
-				if (s.Bounds.Contains(centerPoint))
-					return s;
-			}
-			return swf.Screen.PrimaryScreen;
-		}
+		public float RealScale => GetRealScale() * Scale;
 
-		public float RealScale
-		{
-			get { return GetRealScale() * Scale; }
-		}
+		public float Scale => 96f / 72f;
 
-		public float Scale
-		{
-			get { return 96f / 72f; }
-		}
+		public RectangleF Bounds => Control.Bounds.ScreenToLogical();
 
-		public RectangleF Bounds
-		{
-			get { return (RectangleF)Control.Bounds.ToEto() / GetRealScale(); }
-		}
+		public RectangleF WorkingArea => Control.WorkingArea.ScreenToLogical();
 
-		public RectangleF WorkingArea
-		{
-			get { return (RectangleF)Control.WorkingArea.ToEto() / GetRealScale(); }
-		}
+		public int BitsPerPixel => Control.BitsPerPixel;
 
-		public int BitsPerPixel
-		{
-			get { return Control.BitsPerPixel; }
-		}
-
-		public bool IsPrimary
-		{
-			get { return Control.Primary; }
-		}
+		public bool IsPrimary => Control.Primary;
 	}
 }

--- a/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -607,12 +607,18 @@ namespace Eto.Wpf.Forms
 
 		public PointF PointFromScreen(PointF point)
 		{
-			return Control.IsLoaded ? Control.PointFromScreen(point.ToWpf()).ToEto() : point;
+			if (!Control.IsLoaded)
+				return point;
+
+			point = point.LogicalToScreen();
+			return Control.PointFromScreen(point.ToWpf()).ToEto();
 		}
 
 		public PointF PointToScreen(PointF point)
 		{
-			return Control.IsLoaded ? Control.PointToScreen(point.ToWpf()).ToEto() : point;
+			if (!Control.IsLoaded)
+				return point;
+			return Control.PointToScreen(point.ToWpf()).ToEtoPoint().ScreenToLogical();
 		}
 
 		public Point Location

--- a/Source/Eto.Wpf/WpfExtensions.cs
+++ b/Source/Eto.Wpf/WpfExtensions.cs
@@ -3,6 +3,8 @@ using sw = System.Windows;
 using swm = System.Windows.Media;
 using swi = System.Windows.Input;
 using swc = System.Windows.Controls;
+using swf = System.Windows.Forms;
+using sd = System.Drawing;
 using Eto.Wpf.Forms;
 using Eto.Forms;
 using System.Linq;


### PR DESCRIPTION
WPF Does not report correct window location when using per-monitor DPI settings, as they are transformed by the current screen DPI.  E.g. with 100% left monitor, 200% right monitor, when you move the window from the left to the right, the location becomes incorrect.

- Use Win32 methods to get/set location of windows
- Mouse.Position is now in logical co-ordinates
- Control.PointTo/FromScreen now expect logical co-ordinates
- Add DynamicLayout.BeginCentered/EndCentered