### PR TITLE
RadioButton/CheckBox tweaks for Mac/WPF

### DIFF
--- a/Source/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
@@ -33,6 +33,31 @@ using CGPoint = System.Drawing.PointF;
 
 namespace Eto.Mac.Forms.Controls
 {
+	public class EtoCenteredButton : NSButtonCell
+	{
+		nfloat defaultHeight;
+		public EtoCenteredButton(nfloat defaultHeight)
+		{
+			this.defaultHeight = defaultHeight;
+		}
+
+		public override CGRect DrawingRectForBounds(CGRect theRect)
+		{
+			var rect = base.DrawingRectForBounds(theRect);
+			var titleSize = AttributedTitle.Size;
+			rect.Y += Math.Max(0, (titleSize.Height - defaultHeight) / 2);
+			return rect;
+		}
+
+		public override CGRect TitleRectForBounds(CGRect theRect)
+		{
+			var titleSize = AttributedTitle.Size;
+			var rect = base.TitleRectForBounds(theRect);
+			rect.Y -= Math.Max(0, (titleSize.Height - defaultHeight) / 2);
+			return rect;
+		}
+	}
+
 	public class CheckBoxHandler : MacButton<NSButton, CheckBox, CheckBox.ICallback>, CheckBox.IHandler
 	{
 		public class EtoCheckBoxButton : NSButton, IMacControl
@@ -45,8 +70,17 @@ namespace Eto.Mac.Forms.Controls
 				set { WeakHandler = new WeakReference(value); } 
 			}
 
+			static nfloat defaultHeight;
+			static EtoCheckBoxButton()
+			{
+				var b = new EtoCheckBoxButton();
+				b.SizeToFit();
+				defaultHeight = b.Frame.Height;
+			}
+
 			public EtoCheckBoxButton()
 			{
+				Cell = new EtoCenteredButton(defaultHeight);
 				Title = string.Empty;
 				SetButtonType(NSButtonType.Switch);
 			}

--- a/Source/Eto.Mac/Forms/Controls/RadioButtonHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/RadioButtonHandler.cs
@@ -3,19 +3,34 @@ using Eto.Forms;
 using System.Collections.Generic;
 using System.Linq;
 
-
 #if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
+using CoreImage;
 #else
 using MonoMac.AppKit;
 using MonoMac.Foundation;
 using MonoMac.CoreGraphics;
 using MonoMac.ObjCRuntime;
 using MonoMac.CoreAnimation;
+using MonoMac.CoreImage;
+#if Mac64
+using nfloat = System.Double;
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nfloat = System.Single;
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls
@@ -71,8 +86,17 @@ namespace Eto.Mac.Forms.Controls
 				set { WeakHandler = new WeakReference(value); } 
 			}
 
+			static nfloat defaultHeight;
+			static EtoRadioButton()
+			{
+				var b = new EtoRadioButton();
+				b.SizeToFit();
+				defaultHeight = b.Frame.Height;
+			}
+
 			public EtoRadioButton()
 			{
+				Cell = new EtoCenteredButton(defaultHeight);
 				Title = string.Empty;
 				SetButtonType(NSButtonType.Radio);
 			}

--- a/Source/Eto.Test/Eto.Test.Wpf/Startup.cs
+++ b/Source/Eto.Test/Eto.Test.Wpf/Startup.cs
@@ -1,4 +1,4 @@
-using Eto.Wpf.Forms.Controls;
+﻿using Eto.Wpf.Forms.Controls;
 using System;
 using System.Windows.Media;
 
@@ -12,10 +12,10 @@ namespace Eto.Test.Wpf
 			var platform = new Eto.Wpf.Platform();
 
 			// optional - enables GDI text display mode
-			/*
+			/**/
 			Style.Add<Eto.Wpf.Forms.FormHandler>(null, handler => TextOptions.SetTextFormattingMode(handler.Control, TextFormattingMode.Display));
 			Style.Add<Eto.Wpf.Forms.DialogHandler>(null, handler => TextOptions.SetTextFormattingMode(handler.Control, TextFormattingMode.Display));
