### PR TITLE
Wpf: TabPage and Dpi fixes

### DIFF
--- a/Source/Eto.Test/Eto.Test/Handlers/TabPageHandler.cs
+++ b/Source/Eto.Test/Eto.Test/Handlers/TabPageHandler.cs
@@ -1,4 +1,4 @@
-using Eto.Drawing;
+﻿using Eto.Drawing;
 using Eto.Forms;
 
 namespace Eto.Test.Handlers
@@ -36,8 +36,8 @@ namespace Eto.Test.Handlers
 
 		public Image Image
 		{
-			get;
-			set; // TODO
+			get { return Tab.Image; }
+			set { Tab.Image = value; }
 		}
     }
 }

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/ButtonSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/ButtonSection.cs
@@ -1,4 +1,4 @@
-using Eto.Drawing;
+﻿using Eto.Drawing;
 using Eto.Forms;
 using System.ComponentModel;
 
@@ -7,7 +7,7 @@ namespace Eto.Test.Sections.Controls
 	[Section("Controls", typeof(Button))]
 	public class ButtonSection : Scrollable, INotifyPropertyChanged
 	{
-		Bitmap smallImage = new Bitmap(TestIcons.TestImage, 16, 16);
+		Image smallImage = TestIcons.TestImage.WithSize(16, 16);
 		Bitmap largeImage = TestIcons.TestImage;
 		ButtonImagePosition imagePosition;
 		bool clearMinimumSize;

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/KitchenSinkSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/KitchenSinkSection.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Eto.Drawing;
 using Eto.Forms;
 using System.Collections.Generic;
@@ -8,7 +8,7 @@ namespace Eto.Test.Sections.Controls
 	[Section("Controls", "Kitchen Sink")]
 	public class KitchenSinkSection : Panel
 	{
-		Bitmap bitmap1 = TestIcons.TestImage;
+		Image bitmap1 = TestIcons.TestImage.WithSize(16, 16);
 		Icon icon1 = TestIcons.TestIcon.WithSize(16, 16);
 		Icon icon2 = TestIcons.TestImage.WithSize(16, 16);
 

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/TabControlSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/TabControlSection.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Eto.Drawing;
 using Eto.Forms;
 
@@ -96,11 +96,13 @@ namespace Eto.Test.Sections.Controls
 			control.Pages.Add(new TabPage
 			{
 				Text = "Tab 2",
-				Image = TestIcons.TestIcon,
+				Image = TestIcons.TestIcon.WithSize(16, 16),
 				Content = TabTwo()
 			});
 
 			control.Pages.Add(new TabPage { Text = "Tab 3" });
+
+			control.Pages.Add(new TabPage { Image = TestIcons.TestIcon.WithSize(16, 16) });
 
 			foreach (var page in control.Pages)
 				LogEvents(page);

--- a/Source/Eto.Wpf/Forms/Controls/ButtonHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ButtonHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Eto.Forms;
 using Eto.Drawing;
 #if WINRT
@@ -20,6 +20,16 @@ using WpfLabel = System.Windows.Controls.Label;
 namespace Eto.Wpf.Forms.Controls
 #endif
 {
+	public class EtoButton : swc.Button, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override wf.Size MeasureOverride(wf.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
 	/// <summary>
 	/// Button handler.
 	/// </summary>
@@ -31,37 +41,13 @@ namespace Eto.Wpf.Forms.Controls
 		readonly swc.Image swcimage;
 		readonly WpfLabel label;
 
-#if WPF
-		public class EtoImage : swc.Image
-		{
-			public ButtonHandler Handler { get; set; }
-
-			protected override sw.Size MeasureOverride(sw.Size constraint)
-			{
-				var size = base.MeasureOverride(constraint);
-				var img = Handler.Image;
-				if (img != null)
-				{
-					var imgSize = img.Size;
-					if (double.IsInfinity(constraint.Height) && double.IsInfinity(constraint.Width))
-						size = img.Size.ToWpf();
-					/*
-						size.Height = imgSize.Height;
-					if (double.IsInfinity(constraint.Width))
-						size.Width = imgSize.Width;*/
-				}
-				return size;
-			}
-		}
-#endif
-
 		public static Size DefaultMinimumSize = new Size(80, 23);
 
 		protected override wf.Size DefaultSize => MinimumSize.ToWpf();
 
 		public ButtonHandler()
 		{
-			Control = new swc.Button();
+			Control = new EtoButton { Handler = this };
 			Control.Click += (sender, e) => Callback.OnClick(Widget, EventArgs.Empty);
 			label = new WpfLabel
 			{
@@ -72,11 +58,7 @@ namespace Eto.Wpf.Forms.Controls
 			};
 			swc.Grid.SetColumn(label, 1);
 			swc.Grid.SetRow(label, 1);
-#if WINRT
-			swcimage = new EtoImage();
-#else
-			swcimage = new EtoImage { Handler = this };
-#endif
+			swcimage = new swc.Image();
 			var grid = new swc.Grid();
 			grid.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = sw.GridLength.Auto });
 			grid.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = new sw.GridLength(1, sw.GridUnitType.Star) });
@@ -243,12 +225,7 @@ namespace Eto.Wpf.Forms.Controls
 				if (MinimumSize != value)
 				{
 					Widget.Properties[MinimumSize_Key] = value;
-#if WPF
-					if (Control.IsLoaded)
-						Control.UpdateLayout();
-#else
-					Control.UpdateLayout();
-#endif
+					Control.InvalidateMeasure();
 				}
 			}
 		}

