### PR TITLE
Wpf: ProgressBar fix when embedded in win32 app.

### DIFF
--- a/Source/Eto.Wpf/Forms/Controls/ProgressBarHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ProgressBarHandler.cs
@@ -12,11 +12,33 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected override sw.Size MeasureOverride(sw.Size constraint)
 		{
-			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ??base.MeasureOverride(constraint);
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+
+		bool _isIndeterminate;
+		public new bool IsIndeterminate
+		{
+			get { return _isIndeterminate; }
+			set
+			{
+				if (_isIndeterminate != value)
+				{
+					if (IsLoaded)
+						base.IsIndeterminate = value;
+					_isIndeterminate = value;
+				}
+			}
+		}
+
+		public EtoProgressBar()
+		{
+			// WPF will keep posting to the message loop after a dialog is closed with IsIndeterminate = true
+			Loaded += (sender, e) => base.IsIndeterminate = IsIndeterminate;
+			Unloaded += (sender, e) => base.IsIndeterminate = false;
 		}
 	}
 
-	public class ProgressBarHandler : WpfControl<swc.ProgressBar, ProgressBar, ProgressBar.ICallback>, ProgressBar.IHandler
+	public class ProgressBarHandler : WpfControl<EtoProgressBar, ProgressBar, ProgressBar.ICallback>, ProgressBar.IHandler
 	{
 		protected override sw.Size DefaultSize => new sw.Size(double.NaN, 22);
 

--- a/Source/Eto/Forms/Layout/StackLayout.cs
+++ b/Source/Eto/Forms/Layout/StackLayout.cs
@@ -361,7 +361,7 @@ namespace Eto.Forms
 		{
 			get
 			{
-				return Items.Where(r => r != null).Select(r => r.Control);
+				return Items.Where(r => r?.Control != null).Select(r => r.Control);
 			}
 		}
 


### PR DESCRIPTION
- Wpf: Prevent using a ProgressBar from flooding message loop when IsIndeterminate = true and no longer used.
- StackLayout: Don’t return null in Controls enumeration, prevents unbinding