-			*/
+			/**/
 
 			var app = new TestApplication(platform);
 			app.TestAssemblies.Add(typeof(Startup).Assembly);

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/CheckBoxSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/CheckBoxSection.cs
@@ -1,4 +1,4 @@
-using Eto.Drawing;
+﻿using Eto.Drawing;
 using Eto.Forms;
 
 namespace Eto.Test.Sections.Controls
@@ -20,7 +20,11 @@ namespace Eto.Test.Sections.Controls
 
 			layout.Add(ThreeStateInitialValue());
 
+			layout.Add(new CheckBox { Text = "With Larger Font", Font = SystemFonts.Label(40) });
+			layout.Add(new CheckBox { Text = "With Smaller Font", Font = SystemFonts.Label(6) });
+
 			layout.Add(null, false, true);
+
 
 			Content = layout;
 		}

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/RadioButtonSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/RadioButtonSection.cs
@@ -1,4 +1,4 @@
-using Eto.Drawing;
+﻿using Eto.Drawing;
 using Eto.Forms;
 
 namespace Eto.Test.Sections.Controls
@@ -10,11 +10,16 @@ namespace Eto.Test.Sections.Controls
 		{
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
 
+			layout.BeginVertical();
 			layout.AddRow(new Label { Text = "Default" }, Default(), null);
 
 			layout.AddRow(new Label { Text = "Set Initial Value" }, SetInitialValue(), null);
 
 			layout.AddRow(new Label { Text = "Disabled" }, Disabled(), null);
+			layout.EndVertical();
+
+			layout.Add(new RadioButton { Text = "With Larger Font", Font = SystemFonts.Label(40) });
+			layout.Add(new RadioButton { Text = "With Smaller Font", Font = SystemFonts.Label(6) });
 
 			layout.Add(null, null, true);
 

--- a/Source/Eto.Wpf/Forms/Controls/CheckBoxHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/CheckBoxHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using sw = System.Windows;
 using swc = System.Windows.Controls;
 using Eto.Forms;
@@ -24,6 +24,19 @@ namespace Eto.Wpf.Forms.Controls
 			Control.Checked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 			Control.Unchecked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 			Control.Indeterminate += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
+
+			Control.Style = new sw.Style(typeof(swc.CheckBox))
+			{
+				Triggers = {
+					new sw.Trigger
+					{
+						Property = sw.UIElement.IsEnabledProperty,
+						Value = false,
+						Setters = { new sw.Setter { Property = swc.Control.ForegroundProperty, Value = sw.SystemColors.GrayTextBrush } }
+					}
+				}
+			};
+
 			border = new EtoBorder { Handler = this, Child = Control };
 		}
 

--- a/Source/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using swc = System.Windows.Controls;
 using sw = System.Windows;
 using Eto.Forms;
@@ -17,7 +17,11 @@ namespace Eto.Wpf.Forms.Controls
 
 		public void Create(RadioButton controller)
 		{
-			Control = new swc.RadioButton();
+			Control = new swc.RadioButton
+			{
+				VerticalAlignment = sw.VerticalAlignment.Center,
+				VerticalContentAlignment = sw.VerticalAlignment.Center,
+			};
 			if (controller != null)
 			{
 				var parent = (swc.RadioButton)controller.ControlObject;
@@ -29,6 +33,18 @@ namespace Eto.Wpf.Forms.Controls
 			Control.Loaded += Control_Loaded;
 			Control.Checked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 			Control.Unchecked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
+
+			Control.Style = new sw.Style(typeof(swc.RadioButton))
+			{
+				Triggers = {
+					new sw.Trigger
+					{
+						Property = sw.UIElement.IsEnabledProperty,
+						Value = false,
+						Setters = { new sw.Setter { Property = swc.Control.ForegroundProperty, Value = sw.SystemColors.GrayTextBrush } }
+					}
+				}
+			};
 			border = new EtoBorder { Handler = this, Child = Control };
 		}
 


### PR DESCRIPTION
Mac/Wpf: Ensure RadioButton and CheckBox are vertically centered to text
Wpf: Grey out text for RadioButton/CheckBox when disabled.