### PR TITLE
Fix up Clipboard on all platforms to behave similarly.

### DIFF
--- a/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
+++ b/Source/Eto.Test/Eto.Test/Eto.Test - pcl.csproj
@@ -135,6 +135,7 @@
     <Compile Include="UnitTests\Drawing\FontTests.cs" />
     <Compile Include="UnitTests\Drawing\GraphicsTests.cs" />
     <Compile Include="UnitTests\Drawing\MatrixTests.cs" />
+    <Compile Include="UnitTests\Forms\ClipboardTests.cs" />
     <Compile Include="UnitTests\Forms\Controls\ComboBoxTests.cs" />
     <Compile Include="UnitTests\Forms\Controls\CustomCellTests.cs" />
     <Compile Include="UnitTests\Forms\Controls\NumericStepperTests.cs" />

--- a/Source/Eto.Test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
@@ -19,6 +19,12 @@ namespace Eto.Test.Sections.Behaviors
 				clipboard.Text = "Some text";
 				Update();
 			};
+			var copyHtmlButton = new Button { Text = "Copy Html" };
+			copyHtmlButton.Click += (sender, e) =>
+			{
+				clipboard.Html = "Some <strong style='color:blue'>HTML</strong>";
+				Update();
+			};
 			var copyImageButton = new Button { Text = "Copy Image" };
 			copyImageButton.Click += (sender, e) =>
 			{
@@ -47,7 +53,7 @@ namespace Eto.Test.Sections.Behaviors
 						Orientation = Orientation.Horizontal, 
 						Spacing = 5,
 						Padding = new Padding(10),
-						Items = { copyTextButton, copyImageButton, pasteTextButton, clearButton }
+						Items = { copyTextButton, copyHtmlButton, copyImageButton, pasteTextButton, clearButton }
 					},
 					new StackLayoutItem(pasteData, expand: true)
 				}

--- a/Source/Eto.Test/Eto.Test/UnitTests/Forms/ClipboardTests.cs
+++ b/Source/Eto.Test/Eto.Test/UnitTests/Forms/ClipboardTests.cs
@@ -1,0 +1,85 @@
+using Eto.Forms;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Eto.Test.UnitTests.Forms
+{
+	[TestFixture]
+	public class ClipboardTests : TestBase
+	{
+		[Test]
+		public void GettingAndSettingTextShouldNotCrash()
+		{
+			Invoke(() =>
+			{
+				for (int i = 0; i < 100; i++)
+				{
+					// this crashes on WPF on some machines.. don't know why as I can't repro the issue.
+					var clipboard = new Clipboard();
+					var val = "Hello" + i;
+					clipboard.Text = val;
+					Assert.AreEqual(val, clipboard.Text);
+				}
+			});
+		}
+
+		[Test]
+		public void SettingMultipleFormatsShouldWork()
+		{
+			Invoke(() =>
+			{
+				var byteData = new byte[] { 10, 20, 30 };
+				using (var clipboard = new Clipboard())
+				{
+					clipboard.Text = "Text";
+					clipboard.Html = "<strong>Some Html</strong>";
+					clipboard.SetString("woot", "eto-woot");
+					clipboard.SetData(byteData, "eto-byte-data");
+
+					Assert.AreEqual("Text", clipboard.Text);
+					Assert.AreEqual("<strong>Some Html</strong>", clipboard.Html);
+					Assert.AreEqual("woot", clipboard.GetString("eto-woot"));
+					Assert.AreEqual(byteData, clipboard.GetData("eto-byte-data"));
+
+					Assert.Contains("eto-woot", clipboard.Types);
+					Assert.Contains("eto-byte-data", clipboard.Types);
+				}
+
+				using (var clipboard = new Clipboard())
+				{
+					Assert.AreEqual("Text", clipboard.Text);
+					Assert.AreEqual("<strong>Some Html</strong>", clipboard.Html);
+					Assert.AreEqual("woot", clipboard.GetString("eto-woot"));
+					Assert.AreEqual(byteData, clipboard.GetData("eto-byte-data"));
+
+					Assert.Contains("eto-woot", clipboard.Types);
+					Assert.Contains("eto-byte-data", clipboard.Types);
+
+					clipboard.Clear();
+					CollectionAssert.DoesNotContain("eto-woot", clipboard.Types);
+					CollectionAssert.DoesNotContain("eto-byte-data", clipboard.Types);
+					Assert.AreEqual(null, clipboard.Text);
+					Assert.AreEqual(null, clipboard.Html);
+					Assert.AreEqual(null, clipboard.Image);
+					Assert.AreEqual(null, clipboard.GetString("eto-woot"));
+					Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
+				}
+
+				using (var clipboard = new Clipboard())
+				{
+					CollectionAssert.DoesNotContain("eto-woot", clipboard.Types);
+					CollectionAssert.DoesNotContain("eto-byte-data", clipboard.Types);
+					Assert.AreEqual(null, clipboard.Text);
+					Assert.AreEqual(null, clipboard.Html);
+					Assert.AreEqual(null, clipboard.Image);
+					Assert.AreEqual(null, clipboard.GetString("eto-woot"));
+					Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
+				}
+			});
+		}
+	}
+}

