### PR TITLE
Wpf: Fix using brushes and fonts created from other threads

### DIFF
--- a/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
+++ b/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
@@ -129,8 +129,10 @@
     <Compile Include="Sections\Controls\SplitterSection.cs" />
     <Compile Include="Sections\Controls\SpinnerSection.cs" />
     <Compile Include="Sections\Drawing\DrawLoopSection.cs" />
+    <Compile Include="UnitTests\Drawing\BrushTests.cs" />
     <Compile Include="UnitTests\Drawing\ClipTests.cs" />
     <Compile Include="UnitTests\Drawing\DefaultValueTests.cs" />
+    <Compile Include="UnitTests\Drawing\FontTests.cs" />
     <Compile Include="UnitTests\Drawing\GraphicsTests.cs" />
     <Compile Include="UnitTests\Drawing\MatrixTests.cs" />
     <Compile Include="UnitTests\Forms\Controls\ComboBoxTests.cs" />

--- a/Source/Eto.Test/Eto.Test/Sections/Drawing/AntialiasSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Drawing/AntialiasSection.cs
@@ -19,7 +19,7 @@ namespace Eto.Test.Sections.Drawing
 
 		Control AntialiasOn()
 		{
-			var control = new Drawable { Size = new Size(300, 100), BackgroundColor = Colors.Black };
+			var control = new Drawable { Size = new Size(400, 100), BackgroundColor = Colors.Black };
 
 			var path = CreatePath();
 			control.Paint += (sender, e) =>
@@ -35,9 +35,15 @@ namespace Eto.Test.Sections.Drawing
 				e.Graphics.DrawPath(Pens.White, path);
 				e.Graphics.DrawLine(Pens.White, 0, 20, 100, 100);
 
-				e.Graphics.TranslateTransform(100, 0);
 				e.Graphics.AntiAlias = true;
+				e.Graphics.TranslateTransform(100, 0);
 				e.Graphics.DrawText(SystemFonts.Default(), Brushes.White, 0, 0, "Antialias ON");
+				e.Graphics.DrawPath(Pens.White, path);
+				e.Graphics.DrawLine(Pens.White, 0, 20, 100, 100);
+
+				e.Graphics.AntiAlias = false;
+				e.Graphics.TranslateTransform(100, 0);
+				e.Graphics.DrawText(SystemFonts.Default(), Brushes.White, 0, 0, "Antialias OFF");
 				e.Graphics.DrawPath(Pens.White, path);
 				e.Graphics.DrawLine(Pens.White, 0, 20, 100, 100);
 			};

--- a/Source/Eto.Test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
@@ -257,29 +257,29 @@ namespace Eto.Test.UnitTests.Drawing
 			});
 
 			// test output in test thread
