### PR TITLE
Icon.FromResource should throw ArgumentException when no resources found.

### DIFF
--- a/Source/Eto.Test/Eto.Test/UnitTests/Drawing/IconTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Drawing/IconTests.cs
@@ -67,6 +67,13 @@ namespace Eto.Test.UnitTests.Drawing
 			var fs = fittingSize != null ? (Size?)new Size(fittingSize.Value, fittingSize.Value) : null;
 			Assert.AreEqual(new Size(expectedSize, expectedSize), icon.GetFrame(scale, fs).PixelSize, "");
 		}
+
+		[TestCase("Some.File.That.Does.Not.Exist.png")]
+		[TestCase("Some.File.That.Does.Not.Exist.ico")]
+		public void InvalidResourceShouldThrowException(string resourceName)
+		{
+			Assert.Throws<ArgumentException>(() => Icon.FromResource(resourceName));
+		}
 	}
 }
 


### PR DESCRIPTION
When using Icon.FromResource with a .png, it will search for @2x, etc files.  When none are found you get an odd error instead of an ArgumentException.