--- a/Source/Eto.WinForms/Forms/ClipboardHandler.cs
+++ b/Source/Eto.WinForms/Forms/ClipboardHandler.cs
@@ -40,12 +40,12 @@ namespace Eto.WinForms.Forms
 		{
 			set
 			{
-				Control.SetText(value ?? string.Empty, System.Windows.Forms.TextDataFormat.Html);
+				Control.SetText(value ?? string.Empty, swf.TextDataFormat.Html);
 				Update();
 			}
 			get
 			{
-				return swf.Clipboard.ContainsText(swf.TextDataFormat.Html) ? swf.Clipboard.GetText(swf.TextDataFormat.Html) : null;
+				return swf.Clipboard.ContainsText(swf.TextDataFormat.Html) ? swf.Clipboard.GetText(swf.TextDataFormat.Html)?.TrimEnd('\0') : null;
 			}
 		}
 
@@ -76,22 +76,22 @@ namespace Eto.WinForms.Forms
 			get
 			{
 				Image result = null;
-				
+
 				try
 				{
 					var sdimage = GetImageFromClipboard() as sd.Bitmap;
-					
+
 					if (sdimage != null)
 					{
 						var handler = new BitmapHandler(sdimage);
-						
+
 						result = new Bitmap(handler);
 					}
 				}
 				catch
 				{
 				}
-				
+
 				return result;
 			}
 		}
@@ -203,14 +203,7 @@ namespace Eto.WinForms.Forms
 			return null;
 		}
 