-			Assert.AreEqual(Colors.Blue, bmp.GetPixel(0, 0));
-			Assert.AreEqual(Colors.Green, bmp.GetPixel(10, 0));
-			Assert.AreEqual(Colors.Red, bmp.GetPixel(20, 0));
+			Assert.AreEqual(Colors.Blue, bmp.GetPixel(0, 0), "#1");
+			Assert.AreEqual(Colors.Green, bmp.GetPixel(10, 0), "#2");
+			Assert.AreEqual(Colors.Red, bmp.GetPixel(20, 0), "#3");
 
 			using (var bd = bmp.Lock())
 			{
-				Assert.AreEqual(Colors.Blue, bd.GetPixel(0, 0));
-				Assert.AreEqual(Colors.Green, bd.GetPixel(10, 0));
-				Assert.AreEqual(Colors.Red, bd.GetPixel(20, 0));
+				Assert.AreEqual(Colors.Blue, bd.GetPixel(0, 0), "#4");
+				Assert.AreEqual(Colors.Green, bd.GetPixel(10, 0), "#5");
+				Assert.AreEqual(Colors.Red, bd.GetPixel(20, 0), "#6");
 			}
 			Shown(f => new ImageView { Image = bmp }, 
 				iv => {
 
 				// also test in UI thread
-				Assert.AreEqual(Colors.Blue, bmp.GetPixel(0, 0));
-				Assert.AreEqual(Colors.Green, bmp.GetPixel(10, 0));
-				Assert.AreEqual(Colors.Red, bmp.GetPixel(20, 0));
+				Assert.AreEqual(Colors.Blue, bmp.GetPixel(0, 0), "#7");
+				Assert.AreEqual(Colors.Green, bmp.GetPixel(10, 0), "#8");
+				Assert.AreEqual(Colors.Red, bmp.GetPixel(20, 0), "#9");
 
 				using (var bd = bmp.Lock())
 				{
-					Assert.AreEqual(Colors.Blue, bd.GetPixel(0, 0));
-					Assert.AreEqual(Colors.Green, bd.GetPixel(10, 0));
-					Assert.AreEqual(Colors.Red, bd.GetPixel(20, 0));
+					Assert.AreEqual(Colors.Blue, bd.GetPixel(0, 0), "#10");
+					Assert.AreEqual(Colors.Green, bd.GetPixel(10, 0), "#11");
+					Assert.AreEqual(Colors.Red, bd.GetPixel(20, 0), "#12");
 				}
 			});
 		}

--- a/Source/Eto.Test/Eto.Test/UnitTests/Drawing/BrushTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Drawing/BrushTests.cs
@@ -1,0 +1,58 @@
+﻿using Eto.Drawing;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Eto.Test.UnitTests.Drawing
+{
+	[TestFixture]
+	public class BrushTests : TestBase
+	{
+		[Test]
+		public async Task SolidBrushShouldWorkInMultipleThreads()
+		{
+			await BrushTest(new SolidBrush(Colors.Blue));
+		}
+
+		[Test]
+		public async Task LinearGradientBrushShouldWorkInMultipleThreads()
+		{
+			await BrushTest(new LinearGradientBrush(Colors.Blue, Colors.Green, new PointF(0, 0), new PointF(30, 30)));
+		}
+
+		[Test]
+		public async Task RadialGradientBrushShouldWorkInMultipleThreads()
+		{
+			await BrushTest(new RadialGradientBrush(Colors.Blue, Colors.Green, new PointF(10, 10), new PointF(15, 15), new SizeF(15, 15)));
+		}
+
+		[Test]
+		public async Task TextureBrushShouldWorkInMultipleThreads()
+		{
+			await BrushTest(new TextureBrush(TestIcons.Logo));
+		}
+
+		async Task BrushTest(Brush brush)
+		{
+			// just test that it doesn't crash at this point (for WPF), no actual output test yet.
+			var bmp = new Bitmap(30, 30, PixelFormat.Format32bppRgba);
+			using (var g = new Graphics(bmp))
+			{
+				g.FillRectangle(brush, 0, 0, 10, 10);
+			}
+
+			await Task.Run(() =>
+			{
+				bmp = new Bitmap(30, 30, PixelFormat.Format32bppRgba);
+				using (var g = new Graphics(bmp))
+				{
+					g.FillRectangle(brush, 0, 0, 10, 10);
+				}
+			});
+		}
+
+	}
+}

--- a/Source/Eto.Test/Eto.Test/UnitTests/Drawing/FontTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Drawing/FontTests.cs
@@ -1,0 +1,34 @@
+﻿using Eto.Drawing;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Eto.Test.UnitTests.Drawing
+{
+	[TestFixture]
+	public class FontTests
+	{
+		[Test]
+		public async Task FontShouldWorkInMultipleThreads()
+		{
+			var bmp = new Bitmap(100, 20, PixelFormat.Format32bppRgba);
+			var font = Fonts.Sans(10, FontStyle.Italic, FontDecoration.Underline);
+			using (var g = new Graphics(bmp))
+			{
+				g.DrawText(font, Colors.Blue, 0, 0, "Some Text");
+			}
+
+			await Task.Run(() =>
+			{
+				bmp = new Bitmap(100, 20, PixelFormat.Format32bppRgba);
+				using (var g = new Graphics(bmp))
+				{
+					g.DrawText(font, Colors.Blue, 0, 0, "Some Text");
+				}
+			});
+		}
+	}
+}

