### PR TITLE
Implement Control.Shown event on all platforms

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/DrawableHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/DrawableHandler.cs
@@ -69,6 +69,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleExpose(object o, Gtk.ExposeEventArgs args)
 			{
 				var h = Handler;
+				if (h == null) // can happen if expose event happens after window is closed
+					return;
 				Gdk.EventExpose ev = args.Event;
 				using (var graphics = new Graphics(new GraphicsHandler(h.Control, ev.Window)))
 				{

--- a/Source/Eto.Gtk/Forms/Controls/DropDownHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/DropDownHandler.cs
@@ -231,6 +231,9 @@ namespace Eto.GtkSharp.Forms.Controls
 					Control.PoppedDown += Connector.HandlePoppedDown;
 					break;
 #endif
+				case Eto.Forms.Control.ShownEvent:
+					Control.Mapped += Connector.MappedEvent;
+					break;
 				default:
 					base.AttachEvent(id);
 					break;

--- a/Source/Eto.Gtk/Forms/GtkControl.cs
+++ b/Source/Eto.Gtk/Forms/GtkControl.cs
@@ -357,8 +357,7 @@ namespace Eto.GtkSharp.Forms
 					EventControl.FocusOutEvent += Connector.FocusOutEvent;
 					break;
 				case Eto.Forms.Control.ShownEvent:
-					EventControl.AddEvents((int)Gdk.EventMask.VisibilityNotifyMask);
-					EventControl.VisibilityNotifyEvent += Connector.VisibilityNotifyEvent;
+					EventControl.Mapped += Connector.MappedEvent;
 					break;
 				default:
 					base.AttachEvent(id);
@@ -562,16 +561,15 @@ namespace Eto.GtkSharp.Forms
 					handler.Callback.OnLostFocus(Handler.Widget, EventArgs.Empty);
 			}
 
-			public void VisibilityNotifyEvent(object o, Gtk.VisibilityNotifyEventArgs args)
-			{
-				if (args.Event.State == Gdk.VisibilityState.FullyObscured)
-					Handler.Callback.OnShown(Handler.Widget, EventArgs.Empty);
-			}
-
 			public void HandleControlRealized(object sender, EventArgs e)
 			{
 				Handler.RealizedSetup();
 				Handler.Control.Realized -= HandleControlRealized;
+			}
+
+			public virtual void MappedEvent(object sender, EventArgs e)
+			{
+				Handler.Callback.OnShown(Handler.Widget, EventArgs.Empty);
 			}
 		}
 

--- a/Source/Eto.Gtk/Forms/TableLayoutHandler.cs
+++ b/Source/Eto.Gtk/Forms/TableLayoutHandler.cs
@@ -83,6 +83,7 @@ namespace Eto.GtkSharp.Forms
 		{
 			align = new Gtk.Alignment(0, 0, 1.0F, 1.0F);
 			box = new Gtk.EventBox { Child = align };
+			Control = new Gtk.Table(1, 1, false);
 		}
 
 		public void CreateControl(int cols, int rows)
@@ -91,7 +92,7 @@ namespace Eto.GtkSharp.Forms
 			lastColumnScale = cols - 1;
 			rowScale = new bool[rows];
 			lastRowScale = rows - 1;
-			Control = new Gtk.Table((uint)rows, (uint)cols, false);
+			Control.Resize((uint)rows, (uint)cols);
 			controls = new Control[rows, cols];
 			blank = new Gtk.Widget[rows, cols];
 			align.Add(Control);
@@ -230,6 +231,19 @@ namespace Eto.GtkSharp.Forms
 		{
 			base.OnLoadComplete(e);
 			SetFocusChain();
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Eto.Forms.Control.ShownEvent:
+					Control.Mapped += Connector.MappedEvent;
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
 		}
 	}
 }

--- a/Source/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -51,7 +51,7 @@ namespace Eto.Mac.Forms.Controls
 
 		NSTableView Table { get; }
 
-		bool AutoSizeColumns();
+		bool AutoSizeColumns(bool force);
 	}
 
 	class EtoGridScrollView : NSScrollView, IMacControl
