### PR TITLE
TreeGridView updates

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
@@ -152,6 +152,9 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			switch (id)
 			{
+				case TreeGridView.ActivatedEvent:
+					Tree.RowActivated += Connector.HandleRowActivated;
+					break;
 				case TreeGridView.ExpandingEvent:
 					Tree.TestExpandRow += Connector.HandleTestExpandRow;
 					break;
@@ -245,6 +248,11 @@ namespace Eto.GtkSharp.Forms.Controls
 					h.Callback.OnSelectedItemChanged(h.Widget, EventArgs.Empty);
 					h.lastSelected = item;
 				}
+			}
+
+			public void HandleRowActivated(object o, Gtk.RowActivatedArgs args)
+			{
+				Handler.Callback.OnActivated(Handler.Widget, new TreeGridViewItemEventArgs(Handler.model.GetItemAtPath(args.Path)));
 			}
 		}
 

--- a/Source/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -350,6 +350,17 @@ namespace Eto.Mac.Forms.Controls
 		{
 			switch (id)
 			{
+				case TreeGridView.ActivatedEvent:
+					Widget.KeyDown += (sender, e) =>
+					{
+						if (!e.Handled && e.KeyData == Keys.Enter)
+						{
+							Callback.OnActivated(Widget, new TreeGridViewItemEventArgs(SelectedItem));
+							e.Handled = true;
+						}
+					};
+					Control.DoubleClick += HandleDoubleClick;
+					break;
 				case TreeGridView.ExpandedEvent:
 				case TreeGridView.ExpandingEvent:
 				case TreeGridView.CollapsedEvent:
@@ -369,6 +380,15 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
+		static void HandleDoubleClick(object sender, EventArgs e)
+		{
+			var handler = GetHandler(sender) as TreeGridViewHandler;
+			if (handler != null)
+			{
+				handler.Callback.OnActivated(handler.Widget, new TreeGridViewItemEventArgs(handler.SelectedItem));
+			}
+		}
+
 		protected override NSOutlineView CreateControl()
 		{
 			return new EtoOutlineView(this);
@@ -383,7 +403,9 @@ namespace Eto.Mac.Forms.Controls
 				topitems.Clear();
 				cachedItems.Clear();
 				Control.ReloadData();
+				suppressExpandCollapseEvents++;
 				ExpandItems(null);
+				suppressExpandCollapseEvents--;
 				if (Widget.Loaded)
 					AutoSizeColumns();
 			}

--- a/Source/Eto.Test/Eto.Test/SectionList.cs
+++ b/Source/Eto.Test/Eto.Test/SectionList.cs
@@ -188,42 +188,6 @@ namespace Eto.Test
 		}
 	}
 