--- a/Source/Eto.Wpf/Forms/Controls/LabelHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/LabelHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using Eto.Forms;
 using Eto.Drawing;
 using swc = System.Windows.Controls;
@@ -150,7 +150,6 @@ namespace Eto.Wpf.Forms.Controls
         public override void UpdatePreferredSize()
         {
             ParentMinimumSize = WpfConversions.ZeroSize;
-            SetSize();
             base.UpdatePreferredSize();
         }
 

--- a/Source/Eto.Wpf/Forms/Controls/TabPageHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TabPageHandler.cs
@@ -1,9 +1,10 @@
-using swc = System.Windows.Controls;
+﻿using swc = System.Windows.Controls;
 using sw = System.Windows;
 using swm = System.Windows.Media;
 using Eto.Forms;
 using Eto.Drawing;
 using Eto.Wpf.Drawing;
+using Eto.Wpf.CustomControls;
 
 namespace Eto.Wpf.Forms.Controls
 {
@@ -13,12 +14,23 @@ namespace Eto.Wpf.Forms.Controls
 		readonly swc.DockPanel content;
 		readonly swc.Image headerImage;
 		readonly swc.TextBlock headerText;
+		int spacing = 4;
+
+		public int ImageSpacing
+		{
+			get { return spacing; }
+			set
+			{
+				spacing = value;
+				SetMargin();
+			}
+		}
 
 		public TabPageHandler()
 		{
 			Control = new swc.TabItem();
 			var header = new swc.StackPanel { Orientation = swc.Orientation.Horizontal };
-			headerImage = new swc.Image { MaxHeight = 16, MaxWidth = 16 };
+			headerImage = new swc.Image();
 			headerText = new swc.TextBlock();
 			header.Children.Add(headerImage);
 			header.Children.Add(headerText);
@@ -35,7 +47,11 @@ namespace Eto.Wpf.Forms.Controls
 		public string Text
 		{
 			get { return headerText.Text; }
-			set { headerText.Text = value; }
+			set
+			{
+				headerText.Text = value;
+				SetMargin();
+			}
 		}
 
 		public override Color BackgroundColor
@@ -51,12 +67,21 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				image = value;
 				SetSource();
+				SetMargin();
 			}
 		}
 
 		void SetSource()
 		{
 			headerImage.Source = image.ToWpf(ParentScale);
+		}
+
+		void SetMargin()
+		{
+			if (image != null && !string.IsNullOrEmpty(Text))
+				headerImage.Margin = new sw.Thickness(0, 0, spacing, 0);
+			else
+				headerImage.Margin = new sw.Thickness();
 		}
 
 		protected override bool NeedsPixelSizeNotifications => true;
@@ -74,7 +99,7 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				content.Width = value.Width;
 				content.Height = value.Height;
-                UpdatePreferredSize();
+				UpdatePreferredSize();
 			}
 		}
 

--- a/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -114,9 +114,9 @@ namespace Eto.Wpf.Forms
 			// Desired should also not be bigger than default size if we have no constraint.
 			// Without it, controls like TextArea, GridView, etc will grow to their content.
 			if (double.IsInfinity(constraint.Width) && defaultSize.Width > 0)
-				desired.Width = defaultSize.Width;
+				desired.Width = PreventUserResize ? defaultSize.Width : Math.Max(defaultSize.Width, desired.Width);
 			if (double.IsInfinity(constraint.Height) && defaultSize.Height > 0)
-				desired.Height = defaultSize.Height;
+				desired.Height = PreventUserResize ? defaultSize.Height : Math.Max(defaultSize.Height, desired.Height);
 
 			// use the user preferred size, and ensure it's not larger than available size
 			size = size.IfNaN(desired);
@@ -198,38 +198,6 @@ namespace Eto.Wpf.Forms
 
 		protected virtual void SetSize()
 		{
-			var defaultSize = DefaultSize.ZeroIfNan();
-			if (XScale && Control.IsLoaded)
-			{
-				ContainerControl.Width = double.NaN;
-				ContainerControl.MinWidth = 0;
-			}
-			else
-			{
-				var containerWidth = PreventUserResize && double.IsNaN(UserPreferredSize.Width)
-					? defaultSize.Width <= 0
-						? double.NaN
-						: defaultSize.Width
-					: UserPreferredSize.Width;
-				ContainerControl.Width = Math.Max(containerWidth, parentMinimumSize.Width);
-				ContainerControl.MinWidth = Math.Max(0, double.IsNaN(UserPreferredSize.Width) ? defaultSize.Width : UserPreferredSize.Width);
-			}
-
-			if (YScale && Control.IsLoaded)
-			{
-				ContainerControl.Height = double.NaN;
-				ContainerControl.MinHeight = 0;
-			}
-			else
-			{
-				var containerHeight = PreventUserResize && double.IsNaN(UserPreferredSize.Height)
-					? defaultSize.Height <= 0
-						? double.NaN
-						: defaultSize.Height
-					: UserPreferredSize.Height;
-				ContainerControl.Height = Math.Max(containerHeight, parentMinimumSize.Height);
-				ContainerControl.MinHeight = Math.Max(0, double.IsNaN(UserPreferredSize.Height) ? defaultSize.Height : UserPreferredSize.Height);
-			}
 		}
 
 		public virtual sw.Size GetPreferredSize(sw.Size constraint)


### PR DESCRIPTION
- TabPage now puts a margin between the image and text
- Window.LogicalPixelSize is now reported correctly when using built-in dpi handling
- Button now sizes correctly when adjusting its MinimumSize
- Remove old sizing code to set minimum size of controls as we now rely on Measure/Arrange overrides for all controls.