### PR TITLE
Setting RichTextArea.SelectedText should trigger TextChanged and SelectionChanged events

### DIFF
--- a/Source/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
@@ -301,6 +301,7 @@ namespace Eto.Mac.Forms.Controls
 				default:
 					throw new NotSupportedException();
 			}
+			Callback.OnTextChanged(Widget, EventArgs.Empty);
 		}
 
 		public void Save(Stream stream, RichTextAreaFormat format)

--- a/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
+++ b/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
@@ -219,6 +219,7 @@
     <Compile Include="UnitTests\Forms\Controls\ControlTests.cs" />
     <Compile Include="UnitTests\Forms\Controls\GridViewTests.cs" />
     <Compile Include="UnitTests\Forms\Controls\TreeGridViewTests.cs" />
+    <Compile Include="UnitTests\Forms\Controls\TextAreaTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Sections\Serialization\Json\Test.json">
@@ -241,10 +242,7 @@
     <MonoDevelop>
       <Properties>
         <Policies>
-          <DotNetNamingPolicy DirectoryNamespaceAssociation="PrefixedHierarchical" ResourceNamePolicy="MSBuild">
-            <inheritsSet />
-            <inheritsScope />
-          </DotNetNamingPolicy>
+          <DotNetNamingPolicy DirectoryNamespaceAssociation="PrefixedHierarchical" ResourceNamePolicy="MSBuild" />
         </Policies>
       </Properties>
     </MonoDevelop>

--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/TextAreaTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/Controls/TextAreaTests.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	[TestFixture]
+	public class TextAreaTests : TextAreaTests<TextArea>
+	{
+	}
+
+	public class TextAreaTests<T> : TestBase
+		where T: TextArea, new()
+	{
+		[Test]
+		public void CheckSelectionTextCaretAfterSettingText()
+		{
+			Invoke(() =>
+			{
+				int selectionChanged = 0;
+				int textChanged = 0;
+				string val;
+				var textArea = new T();
+				textArea.TextChanged += (sender, e) => textChanged++;
+				textArea.SelectionChanged += (sender, e) => selectionChanged++;
+				Assert.AreEqual(Range.FromLength(0, 0), textArea.Selection, "#1");
+
+				textArea.Text = val = "Hello there";
+				Assert.AreEqual(Range.FromLength(val.Length, 0), textArea.Selection, "#2");
+				Assert.AreEqual(val.Length, textArea.CaretIndex, "#3");
+				Assert.AreEqual(1, textChanged, "#4");
+				Assert.AreEqual(1, selectionChanged, "#5");
+
+				textArea.Selection = Range.FromLength(6, 5);
+				Assert.AreEqual(Range.FromLength(6, 5), textArea.Selection, "#6");
+				Assert.AreEqual(6, textArea.CaretIndex, "#7");
+				Assert.AreEqual(1, textChanged, "#8");
+				Assert.AreEqual(2, selectionChanged, "#9");
+
+				textArea.Text = val = "Some other text";
+				Assert.AreEqual(Range.FromLength(val.Length, 0), textArea.Selection, "#10");
+				Assert.AreEqual(val.Length, textArea.CaretIndex, "#11");
+				Assert.AreEqual(2, textChanged, "#12");
+				Assert.AreEqual(3, selectionChanged, "#13");
+			});
+		}
+
+		[Test]
+		public void EnabledShouldNotAffectReadOnly()
+		{
+			Invoke(() =>
+			{
+				var textArea = new T();
+				Assert.IsTrue(textArea.Enabled, "#1");
+				Assert.IsFalse(textArea.ReadOnly, "#2");
+				textArea.Enabled = false;
+				Assert.IsFalse(textArea.Enabled, "#3");
+				Assert.IsFalse(textArea.ReadOnly, "#4");
+				textArea.Enabled = true;
+				Assert.IsTrue(textArea.Enabled, "#5");
+				Assert.IsFalse(textArea.ReadOnly, "#6");
+			});
+		}
+
+		[Test]
+		public void SettingSelectedTextShouldTriggerTextChanged()
+		{
+			int textChangedCount = 0;
+			int selectionChangedCount = 0;
+			Shown(form =>
+			{
+				var textArea = new T();
+				textArea.TextChanged += (sender, e) => textChangedCount++;
+				textArea.SelectionChanged += (sender, e) => selectionChangedCount++;
+				textArea.Text = "Hello there friend";
+				Assert.AreEqual(1, textChangedCount, "#1-1");
+				Assert.AreEqual(Range.FromLength(textArea.Text.TrimEnd().Length, 0), textArea.Selection, "#1-2");
+				Assert.AreEqual(1, selectionChangedCount, "#1-3");
+
+				textArea.Selection = Range.FromLength(6, 5);
+				Assert.AreEqual(1, textChangedCount, "#2-1");
+				Assert.AreEqual(2, selectionChangedCount, "#2-2");
+				Assert.AreEqual(Range.FromLength(6, 5), textArea.Selection, "#2-3");
+
+				return textArea;
+
+			}, textArea =>
+			{
+				Assert.AreEqual(1, textChangedCount, "#4-1");
+				Assert.AreEqual(2, selectionChangedCount, "#4-2");
+
+				textArea.SelectedText = "my";
+				Assert.AreEqual(2, textChangedCount, "#5-1");
+				Assert.AreEqual(3, selectionChangedCount, "#5-2");
+				Assert.AreEqual("Hello my friend", textArea.Text.TrimEnd(), "#5-3");
+				Assert.AreEqual(Range.FromLength(6, 2), textArea.Selection, "#5-4");
+
+				textArea.Selection = textArea.Selection.WithLength(textArea.Selection.Length() + 1);
+				Assert.AreEqual(4, selectionChangedCount, "#6");
+
+				textArea.SelectedText = null;
+				Assert.AreEqual(3, textChangedCount, "#7-1");
+				Assert.AreEqual(5, selectionChangedCount, "#7-2");
+				Assert.AreEqual("Hello friend", textArea.Text.TrimEnd(), "#7-3");
+				Assert.AreEqual(Range.FromLength(6, 0), textArea.Selection, "#7-4");
+			});
+		}
+	}
+}

