### PR TITLE
Wpf: This adds a UseMouseSelectionOnly property to TextBoxCell/ImageTextCell to use from a native style.

### DIFF
--- a/Source/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using swc = System.Windows.Controls;
 using sw = System.Windows;
@@ -12,6 +12,18 @@ namespace Eto.Wpf.Forms.Cells
 {
 	public class ImageTextCellHandler : CellHandler<ImageTextCellHandler.Column, ImageTextCell, ImageTextCell.ICallback>, ImageTextCell.IHandler
 	{
+		static readonly object UseMouseSelectionOnly_Key = new object();
+
+		/// <summary>
+		/// This makes the mouse only select text without being able to drag/drop the text.
+		/// By default, when clicking and dragging a selection it would allow you to drag the text to other controls.
+		/// </summary>
+		public bool UseMouseSelectionOnly
+		{
+			get { return Widget.Properties.Get(UseMouseSelectionOnly_Key, false); }
+			set { Widget.Properties.Set(UseMouseSelectionOnly_Key, value); }
+		}
+
 		public TextAlignment TextAlignment
 		{
 			get { return Control.TextAlignment.ToEto(); }
@@ -177,6 +189,13 @@ namespace Eto.Wpf.Forms.Cells
 					if (Handler.AutoSelectMode == AutoSelectMode.OnFocus)
 						control.SelectAll();
 				};
+				if (Handler.UseMouseSelectionOnly)
+				{
+					element.PreviewMouseLeftButtonDown += (sender, e) =>
+					{
+						element.Select(0, 0);
+					};
+				}
 				element.DataContextChanged += (sender, e) =>
 				{
 					var control = sender as swc.TextBox;

--- a/Source/Eto.Wpf/Forms/Cells/TextBoxCellHandler.cs
+++ b/Source/Eto.Wpf/Forms/Cells/TextBoxCellHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using swc = System.Windows.Controls;
 using swd = System.Windows.Data;
@@ -10,6 +10,18 @@ namespace Eto.Wpf.Forms.Cells
 {
 	public class TextBoxCellHandler : CellHandler<TextBoxCellHandler.Column, TextBoxCell, TextBoxCell.ICallback>, TextBoxCell.IHandler
 	{
+		static readonly object UseMouseSelectionOnly_Key = new object();
+
+		/// <summary>
+		/// This makes the mouse only select text without being able to drag/drop the text.
+		/// By default, when clicking and dragging a selection it would allow you to drag the text to other controls.
+		/// </summary>
+		public bool UseMouseSelectionOnly
+		{
+			get { return Widget.Properties.Get(UseMouseSelectionOnly_Key, false); }
+			set { Widget.Properties.Set(UseMouseSelectionOnly_Key, value); }
+		}
+
 		public TextAlignment TextAlignment
 		{
 			get { return Control.TextAlignment.ToEto(); }
@@ -104,6 +116,13 @@ namespace Eto.Wpf.Forms.Cells
 				element.SetBinding(swc.TextBlock.VerticalAlignmentProperty, CreateBinding(nameof(VerticalAlignment)));
 				element.Text = Handler.GetValue(dataItem);
 				Handler.FormatCell(element, cell, dataItem);
+				if (Handler.UseMouseSelectionOnly)
+				{
+					element.PreviewMouseLeftButtonDown += (sender, e) =>
+					{
+						element.Select(0, 0);
+					};
+				}
 
 				element.DataContextChanged += (sender, e) =>
 				{


### PR DESCRIPTION
Sometimes you may wish the mouse in a TextBoxCell and ImageTextCell to only select text but not drag selected text.  This adds a property to the handlers so you can apply it with a style. E.g.

    Style.Add<Eto.Wpf.Forms.Cells.TextBoxCellHandler>("no-mouse-drag", handler => handler.UseMouseSelectionOnly = true);
    Style.Add<Eto.Wpf.Forms.Cells.ImageTextCellHandler>("no-mouse-drag", handler => handler.UseMouseSelectionOnly = true);