### PR TITLE
Mac: Fix Scrollable when dynamically added to a container with a background color

### DIFF
--- a/Source/Eto.Mac/Forms/Controls/PanelHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/PanelHandler.cs
@@ -17,9 +17,13 @@ namespace Eto.Mac.Forms.Controls
 {
 	public class PanelHandler : MacPanel<NSView, Panel, Panel.ICallback>, Panel.IHandler
 	{
+		class EtoPanel : MacEventView
+		{
+		}
+
 		protected override NSView CreateControl()
 		{
-			return new MacEventView();
+			return new EtoPanel { Handler = this };
 		}
 		
 		public override NSView ContainerControl { get { return Control; } }

--- a/Source/Eto.Mac/Forms/Controls/ScrollableHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/ScrollableHandler.cs
@@ -62,7 +62,7 @@ namespace Eto.Mac.Forms.Controls
 
 			public EtoScrollView(ScrollableHandler handler)
 			{
-				BackgroundColor = NSColor.Control;
+				BackgroundColor = NSColor.Clear;
 				BorderType = NSBorderType.BezelBorder;
 				DrawsBackground = false;
 				HasVerticalScroller = true;

--- a/Source/Eto.Mac/Forms/MacBase.cs
+++ b/Source/Eto.Mac/Forms/MacBase.cs
@@ -190,10 +190,20 @@ namespace Eto.Mac.Forms
 			#if OSX
 			if (!typeof(IMacControl).IsAssignableFrom(type))
 				throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Control '{0}' does not inherit from IMacControl", type));
+			if (((IMacControl)control).WeakHandler?.Target == null)
+				throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Control '{0}' has a null handler", type));
 			#endif
 			var classHandle = Class.GetHandle(type);
 			ObjCExtensions.AddMethod(classHandle, selector, action, arguments);
 		}
+
+		public bool HasMethod(IntPtr selector, object control)
+		{
+			var type = control.GetType();
+			var classHandle = Class.GetHandle(type);
+			return ObjCExtensions.GetMethod(classHandle, selector) != IntPtr.Zero;
+		}
+
 
 		public NSObject AddObserver(NSString key, Action<ObserverActionEventArgs> action, NSObject control)
 		{

--- a/Source/Eto.Mac/Forms/MacObject.cs
+++ b/Source/Eto.Mac/Forms/MacObject.cs
@@ -45,9 +45,31 @@ namespace Eto.Mac.Forms
 			get { return Control; }
 		}
 
+		/// <summary>
+		/// Adds the method dynamically to the specified NSObject.
+		/// This uses Objective C to dynamically add the specified method to the class.  Note that you should only pass
+		/// objects that have an eto-specific subclass.
+		/// 
+		/// Typically "v@:[args]"  v = void return, @ = sender 
+		/// Arguments:
+		/// <list type="unordered">
+		///   <item>v - Void</item>
+		///   <item>@ - NSObject</item>
+		///   <item>B - boolean</item>
+		///   <item>d - double</item>
+		///   <item>f - float</item>
+		///   <item>{CGSize=dd} - CGSize struct with double values</item>
+		///   <item>{CGSize=ff} - CGSize struct with float values</item>
+		/// </list>
+		/// </summary>
 		public new void AddMethod (IntPtr selector, Delegate action, string arguments, object control = null)
 		{
 			base.AddMethod (selector, action, arguments, control ?? EventObject);
+		}
+
+		public new bool HasMethod(IntPtr selector, object control = null)
+		{
+			return base.HasMethod(selector, control ?? EventObject);
 		}
 
 		public new NSObject AddObserver (NSString key, Action<ObserverActionEventArgs> action, NSObject control = null)

--- a/Source/Eto.Mac/Messaging.cs
+++ b/Source/Eto.Mac/Messaging.cs
@@ -70,6 +70,9 @@ namespace Eto.Mac
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
 		public static extern void void_objc_msgSendSuper_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);
 
+		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		public static extern void void_objc_msgSendSuper_CGRect(IntPtr receiver, IntPtr selector, CGRect arg1);
+
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
 		public static extern bool bool_objc_msgSend_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);
 

