### PR TITLE
Fix for #480, #833 and test

### DIFF
--- a/Source/Eto.Test/Eto.Test.Wpf/Eto.Test.Wpf - net45.csproj
+++ b/Source/Eto.Test/Eto.Test.Wpf/Eto.Test.Wpf - net45.csproj
@@ -62,6 +62,7 @@
     <Compile Include="Startup.cs" />
     <Compile Include="UnitTests\DataContextTests.cs" />
     <Compile Include="UnitTests\MenuBarTests.cs" />
+    <Compile Include="UnitTests\ScrollableTests.cs" />
     <Compile Include="UnitTests\TransformStackTest.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Source/Eto.Test/Eto.Test.Wpf/UnitTests/ScrollableTests.cs
+++ b/Source/Eto.Test/Eto.Test.Wpf/UnitTests/ScrollableTests.cs
@@ -1,0 +1,25 @@
+﻿using Eto.Drawing;
+using Eto.Forms;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+
+namespace Eto.Test.Wpf.UnitTests
+{
+    [TestFixture]
+    public class ScrollableTests : TestBase
+    {
+        [Test]
+        public void ScrollableShouldSetScrollSize()
+        {
+            Invoke(() =>
+            {
+                var form = new Form();
+
+                var scrollable = new Scrollable();
+                form.Content = scrollable;
+
+                scrollable.ScrollSize = new Size(1000, 1000);
+            });
+        }
+    }
+}

--- a/Source/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
@@ -136,7 +136,7 @@ namespace Eto.Wpf.Forms.Controls
 			}
 			set
 			{
-				var content = (swc.Border)Control.Child;
+				//var content = (swc.Border)Control.Child;
 				scrollSize = value.ToWpf();
 				UpdateSizes();
 			}


### PR DESCRIPTION
Problem:
Assigning a value to the Scrollable.ScrollSize property results in an error: 
> Unable to cast object of type 'EtoScrollViewer' to type 'System.Windows.Controls.Border'.

The bug is found in `Eto / Source / Eto.Wpf / Forms / Controls / ScrollableHandler.cs`, 
`public Size ScrollSize`, in the line 
`var content = (swc.Border) Control.Child;`

The exception is eliminated. I wanted to write a test, but unfortunately, my VS2015 + Resharper at work is buggy and does not want to work with NUnit. And at home the whole project Eto is not build to, I have not yet found why.