### PR TITLE
Wpf: Fix RichTextArea.SelectionUnderline and SelectionStrikethrough in some cases.

### DIFF
--- a/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
+++ b/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
@@ -213,6 +213,7 @@
     <Compile Include="Sections\Behaviors\NotificationSection.cs" />
     <Compile Include="Sections\Controls\MaskedTextStepperSection.cs" />
     <Compile Include="UnitTests\Forms\Controls\TextBoxTests.cs" />
+    <Compile Include="UnitTests\Forms\Controls\RichTextAreaTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Sections\Serialization\Json\Test.json">

--- a/Source/Eto.Test/Eto.Test/Sections/UnitTestSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/UnitTestSection.cs
@@ -31,6 +31,8 @@ namespace Eto.Test.Sections
 				{
 					Application.AsyncInvoke(() => Log.Write(null, "Failed: {0}\n{1}", result.Message, result.StackTrace));
 				}
+				if (result.InconclusiveCount > 0)
+					Application.AsyncInvoke(() => Log.Write(null, "Inconclusive: {0}\n{1}", result.Message, result.StackTrace));
 			}
 		}
 

--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/ControlEventTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/ControlEventTests.cs
@@ -20,7 +20,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					.Where(r =>
 					{
 						var ti = r.GetTypeInfo();
-						return r.FullName.StartsWith("Eto.Forms")
+						return r.FullName.StartsWith("Eto.Forms", StringComparison.Ordinal)
 							&& typeof(Control).GetTypeInfo().IsAssignableFrom(ti)
 							&& !ti.IsAbstract
 							&& !ti.IsGenericType

--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/RichTextAreaTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/RichTextAreaTests.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	[TestFixture]
+	public class RichTextAreaTests : TestBase
+	{
+
+		public static void TestSelectionAttributes(RichTextArea richText, string tag, bool italic = false, bool underline = false, bool bold = false, bool strikethrough = false)
+		{
+			Assert.AreEqual(italic, richText.SelectionItalic, tag + "-1");
+			Assert.AreEqual(underline, richText.SelectionUnderline, tag + "-2");
+			Assert.AreEqual(bold, richText.SelectionBold, tag + "-3");
+			Assert.AreEqual(strikethrough, richText.SelectionStrikethrough, tag + "-4");
+		}
+
+		[Test]
+		public void SelectionAttributesShouldBeCorrectWithLoadedRtf()
+		{
+			Invoke(() =>
+			{
+				// not supported in GTK yet
+				if (Platform.Instance.IsGtk)
+					Assert.Inconclusive("Gtk does not support RTF format");
+
+				var richText = new RichTextArea();
+				richText.Rtf = @"{\rtf1\ansi {Hello \ul Underline \i Italic \b Bold \strike Strike}}";
+				Assert.AreEqual("Hello Underline Italic Bold Strike", richText.Text.TrimEnd(), "#1");
+				richText.CaretIndex = 5;
+				TestSelectionAttributes(richText, "#2");
+				richText.CaretIndex = 7;
+				TestSelectionAttributes(richText, "#3", underline: true);
+				richText.CaretIndex = 17;
+				TestSelectionAttributes(richText, "#4", underline: true, italic: true);
+				richText.CaretIndex = 24;
+				TestSelectionAttributes(richText, "#5", underline: true, italic: true, bold: true);
+				richText.CaretIndex = 29;
+				TestSelectionAttributes(richText, "#6", underline: true, italic: true, bold: true, strikethrough: true);
+			});
+		}
+	}
+}

--- a/Source/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
@@ -398,14 +398,10 @@ namespace Eto.Wpf.Forms.Controls
 		}
 
 