--- a/Source/Eto.Mac/ObjCExtensions.cs
+++ b/Source/Eto.Mac/ObjCExtensions.cs
@@ -29,6 +29,11 @@ namespace Eto.Mac
 			return class_getClassMethod(cls.Handle, selector);
 		}
 
+		public static IntPtr GetMethod(IntPtr cls, IntPtr selector)
+		{
+			return class_getClassMethod(cls, selector);
+		}
+
 		[DllImport("/usr/lib/libobjc.dylib")]
 		static extern bool class_addMethod(IntPtr cls, IntPtr sel, Delegate method, string argTypes);
 

--- a/Source/Eto.Test/Eto.Test.Mac/Eto.Test.Mac - net45.csproj
+++ b/Source/Eto.Test/Eto.Test.Mac/Eto.Test.Mac - net45.csproj
@@ -71,6 +71,7 @@
   <ItemGroup>
     <Compile Include="Startup.cs" />
     <Compile Include="UnitTests\RichTextAreaHandlerTests.cs" />
+    <Compile Include="UnitTests\ScrollableTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/Source/Eto.Test/Eto.Test.Mac/UnitTests/ScrollableTests.cs
+++ b/Source/Eto.Test/Eto.Test.Mac/UnitTests/ScrollableTests.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+using Eto.Forms;
+using Eto.Mac.Forms.Controls;
+using Eto.Drawing;
+namespace Eto.Test.Mac.UnitTests
+{
+	[TestFixture]
+	public class ScrollableTests : TestBase
+	{
+		/// <summary>
+		/// When we set a BackgroundColor of a panel, we set WantsLayer and CanDrawSubviewsIntoLayer to true.
+		/// This causes problems with a Scrollable as it makes the content duplicate when scrolling as it was drawn
+		/// to the parent layer.
+		/// </summary>
+		[Test, ManualTest]
+		public void ScrollableInLayerShouldNotDuplicateContents()
+		{
+			ManualForm("Scroll the box, the content should not duplicate", form =>
+			{
+				form.BackgroundColor = Colors.White;
+				var panel = new Panel { Size = new Size(200, 200) };
+				var button = new Button { Text = "Click Me" };
+				var content = new TableLayout
+				{
+					Rows = {
+						button,
+						panel
+					}
+				};
+
+				button.Click += (sender, e) => 
+				{
+					var scrollContent = new TableLayout();
+					for (int i = 0; i < 50; i++)
+					{
+						scrollContent.Rows.Add(new CheckBox { Text = "Check Box " + i });
+					}
+
+					panel.Content = new TableLayout
+					{
+						Padding = 20,
+						Rows = { new Scrollable { Content = scrollContent } }
+					};
+				};
+
+				return content;
+			});
+		}
+	}
+}

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/ControlColorsSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/ControlColorsSection.cs
@@ -15,21 +15,21 @@ namespace Eto.Test.Sections.Controls
 
 		protected override Control CreateOptions()
 		{
-			var foregroundPicker = new ColorPicker();
+			var foregroundPicker = new ColorPicker { AllowAlpha = true };
 			foregroundPicker.ValueChanged += (sender, e) =>
 			{
 				foreach (var update in foregroundUpdates)
 					update(foregroundPicker.Value);
 			};
 
-			var backgroundPicker = new ColorPicker();
+			var backgroundPicker = new ColorPicker { AllowAlpha = false }; // alpha not supported for all controls
 			backgroundPicker.ValueChanged += (sender, e) =>
 			{
 				foreach (var update in backgroundUpdates)
 					update(backgroundPicker.Value);
 			};
 
-			var formColorPicker = new ColorPicker { Value = BackgroundColor };
+			var formColorPicker = new ColorPicker { Value = BackgroundColor, AllowAlpha = true };
 			formColorPicker.ValueChanged += (sender, e) => BackgroundColor = formColorPicker.Value;
 
 			var fontPicker = new Button { Text = "Pick Font" };


### PR DESCRIPTION

When using a background color (which required a layer), we used CanDrawSubviewsIntoLayer to collapse layers.  This unfortunately made the Scrollable draw its content on the containing layer initially when it was dynamically added to the form.

We no longer use layers to draw the background color - we add the drawRect: method to the ContainerControl dynamically and draw it there.