### PR TITLE
Fix so WPF controls have default style applied after the control is loaded

### DIFF
--- a/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -532,8 +532,9 @@ namespace Eto.Wpf.Forms
 		}
 
 		void Control_Loaded(object sender, sw.RoutedEventArgs e)
-		{
-			SetSize();
+        {
+            SetDefaultStyleOnControlLoaded();
+            SetSize();
 			if (NeedsPixelSizeNotifications && Win32.PerMonitorDpiSupported)
 				OnLogicalPixelSizeChanged();
 		}

--- a/Source/Eto/Platform.cs
+++ b/Source/Eto/Platform.cs
@@ -156,7 +156,6 @@ namespace Eto
 		/// <param name="e">Arguments for the event</param>
 		protected virtual void OnWidgetCreated(WidgetCreatedEventArgs e)
 		{
-			Eto.Style.OnStyleWidgetDefaults(e.Instance);
 			if (WidgetCreated != null)
 				WidgetCreated(this, e);
 		}

--- a/Source/Eto/WidgetHandler.cs
+++ b/Source/Eto/WidgetHandler.cs
@@ -118,23 +118,21 @@ namespace Eto
 				throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, "Event {0} not supported by this control", id));
 			#endif
 		}
-
-		/// <summary>
-		/// Called to initialize this widget after it has been constructed
-		/// </summary>
-		/// <remarks>
-		/// Override this to initialize any of the platform objects.  This is called
-		/// in the widget constructor, after all of the widget's constructor code has been called.
-		/// </remarks>
-		protected virtual void Initialize()
-		{
-			Style.OnStyleWidgetDefaults(this);
-		}
-
+        
 		void Widget.IHandler.Initialize()
 		{
 			Initialize();
-		}
+        }
+
+        /// <summary>
+        /// Call this once the control is loaded, so the default style
+        /// can be set. On WPF the visual tree is only available on some
+        /// comtrols (ie. combobox) after control load
+        /// </summary>
+        protected void SetDefaultStyleOnControlLoaded()
+        {
+            Style.OnStyleWidgetDefaults(this.Widget);
+        }
 
 		/// <summary>
 		/// Gets or sets the widget instance


### PR DESCRIPTION
Previously some controls (such as combobox) would not get styled, as their visual tree was not yet loaded.