### PR TITLE
Mac: Restore menu regardless of if it has a monomac/xammac instance or not

### DIFF
--- a/Source/Eto.Mac/Forms/MacWindow.cs
+++ b/Source/Eto.Mac/Forms/MacWindow.cs
@@ -227,35 +227,13 @@ namespace Eto.Mac.Forms
 		static void HandleDidBecomeKey(object sender, EventArgs e)
 		{
 			var handler = GetHandler(sender) as MacWindow<TControl,TWidget,TCallback>;
-			if (handler == null)
-				return;
-			if (handler.MenuBar != null)
-			{
-				var ptr = Messaging.IntPtr_objc_msgSend(NSApplication.SharedApplication.Handle, selMainMenu);
-				if (Runtime.TryGetNSObject(ptr) == null)
-				{
-					// it's a native menu, so let's hold on to it till we resign key of the form
-					MacExtensions.Retain(ptr);
-					handler.oldMenu = ptr;
-				}
-				NSApplication.SharedApplication.MainMenu = handler.MenuBar;
-			}
-			else
-				handler.oldMenu = IntPtr.Zero;
+			handler?.SetMenu();
 		}
 
 		static void HandleDidResignKey(object sender, EventArgs e)
 		{
 			var handler = GetHandler(sender) as MacWindow<TControl,TWidget,TCallback>;
-			if (handler == null)
-				return;
-			if (handler.oldMenu != IntPtr.Zero)
-			{
-				// restore old native menu
-				Messaging.void_objc_msgSend_IntPtr(NSApplication.SharedApplication.Handle, selSetMainMenu, handler.oldMenu);
-				MacExtensions.Release(handler.oldMenu);
-				handler.oldMenu = IntPtr.Zero;
-			}
+			handler?.RestoreMenu();
 		}
 
 		static bool HandleShouldZoom(NSWindow window, CGRect newFrame)
@@ -591,9 +569,43 @@ namespace Eto.Mac.Forms
 			{
 				menuBar = value;
 				if (Control.IsKeyWindow)
+					SetMenu();
+			}
+		}
+
+		void SetMenu()
+		{
+			if (MenuBar != null)
+			{
+				// if not zero, it's already saved
+				if (oldMenu == IntPtr.Zero)
 				{
-					NSApplication.SharedApplication.MainMenu = (NSMenu)value.ControlObject;
+					oldMenu = Messaging.IntPtr_objc_msgSend(NSApplication.SharedApplication.Handle, selMainMenu);
+					if (oldMenu != IntPtr.Zero)
+					{
+						// remember old native menu so we can restore it later
+						MacExtensions.Retain(oldMenu);
+					}
 				}
+
+				NSApplication.SharedApplication.MainMenu = MenuBar;
+			}
+			else
+			{
+				// restore the menu since we no longer have a menu specific to this window.
+				RestoreMenu();
+			}
+
+		}
+
+		void RestoreMenu()
+		{
+			if (oldMenu != IntPtr.Zero)
+			{
+				// restore old native menu
+				Messaging.void_objc_msgSend_IntPtr(NSApplication.SharedApplication.Handle, selSetMainMenu, oldMenu);
+				MacExtensions.Release(oldMenu);
+				oldMenu = IntPtr.Zero;
 			}
 		}
 


### PR DESCRIPTION
This is when using non-Eto code that utilizes MonoMac/Xamarin.Mac.  In this case, the menu wouldn't be restored when an Eto form loses focus.  Now it saves the old menu, even if it's from Eto and restores it when a window loses focus.  It will also properly save the old menu if you set a window's menu after it is shown.