### PR TITLE
Mac: Fix TextArea.Enabled

### DIFF
--- a/Source/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -410,8 +410,11 @@ namespace Eto.Mac.Forms.Controls
 			{
 				SuppressSelectionChanged++;
 				UnselectAll();
-				var indexes = NSIndexSet.FromArray(value.ToArray());
-				Control.SelectRows(indexes, AllowMultipleSelection);
+				if (value != null)
+				{
+					var indexes = NSIndexSet.FromArray(value.ToArray());
+					Control.SelectRows(indexes, AllowMultipleSelection);
+				}
 				SuppressSelectionChanged--;
 				if (SuppressSelectionChanged == 0)
 					Callback.OnSelectionChanged(Widget, EventArgs.Empty);

--- a/Source/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -216,10 +216,12 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
+		static readonly object ReadOnly_Key = new object();
+
 		public bool ReadOnly
 		{
-			get { return !Control.Editable; }
-			set { Control.Editable = !value; }
+			get { return Widget.Properties.Get<bool>(ReadOnly_Key); }
+			set { Widget.Properties.Set(ReadOnly_Key, value, () => Control.Editable = !value); }
 		}
 
 		public override bool Enabled
@@ -237,6 +239,7 @@ namespace Eto.Mac.Forms.Controls
 				{
 					Control.TextColor = TextColor.ToNSUI();
 					Control.BackgroundColor = BackgroundColor.ToNSUI();
+					Control.Editable = !ReadOnly; // this gets set to false when Selectable is set to false, so we need to re-enable it.
 				}
 			}
 		}

--- a/Source/Eto.Test/Eto.Test.Mac/Eto.Test.Mac - net45.csproj
+++ b/Source/Eto.Test/Eto.Test.Mac/Eto.Test.Mac - net45.csproj
@@ -70,6 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Startup.cs" />
+    <Compile Include="UnitTests\RichTextAreaHandlerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/Source/Eto.Test/Eto.Test.Mac/Eto.Test.Mac64 - net45.csproj
+++ b/Source/Eto.Test/Eto.Test.Mac/Eto.Test.Mac64 - net45.csproj
@@ -69,6 +69,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Startup.cs" />
+    <Compile Include="UnitTests\RichTextAreaHandlerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/Source/Eto.Test/Eto.Test.Mac/Eto.Test.XamMac - net45.csproj
+++ b/Source/Eto.Test/Eto.Test.Mac/Eto.Test.XamMac - net45.csproj
@@ -73,6 +73,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Startup.cs" />
+    <Compile Include="UnitTests\RichTextAreaHandlerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/Source/Eto.Test/Eto.Test.Mac/Eto.Test.XamMac2 - mobile.csproj
+++ b/Source/Eto.Test/Eto.Test.Mac/Eto.Test.XamMac2 - mobile.csproj
@@ -68,6 +68,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Startup.cs" />
+    <Compile Include="UnitTests\RichTextAreaHandlerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/Source/Eto.Test/Eto.Test.Mac/Eto.Test.XamMac2 - net45.csproj
+++ b/Source/Eto.Test/Eto.Test.Mac/Eto.Test.XamMac2 - net45.csproj
@@ -66,6 +66,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Startup.cs" />
+    <Compile Include="UnitTests\RichTextAreaHandlerTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/Source/Eto.Test/Eto.Test.Mac/UnitTests/RichTextAreaHandlerTests.cs
+++ b/Source/Eto.Test/Eto.Test.Mac/UnitTests/RichTextAreaHandlerTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+using Eto.Forms;
+using Eto.Mac.Forms.Controls;
+namespace Eto.Test.Mac.UnitTests
+{
+	[TestFixture]
+	public class RichTextAreaHandlerTests : TestBase
+	{
+		/// <summary>
+		/// Tests the interaction of the Enabled and ReadOnly properties with NSTextArea's Selectable and Editable 
+		/// properties since they are sometimes changed automatically by AppKit when Selectable is set.
+		/// </summary>
+		[Test]
+		public void EnabledShouldChangeEditable()
+		{
+			Invoke(() =>
+			{
+				var richTextArea = new RichTextArea();
+				var handler = richTextArea.Handler as RichTextAreaHandler;
+
+				Assert.IsTrue(richTextArea.Enabled, "#1");
+				Assert.IsFalse(richTextArea.ReadOnly, "#2");
+				Assert.IsTrue(handler.Control.Selectable, "#3");
+				Assert.IsTrue(handler.Control.Editable, "#4");
+				richTextArea.Enabled = false;
+
+				Assert.IsFalse(handler.Control.Selectable, "#5");
+				Assert.IsFalse(handler.Control.Editable, "#6");
+				richTextArea.Enabled = true;
+
+				Assert.IsTrue(handler.Control.Selectable, "#7");
+				Assert.IsTrue(handler.Control.Editable, "#8");
+
+				richTextArea.ReadOnly = true;
+				Assert.IsTrue(handler.Control.Selectable, "#9");
+				Assert.IsFalse(handler.Control.Editable, "#10");
+
+				richTextArea.Enabled = false;
+				Assert.IsFalse(handler.Control.Selectable, "#11");
+				Assert.IsFalse(handler.Control.Editable, "#12");
+
+				richTextArea.Enabled = true;
+				Assert.IsTrue(handler.Control.Selectable, "#13");
+				Assert.IsFalse(handler.Control.Editable, "#14");
+
+				richTextArea.ReadOnly = false;
+				Assert.IsTrue(handler.Control.Selectable, "#15");
+				Assert.IsTrue(handler.Control.Editable, "#16");
+
+				richTextArea.Enabled = false;
+				Assert.IsFalse(handler.Control.Selectable, "#17");
+				Assert.IsFalse(handler.Control.Editable, "#18");
+
+				richTextArea.ReadOnly = true;
+				Assert.IsFalse(handler.Control.Selectable, "#19");
+				Assert.IsFalse(handler.Control.Editable, "#20");
+
+				richTextArea.Enabled = true;
+				Assert.IsTrue(handler.Control.Selectable, "#21");
+				Assert.IsFalse(handler.Control.Editable, "#22");
+
+				richTextArea.ReadOnly = false;
+				Assert.IsTrue(handler.Control.Selectable, "#23");
+				Assert.IsTrue(handler.Control.Editable, "#24");
+			});
+		}
+	}
+}

--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/RichTextAreaTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/RichTextAreaTests.cs
@@ -40,5 +40,22 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				TestSelectionAttributes(richText, "#6", underline: true, italic: true, bold: true, strikethrough: true);
 			});
 		}
+
+		[Test]
+		public void EnabledShouldNotAffectReadOnly()
+		{
+			Invoke(() =>
+			{
+				var richText = new RichTextArea();
+				Assert.IsTrue(richText.Enabled, "#1");
+				Assert.IsFalse(richText.ReadOnly, "#2");
+				richText.Enabled = false;
+				Assert.IsFalse(richText.Enabled, "#3");
+				Assert.IsFalse(richText.ReadOnly, "#4");
+				richText.Enabled = true;
+				Assert.IsTrue(richText.Enabled, "#5");
+				Assert.IsFalse(richText.ReadOnly, "#6");
+			});
+		}
 	}
 }


### PR DESCRIPTION
Fixes setting TextArea.Enabled to false then back to true.  It would leave ReadOnly set to true even though it was not set.

Also fixes minor issue with Grid.SelectedRows to allow it to be set to null.