--- a/Source/Eto.Test/Eto.Test/UnitTests/Drawing/GraphicsTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Drawing/GraphicsTests.cs
@@ -23,5 +23,35 @@ namespace Eto.Test.UnitTests.Drawing
 				Assert.AreEqual(ImageInterpolation.Default, graphics.ImageInterpolation, "ImageInterpolation should be default");
 			});
 		}
+
+		[Test]
+		public void AntiAliasShouldNotInterfereWithTransform()
+		{
+			var bmp = new Bitmap(40, 10, PixelFormat.Format32bppRgba);
+			using (var g = new Graphics(bmp))
+			{
+				g.AntiAlias = true;
+				g.FillRectangle(Colors.Red, 0, 0, 10, 10);
+
+				g.AntiAlias = false;
+				g.TranslateTransform(10, 0);
+				g.FillRectangle(Colors.Green, 0, 0, 10, 10);
+
+				g.AntiAlias = true;
+				g.TranslateTransform(10, 0);
+				g.FillRectangle(Colors.Blue, 0, 0, 10, 10);
+
+				g.AntiAlias = false;
+				g.TranslateTransform(10, 0);
+				g.FillRectangle(Colors.Yellow, 0, 0, 10, 10);
+			}
+			using (var bd = bmp.Lock())
+			{
+				Assert.AreEqual(Colors.Red, bd.GetPixel(0, 0), "#1");
+				Assert.AreEqual(Colors.Green, bd.GetPixel(10, 0), "#2");
+				Assert.AreEqual(Colors.Blue, bd.GetPixel(20, 0), "#3");
+				Assert.AreEqual(Colors.Yellow, bd.GetPixel(30, 0), "#4");
+			}
+		}
 	}
 }

--- a/Source/Eto.Wpf/Drawing/BitmapHandler.cs
+++ b/Source/Eto.Wpf/Drawing/BitmapHandler.cs
@@ -210,15 +210,7 @@ namespace Eto.Wpf.Drawing
 
 		bool RequiresFrozen => Control.Dispatcher?.CheckAccess() != true;
 		swmi.BitmapSource frozenControl;
-		swmi.BitmapSource FrozenControl
-		{
-			get
-			{
-				if (!RequiresFrozen)
-					return Control;
-				return frozenControl ?? Control;
-			}
-		}
+		swmi.BitmapSource FrozenControl => frozenControl ?? Control;
 
 		void SetFrozen()
 		{

--- a/Source/Eto.Wpf/Drawing/FontHandler.cs
+++ b/Source/Eto.Wpf/Drawing/FontHandler.cs
@@ -21,9 +21,9 @@ namespace Eto.Wpf.Drawing
 			control.FontStyle = WpfFontStyle;
 			control.FontWeight = WpfFontWeight;
 			control.FontSize = PixelSize;
-			if (setDecorations != null && WpfTextDecorations != null)
+			if (setDecorations != null && WpfTextDecorationsFrozen != null)
 			{
-				setDecorations(WpfTextDecorations);
+				setDecorations(WpfTextDecorationsFrozen);
 			}
 		}
 
@@ -33,9 +33,9 @@ namespace Eto.Wpf.Drawing
 			control.FontStyle = WpfFontStyle;
 			control.FontWeight = WpfFontWeight;
 			control.FontSize = PixelSize;
-			if (setDecorations != null && WpfTextDecorations != null)
+			if (setDecorations != null && WpfTextDecorationsFrozen != null)
 			{
-				setDecorations(WpfTextDecorations);
+				setDecorations(WpfTextDecorationsFrozen);
 			}
 		}
 
