### PR TITLE
Add better support for more keys in all platforms.

### DIFF
--- a/Source/Eto.Gtk/KeyMap.cs
+++ b/Source/Eto.Gtk/KeyMap.cs
@@ -1,5 +1,6 @@
-using Eto.Forms;
+﻿using Eto.Forms;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Eto.GtkSharp
 {
@@ -14,7 +15,10 @@ namespace Eto.GtkSharp
 		public static Keys ToEto (this Gdk.Key gkey)
 		{
 			Keys key;
-			return Map.TryGetValue(gkey, out key) ? key : Keys.None;
+			if (Map.TryGetValue(gkey, out key))
+				return key;
+			Debug.WriteLine($"Unknown key '{gkey}'");
+			return Keys.None;
 		}
 		
 		public static Keys ToEtoKey (this Gdk.ModifierType modifier)
@@ -47,6 +51,7 @@ namespace Eto.GtkSharp
 		static Dictionary<Gdk.Key, Keys> GetMap()
 		{
 			var keymap = new Dictionary<Gdk.Key, Keys>();
+			// keep in same order as in Keys
 			keymap.Add(Gdk.Key.A, Keys.A);
 			keymap.Add(Gdk.Key.B, Keys.B);
 			keymap.Add(Gdk.Key.C, Keys.C);
@@ -95,31 +100,58 @@ namespace Eto.GtkSharp
 			keymap.Add(Gdk.Key.Key_7, Keys.D7);
 			keymap.Add(Gdk.Key.Key_8, Keys.D8);
 			keymap.Add(Gdk.Key.Key_9, Keys.D9);
+			keymap.Add(Gdk.Key.minus, Keys.Minus);
+			keymap.Add(Gdk.Key.grave, Keys.Grave);
+			keymap.Add(Gdk.Key.Insert, Keys.Insert);
+			keymap.Add(Gdk.Key.Home, Keys.Home);
+			keymap.Add(Gdk.Key.Page_Down, Keys.PageDown);
+			keymap.Add(Gdk.Key.Page_Up, Keys.PageUp);
+			keymap.Add(Gdk.Key.Delete, Keys.Delete);
+			keymap.Add(Gdk.Key.End, Keys.End);
+			keymap.Add(Gdk.Key.KP_Divide, Keys.Divide);
+			keymap.Add(Gdk.Key.KP_Decimal, Keys.Decimal);
+			keymap.Add(Gdk.Key.BackSpace, Keys.Backspace);
 			keymap.Add(Gdk.Key.Up, Keys.Up);
 			keymap.Add(Gdk.Key.Down, Keys.Down);
 			keymap.Add(Gdk.Key.Left, Keys.Left);
 			keymap.Add(Gdk.Key.Right, Keys.Right);
-			keymap.Add(Gdk.Key.Page_Down, Keys.PageDown);
-			keymap.Add(Gdk.Key.Page_Up, Keys.PageUp);
-			keymap.Add(Gdk.Key.Home, Keys.Home);
-			keymap.Add(Gdk.Key.End, Keys.End);
-			keymap.Add(Gdk.Key.space, Keys.Space);
-			keymap.Add(Gdk.Key.Delete, Keys.Delete);
-			keymap.Add(Gdk.Key.BackSpace, Keys.Backspace);
-			keymap.Add(Gdk.Key.Insert, Keys.Insert);
 			keymap.Add(Gdk.Key.Tab, Keys.Tab);
-			keymap.Add(Gdk.Key.Escape, Keys.Escape);
+			keymap.Add(Gdk.Key.space, Keys.Space);
+			keymap.Add(Gdk.Key.Caps_Lock, Keys.CapsLock);
+			keymap.Add(Gdk.Key.Scroll_Lock, Keys.ScrollLock);
+			keymap.Add(Gdk.Key.Key_3270_PrintScreen, Keys.PrintScreen);
+			keymap.Add(Gdk.Key.Num_Lock, Keys.NumberLock);
 			keymap.Add(Gdk.Key.Return, Keys.Enter);
-			
-			keymap.Add(Gdk.Key.period, Keys.Decimal);
-			keymap.Add(Gdk.Key.comma, Keys.Comma);
-			keymap.Add(Gdk.Key.equal, Keys.Equal);
-			keymap.Add(Gdk.Key.minus, Keys.Minus);
+			keymap.Add(Gdk.Key.Escape, Keys.Escape);
+			keymap.Add(Gdk.Key.KP_Multiply, Keys.Multiply);
+			keymap.Add(Gdk.Key.KP_Add, Keys.Add);
+			keymap.Add(Gdk.Key.KP_Subtract, Keys.Subtract);
+			keymap.Add(Gdk.Key.Help, Keys.Help);
+			keymap.Add(Gdk.Key.Pause, Keys.Pause);
+			keymap.Add(Gdk.Key.Clear, Keys.Clear);
+			keymap.Add(Gdk.Key.KP_Equal, Keys.KeypadEqual);
+			keymap.Add(Gdk.Key.Alt_R, Keys.Menu);
+			keymap.Add(Gdk.Key.Alt_L, Keys.Menu);
 			keymap.Add(Gdk.Key.backslash, Keys.Backslash);
-			keymap.Add(Gdk.Key.slash, Keys.ForwardSlash);
-			keymap.Add(Gdk.Key.division, Keys.Divide);
-			//keymap.Add(Gdk.Key.dollar, Keys.Dollar);
+			keymap.Add(Gdk.Key.equal, Keys.Equal);
+			keymap.Add(Gdk.Key.semicolon, Keys.Semicolon);
+			keymap.Add(Gdk.Key.apostrophe, Keys.Quote);
+			keymap.Add(Gdk.Key.comma, Keys.Comma);
+			keymap.Add(Gdk.Key.period, Keys.Period);
+			keymap.Add(Gdk.Key.slash, Keys.Slash);
+			keymap.Add(Gdk.Key.bracketright, Keys.RightBracket);
+			keymap.Add(Gdk.Key.bracketleft, Keys.LeftBracket);
 			keymap.Add(Gdk.Key.Menu, Keys.ContextMenu);
+			keymap.Add(Gdk.Key.KP_0, Keys.Keypad0);
+			keymap.Add(Gdk.Key.KP_1, Keys.Keypad1);
+			keymap.Add(Gdk.Key.KP_2, Keys.Keypad2);
+			keymap.Add(Gdk.Key.KP_3, Keys.Keypad3);
+			keymap.Add(Gdk.Key.KP_4, Keys.Keypad4);
+			keymap.Add(Gdk.Key.KP_5, Keys.Keypad5);
+			keymap.Add(Gdk.Key.KP_6, Keys.Keypad6);
+			keymap.Add(Gdk.Key.KP_7, Keys.Keypad7);
+			keymap.Add(Gdk.Key.KP_8, Keys.Keypad8);
+			keymap.Add(Gdk.Key.KP_9, Keys.Keypad9);
 
 			if (EtoEnvironment.Platform.IsMac)
 			{

--- a/Source/Eto.Mac/KeyMap.cs
+++ b/Source/Eto.Mac/KeyMap.cs
@@ -1,5 +1,6 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using Eto.Forms;
+using System.Diagnostics;
 
 #if XAMMAC2
 using AppKit;
@@ -43,7 +44,10 @@ namespace Eto.Mac
 		public static Keys MapKey(ushort key)
 		{
 			Keys value;
-			return Map.TryGetValue(key, out value) ? value : Keys.None;
+			if (Map.TryGetValue(key, out value))
+				return value;
+			Debug.WriteLine($"Unknown key '{key}'");
+			return Keys.None;
 		}
 
 		enum KeyCharacters
@@ -117,6 +121,7 @@ namespace Eto.Mac
 		static Dictionary<ushort, Keys> GetMap()
 		{
 			var keymap = new Dictionary<ushort, Keys>();
+			// keep in same order as in Keys
 			keymap.Add(0, Keys.A);
 			keymap.Add(11, Keys.B);
 			keymap.Add(8, Keys.C);
@@ -143,16 +148,6 @@ namespace Eto.Mac
 			keymap.Add(7, Keys.X);
 			keymap.Add(16, Keys.Y);
 			keymap.Add(6, Keys.Z);
-			keymap.Add(18, Keys.D1);
-			keymap.Add(19, Keys.D2);
-			keymap.Add(20, Keys.D3);
-			keymap.Add(21, Keys.D4);
-			keymap.Add(23, Keys.D5);
-			keymap.Add(22, Keys.D6);
-			keymap.Add(26, Keys.D7);
-			keymap.Add(28, Keys.D8);
-			keymap.Add(25, Keys.D9);
-			keymap.Add(29, Keys.D0);
 			keymap.Add(122, Keys.F1);
 			keymap.Add(120, Keys.F2);
 			keymap.Add(99, Keys.F3);
@@ -165,37 +160,68 @@ namespace Eto.Mac
 			keymap.Add(109, Keys.F10);
 			keymap.Add(103, Keys.F11);
 			keymap.Add(111, Keys.F12);
-			keymap.Add(50, Keys.Grave);
+			keymap.Add(18, Keys.D1);
+			keymap.Add(19, Keys.D2);
+			keymap.Add(20, Keys.D3);
+			keymap.Add(21, Keys.D4);
+			keymap.Add(23, Keys.D5);
+			keymap.Add(22, Keys.D6);
+			keymap.Add(26, Keys.D7);
+			keymap.Add(28, Keys.D8);
+			keymap.Add(25, Keys.D9);
+			keymap.Add(29, Keys.D0);
 			keymap.Add(27, Keys.Minus);
-			keymap.Add(24, Keys.Equal);
-			keymap.Add(42, Keys.Backslash);
-			keymap.Add(49, Keys.Space);
-			//keymap.Add(30, Keys.]);
-			//keymap.Add(33, Keys.[);
-			keymap.Add(39, Keys.Quote);
-			keymap.Add(41, Keys.Semicolon);
-			keymap.Add(44, Keys.ForwardSlash);
-			keymap.Add(47, Keys.Period);
-			keymap.Add(43, Keys.Comma);
-			keymap.Add(36, Keys.Enter);
-			keymap.Add(48, Keys.Tab);
-			//keymap.Add(76, Keys.Return);
-			keymap.Add(53, Keys.Escape);
-
+			keymap.Add(50, Keys.Grave);
 			keymap.Add(76, Keys.Insert);
-			keymap.Add(51, Keys.Backspace);
+			keymap.Add(115, Keys.Home);
+			keymap.Add(121, Keys.PageDown);
+			keymap.Add(116, Keys.PageUp);
 			keymap.Add(117, Keys.Delete);
-
-			keymap.Add(125, Keys.Down);
+			keymap.Add(119, Keys.End);
+			keymap.Add(75, Keys.Divide);
+			keymap.Add(65, Keys.Decimal);
+			keymap.Add(51, Keys.Backspace);
 			keymap.Add(126, Keys.Up);
+			keymap.Add(125, Keys.Down);
 			keymap.Add(123, Keys.Left);
 			keymap.Add(124, Keys.Right);
-
-			keymap.Add(116, Keys.PageUp);
-			keymap.Add(121, Keys.PageDown);
-			keymap.Add(119, Keys.End);
-			keymap.Add(115, Keys.Home);
+			keymap.Add(48, Keys.Tab);
+			keymap.Add(49, Keys.Space);
+			//keymap.Add(, Keys.CapsLock);
+			//keymap.Add(, Keys.ScrollLock);
+			//keymap.Add(, Keys.PrintScreen);
+			//keymap.Add(, Keys.NumberLock);
+			keymap.Add(36, Keys.Enter);
+			keymap.Add(53, Keys.Escape);
+			keymap.Add(67, Keys.Multiply);
+			keymap.Add(69, Keys.Add);
+			keymap.Add(78, Keys.Subtract);
+			keymap.Add(114, Keys.Help);
+			//keymap.Add(, Keys.Pause);
+			keymap.Add(71, Keys.Clear);
+			keymap.Add(81, Keys.KeypadEqual);
+			//keymap.Add(, Keys.Menu);
+			keymap.Add(42, Keys.Backslash);
+			keymap.Add(24, Keys.Equal);
+			keymap.Add(41, Keys.Semicolon);
+			keymap.Add(39, Keys.Quote);
+			keymap.Add(43, Keys.Comma);
+			keymap.Add(47, Keys.Period);
+			keymap.Add(44, Keys.Slash);
+			keymap.Add(30, Keys.RightBracket);
+			keymap.Add(33, Keys.LeftBracket);
 			keymap.Add(110, Keys.ContextMenu);
+			keymap.Add(82, Keys.Keypad0);
+			keymap.Add(83, Keys.Keypad1);
+			keymap.Add(84, Keys.Keypad2);
+			keymap.Add(85, Keys.Keypad3);
+			keymap.Add(86, Keys.Keypad4);
+			keymap.Add(87, Keys.Keypad5);
+			keymap.Add(88, Keys.Keypad6);
+			keymap.Add(89, Keys.Keypad7);
+			keymap.Add(91, Keys.Keypad8);
+			keymap.Add(92, Keys.Keypad9);
+
 			return keymap;
 		}
 
@@ -232,7 +258,7 @@ namespace Eto.Mac
 			inverse.Add(Keys.Comma, ",");
 			inverse.Add(Keys.Space, " ");
 			inverse.Add(Keys.Backslash, "\\");
-			inverse.Add(Keys.ForwardSlash, "/");
+			inverse.Add(Keys.Slash, "/");
 			inverse.Add(Keys.Equal, "=");
 			inverse.Add(Keys.Grave, "`");
 			inverse.Add(Keys.Minus, "-");

--- a/Source/Eto.WinForms/KeyMap.cs
+++ b/Source/Eto.WinForms/KeyMap.cs
@@ -1,6 +1,7 @@
-using swf = System.Windows.Forms;
+﻿using swf = System.Windows.Forms;
 using Eto.Forms;
 using System.Collections.Generic;
+using System.Diagnostics;
 
 namespace Eto.WinForms
 {
@@ -37,7 +38,10 @@ namespace Eto.WinForms
 		static Keys Find(swf.Keys key)
 		{
 			Keys mapped;
-			return Map.TryGetValue(key, out mapped) ? mapped : Keys.None;
+			if (Map.TryGetValue(key, out mapped))
+				return mapped;
+			Debug.WriteLine($"Unknown key {key}");
+			return Keys.None;
 		}
 		
 		public static swf.Keys Find(Keys key)
@@ -70,6 +74,7 @@ namespace Eto.WinForms
 		static Dictionary<swf.Keys, Keys> GetMap()
 		{
 			var keymap = new Dictionary<swf.Keys, Keys>();
+			// keep in same order as in Keys
 			keymap.Add(swf.Keys.A, Keys.A);
 			keymap.Add(swf.Keys.B, Keys.B);
 			keymap.Add(swf.Keys.C, Keys.C);
@@ -118,33 +123,57 @@ namespace Eto.WinForms
 			keymap.Add(swf.Keys.D7, Keys.D7);
 			keymap.Add(swf.Keys.D8, Keys.D8);
 			keymap.Add(swf.Keys.D9, Keys.D9);
-			keymap.Add(swf.Keys.Space, Keys.Space);
+			keymap.Add(swf.Keys.OemMinus, Keys.Minus);
+			keymap.Add(swf.Keys.Oemtilde, Keys.Grave);
+			keymap.Add(swf.Keys.Insert, Keys.Insert);
+			keymap.Add(swf.Keys.Home, Keys.Home);
+			keymap.Add(swf.Keys.PageDown, Keys.PageDown);
+			keymap.Add(swf.Keys.PageUp, Keys.PageUp);
+			keymap.Add(swf.Keys.Delete, Keys.Delete);
+			keymap.Add(swf.Keys.End, Keys.End);
+			keymap.Add(swf.Keys.Divide, Keys.Divide);
+			keymap.Add(swf.Keys.Decimal, Keys.Decimal);
+			keymap.Add(swf.Keys.Back, Keys.Backspace);
 			keymap.Add(swf.Keys.Up, Keys.Up);
 			keymap.Add(swf.Keys.Down, Keys.Down);
 			keymap.Add(swf.Keys.Left, Keys.Left);
 			keymap.Add(swf.Keys.Right, Keys.Right);
-			keymap.Add(swf.Keys.PageDown, Keys.PageDown);
-			keymap.Add(swf.Keys.PageUp, Keys.PageUp);
-			keymap.Add(swf.Keys.Home, Keys.Home);
-			keymap.Add(swf.Keys.End, Keys.End);
-			keymap.Add(swf.Keys.Alt, Keys.Alt);
-			keymap.Add(swf.Keys.Control, Keys.Control);
-			keymap.Add(swf.Keys.Shift, Keys.Shift);
-			keymap.Add(swf.Keys.Menu, Keys.Menu);
-			keymap.Add(swf.Keys.LWin, Keys.Application);
-			keymap.Add(swf.Keys.RWin, Keys.Application);
-			keymap.Add(swf.Keys.Escape, Keys.Escape);
-			keymap.Add(swf.Keys.Delete, Keys.Delete);
-			keymap.Add(swf.Keys.Back, Keys.Backspace);
-			keymap.Add(swf.Keys.Divide, Keys.Divide);
-			keymap.Add(swf.Keys.Enter, Keys.Enter);
-			keymap.Add(swf.Keys.Insert, Keys.Insert);
-			keymap.Add(swf.Keys.OemPeriod, Keys.Period);
 			keymap.Add(swf.Keys.Tab, Keys.Tab);
-			keymap.Add(swf.Keys.Apps, Keys.ContextMenu);
+			keymap.Add(swf.Keys.Space, Keys.Space);
 			keymap.Add(swf.Keys.CapsLock, Keys.CapsLock);
 			keymap.Add(swf.Keys.Scroll, Keys.ScrollLock);
+			keymap.Add(swf.Keys.PrintScreen, Keys.PrintScreen);
 			keymap.Add(swf.Keys.NumLock, Keys.NumberLock);
+			keymap.Add(swf.Keys.Enter, Keys.Enter);
+			keymap.Add(swf.Keys.Escape, Keys.Escape);
+			keymap.Add(swf.Keys.Multiply, Keys.Multiply);
+			keymap.Add(swf.Keys.Add, Keys.Add);
+			keymap.Add(swf.Keys.Subtract, Keys.Subtract);
+			keymap.Add(swf.Keys.Help, Keys.Help);
+			keymap.Add(swf.Keys.Pause, Keys.Pause);
+			keymap.Add(swf.Keys.Clear, Keys.Clear);
+			//keymap.Add(swf.Keys., Keys.KeypadEqual);
+			keymap.Add(swf.Keys.Menu, Keys.Menu);
+			keymap.Add(swf.Keys.OemPipe, Keys.Backslash);
+			keymap.Add(swf.Keys.Oemplus, Keys.Equal);
+			keymap.Add(swf.Keys.OemSemicolon, Keys.Semicolon);
+			keymap.Add(swf.Keys.OemQuotes, Keys.Quote);
+			keymap.Add(swf.Keys.Oemcomma, Keys.Comma);
+			keymap.Add(swf.Keys.OemPeriod, Keys.Period);
+			keymap.Add(swf.Keys.OemQuestion, Keys.Slash);
+			keymap.Add(swf.Keys.OemCloseBrackets, Keys.RightBracket);
+			keymap.Add(swf.Keys.OemOpenBrackets, Keys.LeftBracket);
+			keymap.Add(swf.Keys.Apps, Keys.ContextMenu);
+			keymap.Add(swf.Keys.NumPad0, Keys.Keypad0);
+			keymap.Add(swf.Keys.NumPad1, Keys.Keypad1);
+			keymap.Add(swf.Keys.NumPad2, Keys.Keypad2);
+			keymap.Add(swf.Keys.NumPad3, Keys.Keypad3);
+			keymap.Add(swf.Keys.NumPad4, Keys.Keypad4);
+			keymap.Add(swf.Keys.NumPad5, Keys.Keypad5);
+			keymap.Add(swf.Keys.NumPad6, Keys.Keypad6);
+			keymap.Add(swf.Keys.NumPad7, Keys.Keypad7);
+			keymap.Add(swf.Keys.NumPad8, Keys.Keypad8);
+			keymap.Add(swf.Keys.NumPad9, Keys.Keypad9);
 			return keymap;
 		}
 

--- a/Source/Eto.Wpf/KeyMap.cs
+++ b/Source/Eto.Wpf/KeyMap.cs
@@ -1,5 +1,6 @@
-using Eto.Forms;
+﻿using Eto.Forms;
 using System.Collections.Generic;
+using System.Diagnostics;
 using swi = System.Windows.Input;
 
 namespace Eto.Wpf
@@ -14,7 +15,10 @@ namespace Eto.Wpf
 		public static Keys ToEto(this swi.Key key)
 		{
 			Keys mapped;
-			return Map.TryGetValue(key, out mapped) ? mapped : Keys.None;
+			if (Map.TryGetValue(key, out mapped))
+				return mapped;
+			Debug.WriteLine($"Unknown key {key}");
+			return Keys.None;
 		}
 
 		public static Keys ToEto(this swi.ModifierKeys modifier)
@@ -62,7 +66,8 @@ namespace Eto.Wpf
 			var inverse = new Dictionary<Keys, swi.Key>();
 			foreach (var entry in GetKeyMap())
 			{
-				inverse.Add(entry.Value, entry.Key);
+				if (!inverse.ContainsKey(entry.Value))
+					inverse.Add(entry.Value, entry.Key);
 			}
 			return inverse;
 		}
@@ -70,6 +75,8 @@ namespace Eto.Wpf
 		static Dictionary<swi.Key, Keys> GetKeyMap()
 		{
 			var keymap = new Dictionary<swi.Key, Keys>();
+
+			// keep in same order as in Keys
 			keymap.Add(swi.Key.A, Keys.A);
 			keymap.Add(swi.Key.B, Keys.B);
 			keymap.Add(swi.Key.C, Keys.C);
@@ -118,33 +125,59 @@ namespace Eto.Wpf
 			keymap.Add(swi.Key.D7, Keys.D7);
 			keymap.Add(swi.Key.D8, Keys.D8);
 			keymap.Add(swi.Key.D9, Keys.D9);
-			keymap.Add(swi.Key.Space, Keys.Space);
+			keymap.Add(swi.Key.OemMinus, Keys.Minus);
+			keymap.Add(swi.Key.OemTilde, Keys.Grave);
+			keymap.Add(swi.Key.Insert, Keys.Insert);
+			keymap.Add(swi.Key.Home, Keys.Home);
+			keymap.Add(swi.Key.PageDown, Keys.PageDown);
+			keymap.Add(swi.Key.PageUp, Keys.PageUp);
+			keymap.Add(swi.Key.Delete, Keys.Delete);
+			keymap.Add(swi.Key.End, Keys.End);
+			keymap.Add(swi.Key.Divide, Keys.Divide);
+			keymap.Add(swi.Key.Decimal, Keys.Decimal);
+			keymap.Add(swi.Key.Back, Keys.Backspace);
 			keymap.Add(swi.Key.Up, Keys.Up);
 			keymap.Add(swi.Key.Down, Keys.Down);
 			keymap.Add(swi.Key.Left, Keys.Left);
 			keymap.Add(swi.Key.Right, Keys.Right);
-			keymap.Add(swi.Key.PageDown, Keys.PageDown);
-			keymap.Add(swi.Key.PageUp, Keys.PageUp);
-			keymap.Add(swi.Key.Home, Keys.Home);
-			keymap.Add(swi.Key.End, Keys.End);
-			/*
-			keymap.Add (swi.Key.LeftAlt, Keys.Alt);
-			keymap.Add (swi.Key.RightAlt, Keys.Alt);
-			keymap.Add (swi.Key.LeftCtrl, Keys.Control);
-			keymap.Add (swi.Key.LeftCtrl, Keys.Control);
-			keymap.Add (swi.Key.LeftShift, Keys.Shift);
-			keymap.Add (swi.Key.RightShift, Keys.Shift);
-			keymap.Add (swi.Key.LWin, Keys.Menu);
-			keymap.Add (swi.Key.RWin, Keys.Menu);
-			 */
-			keymap.Add(swi.Key.Escape, Keys.Escape);
-			keymap.Add(swi.Key.Delete, Keys.Delete);
-			keymap.Add(swi.Key.Back, Keys.Backspace);
-			keymap.Add(swi.Key.Divide, Keys.Divide);
-			keymap.Add(swi.Key.Enter, Keys.Enter);
-			keymap.Add(swi.Key.Insert, Keys.Insert);
 			keymap.Add(swi.Key.Tab, Keys.Tab);
+			keymap.Add(swi.Key.Space, Keys.Space);
+			keymap.Add(swi.Key.CapsLock, Keys.CapsLock);
+			keymap.Add(swi.Key.Scroll, Keys.ScrollLock);
+			keymap.Add(swi.Key.PrintScreen, Keys.PrintScreen);
+			keymap.Add(swi.Key.NumLock, Keys.NumberLock);
+			keymap.Add(swi.Key.Enter, Keys.Enter);
+			keymap.Add(swi.Key.Escape, Keys.Escape);
+			keymap.Add(swi.Key.Multiply, Keys.Multiply);
+			keymap.Add(swi.Key.Add, Keys.Add);
+			keymap.Add(swi.Key.Subtract, Keys.Subtract);
+			keymap.Add(swi.Key.Help, Keys.Help);
+			keymap.Add(swi.Key.Pause, Keys.Pause);
+			keymap.Add(swi.Key.Clear, Keys.Clear);
+			//keymap.Add(swi.Key., Keys.KeypadEqual);
+			keymap.Add(swi.Key.RightAlt, Keys.Menu);
+			keymap.Add(swi.Key.LeftAlt, Keys.Menu);
+			keymap.Add(swi.Key.OemPipe, Keys.Backslash);
+			keymap.Add(swi.Key.OemPlus, Keys.Equal);
+			keymap.Add(swi.Key.OemSemicolon, Keys.Semicolon);
+			keymap.Add(swi.Key.OemQuotes, Keys.Quote);
+			keymap.Add(swi.Key.OemComma, Keys.Comma);
+			keymap.Add(swi.Key.OemPeriod, Keys.Period);
+			keymap.Add(swi.Key.OemQuestion, Keys.Slash);
+			keymap.Add(swi.Key.OemCloseBrackets, Keys.RightBracket);
+			keymap.Add(swi.Key.OemOpenBrackets, Keys.LeftBracket);
 			keymap.Add(swi.Key.Apps, Keys.ContextMenu);
+			keymap.Add(swi.Key.NumPad0, Keys.Keypad0);
+			keymap.Add(swi.Key.NumPad1, Keys.Keypad1);
+			keymap.Add(swi.Key.NumPad2, Keys.Keypad2);
+			keymap.Add(swi.Key.NumPad3, Keys.Keypad3);
+			keymap.Add(swi.Key.NumPad4, Keys.Keypad4);
+			keymap.Add(swi.Key.NumPad5, Keys.Keypad5);
+			keymap.Add(swi.Key.NumPad6, Keys.Keypad6);
+			keymap.Add(swi.Key.NumPad7, Keys.Keypad7);
+			keymap.Add(swi.Key.NumPad8, Keys.Keypad8);
+			keymap.Add(swi.Key.NumPad9, Keys.Keypad9);
+
 			return keymap;
 		}
 	}

--- a/Source/Eto/Forms/Key.cs
+++ b/Source/Eto/Forms/Key.cs
@@ -1,4 +1,4 @@
-using System;
+﻿﻿﻿﻿﻿using System;
 using System.Text;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -16,176 +16,216 @@ namespace Eto.Forms
 		/// <summary>No key</summary>
 		None = 0x0000,
 
-		/// <summary>The A Key</summary>
+		/// <summary>The A key</summary>
 		A = 0x0001,
-		/// <summary>The B Key</summary>
+		/// <summary>The B key</summary>
 		B = 0x0002,
-		/// <summary>The C Key</summary>
+		/// <summary>The C key</summary>
 		C = 0x0003,
-		/// <summary>The D Key</summary>
+		/// <summary>The D key</summary>
 		D = 0x0004,
-		/// <summary>The E Key</summary>
+		/// <summary>The E key</summary>
 		E = 0x0005,
-		/// <summary>The F Key</summary>
+		/// <summary>The F key</summary>
 		F = 0x0006,
-		/// <summary>The G Key</summary>
+		/// <summary>The G key</summary>
 		G = 0x0007,
-		/// <summary>The H Key</summary>
+		/// <summary>The H key</summary>
 		H = 0x0008,
-		/// <summary>The I Key</summary>
+		/// <summary>The I key</summary>
 		I = 0x0009,
-		/// <summary>The J Key</summary>
+		/// <summary>The J key</summary>
 		J = 0x000A,
-		/// <summary>The K Key</summary>
+		/// <summary>The K key</summary>
 		K = 0x000B,
-		/// <summary>The L Key</summary>
+		/// <summary>The L key</summary>
 		L = 0x000C,
-		/// <summary>The M Key</summary>
+		/// <summary>The M key</summary>
 		M = 0x000D,
-		/// <summary>The N Key</summary>
+		/// <summary>The N key</summary>
 		N = 0x000E,
-		/// <summary>The O Key</summary>
+		/// <summary>The O key</summary>
 		O = 0x000F,
-		/// <summary>The P Key</summary>
+		/// <summary>The P key</summary>
 		P = 0x0010,
-		/// <summary>The Q Key</summary>
+		/// <summary>The Q key</summary>
 		Q = 0x0011,
-		/// <summary>The R Key</summary>
+		/// <summary>The R key</summary>
 		R = 0x0012,
-		/// <summary>The S Key</summary>
+		/// <summary>The S key</summary>
 		S = 0x0013,
-		/// <summary>The T Key</summary>
+		/// <summary>The T key</summary>
 		T = 0x0014,
-		/// <summary>The U Key</summary>
+		/// <summary>The U key</summary>
 		U = 0x0015,
-		/// <summary>The V Key</summary>
+		/// <summary>The V key</summary>
 		V = 0x0016,
-		/// <summary>The W Key</summary>
+		/// <summary>The W key</summary>
 		W = 0x0017,
-		/// <summary>The X Key</summary>
+		/// <summary>The X key</summary>
 		X = 0x0018,
-		/// <summary>The Y Key</summary>
+		/// <summary>The Y key</summary>
 		Y = 0x0019,
-		/// <summary>The Z Key</summary>
+		/// <summary>The Z key</summary>
 		Z = 0x001A,
-		/// <summary>The F1 Key</summary>
+		/// <summary>The F1 key</summary>
 		F1 = 0x001B,
-		/// <summary>The F2 Key</summary>
+		/// <summary>The F2 key</summary>
 		F2 = 0x001C,
-		/// <summary>The F3 Key</summary>
+		/// <summary>The F3 key</summary>
 		F3 = 0x001D,
-		/// <summary>The F4 Key</summary>
+		/// <summary>The F4 key</summary>
 		F4 = 0x001E,
-		/// <summary>The F5 Key</summary>
+		/// <summary>The F5 key</summary>
 		F5 = 0x001F,
-		/// <summary>The F6 Key</summary>
+		/// <summary>The F6 key</summary>
 		F6 = 0x0020,
-		/// <summary>The F7 Key</summary>
+		/// <summary>The F7 key</summary>
 		F7 = 0x0021,
-		/// <summary>The F8 Key</summary>
+		/// <summary>The F8 key</summary>
 		F8 = 0x0022,
-		/// <summary>The F9 Key</summary>
+		/// <summary>The F9 key</summary>
 		F9 = 0x0023,
-		/// <summary>The F10 Key</summary>
+		/// <summary>The F10 key</summary>
 		F10 = 0x0024,
-		/// <summary>The F11 Key</summary>
+		/// <summary>The F11 key</summary>
 		F11 = 0x0025,
-		/// <summary>The F12 Key</summary>
+		/// <summary>The F12 key</summary>
 		F12 = 0x0026,
-		/// <summary>The 0 digit Key</summary>
+		/// <summary>The 0 digit key</summary>
 		D0 = 0x0027,
-		/// <summary>The 1 digit Key</summary>
+		/// <summary>The 1 digit key</summary>
 		D1 = 0x0028,
-		/// <summary>The 2 digit Key</summary>
+		/// <summary>The 2 digit key</summary>
 		D2 = 0x0029,
-		/// <summary>The 3 digit Key</summary>
+		/// <summary>The 3 digit key</summary>
 		D3 = 0x002A,
-		/// <summary>The 4 digit Key</summary>
+		/// <summary>The 4 digit key</summary>
 		D4 = 0x002B,
-		/// <summary>The 5 digit Key</summary>
+		/// <summary>The 5 digit key</summary>
 		D5 = 0x002C,
-		/// <summary>The 6 digit Key</summary>
+		/// <summary>The 6 digit key</summary>
 		D6 = 0x002D,
-		/// <summary>The 7 digit Key</summary>
+		/// <summary>The 7 digit key</summary>
 		D7 = 0x002E,
-		/// <summary>The 8 digit Key</summary>
+		/// <summary>The 8 digit key</summary>
 		D8 = 0x002F,
-		/// <summary>The 9 digit Key</summary>
+		/// <summary>The 9 digit key</summary>
 		D9 = 0x0030,
 
-		/// <summary>The Minus '-' Key</summary>
+		/// <summary>The Minus '-' key</summary>
 		Minus = 0x0031,
-		/// <summary>The Plus '+' Key</summary>
-		Plus = 0x0032,
-		/// <summary>The Grave '`' Key</summary>
+		/// <summary>The Plus '+' Key, which usually produces an '=' when pressed without shift and is beside the backspace key.</summary>
+		[Obsolete("Since 2.4, Use Equal")]
+		Plus = Equal,
+		/// <summary>The Grave '`' key</summary>
 		Grave = 0x0033,
-		/// <summary>The Insert Key</summary>
+		/// <summary>The Insert key</summary>
 		Insert = 0x0034,
-		/// <summary>The Home Key</summary>
+		/// <summary>The Home key</summary>
 		Home = 0x0035,
-		/// <summary>The Page Up Key</summary>
+		/// <summary>The Page Up key</summary>
 		PageUp = 0x0036,
-		/// <summary>The Page Down Key</summary>
+		/// <summary>The Page Down key</summary>
 		PageDown = 0x0037,
-		/// <summary>The Delete Key</summary>
+		/// <summary>The Delete key</summary>
 		Delete = 0x0038,
-		/// <summary>The End Key</summary>
+		/// <summary>The End key</summary>
 		End = 0x0039,
-		/// <summary>The Divide '/' Key</summary>
+		/// <summary>The Divide '/' key, usually on the keypad/number pad</summary>
 		Divide = 0x003A,
-		/// <summary>The Decimal '.' Key</summary>
+		/// <summary>The Decimal '.' key, usually on the keypad/number pad</summary>
 		Decimal = 0x003B,
-		/// <summary>The Backspace Key</summary>
+		/// <summary>The Backspace key</summary>
 		Backspace = 0x003C,
-		/// <summary>The Up Key</summary>
+		/// <summary>The Up key</summary>
 		Up = 0x003D,
-		/// <summary>The Down Key</summary>
+		/// <summary>The Down key</summary>
 		Down = 0x003E,
-		/// <summary>The Left Key</summary>
+		/// <summary>The Left key</summary>
 		Left = 0x003F,
-		/// <summary>The Right Key</summary>
+		/// <summary>The Right key</summary>
 		Right = 0x0040,
-		/// <summary>The Tab Key</summary>
+		/// <summary>The Tab key</summary>
 		Tab = 0x0041,
-		/// <summary>The Space Key</summary>
+		/// <summary>The Space key</summary>
 		Space = 0x0042,
-		/// <summary>The Caps Lock Key</summary>
+		/// <summary>The Caps Lock key</summary>
 		CapsLock = 0x0043,
-		/// <summary>The Scroll Lock Key</summary>
+		/// <summary>The Scroll Lock key</summary>
 		ScrollLock = 0x0044,
-		/// <summary>The Print Screen Key</summary>
+		/// <summary>The Print Screen key</summary>
 		PrintScreen = 0x0045,
-		/// <summary>The Number Lock Key</summary>
+		/// <summary>The Number Lock key</summary>
 		NumberLock = 0x0046,
-		/// <summary>The Enter Key</summary>
+		/// <summary>The Enter key</summary>
 		Enter = 0x0047,
-		/// <summary>The Escape Key</summary>
+		/// <summary>The Escape key</summary>
 		Escape = 0x0048,
-		/// <summary>The menu key</summary>
+		/// <summary>The Multiply '*' key, usually on the keypad/number pad</summary>
+		Multiply = 0x0049,
+		/// <summary>The Add '+' key, usually on the keypad/number pad</summary>
+		Add = 0x004A,
+		/// <summary>The Subtract '-' key, usually on the keypad/number pad</summary>
+		Subtract = 0x004B,
+		/// <summary>The Help key</summary>
+		Help = 0x004C,
+		/// <summary>The Pause key</summary>
+		Pause = 0x004D,
+		/// <summary>The Clear key</summary>
+		Clear = 0x004E,
+		/// <summary>The Equal '=' key on the keypad/number pad</summary>
+		KeypadEqual = 0x004F,
+
+		/// <summary>The menu (alt) key</summary>
 		Menu = 0x0050,
-		/// <summary>The Bacslash '\' Key</summary>
+		/// <summary>The Backslash '\' key</summary>
 		Backslash = 0x0051,
-		/// <summary>The Equal '=' Key</summary>
+		/// <summary>The Equal '=' key</summary>
 		Equal = 0x0055,
-		/// <summary>The Semicolon ';' Key</summary>
+		/// <summary>The Semicolon ';' key</summary>
 		Semicolon = 0x0056,
-		/// <summary>The Quote ''' Key</summary>
+		/// <summary>The Quote ''' key</summary>
 		Quote = 0x0057,
 
-		/// <summary>The Comma ',' Key</summary>
+		/// <summary>The Comma ',' key</summary>
 		Comma = 0x0058,
-		/// <summary>The Period '.' Key</summary>
+		/// <summary>The Period '.' key</summary>
 		Period = 0x0059,
-		/// <summary>The Forward Slash '/' Key</summary>
-		ForwardSlash = 0x0060,
+		/// <summary>The Forward Slash '/' key</summary>
+		[Obsolete("Since 2.4, Use Slash instead")]
+		ForwardSlash = Slash,
+		/// <summary>The Slash '/' key</summary>
+		Slash = 0x0060,
 
-		/// <summary>The Right Bracket ']' Key</summary>
+		/// <summary>The Right Bracket ']' key</summary>
 		RightBracket = 0x0061,
-		/// <summary>The Left Bracket '['  Key</summary>
+		/// <summary>The Left Bracket '['  key</summary>
 		LeftBracket = 0x0062,
 
-		/// <summary> /// The context menu Key /// </summary>
+		/// <summary>The context menu key</summary>
 		ContextMenu = 0x0063,
+
+		/// <summary>The keypad/number pad '0' key</summary>
+		Keypad0 = 0x0070,
+		/// <summary>The keypad/number pad '1' key</summary>
+		Keypad1 = 0x0071,
+		/// <summary>The keypad/number pad '2' key</summary>
+		Keypad2 = 0x0072,
+		/// <summary>The keypad/number pad '3' key</summary>
+		Keypad3 = 0x0073,
+		/// <summary>The keypad/number pad '4' key</summary>
+		Keypad4 = 0x0074,
+		/// <summary>The keypad/number pad '5' key</summary>
+		Keypad5 = 0x0075,
+		/// <summary>The keypad/number pad '6' key</summary>
+		Keypad6 = 0x0076,
+		/// <summary>The keypad/number pad '7' key</summary>
+		Keypad7 = 0x0077,
+		/// <summary>The keypad/number pad '8' key</summary>
+		Keypad8 = 0x0078,
+		/// <summary>The keypad/number pad '9' key</summary>
+		Keypad9 = 0x0079,
 
 		/// <summary>The Shift Key Modifier</summary>
 		Shift = 0x1000,
@@ -228,22 +268,29 @@ namespace Eto.Forms
 			{ Keys.D9, "9" },
 
 			{ Keys.Minus, "-" },
-			{ Keys.Plus, "+" },
+			{ Keys.Equal, "=" },
 			{ Keys.Grave, "`" },
 			{ Keys.Divide, "/" },
 			{ Keys.Decimal, "." },
 			{ Keys.Backslash, "\\" },
-			{ Keys.Equal, "=" },
-		
+			{ Keys.KeypadEqual, "=" },
+			{ Keys.Multiply, "*" },
+			{ Keys.Add, "+" },
+			{ Keys.Subtract, "-" },
+			{ Keys.Tab, "\x21E5" },
+			{ Keys.Enter, "\x23ce" },
+			{ Keys.Delete, EtoEnvironment.Platform.IsMac ? "\x232b" : "Del" },
+			{ Keys.Escape, EtoEnvironment.Platform.IsMac ? "\x238b" : "Esc" },
+
 			{ Keys.Semicolon, ";" },
 			{ Keys.Quote, "'" },
 		
 			{ Keys.Comma, "," },
 			{ Keys.Period, "." },
-			{ Keys.ForwardSlash, "/" },
+			{ Keys.Slash, "/" },
 		
-			{ Keys.RightBracket, "(" },
-			{ Keys.LeftBracket, ")" }
+			{ Keys.RightBracket, "[" },
+			{ Keys.LeftBracket, "]" }
 		};
 
 		/// <summary>
@@ -261,11 +308,11 @@ namespace Eto.Forms
 					EtoEnvironment.Platform.IsWindows ? "Win" :
 					"App");
 			if (key.HasFlag(Keys.Control))
-				AppendSeparator(sb, separator, "Ctrl");
+				AppendSeparator(sb, separator, EtoEnvironment.Platform.IsMac ? "^" : "Ctrl");
 			if (key.HasFlag(Keys.Shift))
-				AppendSeparator(sb, separator, "Shift");
+				AppendSeparator(sb, separator, EtoEnvironment.Platform.IsMac ? "\x21e7" : "Shift");
 			if (key.HasFlag(Keys.Alt))
-				AppendSeparator(sb, separator, "Alt");
+				AppendSeparator(sb, separator, EtoEnvironment.Platform.IsMac ? "\x2325" : "Alt");
 
 			var mainKey = key & Keys.KeyMask;
 			string val;


### PR DESCRIPTION
- Map all keys possible
- Keys.Plus is deprecated for Equal (which was only mapped on Gtk and Mac before)
- Keys.ForwardSlash is deprecated for Slash
- Added Keypad0-9, Mulitply, Add, Subtract, Help, Pause, and Clear, and KeypadEqual keys
- Use macOS symbols when translating Keys to a shortcut string on a mac.