-	public class SectionListTreeView : SectionList
-	{
-		TreeView treeView;
-
-		public override Control Control { get { return this.treeView; } }
-
-		public override void Focus() { Control.Focus(); }
-
-		public override ISection SelectedItem
-		{
-			get
-			{
-				var treeItem = treeView.SelectedItem as TreeItem;
-				return treeItem.Tag as ISection;
-			}
-		}
-
-		public SectionListTreeView(IEnumerable<Section> topNodes)
-		{
-			this.treeView = new TreeView();
-			treeView.Style = "sectionList";
-			var top = new TreeItem(Enumerate(topNodes)) { Text = "Top", Tag = topNodes };
-			treeView.DataStore = top;
-			treeView.SelectionChanged += OnSelectedItemChanged;
-		}
-
-		private IEnumerable<ITreeItem> Enumerate(IEnumerable<Section> topNodes)
-		{
-			foreach (var section in topNodes)
-			{
-				var item = new TreeItem(Enumerate(section)) { Text = section.Text, Tag = section };
-				yield return item;
-			}
-		}
-	}
-
 	public class SectionListGridView : SectionList
 	{
 		class MyItem

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/SplitterSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/SplitterSection.cs
@@ -135,7 +135,7 @@ namespace Eto.Test.Sections.Controls
 							Text = "test",
 							Content = new Splitter
 							{
-								Panel1 = new TreeView { Size = new Size(100, 100) },
+								Panel1 = new TreeGridView { Size = new Size(100, 100) },
 								Panel2 = new GridView(),
 								Orientation = Orientation.Horizontal,
 								FixedPanel = SplitterFixedPanel.Panel1,

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/TreeViewSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/TreeViewSection.cs
@@ -5,6 +5,7 @@ using System.Linq;
 
 namespace Eto.Test.Sections.Controls
 {
+	[Obsolete("Since 2.4")]
 	[Section("Controls", typeof(TreeView))]
 	public class TreeViewSection : Scrollable
 	{

--- a/Source/Eto.Test/Eto.Test/Sections/UnitTestSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/UnitTestSection.cs
@@ -172,7 +172,7 @@ namespace Eto.Test.Sections
 	[Section("Automated Tests", "Unit Tests")]
 	public class UnitTestSection : Panel
 	{
-		TreeView tree;
+		TreeGridView tree;
 		Button startButton;
 		CheckBox useTestPlatform;
 		CheckBox includeManualTests;
@@ -195,7 +195,7 @@ namespace Eto.Test.Sections
 				}
 			};
 
-			if (Platform.Supports<TreeView>())
+			if (Platform.Supports<TreeGridView>())
 			{
 
 				search = new SearchBox();
@@ -223,11 +223,15 @@ namespace Eto.Test.Sections
 					timer.Start();
 				};
 
-				tree = new TreeView();
+				tree = new TreeGridView { ShowHeader = false };
+				tree.Columns.Add(new GridColumn
+				{
+					DataCell = new TextBoxCell { Binding = Binding.Property((UnitTestItem m) => m.Text) }
+				});
 
 				tree.Activated += (sender, e) =>
 				{
-					var item = (TreeItem)tree.SelectedItem;
+					var item = (TreeGridItem)tree.SelectedItem;
 					if (item != null)
 					{
 						RunTests(item.Tag as CategoryFilter);
@@ -395,11 +399,16 @@ namespace Eto.Test.Sections
 		void PopulateTree(string filter = null)
 		{
 			var testSuites = GetTestSuites().Select(suite => ToTree(suite.Assembly, suite, filter)).Where(r => r != null).ToList();
-			var treeData = new TreeItem(testSuites);
+			var treeData = new TreeGridItem(testSuites);
 			Application.Instance.AsyncInvoke(() => tree.DataStore = treeData);
 		}
 
-		TreeItem ToTree(Assembly assembly, ITest test, string filter)
+		class UnitTestItem : TreeGridItem
+		{
+			public string Text { get; set; }
+		}
+
+		TreeGridItem ToTree(Assembly assembly, ITest test, string filter)
 		{
 			// add a test
 			var name = test.Name;
@@ -409,7 +418,7 @@ namespace Eto.Test.Sections
 				name = an.Name;
 			}
 
-			var item = new TreeItem { Text = name, Tag = new SingleTestFilter { Test = test, Assembly = assembly } };
+			var item = new UnitTestItem { Text = name, Tag = new SingleTestFilter { Test = test, Assembly = assembly } };
 			var nameMatches = filter == null || test.FullName.IndexOf(filter, StringComparison.OrdinalIgnoreCase) >= 0;
 			if (test.HasChildren)
 			{
@@ -425,7 +434,7 @@ namespace Eto.Test.Sections
 				while (item.Children.Count == 1)
 				{
 					// collapse test nodes
-					var child = item.Children[0] as TreeItem;
+					var child = item.Children[0] as UnitTestItem;
 					if (child.Children.Count == 0)
 						break;
 					if (!child.Text.StartsWith(item.Text, StringComparison.Ordinal))

--- a/Source/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Linq;
 using swf = System.Windows.Forms;
 using sd = System.Drawing;
@@ -62,6 +62,21 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			switch (handler)
 			{
+				case TreeGridView.ActivatedEvent:
+					Control.KeyDown += (sender, e) =>
+					{
+						if (!e.Handled && SelectedItem != null)
+						{
+							Callback.OnActivated(Widget, new TreeGridViewItemEventArgs(SelectedItem));
+							e.Handled = true;
+						}
+					};
+					Control.CellDoubleClick += (sender, e) =>
+					{
+						if (SelectedItem != null)
+							Callback.OnActivated(Widget, new TreeGridViewItemEventArgs(SelectedItem));
+					};
+					break;
 				case TreeGridView.ExpandingEvent:
 					controller.Expanding += (sender, e) => Callback.OnExpanding(Widget, e);
 					break;

--- a/Source/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using swc = System.Windows.Controls;
 using sw = System.Windows;
 using swd = System.Windows.Data;
@@ -27,27 +27,33 @@ namespace Eto.Wpf.Forms.Controls
 			base.Initialize();
 			controller = new TreeController { Handler = this };
 			Control.Background = sw.SystemColors.WindowBrush;
-			Control.KeyDown += (sender, e) =>
-			{
-				if (e.Key == sw.Input.Key.Enter)
-				{
-					if (SelectedItem != null)
-						Callback.OnActivated(Widget, new TreeGridViewItemEventArgs(SelectedItem));
-				}
-			};
-			Control.MouseDoubleClick += delegate
-			{
-				if (SelectedItem != null)
-				{
-					Callback.OnActivated(Widget, new TreeGridViewItemEventArgs(SelectedItem));
-				}
-			};
 		}
 
 		public override void AttachEvent(string id)
 		{
 			switch (id)
 			{
+				case TreeGridView.ActivatedEvent:
+					Control.PreviewKeyDown += (sender, e) =>
+					{
+						if (e.Key == sw.Input.Key.Enter)
+						{
+							if (SelectedItem != null)
+							{
+								Callback.OnActivated(Widget, new TreeGridViewItemEventArgs(SelectedItem));
+								e.Handled = true;
+							}
+						}
+					};
+					Control.MouseDoubleClick += (sender, e) =>
+					{
+						if (SelectedItem != null)
+						{
+							Callback.OnActivated(Widget, new TreeGridViewItemEventArgs(SelectedItem));
+							e.Handled = true;
+						}
+					};
+					break;
 				case TreeGridView.ExpandingEvent:
 					controller.Expanding += (sender, e) => Callback.OnExpanding(Widget, e);
 					break;

--- a/Source/Eto/Forms/Controls/TreeGridView.cs
+++ b/Source/Eto/Forms/Controls/TreeGridView.cs
@@ -97,15 +97,18 @@ namespace Eto.Forms
 		#region Events
 
 		/// <summary>
+		/// Identifier for handlers when attaching the <see cref="Activated"/> event.
+		/// </summary>
+		public const string ActivatedEvent = "TreeGridView.ActivatedEvent";
+
+		/// <summary>
 		/// Occurs when the user activates an item by double clicking or pressing enter.
 		/// </summary>
 		public event EventHandler<TreeGridViewItemEventArgs> Activated
 		{
-			add { Properties.AddEvent(ActivatedKey, value); }
-			remove { Properties.RemoveEvent(ActivatedKey, value); }
+			add { Properties.AddHandlerEvent(ActivatedEvent, value); }
+			remove { Properties.RemoveEvent(ActivatedEvent, value); }
 		}
-
-		static readonly object ActivatedKey = new object();
 
 		/// <summary>
 		/// Raises the <see cref="Activated"/> event.
@@ -113,7 +116,7 @@ namespace Eto.Forms
 		/// <param name="e">Event arguments.</param>
 		protected virtual void OnActivated(TreeGridViewItemEventArgs e)
 		{
-			Properties.TriggerEvent(ActivatedKey, this, e);
+			Properties.TriggerEvent(ActivatedEvent, this, e);
 		}
 
 		/// <summary>


### PR DESCRIPTION
- Fix TreeGridView.Activated event on all desktop platforms
- Mac: Fix auto size of the expanding column of a TreeGridView.  Fixes #738
- Remove deprecated TreeView stuff from Eto.Test, but keep TreeViewSection.