@@ -45,9 +45,9 @@ namespace Eto.Wpf.Drawing
 			control.FontStyle = WpfFontStyle;
 			control.FontWeight = WpfFontWeight;
 			control.FontSize = PixelSize;
-			if (setDecorations != null && WpfTextDecorations != null)
+			if (setDecorations != null && WpfTextDecorationsFrozen != null)
 			{
-				setDecorations(WpfTextDecorations);
+				setDecorations(WpfTextDecorationsFrozen);
 			}
 		}
 
@@ -57,7 +57,7 @@ namespace Eto.Wpf.Drawing
 			control.ApplyPropertyValue(swd.TextElement.FontStyleProperty, WpfFontStyle);
 			control.ApplyPropertyValue(swd.TextElement.FontWeightProperty, WpfFontWeight);
 			control.ApplyPropertyValue(swd.TextElement.FontSizeProperty, PixelSize);
-			control.ApplyPropertyValue(swd.Inline.TextDecorationsProperty, WpfTextDecorations);
+			control.ApplyPropertyValue(swd.Inline.TextDecorationsProperty, WpfTextDecorationsFrozen);
 		}
 
 		sd.Font SDFont
@@ -114,13 +114,17 @@ namespace Eto.Wpf.Drawing
 			return points * (72.0 / 96.0);
 		}
 
-		public sw.FontStyle WpfFontStyle { get; set; }
+		public sw.FontStyle WpfFontStyle { get; private set; }
 
-		public sw.TextDecorationCollection WpfTextDecorations { get; set; }
+		sw.TextDecorationCollection WpfTextDecorations { get; set; }
 
-		public sw.FontWeight WpfFontWeight { get; set; }
+		public sw.TextDecorationCollection WpfTextDecorationsFrozen { get; private set; }
 
-		public double Size { get; set; }
+		void SetFrozenDecorations() => WpfTextDecorationsFrozen = (sw.TextDecorationCollection)WpfTextDecorations?.GetAsFrozen();
+
+		public sw.FontWeight WpfFontWeight { get; private set; }
+
+		public double Size { get; private set; }
 
 		public FontHandler()
 		{
@@ -142,7 +146,10 @@ namespace Eto.Wpf.Drawing
 			this.WpfFontWeight = control.FontWeight;
 			var decorations = control.TextDecorations;
 			if (decorations != null)
+			{
 				this.WpfTextDecorations = new sw.TextDecorationCollection(decorations);
+				SetFrozenDecorations();
+			}
 		}
 
 		public FontHandler(swd.TextSelection range, sw.FrameworkElement control)
@@ -154,7 +161,10 @@ namespace Eto.Wpf.Drawing
 			this.WpfFontWeight = range.GetPropertyValue(swd.TextElement.FontWeightProperty) as sw.FontWeight? ?? swd.TextElement.GetFontWeight(control);
 			var decorations = range.GetPropertyValue(swd.Inline.TextDecorationsProperty) as sw.TextDecorationCollection;
 			if (decorations != null)
+			{
 				this.WpfTextDecorations = new sw.TextDecorationCollection(decorations);
+				SetFrozenDecorations();
+			}
 		}
 
 		public FontHandler(swm.FontFamily family, double size, sw.FontStyle style, sw.FontWeight weight)
@@ -197,6 +207,7 @@ namespace Eto.Wpf.Drawing
 				WpfTextDecorations.Add(sw.TextDecorations.Underline);
 			if (decoration.HasFlag(FontDecoration.Strikethrough))
 				WpfTextDecorations.Add(sw.TextDecorations.Strikethrough);
+			SetFrozenDecorations();
 			this.decoration = decoration;
 		}
 

