### PR TITLE
TextStepper fixes

### DIFF
--- a/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
+++ b/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
@@ -211,6 +211,7 @@
     <Compile Include="Sections\Dialogs\OpenWithDialogSection.cs" />
     <Compile Include="Sections\Controls\DocumentControlSection.cs" />
     <Compile Include="Sections\Behaviors\NotificationSection.cs" />
+    <Compile Include="Sections\Controls\MaskedTextStepperSection.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Sections\Serialization\Json\Test.json">

--- a/Source/Eto.Test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
@@ -26,7 +26,8 @@ namespace Eto.Test.Sections.Behaviors
 			layout.EndHorizontal();
 
 			layout.AddRow(null, CheckBoxControl(), RadioButtonControl());
-			layout.AddRow(null, DateTimeControl(), NumericStepperControl(), DropDownControl(), ComboBoxControl());
+			layout.AddRow(null, DateTimeControl(), DropDownControl(), ComboBoxControl());
+			layout.AddRow(null, NumericStepperControl(), TextStepperControl());
 
 			layout.BeginHorizontal();
 			layout.Add(null);
@@ -114,6 +115,13 @@ namespace Eto.Test.Sections.Behaviors
 		Control NumericStepperControl()
 		{
 			var control = new NumericStepper();
+			LogEvents(control);
+			return control;
+		}
+
+		Control TextStepperControl()
+		{
+			var control = new TextStepper();
 			LogEvents(control);
 			return control;
 		}

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/MaskedTextStepperSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/MaskedTextStepperSection.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Eto.Forms;
+using System.Diagnostics;
+using Eto.Drawing;
+
+
+namespace Eto.Test.Sections.Controls
+{
+	[Section("Controls", typeof(MaskedTextStepper))]
+	public class MaskedTextStepperSection : StackLayout
+	{
+		public MaskedTextStepperSection()
+		{
+			Spacing = 5;
+			Padding = new Padding(10);
+			var tb = new NumericMaskedTextStepper<decimal> { Value = 123.456M };
+			var l = new Label();
+			l.TextBinding.Bind(Binding.Property(tb, c => c.Value).Convert(r => "Value: " + Convert.ToString(r)));
+			Items.Add(new StackLayout { Orientation = Orientation.Horizontal, Spacing = 5, Items = { tb, l } });
+			Items.Add(new NumericMaskedTextStepper<double> { Value = 0.000000123 });
+			Items.Add(new MaskedTextStepper(new FixedMaskedTextProvider("(999) 000-0000")) { ShowPromptOnFocus = true, PlaceholderText = "(123) 456-7890" });
+			Items.Add(new MaskedTextStepper<DateTime>(new FixedMaskedTextProvider<DateTime>("&&/90/0000") { ConvertToValue = DateTime.Parse }));
+			Items.Add(new MaskedTextStepper(new FixedMaskedTextProvider(">L0L 0L0")));
+			Items.Add(new MaskedTextStepper { InsertMode = InsertKeyMode.Toggle });
+		}
+	}
+}