-		bool HasDecorations(swd.TextRange range, sw.TextDecorationCollection decorations, bool useRealPropertyValue = true)
+		bool HasDecorations(swd.TextRange range, sw.TextDecorationCollection decorations)
 		{
 			swd.TextRange realRange;
-			sw.TextDecorationCollection existingDecorations;
-			if (useRealPropertyValue)
-				existingDecorations = range.GetRealPropertyValue(swd.Inline.TextDecorationsProperty, out realRange) as sw.TextDecorationCollection;
-			else
-				existingDecorations = range.GetPropertyValue(swd.Inline.TextDecorationsProperty) as sw.TextDecorationCollection;
+			var existingDecorations = range.GetRealPropertyValue(swd.Inline.TextDecorationsProperty, out realRange) as sw.TextDecorationCollection;
 			return existingDecorations != null && decorations.All(r => existingDecorations.Contains(r));
 		}
 
@@ -462,7 +458,7 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			get
 			{
-				return HasDecorations(Control.Selection, sw.TextDecorations.Underline, Selection.Length() > 0);
+				return HasDecorations(Control.Selection, sw.TextDecorations.Underline);
 			}
 			set
 			{
@@ -477,7 +473,7 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			get
 			{
-				return HasDecorations(Control.Selection, sw.TextDecorations.Strikethrough, Selection.Length() > 0);
+				return HasDecorations(Control.Selection, sw.TextDecorations.Strikethrough);
 			}
 			set
 			{

--- a/Source/Eto/Forms/Controls/RichTextArea.cs
+++ b/Source/Eto/Forms/Controls/RichTextArea.cs
@@ -2,6 +2,7 @@
 using Eto.Drawing;
 using System.IO;
 using System.Collections.Generic;
+using System.Text;
 
 namespace Eto.Forms
 {
@@ -18,6 +19,40 @@ namespace Eto.Forms
 		/// Plain Text only
 		/// </summary>
 		PlainText
+	}
+
+	/// <summary>
+	/// Extensions for <see cref="ITextBuffer"/>
+	/// </summary>
+	public static class TextBufferExtensions
+	{
+		/// <summary>
+		/// Gets the content of the specified buffer as an RTF formatted string. Note that some platforms don't support RTF (e.g. Gtk).
+		/// </summary>
+		/// <returns>The content of the buffer in RTF format.</returns>
+		/// <param name="buffer">Buffer to get the content from.</param>
+		public static string GetRtf(this ITextBuffer buffer)
+		{
+			using (var stream = new MemoryStream())
+			{
+				buffer.Save(stream, RichTextAreaFormat.Rtf);
+				var bytes = stream.ToArray();
+				return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+			}
+		}
+
+		/// <summary>
+		/// Sets the content of the buffer to the specified <paramref name="rtf"/> string. Note that some platforms don't support RTF (e.g. Gtk).
+		/// </summary>
+		/// <param name="buffer">Buffer to set the content for</param>
+		/// <param name="rtf">RTF formatted string to set the buffer</param>
+		public static void SetRtf(this ITextBuffer buffer, string rtf)
+		{
+			using (var stream = new MemoryStream(Encoding.UTF8.GetBytes(rtf)))
+			{
+				buffer.Load(stream, RichTextAreaFormat.Rtf);
+			}
+		}
 	}
 
 	/// <summary>
@@ -218,6 +253,16 @@ namespace Eto.Forms
 		public ITextBuffer Buffer
 		{
 			get { return Handler.Buffer; }
+		}
+
+		/// <summary>
+		/// Gets or sets the content as a RTF (Rich Text Format) string. Note that some platforms don't support RTF (e.g. Gtk).
+		/// </summary>
+		/// <value>The RTF string.</value>
+		public string Rtf
+		{
+			get { return Buffer.GetRtf(); }
+			set { Buffer.SetRtf(value); }
 		}
 
 		/// <summary>


### PR DESCRIPTION
When loading RTF for example and the cursor is over underlined text, it will sometimes not show the correct value for these properties as there’s nefarious empty decoration collections in the document.

- Added RichTextArea.Rtf helper property
- Add ITextBuffer.GetRtf() and SetRtf() helper extension methods
- Added unit tests