### PR TITLE
ImageView updates for sizing when setting to different images

### DIFF
--- a/Source/Eto.Gtk/Forms/Controls/ImageViewHandler.cs
+++ b/Source/Eto.Gtk/Forms/Controls/ImageViewHandler.cs
@@ -93,9 +93,11 @@ namespace Eto.GtkSharp.Forms.Controls
 			set
 			{
 				image = value;
-				if (image != null && (!widthSet || !heightSet))
+				if (!widthSet || !heightSet)
 				{
-					Control.SetSizeRequest(widthSet ? Size.Width : image.Size.Width, heightSet ? Size.Height : image.Size.Height);
+					var imageSize = image?.Size ?? Size.Empty;
+					var size = Size;
+					Control.SetSizeRequest(widthSet ? size.Width : imageSize.Width, heightSet ? size.Height : imageSize.Height);
 				}
 				if (Control.Visible)
 					Control.QueueDraw();

--- a/Source/Eto.Test/Eto.Test/Sections/Controls/ImageViewSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Controls/ImageViewSection.cs
@@ -59,7 +59,7 @@ namespace Eto.Test.Sections.Controls
 
 		Icon GetIcon()
 		{
-			return TestIcons.TestIcon;
+			return TestIcons.Logo;
 		}
 
 		Bitmap GetBitmap()

--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/ImageViewTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/ImageViewTests.cs
@@ -1,17 +1,19 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using Eto.Forms;
 using Eto.Drawing;
+using System.Runtime.ExceptionServices;
+using System.Collections.Generic;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {
 	[TestFixture]
-	public class ImageViewTests
+	public class ImageViewTests : TestBase
 	{
 		[Test]
 		public void NoImageShouldNotCrash()
 		{
-			TestBase.Form(form =>
+			Form(form =>
 			{
 				form.Content = new ImageView();
 				form.Shown += (sender, e) => Application.Instance.AsyncInvoke(form.Close);
@@ -21,7 +23,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		[Test]
 		public void NullImageShouldNotCrash()
 		{
-			TestBase.Form(form =>
+			Form(form =>
 			{
 				form.Content = new ImageView { Image = null };
 				form.Shown += (sender, e) => Application.Instance.AsyncInvoke(form.Close);
@@ -31,11 +33,68 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		[Test]
 		public void ImageShouldNotCrash()
 		{
-			TestBase.Form(form =>
+			Form(form =>
 			{
 				form.Content = new ImageView { Image = TestIcons.TestImage };
 				form.Shown += (sender, e) => Application.Instance.AsyncInvoke(form.Close);
 			});
+		}
+
+		static IEnumerable<object[]> GetImageSizeTests()
+		{
+			var logo = TestIcons.Logo;
+			var image = TestIcons.TestImage;
+			var zeroSize = Platform.Instance.IsGtk ? new Size(1, 1) : new Size(0, 0); // gtk doesn't allow 0,0 size controls?
+			yield return new object[] { logo.WithSize(16, 16), new Size(16, 16), logo.WithSize(32, 32), new Size(32, 32) };
+			yield return new object[] { logo.WithSize(32, 32), new Size(32, 32), null, zeroSize };
+			yield return new object[] { image, image.Size, image.WithSize(32, 32), new Size(32, 32) };
+			if (Platform.Instance.IsWinForms)
+				zeroSize = new Size(1, 1); // what the? Can't figure out how not to do this.. Not detrimental though.
+			yield return new object[] { null, zeroSize, logo.WithSize(32, 32), new Size(32, 32) };
+		}
+
+		[Test, TestCaseSource(nameof(GetImageSizeTests))]
+		public void ImageSizeShouldUpdateImageViewSize(Image startingImage, Size startingSize, Image updateImage, Size updateSize)
+		{
+			Exception exception = null;
+			Form(form =>
+			{
+				var imageView = new ImageView();
+				imageView.Image = startingImage;
+				Assert.AreEqual(new Size(-1, -1), imageView.Size, "#1");
+				form.ClientSize = new Size(200, 200);
+				form.Content = new StackLayout { Items = { imageView } };
+
+				form.Shown += (sender, e) => 
+				{
+					try
+					{
+						imageView.SizeChanged += (sender2, e2) =>
+						{
+							try
+							{
+								Assert.AreEqual(updateSize, imageView.Size);
+								form.Close();
+							}
+							catch (Exception ex)
+							{
+								exception = ex;
+								form.Close();
+							}
+						};
+
+						Assert.AreEqual(startingSize, imageView.Size);
+						imageView.Image = updateImage;
+					}
+					catch (Exception ex)
+					{
+						exception = ex;
+						form.Close();
+					}
+				};
+			});
+			if (exception != null)
+				ExceptionDispatchInfo.Capture(exception).Throw();
 		}
 	}
 }

--- a/Source/Eto.WinForms/Drawing/BitmapHandler.cs
+++ b/Source/Eto.WinForms/Drawing/BitmapHandler.cs
@@ -189,7 +189,8 @@ namespace Eto.WinForms.Drawing
 				var imageSize = Size;
 				var minScale = Math.Min((float)sz.Width / imageSize.Width, (float)sz.Height / imageSize.Height);
 				var newsize = Size.Ceiling((SizeF)imageSize * minScale).ToSD();
-				return new sd.Bitmap(Control, newsize);
+				if (newsize.Width > 0 && newsize.Height > 0)
+					return new sd.Bitmap(Control, newsize);
 			}
 			return Control;
 		}

--- a/Source/Eto.WinForms/Forms/Controls/ImageViewHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/ImageViewHandler.cs
@@ -3,6 +3,8 @@ using sd = System.Drawing;
 using Eto.Forms;
 using Eto.Drawing;
 using Eto.WinForms.Drawing;
+using System;
+using System.ComponentModel;
 
 namespace Eto.WinForms.Forms.Controls
 {
@@ -15,6 +17,7 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			Control = new swf.PictureBox
 			{
+				AutoSize = false,
 				BorderStyle = swf.BorderStyle.None,
 				SizeMode = swf.PictureBoxSizeMode.Zoom
 			};
@@ -35,17 +38,20 @@ namespace Eto.WinForms.Forms.Controls
 			set
 			{
 				base.Size = value;
-				sizeSet = true;
+				sizeSet = value.Width >= 0 || value.Height >= 0;
 				SetImage();
 			}
 		}
-		void SetImage(bool setSize = true)
+
+		void SetImage()
 		{
 			var handler = image?.Handler as IWindowsImageSource;
 			Control.Image = handler?.GetImageWithSize(Widget.Loaded || sizeSet ? (Size?)Size : null);
 
-			if (setSize && !sizeSet && Control.Image != null)
-				Control.Size = Control.Image.Size;
+			if (!sizeSet)
+			{
+				Control.Size = image?.Size.ToSD() ?? sd.Size.Empty;
+			}
 		}
 
 		public Image Image

--- a/Source/Eto.Wpf/CustomControls/MultiSizeImage.cs
+++ b/Source/Eto.Wpf/CustomControls/MultiSizeImage.cs
@@ -167,12 +167,14 @@ namespace Eto.Wpf.CustomControls
 				return new Size(Source.Width, Source.Height);
 		}
 
+		public Size? PreferredSize { get; set; }
+
 		Size MeasureArrangeHelper(Size inputSize)
 		{
 			if (Source == null)
 				return new Size(0, 0);
 			var first = _availableFrames.LastOrDefault();
-			var size = GetSize(first ?? Source);
+			var size = PreferredSize ?? GetSize(first ?? Source);
 
 			Size scale = ComputeScaleFactor(inputSize, size, Stretch, StretchDirection);
 			if (UseSmallestSpace)
@@ -204,7 +206,7 @@ namespace Eto.Wpf.CustomControls
 				return;
 
 			var decoder = bmFrame.Decoder;
-			if (decoder != null && decoder.Frames != null)
+			if (decoder?.Dispatcher == ApplicationHandler.Instance.Control.Dispatcher && decoder?.Frames != null)
 			{
 				var framesInSizeOrder = from frame in decoder.Frames
 										group frame by frame.PixelHeight * frame.PixelWidth into g

--- a/Source/Eto.Wpf/Drawing/IconHandler.cs
+++ b/Source/Eto.Wpf/Drawing/IconHandler.cs
@@ -135,7 +135,9 @@ namespace Eto.Wpf.Drawing
 			var size = fittingSize ?? Size;
 			var frame = Widget.GetFrame(scale, size);
 			var wpfBitmap = frame.ToWpf(scale);
-			if (wpfBitmap.Width == size.Width && wpfBitmap.Height == size.Height)
+			if ((wpfBitmap.Width == size.Width && wpfBitmap.Height == size.Height)
+				|| size.Height == 0
+				|| size.Width == 0)
 				return wpfBitmap;
 
 			return Resize(wpfBitmap, scale, size.Width, size.Height, swm.BitmapScalingMode.Linear);

--- a/Source/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
+++ b/Source/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
@@ -1,5 +1,6 @@
 using swc = System.Windows.Controls;
 using swm = System.Windows.Media;
+using sw = System.Windows;
 using Eto.Forms;
 using Eto.Drawing;
 using System.Windows;
@@ -26,18 +27,31 @@ namespace Eto.Wpf.Forms.Controls
 				Stretch = swm.Stretch.Uniform,
 				StretchDirection = swc.StretchDirection.Both
 			};
+			Control.SizeChanged += Control_SizeChanged;
 		}
 
-		protected override bool NeedsPixelSizeNotifications {  get { return true; } }
-
-		protected override void OnLogicalPixelSizeChanged()
+		void Control_SizeChanged(object sender, SizeChangedEventArgs e)
 		{
-			SetSource();
+			// if we're using an icon, update the current icon when the image size is changed
+			if (image is Icon)
+				SetSource();
 		}
+
+		protected override bool NeedsPixelSizeNotifications => true;
+
+		protected override void OnLogicalPixelSizeChanged() => SetSource();
 
 		void SetSource()
 		{
-			Control.Source = image.ToWpf(ParentScale, UserPreferredSize.ToEtoSize());
+			var fittingSize = image?.Size;
+			if (Widget.Loaded)
+			{
+				// use actual size of the control to get the correct image
+				var size = Size;
+				if (!size.IsEmpty)
+					fittingSize = size;
+			}
+			Control.Source = image.ToWpf(ParentScale, fittingSize);
 		}
 
 		public Image Image
@@ -46,14 +60,9 @@ namespace Eto.Wpf.Forms.Controls
 			set
 			{
 				image = value;
-				var size = image != null ? image.Size : Eto.Drawing.Size.Empty;
-				var ps = UserPreferredSize;
-				if (double.IsNaN(ps.Width))
-					ps.Width = size.Width;
-				if (double.IsNaN(ps.Height))
-					ps.Height = size.Height;
-				UserPreferredSize = ps;
 				SetSource();
+				Control.PreferredSize = image?.Size.ToWpf();
+				Control.InvalidateMeasure();
 			}
 		}
 	}


### PR DESCRIPTION
- When changing the image, the ImageView should auto size to the new image if no explicit size is set
- When setting to null, the size should be 0,0 (or 1,1 on Gtk & WinForms).

Wpf: Fix using a bitmap loaded from a separate thread in some cases
Wpf: Fix ImageView when size is reported as 0,0
WinForms: Fix ImageView when size is reported as 0,0. Fixes #876