--- a/Source/Eto.WinForms/Forms/Controls/RichTextAreaHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/RichTextAreaHandler.cs
@@ -1,4 +1,4 @@
-﻿using Eto.Forms;
+using Eto.Forms;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -253,6 +253,7 @@ namespace Eto.WinForms.Forms.Controls
 
 		public void Load(System.IO.Stream stream, RichTextAreaFormat format)
 		{
+			SuppressSelectionChanged++;
 			switch (format)
 			{
 				case RichTextAreaFormat.Rtf:
@@ -264,6 +265,8 @@ namespace Eto.WinForms.Forms.Controls
 				default:
 					throw new NotSupportedException();
 			}
+			SuppressSelectionChanged--;
+			Selection = Range.FromLength(Control.TextLength, 0);
 		}
 
 		public void Save(System.IO.Stream stream, RichTextAreaFormat format)

--- a/Source/Eto.WinForms/Forms/Controls/TextAreaHandler.cs
+++ b/Source/Eto.WinForms/Forms/Controls/TextAreaHandler.cs
@@ -137,6 +137,22 @@ namespace Eto.WinForms.Forms.Controls
 			set { Control.ForeColor = value.ToSD(); }
 		}
 
+		public override string Text
+		{
+			get { return base.Text; }
+			set
+			{
+				SuppressSelectionChanged++;
+				var val = value ?? string.Empty;
+				base.Text = val;
+				if (!Control.IsHandleCreated) // correct??
+					Callback.OnTextChanged(Widget, EventArgs.Empty);
+				Selection = Range.FromLength(val.Length, 0);
+				Callback.OnSelectionChanged(Widget, EventArgs.Empty);
+				SuppressSelectionChanged--;
+			}
+		}
+
 		public void Append(string text, bool scrollToCursor)
 		{
 			if (scrollToCursor)
@@ -158,9 +174,12 @@ namespace Eto.WinForms.Forms.Controls
 			set
 			{
 				var start = Control.SelectionStart;
-				Control.SelectedText = value;
-				if (value != null)
-					Control.Select(start, value.Length);
+				SuppressSelectionChanged++;
+				var val = value ?? string.Empty;
+				Control.SelectedText = val;
+				Control.Select(start, val.Length);
+				Callback.OnSelectionChanged(Widget, EventArgs.Empty);
+				SuppressSelectionChanged--;
 			}
 		}
 