@@ -68,7 +68,7 @@ namespace Eto.Mac.Forms.Controls
 
 			if (!autoSized)
 			{
-				autoSized = Handler.AutoSizeColumns();
+				autoSized = Handler.AutoSizeColumns(false);
 			}
 		}
 	}
@@ -282,7 +282,7 @@ namespace Eto.Mac.Forms.Controls
 		static void HandleScrolled(ObserverActionEventArgs e)
 		{
 			var handler = (GridHandler<TControl,TWidget,TCallback>)e.Handler;
-			handler.AutoSizeColumns();
+			handler.AutoSizeColumns(false);
 		}
 
 		public override void AttachEvent(string id)
@@ -326,13 +326,13 @@ namespace Eto.Mac.Forms.Controls
 
 		NSRange autoSizeRange;
 
-		public bool AutoSizeColumns()
+		public bool AutoSizeColumns(bool force)
 		{
 			if (Widget.Loaded)
 			{
 				var rect = Table.VisibleRect();
 				var newRange = Table.RowsInRect(rect);
-				if (newRange.Length > 0 && (autoSizeRange.Location != newRange.Location || autoSizeRange.Length != newRange.Length))
+				if (newRange.Length > 0 && (force || autoSizeRange.Location != newRange.Location || autoSizeRange.Length != newRange.Length))
 				{
 					IsAutoSizingColumns = true;
 					foreach (var col in ColumnHandlers)

--- a/Source/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -305,7 +305,7 @@ namespace Eto.Mac.Forms.Controls
 			public override void AddRange(IEnumerable<object> items)
 			{
 				Handler.Control.ReloadData();
-				Handler.AutoSizeColumns();
+				Handler.AutoSizeColumns(true);
 			}
 
 			static Selector selInsertRowsWithAnimation = new Selector("insertRowsAtIndexes:withAnimation:");
@@ -322,7 +322,7 @@ namespace Eto.Mac.Forms.Controls
 				else
 					Handler.Control.ReloadData();
 
-				Handler.AutoSizeColumns();
+				Handler.AutoSizeColumns(true);
 			}
 
 			public override void InsertItem(int index, object item)
@@ -342,7 +342,7 @@ namespace Eto.Mac.Forms.Controls
 					Handler.SuppressSelectionChanged--;
 				}
 
-				Handler.AutoSizeColumns();
+				Handler.AutoSizeColumns(true);
 			}
 
 			public override void RemoveItem(int index)
@@ -373,13 +373,13 @@ namespace Eto.Mac.Forms.Controls
 						Handler.Callback.OnSelectionChanged(Handler.Widget, EventArgs.Empty);
 				}
 
-				Handler.AutoSizeColumns();
+				Handler.AutoSizeColumns(true);
 			}
 
 			public override void RemoveAllItems()
 			{
 				Handler.Control.ReloadData();
-				Handler.AutoSizeColumns();
+				Handler.AutoSizeColumns(true);
 			}
 		}
 
@@ -393,7 +393,7 @@ namespace Eto.Mac.Forms.Controls
 				collection = new CollectionHandler{ Handler = this };
 				collection.Register(value);
 				if (Widget.Loaded)
-					AutoSizeColumns();
+					AutoSizeColumns(true);
 			}
 		}
 

--- a/Source/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -193,7 +193,7 @@ namespace Eto.Mac.Forms.Controls
 					h.ExpandItems(myitem);
 					h.suppressExpandCollapseEvents--;
 					h.Callback.OnExpanded(h.Widget, new TreeGridViewItemEventArgs(myitem.Item));
-					h.AutoSizeColumns();
+					h.AutoSizeColumns(true);
 				}
 			}
 
@@ -407,7 +407,7 @@ namespace Eto.Mac.Forms.Controls
 				ExpandItems(null);
 				suppressExpandCollapseEvents--;
 				if (Widget.Loaded)
-					AutoSizeColumns();
+					AutoSizeColumns(true);
 			}
 		}
 
@@ -643,7 +643,7 @@ namespace Eto.Mac.Forms.Controls
 				Control.ReloadItem(myitem, true);
 				SetItemExpansion(myitem);
 				ExpandItems(myitem);
