### PR TITLE
XamMac: Fix regression when using BackgroundColor

### DIFF
--- a/Source/Eto.Mac/Forms/MacView.cs
+++ b/Source/Eto.Mac/Forms/MacView.cs
@@ -610,7 +610,7 @@ namespace Eto.Mac.Forms
 			{
 				if (color.Value.A > 0)
 				{
-					AddMethod(selDrawRect, new Action<IntPtr, IntPtr, CGRect>(DrawBackgroundRect), EtoEnvironment.Is64BitProcess ? "v@:{CGRect dddd}" : "v@:{CGRect ffff}", ContainerControl);
+					AddMethod(selDrawRect, new Action<IntPtr, IntPtr, CGRect>(DrawBackgroundRect), EtoEnvironment.Is64BitProcess ? "v@:{CGRect=dddd}" : "v@:{CGRect=ffff}", ContainerControl);
 				}
 				ContainerControl.SetNeedsDisplay();
 			}


### PR DESCRIPTION
Xamarin.Mac is more picky on the method signature, although it was incorrectly missing the '=' between the type and declaration.  It assumes it is there otherwise it goes out of bounds.

Fixes #848