### PR TITLE
Mac: Fix setting owner of a Dialog, etc.

### DIFF
--- a/Source/Eto.Mac/Eto.XamMac2 - mobile.csproj
+++ b/Source/Eto.Mac/Eto.XamMac2 - mobile.csproj
@@ -235,6 +235,7 @@
     <Compile Include="Drawing\IconFrameHandler.cs" />
     <Compile Include="Forms\Controls\StepperHandler.cs" />
     <Compile Include="CrashReporter.cs" />
+    <Compile Include="Forms\OpenWithDialogHandler.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/Source/Eto.Mac/Forms/Controls/SpinnerHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/SpinnerHandler.cs
@@ -60,12 +60,12 @@ namespace Eto.Mac.Forms.Controls
 		public override void OnSizeChanged(EventArgs e)
 		{
 			base.OnSizeChanged(e);
-			var size = Math.Max(Size.Width, Size.Height);
+			var size = Math.Min(Size.Width, Size.Height);
 			if (size <= 8)
 				Control.ControlSize = NSControlSize.Mini;
 			else if (size <= 20)
 				Control.ControlSize = NSControlSize.Small;
-			else if (size <= 30)
+			else //if (size <= 30)
 				Control.ControlSize = NSControlSize.Regular;
 			Control.SizeToFit();
 			Control.CenterInParent();

--- a/Source/Eto.Mac/Forms/DialogHandler.cs
+++ b/Source/Eto.Mac/Forms/DialogHandler.cs
@@ -147,8 +147,8 @@ namespace Eto.Mac.Forms
 			Callback.OnShown(Widget, EventArgs.Empty);
 
 			Widget.Closed += HandleClosed;
-			if (DisplayMode.HasFlag(DialogDisplayMode.Attached) && Control.ParentWindow != null)
-				MacModal.RunSheet(Widget, Control, out session);
+			if (DisplayMode.HasFlag(DialogDisplayMode.Attached) && Widget.Owner != null)
+				MacModal.RunSheet(Widget, Control, Widget.Owner.ToNative(), out session);
 			else
 			{
 				Control.MakeKeyWindow();
@@ -163,9 +163,9 @@ namespace Eto.Mac.Forms
 			Callback.OnShown(Widget, EventArgs.Empty);
 
 			Widget.Closed += HandleClosed;
-			if (DisplayMode.HasFlag(DialogDisplayMode.Attached))
+			if (DisplayMode.HasFlag(DialogDisplayMode.Attached) && Widget.Owner != null)
 			{
-				MacModal.BeginSheet(Widget, Control, out session, () => tcs.SetResult(true));
+				MacModal.BeginSheet(Widget, Control, Widget.Owner.ToNative(), out session, () => tcs.SetResult(true));
 			}
 			else
 			{
@@ -195,10 +195,10 @@ namespace Eto.Mac.Forms
 				base.Close();
 		}
 
-		public override void SetOwner (Window owner)
+		public override void SetOwner(Window owner)
 		{
-			base.SetOwner (owner);
-			Control.ParentWindow = owner.ToNative ();
+			base.SetOwner(owner);
+			Control.OwnerWindow = owner.ToNative();
 		}
 
 		public void InsertDialogButton(bool positive, int index, Button item)

--- a/Source/Eto.Mac/Forms/MacModal.cs
+++ b/Source/Eto.Mac/Forms/MacModal.cs
@@ -135,10 +135,9 @@ namespace Eto.Mac.Forms
 			app.EndModalSession(session);
 		}
 
-		public static void RunSheet(Window window, NSWindow theWindow, out ModalEventArgs helper)
+		public static void RunSheet(Window window, NSWindow theWindow, NSWindow parent, out ModalEventArgs helper)
 		{
 			var app = NSApplication.SharedApplication;
-			var parent = theWindow.ParentWindow;
 			app.BeginSheet(theWindow, parent, delegate
 			{
 				NSApplication.SharedApplication.StopModal();				
@@ -168,10 +167,9 @@ namespace Eto.Mac.Forms
 			/**/
 		}
 
-		public static void BeginSheet(Window window, NSWindow theWindow, out ModalEventArgs helper, Action completed)
+		public static void BeginSheet(Window window, NSWindow theWindow, NSWindow parent, out ModalEventArgs helper, Action completed)
 		{
 			var app = NSApplication.SharedApplication;
-			var parent = theWindow.ParentWindow;
 			app.BeginSheet(theWindow, parent, delegate
 			{
 				NSApplication.SharedApplication.StopModal();

--- a/Source/Eto.Mac/Forms/MacView.cs
+++ b/Source/Eto.Mac/Forms/MacView.cs
@@ -93,9 +93,9 @@ namespace Eto.Mac.Forms
 	}
 
 	public abstract class MacView<TControl, TWidget, TCallback> : MacObject<TControl, TWidget, TCallback>, Control.IHandler, IMacViewHandler
-		where TControl: NSObject
-		where TWidget: Control
-		where TCallback: Control.ICallback
+		where TControl : NSObject
+		where TWidget : Control
+		where TCallback : Control.ICallback
 	{
 		bool mouseMove;
 		NSTrackingArea tracking;
@@ -149,13 +149,14 @@ namespace Eto.Mac.Forms
 
 		public virtual Size Size
 		{
-			get { 
+			get
+			{
 				if (!Widget.Loaded)
 					return PreferredSize ?? new Size(-1, -1);
-				return ContainerControl.Frame.Size.ToEtoSize(); 
+				return ContainerControl.Frame.Size.ToEtoSize();
 			}
 			set
-			{ 
+			{
 				var oldSize = GetPreferredSize(Size.MaxValue);
 				PreferredSize = value;
 
@@ -330,7 +331,7 @@ namespace Eto.Mac.Forms
 					AddMethod(selBecomeFirstResponder, new Func<IntPtr, IntPtr, bool>(TriggerGotFocus), "B@:");
 					break;
 				case Eto.Forms.Control.ShownEvent:
-				// TODO
+					// TODO
 					break;
 				case Eto.Forms.Control.TextInputEvent:
 					AddMethod(selInsertText, new Action<IntPtr, IntPtr, IntPtr>(TriggerTextInput), "v@:@");
@@ -437,7 +438,7 @@ namespace Eto.Mac.Forms
 				var args = MacConversions.GetMouseEvent(handler.ContainerControl, theEvent, false);
 				if (theEvent.ClickCount >= 2)
 					handler.Callback.OnMouseDoubleClick(handler.Widget, args);
-			
+
 				if (!args.Handled)
 				{
 					handler.Callback.OnMouseDown(handler.Widget, args);
@@ -579,14 +580,35 @@ namespace Eto.Mac.Forms
 			}
 		}
 
+		static Selector selSetCanDrawSubviewsIntoLayer = new Selector("setCanDrawSubviewsIntoLayer:");
+#if MONOMAC
+		static IntPtr selSetCanDrawSubviewsIntoLayerHandle = Selector.GetHandle("setCanDrawSubviewsIntoLayer:");
+#endif
+
 		protected virtual void SetBackgroundColor(Color? color)
 		{
-			if (color != null) {
-				if (color.Value.A > 0) {
+			if (color != null)
+			{
+				if (color.Value.A > 0)
+				{
 					ContainerControl.WantsLayer = true;
+
+					// >= 10.9
+					if (ContainerControl.RespondsToSelector(selSetCanDrawSubviewsIntoLayer))
+					{
+						// collapse child layers into the parent layer
+#if MONOMAC
+						Messaging.void_objc_msgSend_bool(ContainerControl.Handle, selSetCanDrawSubviewsIntoLayerHandle, true);
+#else
+						ContainerControl.CanDrawSubviewsIntoLayer = true;
+#endif
+					}
 					var layer = ContainerControl.Layer;
 					if (layer != null)
+					{
 						layer.BackgroundColor = color.Value.ToCG();
+						layer.NeedsDisplayOnBoundsChange = true;
+					}
 				}
 				else {
 					ContainerControl.WantsLayer = false;

--- a/Source/Eto.Mac/Forms/MacWindow.cs
+++ b/Source/Eto.Mac/Forms/MacWindow.cs
@@ -58,14 +58,17 @@ namespace Eto.Mac.Forms
 
 		public bool DisableCenterParent { get; set; }
 
+		public NSWindow OwnerWindow { get; set; }
+
 		public override void Center()
 		{
 			if (DisableCenterParent)
 				return;
 			// implement centering to parent if there is a parent window for this one..
-			if (ParentWindow != null)
+			var window = OwnerWindow ?? ParentWindow;
+			if (window != null)
 			{
-				var parentFrame = ParentWindow.Frame;
+				var parentFrame = window.Frame;
 				var frame = Frame;
 				var location = new CGPoint((parentFrame.Width - frame.Width) / 2 + parentFrame.X, (parentFrame.Height - frame.Height) / 2 + parentFrame.Y);
 				SetFrameOrigin(location);

--- a/Source/Eto.Mac/Messaging.cs
+++ b/Source/Eto.Mac/Messaging.cs
@@ -83,6 +83,9 @@ namespace Eto.Mac
 		public static extern void void_objc_msgSend_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);
 
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		public static extern void void_objc_msgSend_bool(IntPtr receiver, IntPtr selector, bool arg1);
+
+		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
 		public static extern IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector);
 
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/KitchenSinkSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/KitchenSinkSection.cs
@@ -9,7 +9,8 @@ namespace Eto.Test.Sections.Controls
 	public class KitchenSinkSection : Panel
 	{
 		Bitmap bitmap1 = TestIcons.TestImage;
-		Icon icon1 = TestIcons.TestIcon;
+		Icon icon1 = TestIcons.TestIcon.WithSize(16, 16);
+		Icon icon2 = TestIcons.TestImage.WithSize(16, 16);
 
 		public KitchenSinkSection()
 		{
@@ -33,10 +34,20 @@ namespace Eto.Test.Sections.Controls
 			return container;
 		}
 
-		Control ComboBox()
+		Control DropDown()
 		{
 			var control = new DropDown();
-			control.Items.Add(new ListItem { Text = "Combo Box" });
+			control.Items.Add(new ListItem { Text = "DropDown" });
+			control.Items.Add(new ListItem { Text = "Item 2" });
+			control.Items.Add(new ListItem { Text = "Item 3" });
+			control.SelectedIndex = 0;
+			return control;
+		}
+
+		Control ComboBox()
+		{
+			var control = new ComboBox();
+			control.Items.Add(new ListItem { Text = "ComboBox" });
 			control.Items.Add(new ListItem { Text = "Item 2" });
 			control.Items.Add(new ListItem { Text = "Item 3" });
 			control.SelectedIndex = 0;
@@ -54,9 +65,9 @@ namespace Eto.Test.Sections.Controls
 		Control ListBox()
 		{
 			var control = new ListBox { Size = new Size(150, 50) };
-			control.Items.Add(new ImageListItem { Text = "Simple List Box 1", Image = bitmap1 });
-			control.Items.Add(new ImageListItem { Text = "Simple List Box 2", Image = icon1 });
-			control.Items.Add(new ImageListItem { Text = "Simple List Box 3", Image = bitmap1 });
+			control.Items.Add(new ImageListItem { Text = "ListBox", Image = icon1 });
+			control.Items.Add(new ImageListItem { Text = "ListBox 2", Image = icon2 });
+			control.Items.Add(new ImageListItem { Text = "ListBox 3", Image = icon1 });
 			return control;
 		}
 
@@ -66,34 +77,52 @@ namespace Eto.Test.Sections.Controls
 			layout.BeginVertical();
 			layout.BeginHorizontal();
 			layout.Add(new Label { Text = "Label", VerticalAlignment = VerticalAlignment.Center });
-			layout.AddAutoSized(new Button { Text = "Button Control" }, centered: true);
+			layout.AddCentered(new Button { Text = "Button" });
+			layout.AddCentered(new LinkButton { Text = "LinkButton" });
+			layout.Add(new Label { Text = "ImageView", VerticalAlignment = VerticalAlignment.Center });
 			layout.Add(new ImageView { Image = icon1, Size = new Size(64, 64) });
 			layout.Add(null);
 			layout.EndHorizontal();
-			layout.EndBeginVertical();
-			layout.AddRow(new CheckBox { Text = "Check Box (/w three state)", ThreeState = true, Checked = null }, RadioButtons(), null);
-			layout.EndBeginVertical();
-			layout.AddRow(new TextBox { Text = "Text Box", Size = new Size(150, -1) }, new PasswordBox { Text = "Password Box", Size = new Size(150, -1) }, null);
-			layout.EndBeginVertical();
-			layout.AddRow(ComboBox(), new DateTimePicker { Value = DateTime.Now }, null);
-			layout.EndBeginVertical();
-			layout.AddRow(new NumericStepper { Value = 50 }, null);
-			layout.EndBeginVertical();
-			layout.AddRow(ListBox(), new TextArea { Text = "Text Area", Size = new Size(150, 50) }, null);
-			layout.EndBeginVertical();
-			layout.AddRow(new Slider { Value = 50, TickFrequency = 10 });
-			layout.EndBeginVertical();
-			layout.AddRow(new ProgressBar { Value = 25 });
-			layout.EndBeginVertical();
-			layout.AddRow(new GroupBox { Text = "Group Box", Content = new Label { Text = "I'm in a group box" } });
 
 			layout.EndBeginVertical();
 
+			layout.AddSeparateRow(new CheckBox { Text = "CheckBox", ThreeState = true }, RadioButtons(), null);
+			layout.AddSeparateRow(new TextBox { Text = "TextBox", Size = new Size(150, -1) }, "PasswordBox", new PasswordBox { Text = "PasswordBox", Size = new Size(150, -1) }, null);
+			layout.AddSeparateRow(DropDown(), ComboBox(), null);
+			layout.AddSeparateRow("Stepper", new Stepper(), "NumericStepper", new NumericStepper { Value = 50, DecimalPlaces = 1 }, new TextStepper { Text = "TextStepper" }, null);
+
+			layout.BeginVertical();
+			layout.BeginHorizontal();
+			layout.BeginVertical();
+			layout.AddSeparateRow("DateTimePicker", new DateTimePicker { Value = DateTime.Now }, null);
+			layout.AddSeparateRow(new TextArea { Text = "TextArea", Size = new Size(150, 50) }, CreateRichTextArea(), null);
+			layout.AddSeparateRow(ListBox(), new GroupBox { Text = "GroupBox", Content = new Label { Text = "I'm in a group box" } }, null);
+			layout.EndVertical();
+			layout.AddSeparateColumn("Calendar", new Calendar(), null);
+			layout.EndHorizontal();
+			layout.EndVertical();
+
+			layout.AddSeparateRow("Slider", new Slider { Value = 50, TickFrequency = 10 });
+			layout.AddSeparateRow("ProgressBar", new ProgressBar { Value = 25, Width = 100 }, "Spinner", new Spinner { Enabled = true }, null);
+			layout.EndVertical();
 
 			layout.EndVertical();
 			layout.Add(null);
 
 			return layout;
+		}
+
+		RichTextArea CreateRichTextArea()
+		{
+			var richTextArea = new RichTextArea { Text = "RichTextArea", Size = new Size(150, 50) };
+			richTextArea.Buffer.SetBold(new Range<int>(0, 3), true);
+			richTextArea.Buffer.SetForeground(new Range<int>(0, 3), Colors.Blue);
+			richTextArea.Buffer.SetItalic(new Range<int>(4, 7), true);
+			richTextArea.Buffer.SetStrikethrough(new Range<int>(4, 7), true);
+			richTextArea.Buffer.SetForeground(new Range<int>(4, 7), Colors.Green);
+			richTextArea.Buffer.SetUnderline(new Range<int>(8, 11), true);
+			richTextArea.Buffer.SetForeground(new Range<int>(8, 11), Colors.Red);
+			return richTextArea;
 		}
 
 		IEnumerable<object> ComboCellItems()
@@ -109,15 +138,15 @@ namespace Eto.Test.Sections.Controls
 		{
 			var control = new GridView { Size = new Size(-1, 150) };
 
-			control.Columns.Add(new GridColumn { DataCell = new ImageViewCell(0), HeaderText = "Image" });
-			control.Columns.Add(new GridColumn { DataCell = new CheckBoxCell(1), HeaderText = "Check", Editable = true });
-			control.Columns.Add(new GridColumn { DataCell = new TextBoxCell(2), HeaderText = "Text", Editable = true });
-			control.Columns.Add(new GridColumn { DataCell = new ComboBoxCell(3) { DataStore = ComboCellItems() }, HeaderText = "Combo", Editable = true });
+			control.Columns.Add(new GridColumn { DataCell = new ImageViewCell(0), HeaderText = "ImageViewCell" });
+			control.Columns.Add(new GridColumn { DataCell = new CheckBoxCell(1), HeaderText = "CheckBoxCell", Editable = true });
+			control.Columns.Add(new GridColumn { DataCell = new TextBoxCell(2), HeaderText = "TextBoxCell", Editable = true });
+			control.Columns.Add(new GridColumn { DataCell = new ComboBoxCell(3) { DataStore = ComboCellItems() }, HeaderText = "ComboBoxCell", Editable = true });
 
 			var items = new List<GridItem>();
-			items.Add(new GridItem(bitmap1, true, "Text in Grid 1", "1"));
-			items.Add(new GridItem(icon1, false, "Text in Grid 2", "2"));
-			items.Add(new GridItem(bitmap1, null, "Text in Grid 3", "3"));
+			items.Add(new GridItem(bitmap1, true, "GridView 1", "1"));
+			items.Add(new GridItem(icon1, false, "GridView 2", "2"));
+			items.Add(new GridItem(bitmap1, null, "GridView 3", "3"));
 
 			control.DataStore = items;
 
@@ -128,18 +157,18 @@ namespace Eto.Test.Sections.Controls
 		{
 			if (level > 4)
 				yield break;
-			yield return new TreeGridItem(TreeChildren(level + 1), bitmap1, "Text in Tree 1", true, "1") { Expanded = level < 2 };
-			yield return new TreeGridItem(icon1, "Text in Tree 2", false, "2");
-			yield return new TreeGridItem(TreeChildren(level + 1), bitmap1, "Text in Tree 3", null, "3");
+			yield return new TreeGridItem(TreeChildren(level + 1), bitmap1, "TreeGridView 1", true, "1") { Expanded = level < 2 };
+			yield return new TreeGridItem(icon1, "TreeGridView 2", false, "2");
+			yield return new TreeGridItem(TreeChildren(level + 1), bitmap1, "TreeGridView 3", null, "3");
 		}
 
 		Control TreeView()
 		{
 			var control = new TreeGridView { Size = new Size(-1, 150) };
 
-			control.Columns.Add(new GridColumn { DataCell = new ImageTextCell(0, 1), HeaderText = "Image and Text" });
-			control.Columns.Add(new GridColumn { DataCell = new CheckBoxCell(2), HeaderText = "Check", Editable = true, AutoSize = true });
-			control.Columns.Add(new GridColumn { DataCell = new ComboBoxCell(3) { DataStore = ComboCellItems() }, HeaderText = "Combo", Editable = true });
+			control.Columns.Add(new GridColumn { DataCell = new ImageTextCell(0, 1), HeaderText = "ImageTextCell" });
+			control.Columns.Add(new GridColumn { DataCell = new CheckBoxCell(2), HeaderText = "CheckBoxCell", Editable = true, AutoSize = true });
+			control.Columns.Add(new GridColumn { DataCell = new ComboBoxCell(3) { DataStore = ComboCellItems() }, HeaderText = "ComboBoxCell", Editable = true });
 
 			control.DataStore = new TreeGridItemCollection(TreeChildren());
 
@@ -151,7 +180,7 @@ namespace Eto.Test.Sections.Controls
 			try
 			{
 				var control = new WebView { Size = new Size(-1, 100) };
-				control.LoadHtml("<html><head><title>Hello</title></head><body><h1>Web View</h1><p>This is a web view loaded with a html string</p></body>");
+				control.LoadHtml("<html><head><title>Hello</title></head><body><h1>WebView</h1><p>This is a web view loaded with a html string</p></body>");
 				return control;
 			}
 			catch (Exception)

--- a/Source/Eto/Forms/Layout/DynamicLayout.cs
+++ b/Source/Eto/Forms/Layout/DynamicLayout.cs
@@ -402,9 +402,7 @@ namespace Eto.Forms
 		/// <param name="controls">Controls.</param>
 		public DynamicRow AddSeparateRow(params Control[] controls)
 		{
-			var row = AddSeparateRow(padding: null);
-			row.Add(controls);
-			return row;
+			return AddSeparateRow(padding: null, controls: controls);
 		}
 
 		/// <summary>
@@ -436,6 +434,58 @@ namespace Eto.Forms
 				row.Add(controls);
 			EndVertical();
 			return row;
+		}
+
+		/// <summary>
+		/// Adds a separate vertical column of items in a new vertical section
+		/// </summary>
+		/// <remarks>
+		/// This performs the same as the following, but in a single line:
+		/// <code>
+		/// 	layout.BeginVertical();
+		/// 	layout.Add(control1);
+		/// 	layout.Add(control2);
+		/// 	...
+		/// 	layout.EndVertical();
+		/// </code>
+		/// </remarks>
+		/// <returns>The table added to contain the items</returns>
+		/// <param name="controls">Controls to add initially</param>
+		public DynamicTable AddSeparateColumn(params Control[] controls)
+		{
+			return AddSeparateColumn(padding: null, controls: controls);
+		}
+
+		/// <summary>
+		/// Adds a separate vertical column of items in a new vertical section
+		/// </summary>
+		/// <remarks>
+		/// This performs the same as the following, but in a single line:
+		/// <code>
+		/// 	layout.BeginVertical(padding, spacing, xscale, yscale);
+		/// 	layout.Add(control1);
+		/// 	layout.Add(control2);
+		/// 	...
+		/// 	layout.EndVertical();
+		/// </code>
+		/// </remarks>
+		/// <returns>The table added to contain the items</returns>
+		/// <param name="padding">Padding for the vertical section</param>
+		/// <param name="spacing">Spacing between each cell in the column</param>
+		/// <param name="xscale">Xscale for the vertical section</param>
+		/// <param name="yscale">Yscale for the vertical section</param>
+		/// <param name="controls">Controls to add initially</param>
+		public DynamicTable AddSeparateColumn(Padding? padding = null, int? spacing = null, bool? xscale = null, bool? yscale = null, IEnumerable<Control> controls = null)
+		{
+			var spacingSize = spacing != null ? (Size?)new Size(0, spacing.Value) : null;
+			var table = BeginVertical(padding, spacingSize, xscale, yscale);
+			if (controls != null)
+			{
+				foreach (var control in controls)
+					Add(control);
+			}
+			EndVertical();
+			return table;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Apparently, the use of NSWindow.ParentWindow is an incorrect way to set the parent of a dialog.  The only way it seems is to use a sheet, otherwise the Dialog will always be application modal instead of modal only to the owner window.

- Mac: Fix setting the BackgroundColor on a container control where the children would stretch instead of redraw when the container is resized.
- Mac: Fix Spinner to autosize to the minimum of the width/height instead of the maximum so it’ll fit properly
- Add DynamicLayout.AddSeparateColumn() helper (same concept as AddSeparateRow())
- Update KitchenSinkSection to add some of the newer controls
- Update DialogSection test to add more options and apply them to the KitchenSink dialog as well.