### PR TITLE
Wpf: Fix regression when controls are set to their default size.

### DIFF
--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/ControlTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/ControlTests.cs
@@ -2,6 +2,7 @@
 using Eto.Forms;
 using NUnit.Framework;
 using System.Collections.Generic;
+using Eto.Drawing;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {
@@ -19,12 +20,57 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		[TestCaseSource("Controls")]
 		public void DefaultValuesShouldBeCorrect(Control control)
 		{
-            TestProperties(f => control,
-			               c => c.Enabled,
-			               c => c.ToolTip,
-			               c => c.TabIndex
+			TestProperties(f => control,
+						   c => c.Enabled,
+						   c => c.ToolTip,
+						   c => c.TabIndex
 			);
-			
+
+		}
+
+		[ManualTest, Test]
+		public void ControlsShouldHaveSaneDefaultWidths()
+		{
+			ManualForm(
+				"Check to make sure the text/entry boxes have the correct widths and do not grow when entering text",
+				form =>
+				{
+					var longText = "Some very long text that should not make the control grow larger than its default size";
+					return new Scrollable
+					{
+						Content = new StackLayout
+						{
+							Items = {
+								new Button { Text = "Button" },
+								new Calendar(),
+								new CheckBox { Text = "CheckBox" },
+								new ColorPicker(),
+								new ComboBox { Text = longText, Items = { "Item 1", "Item 2", "Item 3" } },
+								new DateTimePicker(),
+								new Drawable { Size = new Size(100, 20), BackgroundColor = Colors.Blue }, // not actually visible without a size
+								new DropDown { Items = { "Item 1", "Item 2", "Item 3" } },
+								new Expander { Header = "Hello", Content = new Label { Text = "Some content" } },
+								new FilePicker { FilePath = "/some/path/that/is/long/which/should/not/make/it/too/big" },
+								new GroupBox { Content = "Some content", Text = "Some text" },
+								new LinkButton {  Text = "LinkButton"},
+								new NumericStepper(),
+								new PasswordBox(),
+								new ProgressBar { Value = 50 },
+								new RadioButton { Text = "RadioButton" },
+								new RichTextArea { Text = longText },
+								new SearchBox { Text = longText },
+								new Slider { Value = 50 },
+								new Spinner(),
+								new Stepper(),
+								new TabControl { Pages = { new TabPage { Text = "TabPage", Content = "Tab content" } } },
+								new TextArea { Text = longText },
+								new TextBox { Text = longText },
+								new TextStepper { Text = longText },
+								//new WebView()
+							}
+						}
+					};
+				});
 		}
 	}
 }

--- a/Source/Eto.Wpf/Forms/Controls/ComboBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ComboBoxHandler.cs
@@ -40,7 +40,7 @@ namespace Eto.Wpf.Forms.Controls
 				if (!AutoComplete)
 				{
 					// with autocomplete off, items aren't selected based on typed text but should be
-					var item = DataStore.FirstOrDefault(o => Widget.ItemTextBinding.GetValue(o) == text);
+					var item = DataStore?.FirstOrDefault(o => Widget.ItemTextBinding.GetValue(o) == text);
 					if (item != null)
 					{
 						Control.SelectedItem = item;

--- a/Source/Eto.Wpf/Forms/Controls/ProgressBarHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ProgressBarHandler.cs
@@ -40,7 +40,7 @@ namespace Eto.Wpf.Forms.Controls
 
 	public class ProgressBarHandler : WpfControl<EtoProgressBar, ProgressBar, ProgressBar.ICallback>, ProgressBar.IHandler
 	{
-		protected override sw.Size DefaultSize => new sw.Size(double.NaN, 22);
+		protected override sw.Size DefaultSize => new sw.Size(100, 22);
 
 		public ProgressBarHandler()
 		{

--- a/Source/Eto.Wpf/Forms/Controls/SliderHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/SliderHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using swc = System.Windows.Controls;
 using sw = System.Windows;
 using Eto.Forms;
@@ -27,6 +27,16 @@ namespace Eto.Wpf.Forms.Controls
 				TickPlacement = swc.Primitives.TickPlacement.BottomRight
 			};
 			Control.ValueChanged += (sender, e) => Callback.OnValueChanged(Widget, EventArgs.Empty);
+		}
+
+		protected override sw.Size DefaultSize 
+		{
+			get {
+				if (Orientation == Orientation.Horizontal)
+					return new sw.Size(100, double.NaN);
+				else
+					return new sw.Size(double.NaN, 100);
+			}
 		}
 
 		public override bool UseMousePreview { get { return true; } }


### PR DESCRIPTION
Wpf: Fix setting text before setting data store
Wpf: ProgressBar and Slider should have sane default sizes