### PR TITLE
Wpf: fix first column all white DrawableCell in TreeGridView (#789)

### DIFF
--- a/Source/Eto.Wpf/Forms/Cells/DrawableCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/DrawableCellHandler.cs
@@ -26,6 +26,7 @@ namespace Eto.Wpf.Forms.Cells
 			protected override void OnRender(swm.DrawingContext dc)
 			{
 				var handler = Column.Handler;
+				RenderSize = new System.Windows.Size(this.Column.ActualWidth, RenderSize.Height);
 				var graphics = new Graphics(new GraphicsHandler(this, dc, new sw.Rect(RenderSize), new RectangleF(RenderSize.ToEto()), false));
 				var state = IsSelected ? CellStates.Selected : CellStates.None;
 #pragma warning disable 618

--- a/Source/Eto.Wpf/WpfExtensions.cs
+++ b/Source/Eto.Wpf/WpfExtensions.cs
@@ -131,6 +131,8 @@ namespace Eto.Wpf
 			{
 				if (current == control)
 					return true;
+				if (current is System.Windows.Documents.Hyperlink)
+					return false;
 				current = swm.VisualTreeHelper.GetParent(current);
 			}
 			return false;


### PR DESCRIPTION
A DrawableCell in a TreeGridView (if it was the first column) was always rendered all white,
the RenderSize width needs to be set explicitly based from the column width.