--- a/Source/Eto.Wpf/Drawing/LinearGradientBrushHandler.cs
+++ b/Source/Eto.Wpf/Drawing/LinearGradientBrushHandler.cs
@@ -10,13 +10,17 @@ namespace Eto.Wpf.Drawing
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	public class LinearGradientBrushHandler : LinearGradientBrush.IHandler
 	{
+		static swm.LinearGradientBrush Get(LinearGradientBrush widget) => ((FrozenBrushWrapper)widget.ControlObject).Brush as swm.LinearGradientBrush;
+
+		static void SetFrozen(LinearGradientBrush widget) => ((FrozenBrushWrapper)widget.ControlObject).SetFrozen();
+
 		public object Create(Color startColor, Color endColor, PointF startPoint, PointF endPoint)
 		{
-			return new swm.LinearGradientBrush(startColor.ToWpf(), endColor.ToWpf(), startPoint.ToWpf(), endPoint.ToWpf())
+			return new FrozenBrushWrapper(new swm.LinearGradientBrush(startColor.ToWpf(), endColor.ToWpf(), startPoint.ToWpf(), endPoint.ToWpf())
 			{
 				MappingMode = swm.BrushMappingMode.Absolute,
 				SpreadMethod = swm.GradientSpreadMethod.Pad
-			};
+			});
 		}
 
 		public object Create(RectangleF rectangle, Color startColor, Color endColor, float angle)
@@ -25,31 +29,33 @@ namespace Eto.Wpf.Drawing
 			var startPoint = rectangle.Location.ToWpf();
 			matrix.RotateAtPrepend(angle - 45, startPoint.X, startPoint.Y);
 			var endPoint = matrix.Transform(rectangle.EndLocation.ToWpf());
-			return new swm.LinearGradientBrush(startColor.ToWpf(), endColor.ToWpf(), startPoint, endPoint)
+			return new FrozenBrushWrapper(new swm.LinearGradientBrush(startColor.ToWpf(), endColor.ToWpf(), startPoint, endPoint)
 			{
 				MappingMode = swm.BrushMappingMode.Absolute,
 				SpreadMethod = swm.GradientSpreadMethod.Pad
-			};
+			});
 		}
 
 		public IMatrix GetTransform(LinearGradientBrush widget)
 		{
-			return ((swm.LinearGradientBrush)widget.ControlObject).Transform.ToEtoMatrix();
+			return Get(widget).Transform.ToEtoMatrix();
 		}
 
 		public void SetTransform(LinearGradientBrush widget, IMatrix transform)
 		{
-			((swm.LinearGradientBrush)widget.ControlObject).Transform = transform.ToWpfTransform();
+			Get(widget).Transform = transform.ToWpfTransform();
+			SetFrozen(widget);
 		}
 
 		public GradientWrapMode GetGradientWrap(LinearGradientBrush widget)
 		{
-			return ((swm.LinearGradientBrush)widget.ControlObject).SpreadMethod.ToEto();
+			return Get(widget).SpreadMethod.ToEto();
 		}
 
 		public void SetGradientWrap(LinearGradientBrush widget, GradientWrapMode gradientWrap)
 		{
-			((swm.LinearGradientBrush)widget.ControlObject).SpreadMethod = gradientWrap.ToWpf();
+			Get(widget).SpreadMethod = gradientWrap.ToWpf();
+			SetFrozen(widget);
 		}
 	}
 }

