### PR TITLE
Make MaskedTextBox/Stepper’s UpdateText method protected virtual.

### DIFF
--- a/Source/Eto/Forms/Controls/MaskedTextBox.cs
+++ b/Source/Eto/Forms/Controls/MaskedTextBox.cs
@@ -305,7 +305,16 @@ namespace Eto.Forms
 			UpdateText();
 		}
 
-		internal void UpdateText()
+		/// <summary>
+		/// Updates the text to the display text from the provider.
+		/// </summary>
+		/// <remarks>
+		/// Call this in a subclass when you want to update the text based on the state of the control.
+		/// When the <see cref="IMaskedTextProvider.IsEmpty"/> is true, it will set the text to null to show the placeholder text.
+		/// 
+		/// Override this to perform other actions before or after the text of the control is updated.
+		/// </remarks>
+		protected virtual void UpdateText()
 		{
 			if (provider == null)
 				return;

--- a/Source/Eto/Forms/Controls/MaskedTextStepper.cs
+++ b/Source/Eto/Forms/Controls/MaskedTextStepper.cs
@@ -279,7 +279,16 @@ namespace Eto.Forms
 			UpdateText();
 		}
 
-		internal void UpdateText()
+		/// <summary>
+		/// Updates the text to the display text from the provider.
+		/// </summary>
+		/// <remarks>
+		/// Call this in a subclass when you want to update the text based on the state of the control.
+		/// When the <see cref="IMaskedTextProvider.IsEmpty"/> is true, it will set the text to null to show the placeholder text.
+		/// 
+		/// Override this to perform other actions before or after the text of the control is updated.
+		/// </remarks>
+		protected virtual void UpdateText()
 		{
 			if (provider == null)
 				return;


### PR DESCRIPTION
Useful when creating subclasses that may have different states of the control or react to other events and properties.