### PR TITLE
Wpf: Property attach/detach controls in CustomCell when cell is loade…

### DIFF
--- a/Source/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
@@ -79,6 +79,16 @@ namespace Eto.Wpf.Forms.Cells
 				{
 					control = new EtoBorder { Column = this };
 					control.Args = new WpfCellEventArgs(-1, null, CellStates.None);
+					control.Unloaded += (sender, e) =>
+					{
+						var ctl = sender as EtoBorder;
+						ctl.Control?.DetachNative();
+					};
+					control.Loaded += (sender, e) =>
+					{
+						var ctl = sender as EtoBorder;
+						ctl.Control?.AttachNative();
+					};
 					control.DataContextChanged += (sender, e) =>
 					{
 						var ctl = sender as EtoBorder;
@@ -91,12 +101,12 @@ namespace Eto.Wpf.Forms.Cells
 							Stack<Control> cache;
 							if (child != null)
 							{
-							// store old child into cache
-							cache = GetCached(ctl.Identifier);
+								// store old child into cache
+								cache = GetCached(ctl.Identifier);
 								cache.Push(child);
 							}
-						// get new from cache or create if none created yet
-						cache = GetCached(id);
+							// get new from cache or create if none created yet
+							cache = GetCached(id);
 							if (cache.Count > 0)
 								child = cache.Pop();
 							else
@@ -105,7 +115,7 @@ namespace Eto.Wpf.Forms.Cells
 							var handler = child.GetWpfFrameworkElement();
 							if (handler != null)
 								handler.SetScale(true, true);
-							ctl.Child = child.ToNative(true);
+							ctl.Child = child.ToNative(ctl.IsLoaded);
 						}
 						Handler.Callback.OnConfigureCell(Handler.Widget, ctl.Args, child);
 

--- a/Source/Eto.Wpf/Forms/Controls/DrawableHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/DrawableHandler.cs
@@ -150,7 +150,8 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected override void OnLogicalPixelSizeChanged()
 		{
-			Invalidate(false);
+			if (Control.IsLoaded)
+				Invalidate(false);
 		}
 
 		public override void OnUnLoad(EventArgs e)
@@ -362,12 +363,6 @@ namespace Eto.Wpf.Forms.Controls
 
 		public override void Invalidate(bool invalidateChildren)
 		{
-			if (!Control.IsLoaded)
-			{
-				if (Widget.Loaded)
-					Application.Instance.AsyncInvoke(() => Invalidate(invalidateChildren));
-				return;
-			}
 			if (tiled)
 			{
 				foreach (var tile in visibleTiles.Values)
@@ -389,12 +384,6 @@ namespace Eto.Wpf.Forms.Controls
 
 		public override void Invalidate(Rectangle rect, bool invalidateChildren)
 		{
-			if (!Control.IsLoaded)
-			{
-				if (Widget.Loaded)
-					Application.Instance.AsyncInvoke(() => Invalidate(rect, invalidateChildren));
-				return;
-			}
 			if (tiled)
 			{
 				foreach (var tile in visibleTiles.Values)

--- a/Source/Eto/Forms/Controls/Control.cs
+++ b/Source/Eto/Forms/Controls/Control.cs
@@ -811,6 +811,21 @@ namespace Eto.Forms
 			}
 		}
 
+		/// <summary>
+		/// Detaches the control when it is used in a native application, when you want to reuse the control.
+		/// </summary>
+		/// <remarks>
+		/// This should only be called after <see cref="AttachNative"/> has been called, which is usually done by calling
+		/// to <c>ToNative(true)</c>.
+		/// </remarks>
+		public void DetachNative()
+		{
+			using (Platform.Context)
+			{
+				OnUnLoad(EventArgs.Empty);
+			}
+		}
+
 		internal void TriggerPreLoad(EventArgs e)
 		{
 			using (Platform.Context)


### PR DESCRIPTION
…d/unloaded.

Wpf: Fix possible infinite loop in Drawable.Invalidate() when control is not loaded but the Widget is.
Added Control.DetachNative() so one could detach a control when you want to reuse it.