-				AutoSizeColumns();
+				AutoSizeColumns(true);
 				var isSelectionChanged = false;
 				foreach (var sel in selection)
 				{

--- a/Source/Eto.Mac/Forms/DialogHandler.cs
+++ b/Source/Eto.Mac/Forms/DialogHandler.cs
@@ -144,7 +144,7 @@ namespace Eto.Mac.Forms
 		public virtual void ShowModal()
 		{
 			session = null;
-			Callback.OnShown(Widget, EventArgs.Empty);
+			Application.Instance.AsyncInvoke(FireOnShown); // fire after dialog is shown
 
 			Widget.Closed += HandleClosed;
 			if (DisplayMode.HasFlag(DialogDisplayMode.Attached) && Widget.Owner != null)
@@ -160,7 +160,6 @@ namespace Eto.Mac.Forms
 		{
 			var tcs = new TaskCompletionSource<bool>();
 			session = null;
-			Callback.OnShown(Widget, EventArgs.Empty);
 
 			Widget.Closed += HandleClosed;
 			if (DisplayMode.HasFlag(DialogDisplayMode.Attached) && Widget.Owner != null)
@@ -172,6 +171,7 @@ namespace Eto.Mac.Forms
 				Control.MakeKeyWindow();
 				Application.Instance.AsyncInvoke(() =>
 				{
+					Application.Instance.AsyncInvoke(FireOnShown); // fire after dialog is shown
 					MacModal.Run(Widget, Control, out session);
 					tcs.SetResult(true);
 				});

--- a/Source/Eto.Mac/Forms/FormHandler.cs
+++ b/Source/Eto.Mac/Forms/FormHandler.cs
@@ -100,9 +100,11 @@ namespace Eto.Mac.Forms
 			{
 				Control.OrderFront(ApplicationHandler.Instance.AppDelegate);
 			}
-			
+
 			if (!visible)
-				Callback.OnShown(Widget, EventArgs.Empty);
+			{
+				FireOnShown();
+			}
 		}
 
 		public bool ShowActivated { get; set; } = true;

--- a/Source/Eto.Mac/Forms/MacControlExtensions.cs
+++ b/Source/Eto.Mac/Forms/MacControlExtensions.cs
@@ -78,6 +78,17 @@ namespace Eto.Mac.Forms
 			return child == null ? null : child.GetMacContainer();
 		}
 
+		public static IMacViewHandler GetMacViewHandler(this Control control)
+		{
+			if (control == null)
+				return null;
+			var container = control.Handler as IMacViewHandler;
+			if (container != null)
+				return container;
+			var child = control.ControlObject as Control;
+			return child == null ? null : child.GetMacViewHandler();
+		}
+
 		public static IMacControlHandler GetMacControl(this Control control)
 		{
 			if (control == null)

--- a/Source/Eto.Mac/Forms/MacWindow.cs
+++ b/Source/Eto.Mac/Forms/MacWindow.cs
@@ -713,7 +713,7 @@ namespace Eto.Mac.Forms
 				{
 					Control.IsVisible = value;
 					if (Widget.Loaded && value)
-						Callback.OnShown(Widget, EventArgs.Empty);
+						FireOnShown();
 				}
 			}
 		}

--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/ControlEventTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/ControlEventTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using NUnit.Framework;
 using Eto.Forms;