--- a/Source/Eto/Forms/Controls/RichTextArea.cs
+++ b/Source/Eto/Forms/Controls/RichTextArea.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Drawing;
 using System.IO;
 using System.Collections.Generic;
@@ -44,6 +44,9 @@ namespace Eto.Forms
 		/// <summary>
 		/// Sets the content of the buffer to the specified <paramref name="rtf"/> string. Note that some platforms don't support RTF (e.g. Gtk).
 		/// </summary>
+		/// <remarks>
+		/// The CaretIndex and Selection will be set to the end of the string after set.
+		/// </remarks>
 		/// <param name="buffer">Buffer to set the content for</param>
 		/// <param name="rtf">RTF formatted string to set the buffer</param>
 		public static void SetRtf(this ITextBuffer buffer, string rtf)
@@ -125,6 +128,9 @@ namespace Eto.Forms
 		/// <summary>
 		/// Loads the specified format from the stream, replacing the content of the buffer.
 		/// </summary>
+		/// <remarks>
+		/// The CaretIndex and Selection will be set to the end of the string after set.
+		/// </remarks>
 		/// <param name="stream">Stream to load from.</param>
 		/// <param name="format">Format of the stream to load.</param>
 		void Load(Stream stream, RichTextAreaFormat format);
@@ -258,6 +264,9 @@ namespace Eto.Forms
 		/// <summary>
 		/// Gets or sets the content as a RTF (Rich Text Format) string. Note that some platforms don't support RTF (e.g. Gtk).
 		/// </summary>
+		/// <remarks>
+		/// The CaretIndex and Selection will be set to the end of the string after set.
+		/// </remarks>
 		/// <value>The RTF string.</value>
 		public string Rtf
 		{

--- a/Source/Eto/Forms/Controls/TextControl.cs
+++ b/Source/Eto/Forms/Controls/TextControl.cs
@@ -46,6 +46,9 @@ namespace Eto.Forms
 		/// <summary>
 		/// Gets or sets the text of the control.
 		/// </summary>
+		/// <remarks>
+		/// Usually, the caret and selection will be set to the end of the string after its set.
+		/// </remarks>
 		/// <value>The text content.</value>
 		public virtual string Text
 		{

--- a/Source/Eto/Forms/Range.cs
+++ b/Source/Eto/Forms/Range.cs
@@ -292,5 +292,35 @@ namespace Eto.Forms
 		{
 			return range.End - range.Start + 1;
 		}
+
+		/// <summary>
+		/// Creates a new range starting at the same position as the specified <paramref name="range"/> and a new length.
+		/// </summary>
+		/// <returns>The length for the new range.</returns>
+		/// <param name="range">Range with the same start but different length of the specified range.</param>
+		/// <param name="length">Length of the new range.</param>
+		public static Range<int> WithLength(this Range<int> range, int length) => new Range<int>(range.Start, range.Start + length - 1);
+	}
+
+	/// <summary>
+	/// Helpers for the <see cref="Range{T}"/> structure.
+	/// </summary>
+	public static class Range
+	{
+		/// <summary>
+		/// Creates a new integer range with the specified start and length.
+		/// </summary>
+		/// <returns>A new range with the specified start and length.</returns>
+		/// <param name="start">Start of the range.</param>
+		/// <param name="length">Length of the range.</param>
+		public static Range<int> FromLength(int start, int length) => new Range<int>(start, start + length - 1);
+
+		/// <summary>
+		/// Creates a new long range with the specified start and length.
+		/// </summary>
+		/// <returns>A new range with the specified start and length.</returns>
+		/// <param name="start">Start of the range.</param>
+		/// <param name="length">Length of the range.</param>
+		public static Range<long> FromLength(long start, long length) => new Range<long>(start, start + length - 1);
 	}
 }

--- a/Source/Eto/PropertyStore.cs
+++ b/Source/Eto/PropertyStore.cs
@@ -342,7 +342,7 @@ namespace Eto
 			if (!IsEqual(existing, value))
 			{
 				Set<T>(key, value, defaultValue);
-				propertyChanged();
+				propertyChanged?.Invoke();
 				return true;
 			}
 			return false;


### PR DESCRIPTION
Changing TextArea/RichTextArea Text property should set selection to end on all platforms.
Add Range.FromLength() and WithLength() helper methods for int-based ranges.
Wpf: Implement RichTextArea.CaretIndexChanged event