### PR TITLE
Wpf: Fix Graphics.Clear() on a Bitmap

### DIFF
--- a/Source/Eto.Test/Eto.Test/Sections/Drawing/ClearSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Drawing/ClearSection.cs
@@ -1,5 +1,6 @@
 using Eto.Drawing;
 using Eto.Forms;
+using System;
 using System.ComponentModel;
 
 namespace Eto.Test.Sections.Drawing
@@ -96,13 +97,17 @@ namespace Eto.Test.Sections.Drawing
 					graphics.Clear(new SolidBrush(new Color(Colors.Red, 0.5f)));
 				else
 					graphics.Clear();
-				graphics.FillEllipse(Brushes.Blue, 25, 25, 150, 150);
+				var rnd = new Random();
+				graphics.FillEllipse(Brushes.Blue, rnd.Next(50), rnd.Next(50), 150, 150);
 			}
 		}
 
+		Bitmap image;
+
 		Image CreateImage()
 		{
-			var image = new Bitmap(200, 200, PixelFormat.Format32bppRgba);
+			if (image == null)
+				image = new Bitmap(200, 200, PixelFormat.Format32bppRgba);
 			using (var graphics = new Graphics(image))
 			{
 				DrawSample(graphics);

--- a/Source/Eto.Wpf/Drawing/GraphicsHandler.cs
+++ b/Source/Eto.Wpf/Drawing/GraphicsHandler.cs
@@ -345,10 +345,7 @@ namespace Eto.Wpf.Drawing
 				Control.Close();
 				var handler = (BitmapHandler)image.Handler;
 				var bmp = image.ToWpf();
-				var newbmp = bmp as swmi.RenderTargetBitmap;
-				if (newbmp == null || newbmp.IsFrozen)
-					newbmp = new swmi.RenderTargetBitmap(bmp.PixelWidth, bmp.PixelHeight, bmp.DpiX, bmp.DpiY, swm.PixelFormats.Pbgra32);
-
+				var newbmp = new swmi.RenderTargetBitmap(bmp.PixelWidth, bmp.PixelHeight, bmp.DpiX, bmp.DpiY, swm.PixelFormats.Pbgra32);
 				newbmp.RenderWithCollect(visual);
 				handler.SetBitmap(newbmp);
 				return true;
@@ -609,10 +606,9 @@ namespace Eto.Wpf.Drawing
 				maskgeometry = swm.Geometry.Combine(boundsgeometry, maskgeometry, swm.GeometryCombineMode.Exclude, null);
 				var dr = new swm.GeometryDrawing(swm.Brushes.Black, null, maskgeometry);
 				var db = new swm.DrawingBrush(dr);
-				//db.Transform = new swm.TranslateTransform (0.5, 0.5);
 
+				visual = drawingVisual = new swm.DrawingVisual();
 				Control = drawingVisual.RenderOpen();
-				Control.PushGuidelineSet(new swm.GuidelineSet(new [] { bounds.Left, bounds.Right }, new [] { bounds.Top, bounds.Bottom }));
 				Control.PushOpacityMask(db);
 				Control.DrawImage(newbmp, bounds);
 				Control.Pop();


### PR DESCRIPTION
If modifying the same image multiple times it wouldn’t update the image properly.

Fixes #702