### PR TITLE
Wpf: Fix some bugs in GridView/TreeGridView

### DIFF
--- a/Source/Eto.Test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -493,19 +493,23 @@ namespace Eto.Test.Sections.Controls
 			{
 				// initialize to random values
 				this.Row = row;
-				var val = rand.Next(3);
+				var val = row % 3;
 				check = val == 0 ? (bool?)false : val == 1 ? (bool?)true : null;
 
-				val = rand.Next(3);
+				val = row % 2;
 				Image = val == 0 ? image1 : val == 1 ? (Image)image2 : null;
 
 				text = string.Format("Col 1 Row {0}", row);
 
-				Color = Color.FromArgb(rand.Next(256), rand.Next(256), rand.Next(256));
+				Color = Color.FromElementId(row);
 
-				dropDownKey = "Item " + Convert.ToString(rand.Next(4) + 1);
+				val = row % 5;
+				if (val < 4)
+					dropDownKey = "Item " + Convert.ToString(val + 1);
 
-				progress = rand.Next() % 10 != 0 ? (float?)rand.NextDouble() : null;
+				val = row % 12;
+				if (val <= 10)
+					progress = (float)Math.Round(val / 10f, 1);
 			}
 
 			public override string ToString()

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
@@ -14,7 +14,7 @@ namespace Eto.Test.Sections.Controls
 		readonly CheckBox allowExpanding;
 		readonly TreeGridView grid;
 		int newItemCount;
-		static readonly Image Image = TestIcons.TestIcon;
+		static readonly Image Image = TestIcons.TestIcon.WithSize(16, 16);
 		Label hoverNodeLabel;
 		bool cancelLabelEdit;
 

--- a/Source/Eto.Wpf/Forms/Cells/CheckBoxCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/CheckBoxCellHandler.cs
@@ -28,6 +28,7 @@ namespace Eto.Wpf.Forms.Cells
 		class Column : swc.DataGridCheckBoxColumn
 		{
 			public CheckBoxCellHandler Handler { get; set; }
+			bool enableEvents;
 
 			protected override sw.FrameworkElement GenerateElement(swc.DataGridCell cell, object dataItem)
 			{
@@ -44,7 +45,9 @@ namespace Eto.Wpf.Forms.Cells
 					element.DataContextChanged += (sender, e) =>
 					{
 						var control = sender as swc.CheckBox;
+						enableEvents = false;
 						control.IsChecked = Handler.GetValue(control.DataContext);
+						enableEvents = true;
 						Handler.FormatCell(control, cell, control.DataContext);
 					};
 					SetControlInitialized(element, true);
@@ -64,11 +67,15 @@ namespace Eto.Wpf.Forms.Cells
 				{
 					element.Checked += (sender, e) =>
 					{
+						if (!enableEvents)
+							return;
 						var control = (swc.CheckBox)sender;
 						Handler.SetValue(control.DataContext, control.IsChecked);
 					};
 					element.Unchecked += (sender, e) =>
 					{
+						if (!enableEvents)
+							return;
 						var control = (swc.CheckBox)sender;
 						Handler.SetValue(control.DataContext, control.IsChecked);
 					};

--- a/Source/Eto.Wpf/Forms/Cells/ComboBoxCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/ComboBoxCellHandler.cs
@@ -47,13 +47,10 @@ namespace Eto.Wpf.Forms.Cells
 			{
 				if (!IsControlInitialized(control))
 				{
-					control.DataContextChanged += (sender, e) => SetValue(cell, (swc.ComboBox)sender, e.NewValue);
+					control.DataContextChanged += (sender, e) => SetValue(control.GetParent<swc.DataGridCell>(), (swc.ComboBox)sender, e.NewValue);
 					SetControlInitialized(control, true);
 				}
-				else
-				{
-					SetValue(cell, control, dataItem);
-				}
+				SetValue(cell, control, dataItem);
 			}
 
 			void SetValue(swc.DataGridCell cell, swc.ComboBox control, object dataItem)

--- a/Source/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
@@ -72,7 +72,7 @@ namespace Eto.Wpf.Forms.Cells
 				return cachedList;
 			}
 
-			EtoBorder Create(swc.DataGridCell cell, object dataItem)
+			EtoBorder Create(swc.DataGridCell cell)
 			{
 				var control = cell.Content as EtoBorder;
 				if (control == null)
@@ -133,18 +133,17 @@ namespace Eto.Wpf.Forms.Cells
 						Handler.Callback.OnConfigureCell(Handler.Widget, control.Args, control.Control);
 					};
 				}
-				control.DataContext = dataItem;
 				return control;
 			}
 
 			protected override sw.FrameworkElement GenerateElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell, dataItem));
+				return Handler.SetupCell(Create(cell));
 			}
 
 			protected override sw.FrameworkElement GenerateEditingElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell, dataItem));
+				return Handler.SetupCell(Create(cell));
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/Cells/DrawableCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/DrawableCellHandler.cs
@@ -39,7 +39,7 @@ namespace Eto.Wpf.Forms.Cells
 		{
 			public DrawableCellHandler Handler { get; set; }
 
-			EtoCanvas Create(swc.DataGridCell cell, object dataItem)
+			EtoCanvas Create(swc.DataGridCell cell)
 			{
 				var control = cell.Content as EtoCanvas;
 				if (control == null)
@@ -63,18 +63,17 @@ namespace Eto.Wpf.Forms.Cells
 						control.InvalidateVisual();
 					};
 				}
-				control.DataContext = dataItem;
 				return control;
 			}
 
 			protected override sw.FrameworkElement GenerateElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell, dataItem));
+				return Handler.SetupCell(Create(cell));
 			}
 
 			protected override sw.FrameworkElement GenerateEditingElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell, dataItem));
+				return Handler.SetupCell(Create(cell));
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/Controls/StepperHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/StepperHandler.cs
@@ -35,7 +35,7 @@ namespace Eto.Wpf.Forms.Controls
 			gridContent = parentGrid.FindChild<swc.Grid>("gridContent");
 			if (gridContent == null)
 				return;
-			gridContent.MinWidth = originalWidth = gridContent.Width;
+			gridContent.MinWidth = originalWidth = double.IsNaN(gridContent.Width) ? 0 : gridContent.Width;
 			gridContent.Width = double.NaN;
 		}
 

--- a/Source/Eto.Wpf/WpfExtensions.cs
+++ b/Source/Eto.Wpf/WpfExtensions.cs
@@ -27,6 +27,19 @@ namespace Eto.Wpf
 			return null;
 		}
 
+		public static T GetParent<T>(this sw.FrameworkElement control)
+			where T : class
+		{
+			while (control != null)
+			{
+				var tmp = control.Parent as T;
+				if (tmp != null)
+					return tmp;
+				control = control.Parent as sw.FrameworkElement;
+			}
+			return null;
+		}
+
 		public static IEnumerable<sw.DependencyObject> GetParents(this sw.FrameworkElement control)
 		{
 			while (control != null)


### PR DESCRIPTION
- CheckBoxCell triggered change events while scrolling if a previous row was checked/unchecked
- ComboBoxCell did not apply formatting when initially displayed
- CustomCell and Drawable did not change data context properly when scrolling
- Fix possible crash in Stepper