### PR TITLE
Wpf: Fix focus events

### DIFF
--- a/Source/Eto.Test/Eto.Test/Sections/Behaviors/FocusEventsSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Behaviors/FocusEventsSection.cs
@@ -11,11 +11,11 @@ namespace Eto.Test.Sections.Behaviors
 
 			control.GotFocus += delegate
 			{
-				Log.Write(control, "GotFocus");
+				Log.Write(control, $"GotFocus, HasFocus: {control.HasFocus}");
 			};
 			control.LostFocus += delegate
 			{
-				Log.Write(control, "LostFocus");
+				Log.Write(control, $"LostFocus, HasFocus: {control.HasFocus}");
 			};
 		}
 	}

--- a/Source/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -64,7 +64,11 @@ namespace Eto.Wpf.Forms.Controls
 		public TextAlignment TextAlignment
 		{
 			get { return TextBox.TextAlignment.ToEto(); }
-			set { TextBox.TextAlignment = value.ToWpfTextAlignment(); }
+			set
+			{
+				TextBox.TextAlignment = value.ToWpfTextAlignment();
+				TextBox.HorizontalContentAlignment = value.ToWpf();
+			}
 		}
 
 		public TextBoxHandler ()

--- a/Source/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
@@ -28,6 +28,8 @@ namespace Eto.Wpf.Forms.Controls
 			Control = new EtoButtonSpinner
 			{
 				Handler = this,
+				IsTabStop = false,
+				Focusable = false,
 				Content = new mwc.WatermarkTextBox
 				{
 					BorderThickness = new sw.Thickness(0),

--- a/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -300,7 +300,7 @@ namespace Eto.Wpf.Forms
 
 		public virtual bool HasFocus
 		{
-			get { return Control.IsKeyboardFocused; }
+			get { return Control.IsKeyboardFocusWithin; }
 		}
 
 		public bool Visible
@@ -424,10 +424,16 @@ namespace Eto.Wpf.Forms
 					};
 					break;
 				case Eto.Forms.Control.GotFocusEvent:
-					Control.GotKeyboardFocus += (sender, e) => Callback.OnGotFocus(Widget, EventArgs.Empty);
+					Control.IsKeyboardFocusWithinChanged += (sender, e) =>
+					{
+						if (HasFocus)
+							Callback.OnGotFocus(Widget, EventArgs.Empty);
+						else
+							Callback.OnLostFocus(Widget, EventArgs.Empty);
+					};
 					break;
 				case Eto.Forms.Control.LostFocusEvent:
-					Control.LostKeyboardFocus += (sender, e) => Callback.OnLostFocus(Widget, EventArgs.Empty);
+					HandleEvent(Eto.Forms.Control.GotFocusEvent);
 					break;
 				default:
 					base.AttachEvent(id);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: 2.4.0.{build}
 install:
-- curl -fsS -o gtk-sharp.msi %GTKSHARP_LOCATION%/gtk-sharp-2.12.38.msi
+- appveyor DownloadFile %GTKSHARP_LOCATION%/gtk-sharp-2.12.38.msi -FileName gtk-sharp.msi
 - msiexec /i gtk-sharp.msi /qn /norestart
 build_script:
 - set BASE=%APPVEYOR_BUILD_FOLDER%
@@ -8,7 +8,7 @@ build_script:
 - set BUILD_VERSION=2.4.0-build%BUILD_VERSION:~-4%
 - echo Downloading XamMac.dll for build..
 - mkdir %BASE%\BuildOutput\net45\Release
-- curl -fsS -o %BASE%\BuildOutput\net45\Release\XamMac.dll %XAMMAC_LOCATION%/XamMac.dll
+- appveyor DownloadFile %XAMMAC_LOCATION%/XamMac.dll -FileName "%BASE%\BuildOutput\net45\Release\XamMac.dll"
 - msbuild -t:Package -p:BuildVersion=%BUILD_VERSION% Resources\Build.proj /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /consoleloggerparameters:NoSummary
 test: off
 #test_script:


### PR DESCRIPTION
- GotFocus/LostFocus would fire many times for most controls, even when it didn’t lose focus
- TextStepper should not allow keyboard focus to the spin buttons to have similar behaviour to NumericStepper.
- Show HasFocus property in the FocusEventsSection test.