### PR TITLE
Mac: Fix resizing a Splitter when code updates the layout during the resize.

### DIFF
--- a/Source/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -625,7 +625,8 @@ namespace Eto.Mac.Forms.Controls
 
 		void UpdatePosition()
 		{
-			Control.ResizeSubviewsWithOldSize(CGSize.Empty);
+			if (!Control.InLiveResize)
+				Control.ResizeSubviewsWithOldSize(CGSize.Empty);
 		}
 	}
 }


### PR DESCRIPTION
For example, the AnchorSection would mess up the splitter when resizing the window.