### PR TITLE
Mac: Fix constraint warnings when using an NSScrollView

### DIFF
--- a/Source/Eto.Mac/Forms/Controls/ListBoxHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/ListBoxHandler.cs
@@ -51,6 +51,31 @@ namespace Eto.Mac.Forms.Controls
 		public WeakReference WeakHandler { get; set; }
 
 		public object Handler { get { return WeakHandler.Target; } set { WeakHandler = new WeakReference(value); } }
+
+		NSBorderType? _borderType;
+
+		public override NSBorderType BorderType
+		{
+			get { return _borderType ?? base.BorderType; }
+			set
+			{
+				base.BorderType = value;
+				_borderType = value;
+			}
+		}
+
+		public override void SetFrameSize(CGSize newSize)
+		{
+			if (_borderType != null)
+			{
+				// when we're below 2,2, turn off the border so we don't get constraint warnings
+				if (newSize.Width < 2 || newSize.Height < 2)
+					base.BorderType = NSBorderType.NoBorder;
+				else
+					base.BorderType = _borderType.Value;
+			}
+			base.SetFrameSize(newSize);
+		}
 	}
 
 	public class ListBoxHandler : MacControl<NSTableView, ListBox, ListBox.ICallback>, ListBox.IHandler

--- a/Source/Eto.Mac/Forms/MacView.cs
+++ b/Source/Eto.Mac/Forms/MacView.cs
@@ -167,15 +167,20 @@ namespace Eto.Mac.Forms
 				var newSize = oldFrameSize;
 				if (value.Width >= 0)
 					newSize.Width = value.Width;
+				else if (!Widget.Loaded)
+					newSize.Width = oldSize.Width;
+				
 				if (value.Height >= 0)
 					newSize.Height = value.Height;
+				else if (!Widget.Loaded)
+					newSize.Height = oldSize.Height;
 
 				// this doesn't get to our overridden method to handle the event (since it calls [super setFrameSize:]) so trigger event manually.
 				ContainerControl.SetFrameSize(newSize);
 				if (oldFrameSize != newSize)
 					Callback.OnSizeChanged(Widget, EventArgs.Empty);
 
-				AutoSize = value.Width == -1 && value.Height == -1;
+				AutoSize = value.Width == -1 || value.Height == -1;
 				CreateTracking();
 				LayoutIfNeeded(oldSize);
 			}
@@ -235,7 +240,13 @@ namespace Eto.Mac.Forms
 				var preferredSize = PreferredSize.Value;
 				// only get natural size if the size isn't explicitly set.
 				if (preferredSize.Width == -1 || preferredSize.Height == -1)
+				{
+					if (preferredSize.Width >= 0)
+						availableSize.Width = preferredSize.Width;
+					if (preferredSize.Height >= 0)
+						availableSize.Height = preferredSize.Height;
 					size = GetNaturalSize(availableSize);
+				}
 				else
 					size = SizeF.Empty;
 


### PR DESCRIPTION
When an NSScrollView is set to 0,0 size, it shouldn't give constraint warnings.  The warnings were due to using a border which requires at least a 2,2 size so we turn off the border if it's smaller than 2,2 and restore if it gets bigger.