### PR TITLE
Gtk: Fix mouse events with TableLayout.

### DIFF
--- a/Source/Eto.Gtk/Forms/TableLayoutHandler.cs
+++ b/Source/Eto.Gtk/Forms/TableLayoutHandler.cs
@@ -18,10 +18,9 @@ namespace Eto.GtkSharp.Forms
 		Gtk.Widget[,] blank;
 		Size? spacing;
 
-		public override Gtk.Widget ContainerControl
-		{
-			get { return box; }
-		}
+		public override Gtk.Widget ContainerControl => box;
+
+		public override Gtk.Widget EventControl => ContainerControl;
 
 		public Size Spacing
 		{

--- a/Source/Eto.Test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
@@ -15,7 +15,7 @@ namespace Eto.Test.Sections.Behaviors
 				layout.Add(options);
 
 			layout.BeginVertical();
-			layout.AddRow(null, LabelControl(), ButtonControl(), new Panel(), null);
+			layout.AddRow(null, LabelControl(), ButtonControl(), LinkButtonControl(), new Panel(), null);
 			layout.AddRow(null, TextBoxControl(), PasswordBoxControl());
 
 			layout.BeginHorizontal();
@@ -26,18 +26,22 @@ namespace Eto.Test.Sections.Behaviors
 			layout.EndHorizontal();
 
 			layout.AddRow(null, CheckBoxControl(), RadioButtonControl());
-			layout.AddRow(null, DateTimeControl(), NumericStepperControl());
-			layout.AddRow(null, DropDownControl(), ComboBoxControl());
+			layout.AddRow(null, DateTimeControl(), NumericStepperControl(), DropDownControl(), ComboBoxControl());
 
 			layout.BeginHorizontal();
 			layout.Add(null);
 			layout.Add(ColorPickerControl());
-			if (Platform.Supports<GroupBox>())
-				layout.Add(GroupBoxControl());
+			layout.Add(SliderControl());
 			layout.EndHorizontal();
 
-			layout.AddRow(null, LinkButtonControl(), SliderControl());
-			layout.AddRow(null, DrawableControl(), ImageViewControl());
+			layout.BeginHorizontal();
+			layout.Add(null);
+			layout.Add(DrawableControl());
+			layout.Add(ImageViewControl());
+			if (Platform.Supports<GroupBox>())
+				layout.Add(GroupBoxControl());
+			layout.Add(TableLayoutControl());
+			layout.EndHorizontal();
 			layout.EndVertical();
 			layout.Add(null);
 
@@ -145,6 +149,26 @@ namespace Eto.Test.Sections.Behaviors
 			LogEvents(control);
 			return control;
 		}
+
+		Control TableLayoutControl()
+		{
+			Func<Panel> createPanel = () => new Panel { Size = new Size(50, 20), BackgroundColor = Colors.Green };
+
+			var control = new TableLayout(
+				new TableRow(createPanel(), createPanel()),
+				new TableRow(createPanel(), createPanel()),
+				new TableRow(createPanel(), createPanel()),
+				new TableRow(createPanel(), createPanel())
+			);
+
+			control.Spacing = new Size(5, 5);
+			control.Padding = 10;
+			control.BackgroundColor = Colors.Blue;
+
+			LogEvents(control);
+			return control;
+		}
+
 
 		Control DrawableControl()
 		{

--- a/Source/Eto/Forms/Application.cs
+++ b/Source/Eto/Forms/Application.cs
@@ -162,7 +162,8 @@ namespace Eto.Forms
 		static Application()
 		{
 			EventLookup.Register<Application>(c => c.OnTerminating(null), Application.TerminatingEvent);
-		}
+			EventLookup.Register<Application>(c => c.OnUnhandledException(null), Application.UnhandledExceptionEvent);
+}
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Eto.Forms.Application"/> class.


### PR DESCRIPTION
Register Application.UnhandledExceptionEvent properly to handle subclass overrides

Fixes #728