--- a/Source/Eto.Wpf/Forms/Controls/ComboBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ComboBoxHandler.cs
@@ -104,18 +104,19 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
+		protected override swc.Border BorderControl => Control.FindChild<swc.Border>("Border");
+
+		protected swc.Border DropDownButton => Control.FindChild<swc.Border>("templateRoot");
+
 		public override Color BackgroundColor
 		{
-			get
-			{
-				var contentHost = Control.ContentHost;
-				return (contentHost != null ? contentHost.Background : sw.SystemColors.WindowBrush).ToEtoColor();
-			}
+			get { return base.BackgroundColor; }
 			set
 			{
-				var contentHost = Control.ContentHost;
-				if (contentHost != null)
-					contentHost.Background = value.ToWpfBrush(contentHost.Background);
+				base.BackgroundColor = value;
+				var tb = DropDownButton;
+				if (tb != null)
+					tb.Background = value.ToWpfBrush(tb.Background);
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/Controls/DropDownHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/DropDownHandler.cs
@@ -143,16 +143,17 @@ namespace Eto.Wpf.Forms.Controls
 			set { Control.SelectedIndex = value; }
 		}
 
+		protected virtual swc.Border BorderControl => Control.FindChild<swc.Border>();
+
 		public override Color BackgroundColor
 		{
 			get
 			{
-				var border = Control.FindChild<swc.Border>();
-				return border != null ? border.Background.ToEtoColor() : base.BackgroundColor;
+				return BorderControl?.Background.ToEtoColor() ?? base.BackgroundColor;
 			}
 			set
 			{
-				var border = Control.FindChild<swc.Border>();
+				var border = BorderControl;
 				if (border != null)
 				{
 					border.Background = value.ToWpfBrush(border.Background);

--- a/Source/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
@@ -7,6 +7,7 @@ using sw = System.Windows;
 using swc = System.Windows.Controls;
 using mwc = Xceed.Wpf.Toolkit;
 using Eto.Forms;
+using Eto.Drawing;
 
 namespace Eto.Wpf.Forms.Controls
 {
@@ -31,6 +32,7 @@ namespace Eto.Wpf.Forms.Controls
 				{
 					BorderThickness = new sw.Thickness(0),
 					BorderBrush = null,
+					Background = null,
 					Padding = new sw.Thickness(0),
 				},
 			};
@@ -52,6 +54,12 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			get { return Control.ShowButtonSpinner; }
 			set { Control.ShowButtonSpinner = value; }
+		}
+
+		public override Color TextColor
+		{
+			get { return TextBox.Foreground.ToEtoColor(); }
+			set { TextBox.Foreground = value.ToWpfBrush(TextBox.Foreground); }
 		}
 
 		mwc.WatermarkTextBox WatermarkTextBox => (mwc.WatermarkTextBox)Control.Content;

--- a/Source/Eto/Eto - pcl.csproj
+++ b/Source/Eto/Eto - pcl.csproj
@@ -348,6 +348,7 @@
     <Compile Include="Forms\Controls\DocumentPage.cs" />
     <Compile Include="Forms\TrayIndicator.cs" />
     <Compile Include="Forms\Notification.cs" />
+    <Compile Include="Forms\Controls\MaskedTextStepper.cs" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\..\LICENSE">

--- a/Source/Eto/Forms/Controls/MaskedTextStepper.cs
+++ b/Source/Eto/Forms/Controls/MaskedTextStepper.cs
@@ -1,33 +1,10 @@
 ﻿using System;
-using System.Text;
 using System.Linq;
-using System.Globalization;
 using System.ComponentModel;
-using System.Collections.Generic;
-using System.Reflection;
 
 
 namespace Eto.Forms
 {
-	/// <summary>
-	/// Mode for insertion of text when the user types into a control.
-	/// </summary>
-	public enum InsertKeyMode
-	{
-		/// <summary>
-		/// Always insert, shifting any characters to the right of the caret position when inserting or deleting text.
-		/// </summary>
-		Insert,
-		/// <summary>
-		/// Always overwrite and do not shift characters when inserting or deleting text.
-		/// </summary>
-		Overwrite,
-		/// <summary>
-		/// Allow the user to toggle the insert mode (fn+Return on OS X or insert key on other keyboards)
-		/// </summary>
-		Toggle
-	}
-
 	/// <summary>
 	/// Masked text box with a variable length numeric mask.
 	/// </summary>
@@ -35,16 +12,13 @@ namespace Eto.Forms
 	/// This provides a text box that limits the user input to only allow numeric values.
 	/// </remarks>
 	/// <typeparam name="T">Numeric type such as int, decimal, double, etc.</typeparam>
-	public class NumericMaskedTextBox<T> : MaskedTextBox<T>
+	public class NumericMaskedTextStepper<T> : MaskedTextStepper<T>
 	{
 		/// <summary>
 		/// Gets the numeric provider.
 		/// </summary>
 		/// <value>The masked text provider.</value>
-		public new NumericMaskedTextProvider<T> Provider
-		{
-			get { return (NumericMaskedTextProvider<T>)base.Provider; }
-		}
+		public new NumericMaskedTextProvider<T> Provider => (NumericMaskedTextProvider<T>)base.Provider;
 
 		/// <summary>
 		/// Gets or sets a value indicating whether the mask can accept a sign.
@@ -54,9 +28,9 @@ namespace Eto.Forms
 		/// </remarks>
 		/// <value><c>true</c> to allow sign character; otherwise, <c>false</c>.</value>
 		public bool AllowSign
-		{ 
+		{
 			get { return Provider.AllowSign; }
-			set { Provider.AllowSign = value; } 
+			set { Provider.AllowSign = value; }
 		}
 
 		/// <summary>
@@ -74,9 +48,9 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="Eto.Forms.NumericMaskedTextBox{T}"/> class.
+		/// Initializes a new instance of the <see cref="Forms.NumericMaskedTextStepper{T}"/> class.
 		/// </summary>
-		public NumericMaskedTextBox()
+		public NumericMaskedTextStepper()
 			: base(new NumericMaskedTextProvider<T>())
 		{
 		}
@@ -90,7 +64,7 @@ namespace Eto.Forms
 	/// 
 	/// The <see cref="Provider"/> specified for the control is responsible for converting the value.
 	/// </remarks>
-	public class MaskedTextBox<T> : MaskedTextBox
+	public class MaskedTextStepper<T> : MaskedTextStepper
 	{
 		/// <summary>
 		/// Event to handle when the <see cref="Value"/> property changes
@@ -112,17 +86,17 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="Eto.Forms.MaskedTextBox{T}"/> class.
+		/// Initializes a new instance of the <see cref="Forms.MaskedTextStepper{T}"/> class.
 		/// </summary>
-		public MaskedTextBox()
+		public MaskedTextStepper()
 		{
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="Eto.Forms.MaskedTextBox{T}"/> class with the specified masked text provider.
+		/// Initializes a new instance of the <see cref="Forms.MaskedTextStepper{T}"/> class with the specified masked text provider.
 		/// </summary>
 		/// <param name="provider">Masked text provider to format the mask.</param>
-		public MaskedTextBox(IMaskedTextProvider<T> provider)
+		public MaskedTextStepper(IMaskedTextProvider<T> provider)
 			: base(provider)
 		{
 		}
@@ -146,11 +120,11 @@ namespace Eto.Forms
 		/// Gets a binding for the <see cref="Value"/> property.
 		/// </summary>
 		/// <value>The value binding.</value>
-		public BindableBinding<MaskedTextBox<T>, T> ValueBinding
+		public BindableBinding<MaskedTextStepper<T>, T> ValueBinding
 		{
 			get
 			{
-				return new BindableBinding<MaskedTextBox<T>, T>(
+				return new BindableBinding<MaskedTextStepper<T>, T>(
 					this,
 					c => c.Value,
 					(c, v) => c.Value = v,
@@ -169,7 +143,7 @@ namespace Eto.Forms
 	/// The mask can implement any format it wishes, including both fixed or variable length masks.
 	/// </remarks>
 	[ContentProperty("Provider")]
-	public class MaskedTextBox : TextBox
+	public class MaskedTextStepper : TextStepper
 	{
 		IMaskedTextProvider provider;
 		static readonly object InsertKeyModeKey = new object();
@@ -186,7 +160,7 @@ namespace Eto.Forms
 			get
 			{
 				// cache whether the platform supports the insert key for Keyboard.IsKeyLocked
-				return Platform.Instance.GetSharedProperty<bool>(SupportsInsertKey, () => Keyboard.SupportedLockKeys.Contains(Keys.Insert));
+				return Platform.Instance.GetSharedProperty(SupportsInsertKey, () => Keyboard.SupportedLockKeys.Contains(Keys.Insert));
 			}
 		}
 
@@ -195,7 +169,7 @@ namespace Eto.Forms
 		/// </summary>
 		static bool ManualOverwriteMode
 		{
-			get { return Platform.Instance.GetSharedProperty<bool>(OverwriteModeKey, () => false); }
+			get { return Platform.Instance.GetSharedProperty(OverwriteModeKey, () => false); }
 			set { Platform.Instance.SetSharedProperty(OverwriteModeKey, value); }
 		}
 
@@ -241,7 +215,7 @@ namespace Eto.Forms
 				if (InsertMode == InsertKeyMode.Overwrite)
 					return true;
 				var overwrite = SupportsInsert ? Keyboard.IsKeyLocked(Keys.Insert) : ManualOverwriteMode;
-				return InsertMode == InsertKeyMode.Toggle && overwrite; 
+				return InsertMode == InsertKeyMode.Toggle && overwrite;
 			}
 		}
 
@@ -253,10 +227,10 @@ namespace Eto.Forms
 		{
 			get { return Properties.Get<bool>(ShowPromptOnFocusKey); }
 			set
-			{ 
+			{
 				if (ShowPromptOnFocus != value)
 				{
-					Properties[ShowPromptOnFocusKey] = value; 
+					Properties[ShowPromptOnFocusKey] = value;
 					UpdateText();
 				}
 			}
@@ -272,19 +246,19 @@ namespace Eto.Forms
 		{
 			get { return Properties.Get<bool?>(ShowPlaceholderWhenEmptyKey) ?? true; }
 			set
-			{ 
+			{
 				if (ShowPlaceholderWhenEmpty != value)
 				{
-					Properties[ShowPlaceholderWhenEmptyKey] = value; 
+					Properties[ShowPlaceholderWhenEmptyKey] = value;
 					UpdateText();
 				}
 			}
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="Eto.Forms.MaskedTextBox"/> class.
+		/// Initializes a new instance of the <see cref="MaskedTextStepper"/> class.
 		/// </summary>
-		public MaskedTextBox()
+		public MaskedTextStepper()
 		{
 			HandleEvent(TextChangingEvent);
 			HandleEvent(KeyDownEvent);
@@ -293,10 +267,10 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="Eto.Forms.MaskedTextBox"/> class with the specified masked text provider.
+		/// Initializes a new instance of the <see cref="MaskedTextStepper"/> class with the specified masked text provider.
 		/// </summary>
 		/// <param name="provider">Masked text provider to specify the format of the mask.</param>
-		public MaskedTextBox(IMaskedTextProvider provider)
+		public MaskedTextStepper(IMaskedTextProvider provider)
 			: this()
 		{
 			if (provider == null)
@@ -476,10 +450,7 @@ namespace Eto.Forms
 		/// Gets a value indicating whether the mask is completed.
 		/// </summary>
 		/// <value><c>true</c> if mask completed; otherwise, <c>false</c>.</value>
-		public bool MaskCompleted
-		{
-			get { return provider != null && provider.MaskCompleted; }
-		}
+		public bool MaskCompleted => provider?.MaskCompleted == true;
 	}
 }
 

--- a/Source/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/Source/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -27,7 +27,7 @@ namespace Eto.Forms
 		/// <remarks>Note that on some platforms (e.g. Mac), setting the background color of a control can change the performance
 		/// characteristics of the control and its children, since it must enable layers to do so.</remarks>
 		/// <value>The color of the background.</value>
-		public Color BackgroundColor
+		public virtual Color BackgroundColor
 		{
 			get { return Control.BackgroundColor; }
 			set { Control.BackgroundColor = value; }
@@ -49,7 +49,7 @@ namespace Eto.Forms
 		/// Gets or sets the size of the control. Use -1 to specify auto sizing for either the width and/or height.
 		/// </summary>
 		/// <value>The size.</value>
-		public Size Size
+		public virtual Size Size
 		{
 			get { return Control.Size; }
 			set { Control.Size = value; }
@@ -286,6 +286,24 @@ namespace Eto.Forms
 			get { return Control; }
 		}
 
+		/// <summary>
+		/// Gets the control used to attach keyboard and text input events
+		/// </summary>
+		/// <value>The keyboard control.</value>
+		protected virtual Control KeyboardControl => Control;
+
+		/// <summary>
+		/// Gets the control used to attach mouse events
+		/// </summary>
+		/// <value>The mouse control.</value>
+		protected virtual Control MouseControl => Control;
+
+		/// <summary>
+		/// Gets the control used to attach focus events.
+		/// </summary>
+		/// <value>The focus control.</value>
+		protected virtual Control FocusControl => KeyboardControl;
+
 		#region Events
 
 		/// <summary>
@@ -300,43 +318,43 @@ namespace Eto.Forms
 			switch (id)
 			{
 				case Eto.Forms.Control.KeyDownEvent:
-					Control.KeyDown += (s, e) => Callback.OnKeyDown(Widget, e);
+					KeyboardControl.KeyDown += (s, e) => Callback.OnKeyDown(Widget, e);
 					break;
 				case Eto.Forms.Control.KeyUpEvent:
-					Control.KeyUp += (s, e) => Callback.OnKeyUp(Widget, e);
+					KeyboardControl.KeyUp += (s, e) => Callback.OnKeyUp(Widget, e);
 					break;
 				case Eto.Forms.Control.SizeChangedEvent:
 					Control.SizeChanged += (s, e) => Callback.OnSizeChanged(Widget, e);
 					break;
 				case Eto.Forms.Control.MouseDoubleClickEvent:
-					Control.MouseDoubleClick += (s, e) => Callback.OnMouseDoubleClick(Widget, e);
+					MouseControl.MouseDoubleClick += (s, e) => Callback.OnMouseDoubleClick(Widget, e);
 					break;
 				case Eto.Forms.Control.MouseEnterEvent:
-					Control.MouseEnter += (s, e) => Callback.OnMouseEnter(Widget, e);
+					MouseControl.MouseEnter += (s, e) => Callback.OnMouseEnter(Widget, e);
 					break;
 				case Eto.Forms.Control.MouseLeaveEvent:
-					Control.MouseLeave += (s, e) => Callback.OnMouseLeave(Widget, e);
+					MouseControl.MouseLeave += (s, e) => Callback.OnMouseLeave(Widget, e);
 					break;
 				case Eto.Forms.Control.MouseDownEvent:
-					Control.MouseDown += (s, e) => Callback.OnMouseDown(Widget, e);
+					MouseControl.MouseDown += (s, e) => Callback.OnMouseDown(Widget, e);
 					break;
 				case Eto.Forms.Control.MouseUpEvent:
-					Control.MouseUp += (s, e) => Callback.OnMouseUp(Widget, e);
+					MouseControl.MouseUp += (s, e) => Callback.OnMouseUp(Widget, e);
 					break;
 				case Eto.Forms.Control.MouseMoveEvent:
-					Control.MouseMove += (s, e) => Callback.OnMouseMove(Widget, e);
+					MouseControl.MouseMove += (s, e) => Callback.OnMouseMove(Widget, e);
 					break;
 				case Eto.Forms.Control.MouseWheelEvent:
-					Control.MouseWheel += (s, e) => Callback.OnMouseWheel(Widget, e);
+					MouseControl.MouseWheel += (s, e) => Callback.OnMouseWheel(Widget, e);
 					break;
 				case Eto.Forms.Control.GotFocusEvent:
-					Control.GotFocus += (s, e) => Callback.OnGotFocus(Widget, e);
+					FocusControl.GotFocus += (s, e) => Callback.OnGotFocus(Widget, e);
 					break;
 				case Eto.Forms.Control.LostFocusEvent:
-					Control.LostFocus += (s, e) => Callback.OnLostFocus(Widget, e);
+					FocusControl.LostFocus += (s, e) => Callback.OnLostFocus(Widget, e);
 					break;
 				case Eto.Forms.Control.TextInputEvent:
-					Control.TextInput += (s, e) => Callback.OnTextInput(Widget, e);
+					KeyboardControl.TextInput += (s, e) => Callback.OnTextInput(Widget, e);
 					break;
 				default:
 					base.AttachEvent(id);

--- a/Source/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
+++ b/Source/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
@@ -214,6 +214,26 @@ namespace Eto.Forms.ThemedControls
 		}
 
 		/// <summary>
+		/// Gets the control used to attach keyboard and text input events
+		/// </summary>
+		/// <value>The keyboard control.</value>
+		protected override Control KeyboardControl => textBox;
+
+		/// <summary>
+		/// Gets or sets the color for the background of the control
+		/// </summary>
+		/// <remarks>
+		/// Note that on some platforms (e.g. Mac), setting the background color of a control can change the performance
+		/// characteristics of the control and its children, since it must enable layers to do so.
+		/// </remarks>
+		/// <value>The color of the background.</value>
+		public override Color BackgroundColor
+		{
+			get { return textBox.BackgroundColor; }
+			set { textBox.BackgroundColor = value; }
+		}
+
+		/// <summary>
 		/// Attaches the specified event to the platform-specific control
 		/// </summary>
 		/// <remarks>Implementors should override this method to handle any events that the widget


### PR DESCRIPTION
Wpf: Fix setting TextStepper.BackgroundColor and TextColor
Wpf: Fix ComboBox.BackgroundColor to fill entire combo box not just text area
Mac: Fix setting BackgroundColor for ThemedTextStepperHandler
Add MaskedTextStepper and NumericMaskedTextStepper