--- a/Source/Eto.Wpf/Drawing/RadialGradientBrushHandler.cs
+++ b/Source/Eto.Wpf/Drawing/RadialGradientBrushHandler.cs
@@ -10,30 +10,35 @@ namespace Eto.Wpf.Drawing
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	public class RadialGradientBrushHandler : RadialGradientBrush.IHandler
 	{
+		static swm.RadialGradientBrush Get(RadialGradientBrush widget) => ((FrozenBrushWrapper)widget.ControlObject).Brush as swm.RadialGradientBrush;
+
+		static void SetFrozen(RadialGradientBrush widget) => ((FrozenBrushWrapper)widget.ControlObject).SetFrozen();
 
 		public IMatrix GetTransform(RadialGradientBrush widget)
 		{
-			return ((swm.RadialGradientBrush)widget.ControlObject).Transform.ToEtoMatrix();
+			return Get(widget).Transform.ToEtoMatrix();
 		}
 
 		public void SetTransform(RadialGradientBrush widget, IMatrix transform)
 		{
-			((swm.RadialGradientBrush)widget.ControlObject).Transform = transform.ToWpfTransform();
+			Get(widget).Transform = transform.ToWpfTransform();
+			SetFrozen(widget);
 		}
 
 		public GradientWrapMode GetGradientWrap(RadialGradientBrush widget)
 		{
-			return ((swm.RadialGradientBrush)widget.ControlObject).SpreadMethod.ToEto();
+			return Get(widget).SpreadMethod.ToEto();
 		}
 
 		public void SetGradientWrap(RadialGradientBrush widget, GradientWrapMode gradientWrap)
 		{
-			((swm.RadialGradientBrush)widget.ControlObject).SpreadMethod = gradientWrap.ToWpf ();
+			Get(widget).SpreadMethod = gradientWrap.ToWpf();
+			SetFrozen(widget);
 		}
 
 		public object Create(Color startColor, Color endColor, PointF center, PointF gradientOrigin, SizeF radius)
 		{
-			return new swm.RadialGradientBrush(startColor.ToWpf(), endColor.ToWpf())
+			return new FrozenBrushWrapper(new swm.RadialGradientBrush(startColor.ToWpf(), endColor.ToWpf())
 			{
 				Center = center.ToWpf(),
 				GradientOrigin = gradientOrigin.ToWpf(),
@@ -41,7 +46,7 @@ namespace Eto.Wpf.Drawing
 				RadiusY = radius.Height,
 				MappingMode = swm.BrushMappingMode.Absolute,
 				SpreadMethod = swm.GradientSpreadMethod.Pad
-			};
+			});
 		}
 	}
 }

--- a/Source/Eto.Wpf/Drawing/SolidBrushHandler.cs
+++ b/Source/Eto.Wpf/Drawing/SolidBrushHandler.cs
@@ -3,6 +3,21 @@ using swm = System.Windows.Media;
 
 namespace Eto.Wpf.Drawing
 {
+	class FrozenBrushWrapper
+	{
+		public FrozenBrushWrapper(swm.Brush brush)
+		{
+			Brush = brush;
+			SetFrozen();
+		}
+
+		public swm.Brush Brush { get; }
+
+		public swm.Brush FrozenBrush { get; private set; }
+
+		public void SetFrozen() => FrozenBrush = (swm.Brush)Brush.GetAsFrozen();
+	}
+
 	/// <summary>
 	/// Handler for <see cref="ISolidBrush"/>
 	/// </summary>
@@ -10,19 +25,24 @@ namespace Eto.Wpf.Drawing
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	public class SolidBrushHandler : SolidBrush.IHandler
 	{
-		public Color GetColor (SolidBrush widget)
+		static swm.SolidColorBrush Get(SolidBrush widget) => ((FrozenBrushWrapper)widget.ControlObject).Brush as swm.SolidColorBrush;
+
+		static void SetFrozen(SolidBrush widget) => ((FrozenBrushWrapper)widget.ControlObject).SetFrozen();
+
+		public Color GetColor(SolidBrush widget)
 		{
-			return ((swm.SolidColorBrush)widget.ControlObject).Color.ToEto ();
+			return Get(widget).Color.ToEto();
 		}
 
-		public void SetColor (SolidBrush widget, Color color)
+		public void SetColor(SolidBrush widget, Color color)
 		{
-			((swm.SolidColorBrush)widget.ControlObject).Color = color.ToWpf ();
+			Get(widget).Color = color.ToWpf();
+			SetFrozen(widget);
 		}
 
-		public object Create (Color color)
+		public object Create(Color color)
 		{
-			return new swm.SolidColorBrush (color.ToWpf ());
+			return new FrozenBrushWrapper(new swm.SolidColorBrush(color.ToWpf()));
 		}
 	}
 }