-		public string[] Types
-		{
-			get
-			{
-				var data = swf.Clipboard.GetDataObject();
-				return data != null ? data.GetFormats() : null;
-			}
-		}
+		public string[] Types => swf.Clipboard.GetDataObject()?.GetFormats();
 
 		public void Clear()
 		{

--- a/Source/Eto.Wpf/Forms/ClipboardHandler.cs
+++ b/Source/Eto.Wpf/Forms/ClipboardHandler.cs
@@ -6,99 +6,144 @@ using System.ComponentModel;
 using System.IO;
 using System.Runtime.InteropServices;
 using System.Text;
+using System.Threading;
 using sw = System.Windows;
 using swm = System.Windows.Media;
 using swmi = System.Windows.Media.Imaging;
 
 namespace Eto.Wpf.Forms
 {
-	public class ClipboardHandler : WidgetHandler<object, Clipboard>, Clipboard.IHandler
+	public class ClipboardHandler : WidgetHandler<sw.DataObject, Clipboard>, Clipboard.IHandler
 	{
-		public string[] Types
+		public ClipboardHandler()
 		{
-			get { return sw.Clipboard.GetDataObject().GetFormats(); }
+			Control = new sw.DataObject();
+		}
+
+		public string[] Types => sw.Clipboard.GetDataObject()?.GetFormats();
+
+		void Update()
+		{
+			// internally WPF retries here so no need to retry
+			sw.Clipboard.SetDataObject(Control);
+		}
+
+		T Retry<T>(Func<T> getValue)
+		{
+			for (int i = 0; i < 10; i++)
+			{
+				try
+				{
+					return getValue();
+				}
+				catch (COMException ex)
+				{
+					// cannot open clipboard, so retry 10 times after 100ms
+					// WPF sometimes throws this when trying to get a value
+					// as it appears to retry when getting the data object, but not when 
+					if (ex.HResult != unchecked((int)0x800401D0) || i == 9)
+						throw;
+				}
+				Thread.Sleep(100);
+			}
+			throw new InvalidOperationException(); // should not get here
 		}
 
 		public void SetString(string value, string type)
 		{
 			if (string.IsNullOrEmpty(type))
-				sw.Clipboard.SetText(value);
+				Control.SetText(value);
 			else
-				sw.Clipboard.SetData(type, value);
+				Control.SetData(type, value);
+			Update();
 		}
 
 		public void SetData(byte[] value, string type)
 		{
-			sw.Clipboard.SetData(type, value);
+			Control.SetData(type, value);
+			Update();
 		}
 
 		public string GetString(string type)
 		{
 			if (string.IsNullOrEmpty(type))
 				return Text;
-			return sw.Clipboard.ContainsData(type) ? Convert.ToString(sw.Clipboard.GetData(type)) : null;
+			return Retry(() => sw.Clipboard.ContainsData(type) ? Convert.ToString(sw.Clipboard.GetData(type)) : null);
 		}
 
 		public byte[] GetData(string type)
 		{
-			if (sw.Clipboard.ContainsData(type))
+			return Retry(() =>
 			{
-				var data = sw.Clipboard.GetData(type);
-				var bytes = data as byte[];
-				if (bytes != null)
-					return bytes;
-				if (data != null)
+				if (sw.Clipboard.ContainsData(type))
 				{
-					var converter = TypeDescriptor.GetConverter(data.GetType());
-					if (converter != null && converter.CanConvertTo(typeof(byte[])))
+					var data = sw.Clipboard.GetData(type);
+					var bytes = data as byte[];
+					if (bytes != null)
+						return bytes;
+					if (data != null)
 					{
-						return converter.ConvertTo(data, typeof(byte[])) as byte[];
+						var converter = TypeDescriptor.GetConverter(data.GetType());
+						if (converter != null && converter.CanConvertTo(typeof(byte[])))
+						{
+							return converter.ConvertTo(data, typeof(byte[])) as byte[];
+						}
+					}
+					if (data is string)
+					{
+						return Encoding.UTF8.GetBytes(data as string);
+					}
+					if (data is IConvertible)
+					{
+						return Convert.ChangeType(data, typeof(byte[])) as byte[];
 					}
 				}
-				if (data is string)
-				{
-					return Encoding.UTF8.GetBytes(data as string);
-				}
-				if (data is IConvertible)
-				{
-					return Convert.ChangeType(data, typeof(byte[])) as byte[];
-				}
-			}
-			return null;
+				return null;
+			});
 		}
 
 		public string Text
 		{
-			get { return sw.Clipboard.ContainsText() ? sw.Clipboard.GetText() : null; }
-			set { sw.Clipboard.SetText(value); }
+			get { return Retry(() => sw.Clipboard.ContainsText() ? sw.Clipboard.GetText() : null); }
+			set
+			{
+				Control.SetText(value);
+				Update();
+			}
 		}
 
 		public string Html
 		{
-			get { return sw.Clipboard.ContainsText(sw.TextDataFormat.Html) ? sw.Clipboard.GetText(sw.TextDataFormat.Html) : null; }
-			set { sw.Clipboard.SetText(value, sw.TextDataFormat.Html); }
+			get { return Retry(() => sw.Clipboard.ContainsText(sw.TextDataFormat.Html) ? sw.Clipboard.GetText(sw.TextDataFormat.Html) : null); }
+			set
+			{
+				Control.SetText(value, sw.TextDataFormat.Html);
+				Update();
+			}
 		}
 
 		public Image Image
 		{
-			get { return sw.Clipboard.ContainsImage() ? new Bitmap(new BitmapHandler(sw.Clipboard.GetImage())) : null; }
+			get { return Retry(() => sw.Clipboard.ContainsImage() ? new Bitmap(new BitmapHandler(sw.Clipboard.GetImage())) : null); }
 			set
 			{
 				var dib = (value as Bitmap).ToDIB();
 				if (dib != null)
 				{
 					// write a DIB here, so we can preserve transparency of the image
-					sw.Clipboard.SetData(sw.DataFormats.Dib, dib);
+					Control.SetData(sw.DataFormats.Dib, dib);
 					return;
 				}
 
-				sw.Clipboard.SetImage(value.ToWpf());
+				Control.SetImage(value.ToWpf());
+				Update();
 			}
 		}
 
 		public void Clear()
 		{
 			sw.Clipboard.Clear();
+			Control = new sw.DataObject();
 		}
 	}
 }


### PR DESCRIPTION
- Wpf: Can now specify more than one type in the clipboard by setting various properties.
- Wpf: Added protection when getting the value and retries 10 times after 100ms delay as some times it throws a com exception that it cannot open the clipboard.
- Gtk: Fix up Clipboard.Image so it doesn't wipe all other values in the clipboard
- Gtk: Setting Clipboard.Text sets all text variants, not just utf8.
- Gtk: Getting/Setting Clipboard.Html now works correctly
- Added unit tests to verify behaviour