@@ -8,44 +8,18 @@ using System.Reflection;
 namespace Eto.Test.UnitTests.Forms.Controls
 {
 	[TestFixture]
-	public class ControlEventTests
+	public class ControlEventTests : TestBase
 	{
-		static IEnumerable<Control> GetControls()
-		{
-			var controls = new List<Control>();
-			TestBase.Invoke(() =>
-			{
-				var controlTypes = typeof(Control)
-					.GetTypeInfo().Assembly.ExportedTypes
-					.Where(r =>
-					{
-						var ti = r.GetTypeInfo();
-						return r.FullName.StartsWith("Eto.Forms", StringComparison.Ordinal)
-							&& typeof(Control).GetTypeInfo().IsAssignableFrom(ti)
-							&& !ti.IsAbstract
-							&& !ti.IsGenericType
-							&& ti.DeclaredConstructors.Any(c => c.GetParameters().Length == 0);
-					});
-				foreach (var type in controlTypes)
-				{
-					if (!Platform.Instance.Supports(type))
-						continue;
-					controls.Add((Control)Activator.CreateInstance(type));
-				}
-			});
-			return controls;
-		
-		}
-
 		/// <summary>
 		/// Test to ensure all common events can be handled
 		/// </summary>
 		[Test]
-		[TestCaseSource("GetControls")]
-		public void ControlEventsShouldBeHandled(Control control)
+		[TestCaseSource(nameof(GetAllControlTypes))]
+		public void ControlEventsShouldBeHandled(Type controlType)
 		{
 			TestBase.Invoke(() =>
 			{
+				var control = (Control)Activator.CreateInstance(controlType);
 				try
 				{
 					control.SizeChanged += Control_EventHandler;

--- a/Source/Eto.Test/Eto.Test/UnitTests/TestBase.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/TestBase.cs
@@ -1,4 +1,4 @@
-﻿using Eto.Drawing;
+using Eto.Drawing;
 using Eto.Forms;
 using NUnit.Framework;
 using System;
@@ -186,7 +186,7 @@ namespace Eto.Test.UnitTests
 		/// <param name="test">Delegate to execute on the form</param>
 		/// <param name="timeout">Timeout to wait for the operation to complete</param>
 		public static void Form<T>(Action<T> test, int timeout = DefaultTimeout)
-			where T: Form, new()
+			where T : Form, new()
 		{
 			T form = null;
 			bool shown = false;
@@ -217,7 +217,11 @@ namespace Eto.Test.UnitTests
 				{
 					var application = Application;
 					if (application != null)
-						application.Invoke(form.Close);
+						application.Invoke(() =>
+						{
+							if (form.Loaded)
+								form.Close();
+						});
 					else
 						form.Close();
 				}
@@ -421,7 +425,7 @@ namespace Eto.Test.UnitTests
 		}
 
 		public static PropertyTestInfo PropertyTest<T>(params Expression<Func<T, object>>[] param)
-			where T: new()
+			where T : new()
 		{
 			return new PropertyTestInfo
 			{
@@ -434,7 +438,8 @@ namespace Eto.Test.UnitTests
 		public static void TestProperties<T>(Func<Form, T> create, params Expression<Func<T, object>>[] properties)
 		{
 			PropertyTestInfo test = null;
-			Shown(form => {
+			Shown(form =>
+			{
 				var ctl = create(form);
 				test = PropertyTest<T>(() => ctl, properties);
 				test.Run();
@@ -465,6 +470,35 @@ namespace Eto.Test.UnitTests
 			{
 				return $"{Type}: {string.Join(",", Properties)}";
 			}
+		}
+
+		public static IEnumerable<Type> GetAllControlTypes()
+		{
+			return typeof(Control)
+				.GetTypeInfo().Assembly.ExportedTypes
+				.Where(r =>
+				{
+					var ti = r.GetTypeInfo();
+					return
+						r.FullName.StartsWith("Eto.Forms", StringComparison.Ordinal)
+						&& Platform.Instance.Supports(r)
+						&& typeof(Control).GetTypeInfo().IsAssignableFrom(ti)
+						&& !ti.IsAbstract
+						&& !ti.IsGenericType
+						&& ti.DeclaredConstructors.Any(c => c.GetParameters().Length == 0);
+				})
+				.OrderBy(r => r.FullName);
+		}
+
+		public static IEnumerable<Type> GetControlTypes()
+		{
+			return GetAllControlTypes()
+				.Where(r =>
+				{
+					var ti = r.GetTypeInfo();
+					return !typeof(Window).GetTypeInfo().IsAssignableFrom(ti)
+						&& !typeof(TabPage).GetTypeInfo().IsAssignableFrom(ti);
+				});
 		}
 	}
 }

--- a/Source/Eto.WinForms/CustomControls/ExtendedDateTimePicker.cs
+++ b/Source/Eto.WinForms/CustomControls/ExtendedDateTimePicker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using swf = System.Windows.Forms;
@@ -24,11 +24,11 @@ namespace Eto.WinForms.CustomControls
 		int selectedSegment = -1;
 
 		const swf.TextFormatFlags RenderTextFormat = swf.TextFormatFlags.SingleLine
-		                                             | swf.TextFormatFlags.NoPrefix
-		                                             | swf.TextFormatFlags.TextBoxControl
-		                                             | swf.TextFormatFlags.Right
-		                                             | swf.TextFormatFlags.VerticalCenter
-		                                             | swf.TextFormatFlags.NoPadding;
+													 | swf.TextFormatFlags.NoPrefix
+													 | swf.TextFormatFlags.TextBoxControl
+													 | swf.TextFormatFlags.Right
+													 | swf.TextFormatFlags.VerticalCenter
+													 | swf.TextFormatFlags.NoPadding;
 
 		class Segment
 		{
@@ -102,46 +102,43 @@ namespace Eto.WinForms.CustomControls
 			if (format == null)
 				return;
 
-			using (var g = CreateGraphics())
+			var pixelPos = 0;
+			var pos = 0;
+			while (pos < format.Length)
 			{
-				var pixelPos = 0;
-				var pos = 0;
-				while (pos < format.Length)
+				var ch = format[pos];
+				var def = defs.FirstOrDefault(r => r.Char == ch);
+				if (def != null)
 				{
-					var ch = format[pos];
-					var def = defs.FirstOrDefault(r => r.Char == ch);
-					if (def != null)
+					var endPos = pos;
+					while (endPos < format.Length - 1 && format[endPos + 1] == ch)
+						endPos++;
+					var str = def.MaxWidth(format.Substring(pos, (endPos - pos + 1)));
+					var strSize = swf.TextRenderer.MeasureText(str, Font, sd.Size.Empty, RenderTextFormat);
+					var segment = new Segment
 					{
-						var endPos = pos;
-						while (endPos < format.Length - 1 && format[endPos + 1] == ch)
-							endPos++;
-						var str = def.MaxWidth(format.Substring(pos, (endPos - pos + 1)));
-						var strSize = swf.TextRenderer.MeasureText(g, str, Font, sd.Size.Empty, RenderTextFormat);
-						var segment = new Segment
-						{
-							Start = pixelPos,
-							Width = strSize.Width,
-							Format = format.Substring(pos, endPos - pos + 1),
-							Def = def
-						};
-						segments.Add(segment);
-						pos = endPos;
-						pixelPos += segment.Width;
-					}
-					else
-					{
-						var strSize = swf.TextRenderer.MeasureText(g, ch.ToString(CultureInfo.InvariantCulture), Font, sd.Size.Empty, RenderTextFormat);
-						var segment = new Segment
-						{
-							Start = pixelPos,
-							Width = strSize.Width,
-							StaticText = ch.ToString(CultureInfo.InvariantCulture)
-						};
-						segments.Add(segment);
-						pixelPos += segment.Width;
-					}
-					pos++;
+						Start = pixelPos,
+						Width = strSize.Width,
+						Format = format.Substring(pos, endPos - pos + 1),
+						Def = def
+					};
+					segments.Add(segment);
+					pos = endPos;
+					pixelPos += segment.Width;
 				}
+				else
+				{
+					var strSize = swf.TextRenderer.MeasureText(ch.ToString(CultureInfo.InvariantCulture), Font, sd.Size.Empty, RenderTextFormat);
+					var segment = new Segment
+					{
+						Start = pixelPos,
+						Width = strSize.Width,
+						StaticText = ch.ToString(CultureInfo.InvariantCulture)
+					};
+					segments.Add(segment);
+					pixelPos += segment.Width;
+				}
+				pos++;
 			}
 
 		}
@@ -269,7 +266,7 @@ namespace Eto.WinForms.CustomControls
 			{
 				g.FillRectangle(bgBrush, e.ClipRectangle);
 			}
-			
+
 			// calculate text location
 			var font = Font;
 			var fontSize = swf.TextRenderer.MeasureText(g, "9/", font, new sd.Size(int.MaxValue, int.MaxValue), RenderTextFormat);
@@ -395,7 +392,7 @@ namespace Eto.WinForms.CustomControls
 		}
 
 		bool showBorder = true;
-        public bool ShowBorder
+		public bool ShowBorder
 		{
 			get { return showBorder; }
 			set

--- a/Source/Eto.WinForms/Forms/Controls/DropDownHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/DropDownHandler.cs
@@ -60,18 +60,15 @@ namespace Eto.WinForms.Forms.Controls
 			{
 				var size = new sd.Size(16, 20);
 				var font = Font;
-				using (var g = CreateGraphics())
+				foreach (object item in Items)
 				{
-					foreach (object item in Items)
-					{
-						var text = GetItemText(item);
-						var itemSize = swf.TextRenderer.MeasureText(g, text, font);
-						var image = (item as EtoComboBoxItem)?.Image;
-						if (image != null)
-							itemSize.Width += 18;
-						size.Width = Math.Max(size.Width, (int) itemSize.Width);
-						size.Height = Math.Max(size.Height, (int) itemSize.Height);
-					}
+					var text = GetItemText(item);
+					var itemSize = swf.TextRenderer.MeasureText(text, font);
+					var image = (item as EtoComboBoxItem)?.Image;
+					if (image != null)
+						itemSize.Width += 18;
+					size.Width = Math.Max(size.Width, (int) itemSize.Width);
+					size.Height = Math.Max(size.Height, (int) itemSize.Height);
 				}
 				// for drop down glyph and border
 				if (DrawMode == swf.DrawMode.OwnerDrawFixed)

--- a/Source/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using sd = System.Drawing;
 using swf = System.Windows.Forms;
@@ -249,6 +249,8 @@ namespace Eto.WinForms.Forms.Controls
 			{
 				SwfTextBox.SelectionStart = value;
 				SwfTextBox.SelectionLength = 0;
+				if (!Widget.Loaded)
+					ShouldSelect = false;
 			}
 		}
 
@@ -259,6 +261,8 @@ namespace Eto.WinForms.Forms.Controls
 			{
 				SwfTextBox.SelectionStart = value.Start;
 				SwfTextBox.SelectionLength = value.Length();
+				if (!Widget.Loaded)
+					ShouldSelect = false;
 			}
 		}
 

--- a/Source/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using swf = System.Windows.Forms;
 using sd = System.Drawing;
@@ -65,7 +65,7 @@ namespace Eto.WinForms.Forms.Controls
 				case TreeGridView.ActivatedEvent:
 					Control.KeyDown += (sender, e) =>
 					{
-						if (!e.Handled && SelectedItem != null)
+						if (!e.Handled && SelectedItem != null && e.KeyData == swf.Keys.Enter)
 						{
 							Callback.OnActivated(Widget, new TreeGridViewItemEventArgs(SelectedItem));
 							e.Handled = true;

--- a/Source/Eto.WinForms/Forms/WindowsControl.cs
+++ b/Source/Eto.WinForms/Forms/WindowsControl.cs
@@ -389,6 +389,18 @@ namespace Eto.WinForms.Forms
 				case Eto.Forms.Control.LostFocusEvent:
 					Control.LostFocus += (sender, e) => Callback.OnLostFocus(Widget, EventArgs.Empty);
 					break;
+				case Eto.Forms.Control.ShownEvent:
+					bool? last = null;
+					Control.VisibleChanged += (sender, e) =>
+					{
+						var visible = Control.Visible;
+						if (last == visible || !Widget.Loaded)
+							return;
+						last = visible;
+						if (visible)
+							Callback.OnShown(Widget, EventArgs.Empty);
+					};
+					break;
 				default:
 					base.AttachEvent(id);
 					break;
@@ -612,7 +624,29 @@ namespace Eto.WinForms.Forms
 		public virtual void OnLoad(EventArgs e)
 		{
 			SetMinimumSizeInternal(false);
+
+			if (Widget.VisualParent?.Loaded != false && !(Widget is Window))
+			{
+				// adding dynamically or loading without a parent (e.g. embedding into a native app)
+				Application.Instance.AsyncInvoke(FireOnShown);
+			}
 		}
+
+		static void FireOnShown(Control control)
+		{
+			if (!control.Visible)
+				return;
+			var handler = control.Handler as IWindowsControl;
+			handler?.Callback.OnShown(control, EventArgs.Empty);
+
+			foreach (var ctl in control.VisualControls)
+			{
+				if (ctl.Visible)
+					FireOnShown(ctl);
+			}
+		}
+
+		protected void FireOnShown() => FireOnShown(Widget);
 
 		public virtual void OnLoadComplete(EventArgs e)
 		{
@@ -769,8 +803,8 @@ namespace Eto.WinForms.Forms
 
 		public virtual int TabIndex
 		{
-			get { return Control.TabIndex; }
-			set { Control.TabIndex = value; }
+			get { return Control.TabIndex == 0 ? int.MaxValue : Control.TabIndex - 1; }
+			set { Control.TabIndex = value == int.MaxValue ? 0 : value + 1; }
 		}
 
 		public virtual IEnumerable<Control> VisualControls => Enumerable.Empty<Control>();

--- a/Source/Eto/Forms/Controls/Spinner.cs
+++ b/Source/Eto/Forms/Controls/Spinner.cs
@@ -1,26 +1,38 @@
 using System;
+using System.ComponentModel;
 
 namespace Eto.Forms
 {
-	/// <summary>
-	/// Presents a spinning indeterminate progress spinner wheel
-	/// </summary>
-	/// <remarks>
-	/// Use the <see cref="Control.Enabled"/> property to control whether the spinner is active or not.
-	/// </remarks>
-	/// <copyright>(c) 2013 by Curtis Wensley</copyright>
-	/// <license type="BSD-3">See LICENSE for full terms</license>
-	[Handler(typeof(Spinner.IHandler))]
-	public class Spinner : Control
-	{
-		/// <summary>
-		/// Handler interface for the <see cref="Spinner"/> control
-		/// </summary>
-		/// <copyright>(c) 2013 by Curtis Wensley</copyright>
-		/// <license type="BSD-3">See LICENSE for full terms</license>
-		public new interface IHandler : Control.IHandler
-		{
-		}
-	}
+    /// <summary>
+    /// Presents a spinning indeterminate progress spinner wheel
+    /// </summary>
+    /// <remarks>
+    /// Use the <see cref="Control.Enabled"/> property to control whether the spinner is active or not.
+    /// </remarks>
+    /// <copyright>(c) 2013 by Curtis Wensley</copyright>
+    /// <license type="BSD-3">See LICENSE for full terms</license>
+    [Handler(typeof(Spinner.IHandler))]
+    public class Spinner : Control
+    {
+        /// <summary>
+        /// Handler interface for the <see cref="Spinner"/> control
+        /// </summary>
+        /// <copyright>(c) 2013 by Curtis Wensley</copyright>
+        /// <license type="BSD-3">See LICENSE for full terms</license>
+        public new interface IHandler : Control.IHandler
+        {
+        }
+
+        /// <summary>
+        /// Gets or sets a value indicating whether the Spinner is spinning, default is false.
+        /// </summary>
+        /// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
+        [DefaultValue(false)]
+        public override bool Enabled
+        {
+            get { return base.Enabled; }
+            set { base.Enabled = value; }
+        }
+    }
 }
 

--- a/Source/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/Source/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -396,6 +396,9 @@ namespace Eto.Forms
 				case Eto.Forms.Control.TextInputEvent:
 					KeyboardControl.TextInput += (s, e) => Callback.OnTextInput(Widget, e);
 					break;
+				case Eto.Forms.Control.ShownEvent:
+					Control.Shown += (s, e) => Callback.OnShown(Widget, e);
+					break;
 				default:
 					base.AttachEvent(id);
 					break;


### PR DESCRIPTION
- Gtk: Fix getting/setting properties/events before TableLayout is created (e.g. using Rows to construct)
- Mac: Fix autosizing columns when TreeGridView/GridView data is changed and visible rows are unchanged.
- WinForms: Fix TreeGridView.Activated event to only trigger when the Enter key is pressed (instead of any key)
- WinForms: TextBox should not select all when setting the selection or caret before it is shown