--- a/Source/Eto.Wpf/Drawing/TextureBrushHandler.cs
+++ b/Source/Eto.Wpf/Drawing/TextureBrushHandler.cs
@@ -10,20 +10,26 @@ namespace Eto.Wpf.Drawing
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	public class TextureBrushHandler : TextureBrush.IHandler
 	{
-		public IMatrix GetTransform (TextureBrush widget)
+		static swm.ImageBrush Get(TextureBrush widget) => ((FrozenBrushWrapper)widget.ControlObject).Brush as swm.ImageBrush;
+
+		static void SetFrozen(TextureBrush widget) => ((FrozenBrushWrapper)widget.ControlObject).SetFrozen();
+
+		public IMatrix GetTransform(TextureBrush widget)
 		{
-			return ((swm.ImageBrush)widget.ControlObject).Transform.ToEtoMatrix ();
+			return Get(widget).Transform.ToEtoMatrix();
 		}
 
-		public void SetTransform (TextureBrush widget, IMatrix transform)
+		public void SetTransform(TextureBrush widget, IMatrix transform)
 		{
-			((swm.ImageBrush)widget.ControlObject).Transform = transform.ToWpfTransform ();
+			Get(widget).Transform = transform.ToWpfTransform();
+			SetFrozen(widget);
 		}
 
-		public object Create (Image image, float opacity)
+		public object Create(Image image, float opacity)
 		{
-			var rect = new System.Windows.Rect (0, 0, image.Size.Width, image.Size.Height);
-			return new swm.ImageBrush (image.ToWpf ()) {
+			var rect = new System.Windows.Rect(0, 0, image.Size.Width, image.Size.Height);
+			return new FrozenBrushWrapper(new swm.ImageBrush(image.ToWpf())
+			{
 				TileMode = swm.TileMode.Tile,
 				Opacity = opacity,
 				Stretch = swm.Stretch.None,
@@ -31,13 +37,14 @@ namespace Eto.Wpf.Drawing
 				Viewbox = rect,
 				ViewportUnits = swm.BrushMappingMode.Absolute,
 				Viewport = rect
-			};
+			});
 		}
 
 
-		public void SetOpacity (TextureBrush widget, float opacity)
+		public void SetOpacity(TextureBrush widget, float opacity)
 		{
-			((swm.ImageBrush)widget.ControlObject).Opacity = opacity;
+			Get(widget).Opacity = opacity;
+			SetFrozen(widget);
 		}
 	}
 }

--- a/Source/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
@@ -290,7 +290,7 @@ namespace Eto.Wpf.Forms.Controls
 				SetSelectionAttribute(swd.TextElement.FontStyleProperty, handler?.WpfFontStyle);
 				SetSelectionAttribute(swd.TextElement.FontWeightProperty, handler?.WpfFontWeight);
 				SetSelectionAttribute(swd.TextElement.FontSizeProperty, handler?.PixelSize);
-				SetSelectionAttribute(swd.Inline.TextDecorationsProperty, handler?.WpfTextDecorations);
+				SetSelectionAttribute(swd.Inline.TextDecorationsProperty, handler?.WpfTextDecorationsFrozen);
 			}
 		}
 

--- a/Source/Eto.Wpf/WpfConversions.cs
+++ b/Source/Eto.Wpf/WpfConversions.cs
@@ -446,12 +446,9 @@ namespace Eto.Wpf
 			}
 		}
 
-		public static swm.Brush ToWpf(this Brush brush, bool clone = false)
+		public static swm.Brush ToWpf(this Brush brush)
 		{
-			var b = (swm.Brush)brush.ControlObject;
-			if (clone)
-				b = b.Clone();
-			return b;
+			return ((FrozenBrushWrapper)brush.ControlObject).FrozenBrush;
 		}
 
 		public static swm.Matrix ToWpf(this IMatrix matrix)


### PR DESCRIPTION
- Wpf: Also fix turning on/off Graphics.AntiAlias and add unit test
- Add unit tests for font and brushes when used from other threads.

Fixes #645