### PR TITLE
Wpf: Add WindowsFormsHostHandler

### DIFF
--- a/Source/Eto.WinForms/Eto.WinForms - net45.csproj
+++ b/Source/Eto.WinForms/Eto.WinForms - net45.csproj
@@ -312,6 +312,7 @@
     <Compile Include="Win32TextBox.cs" />
     <Compile Include="Forms\Controls\CalendarHandler.cs" />
     <Compile Include="Forms\Controls\LinkButtonHandler.cs" />
+    <Compile Include="WinConversions.shared.cs" />
     <Compile Include="WinFormsHelpers.cs" />
     <Compile Include="Forms\HwndFormHandler.cs" />
     <Compile Include="Forms\Controls\NativeControlHandler.cs" />

--- a/Source/Eto.WinForms/KeyMap.cs
+++ b/Source/Eto.WinForms/KeyMap.cs
@@ -3,9 +3,17 @@ using Eto.Forms;
 using System.Collections.Generic;
 using System.Diagnostics;
 
+#if WPF
+namespace Eto.Wpf
+#else
 namespace Eto.WinForms
+#endif
 {
+#if WPF
+	public static class KeyMapWinForms
+#else
 	public static class KeyMap
+#endif
 	{
 		static Dictionary<swf.Keys, Keys> _map;
 		static Dictionary<Keys, swf.Keys> _inverseMap;

--- a/Source/Eto.WinForms/WinConversions.cs
+++ b/Source/Eto.WinForms/WinConversions.cs
@@ -15,27 +15,6 @@ namespace Eto.WinForms
 {
 	public static partial class WinConversions
 	{
-		public const float WheelDelta = 120f;
-
-		public static Padding ToEto(this swf.Padding padding)
-		{
-			return new Padding(padding.Left, padding.Top, padding.Right, padding.Bottom);
-		}
-
-		public static swf.Padding ToSWF(this Padding padding)
-		{
-			return new swf.Padding(padding.Left, padding.Top, padding.Right, padding.Bottom);
-		}
-
-		public static Color ToEto(this sd.Color color)
-		{
-			return new Color(color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f);
-		}
-
-		public static sd.Color ToSD(this Color color)
-		{
-			return sd.Color.FromArgb((byte)(color.A * 255), (byte)(color.R * 255), (byte)(color.G * 255), (byte)(color.B * 255));
-		}
 
 		public static DialogResult ToEto(this swf.DialogResult result)
 		{
@@ -188,126 +167,6 @@ namespace Eto.WinForms
 			return ret;
 		}
 
-		public static Point ToEto(this sd.Point point)
-		{
-			return new Point(point.X, point.Y);
-		}
-
-		public static PointF ToEto(this sd.PointF point)
-		{
-			return new PointF(point.X, point.Y);
-		}
-
-		public static sd.PointF ToSD(this PointF point)
-		{
-			return new sd.PointF(point.X, point.Y);
-		}
-
-		public static sd.Point ToSDPoint(this PointF point)
-		{
-			return new sd.Point((int)point.X, (int)point.Y);
-		}
-
-		public static Size ToEto(this sd.Size size)
-		{
-			return new Size(size.Width, size.Height);
-		}
-
-		public static sd.Size ToSD(this Size size)
-		{
-			return new sd.Size(size.Width, size.Height);
-		}
-
-		public static Size ToEtoF(this sd.SizeF size)
-		{
-			return new Size((int)size.Width, (int)size.Height);
-		}
-
-		public static SizeF ToEto(this sd.SizeF size)
-		{
-			return new SizeF(size.Width, size.Height);
-		}
-
-		public static sd.SizeF ToSD(this SizeF size)
-		{
-			return new sd.SizeF(size.Width, size.Height);
-		}
-
-		public static Rectangle ToEto(this sd.Rectangle rect)
-		{
-			return new Rectangle(rect.X, rect.Y, rect.Width, rect.Height);
-		}
-
-		public static RectangleF ToEto(this sd.RectangleF rect)
-		{
-			return new RectangleF(rect.X, rect.Y, rect.Width, rect.Height);
-		}
-
-		public static sd.Rectangle ToSD(this Rectangle rect)
-		{
-			return new sd.Rectangle(rect.X, rect.Y, rect.Width, rect.Height);
-		}
-
-		public static sd.RectangleF ToSD(this RectangleF rect)
-		{
-			return new sd.RectangleF(rect.X, rect.Y, rect.Width, rect.Height);
-		}
-
-		public static sd.Rectangle ToSDRectangle(this RectangleF rect)
-		{
-			return new sd.Rectangle((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height);
-		}
-
-		internal static sd.Point[] ToSD(this Point[] points)
-		{
-			var result =
-				new sd.Point[points.Length];
-
-			for (var i = 0;
-				i < points.Length;
-				++i)
-			{
-				var p = points[i];
-				result[i] =
-					new sd.Point(p.X, p.Y);
-			}
-
-			return result;
-		}
-
-		internal static sd.PointF[] ToSD(this PointF[] points)
-		{
-			var result =
-				new sd.PointF[points.Length];
-
-			for (var i = 0;
-				i < points.Length;
-				++i)
-			{
-				var p = points[i];
-				result[i] =
-					new sd.PointF(p.X, p.Y);
-			}
-
-			return result;
-		}
-
-		internal static PointF[] ToEto(this sd.PointF[] points)
-		{
-			var result =
-				new PointF[points.Length];
-
-			for (var i = 0;
-				i < points.Length;
-				++i)
-			{
-				var p = points[i];
-				result[i] =
-					new PointF(p.X, p.Y);
-			}
-
-			return result;
-		}
 
 		public static sd.Graphics ToSD(this Graphics graphics)
 		{
@@ -382,36 +241,6 @@ namespace Eto.WinForms
 		public static FontFamily ToEto(this sd.FontFamily family)
 		{
 			return family == null ? null : new FontFamily(new FontFamilyHandler(family));
-		}
-
-		public static MouseEventArgs ToEto(this swf.MouseEventArgs e, swf.Control control)
-		{
-			var point = control.PointToClient(swf.Control.MousePosition).ToEto();
-			var buttons = ToEto(e.Button);
-			var modifiers = swf.Control.ModifierKeys.ToEto();
-
-			return new MouseEventArgs(buttons, modifiers, point, new SizeF(0, (float)e.Delta / WheelDelta));
-		}
-
-		public static SizeF ToEtoDelta(this swf.MouseEventArgs e)
-		{
-			return new SizeF(0, (float)e.Delta / WheelDelta);
-		}
-
-		public static MouseButtons ToEto(this swf.MouseButtons button)
-		{
-			MouseButtons buttons = MouseButtons.None;
-
-			if ((button & swf.MouseButtons.Left) != 0)
-				buttons |= MouseButtons.Primary;
-
-			if ((button & swf.MouseButtons.Right) != 0)
-				buttons |= MouseButtons.Alternate;
-
-			if ((button & swf.MouseButtons.Middle) != 0)
-				buttons |= MouseButtons.Middle;
-
-			return buttons;
 		}
 
 		/// <summary>

--- a/Source/Eto.WinForms/WinConversions.shared.cs
+++ b/Source/Eto.WinForms/WinConversions.shared.cs
@@ -1,0 +1,192 @@
+using System;
+using System.Globalization;
+using Eto.Drawing;
+using Eto.Forms;
+using sd = System.Drawing;
+using sdp = System.Drawing.Printing;
+using sd2 = System.Drawing.Drawing2D;
+using swf = System.Windows.Forms;
+using sdi = System.Drawing.Imaging;
+
+#if WPF
+namespace Eto.Wpf
+#else
+namespace Eto.WinForms
+#endif
+{
+	public static partial class WinConversions
+	{
+		public const float WheelDelta = 120f;
+
+		public static MouseEventArgs ToEto(this swf.MouseEventArgs e, swf.Control control)
+		{
+			var point = control.PointToClient(swf.Control.MousePosition).ToEto();
+			var buttons = ToEto(e.Button);
+			var modifiers = swf.Control.ModifierKeys.ToEto();
+
+			return new MouseEventArgs(buttons, modifiers, point, new SizeF(0, (float)e.Delta / WheelDelta));
+		}
+
+		public static SizeF ToEtoDelta(this swf.MouseEventArgs e)
+		{
+			return new SizeF(0, (float)e.Delta / WheelDelta);
+		}
+
+		public static MouseButtons ToEto(this swf.MouseButtons button)
+		{
+			MouseButtons buttons = MouseButtons.None;
+
+			if ((button & swf.MouseButtons.Left) != 0)
+				buttons |= MouseButtons.Primary;
+
+			if ((button & swf.MouseButtons.Right) != 0)
+				buttons |= MouseButtons.Alternate;
+
+			if ((button & swf.MouseButtons.Middle) != 0)
+				buttons |= MouseButtons.Middle;
+
+			return buttons;
+		}
+
+		public static Padding ToEto(this swf.Padding padding)
+		{
+			return new Padding(padding.Left, padding.Top, padding.Right, padding.Bottom);
+		}
+
+		public static swf.Padding ToSWF(this Padding padding)
+		{
+			return new swf.Padding(padding.Left, padding.Top, padding.Right, padding.Bottom);
+		}
+
+		public static Color ToEto(this sd.Color color)
+		{
+			return new Color(color.R / 255f, color.G / 255f, color.B / 255f, color.A / 255f);
+		}
+
+		public static sd.Color ToSD(this Color color)
+		{
+			return sd.Color.FromArgb((byte)(color.A * 255), (byte)(color.R * 255), (byte)(color.G * 255), (byte)(color.B * 255));
+		}
+
+		public static Point ToEto(this sd.Point point)
+		{
+			return new Point(point.X, point.Y);
+		}
+
+		public static PointF ToEto(this sd.PointF point)
+		{
+			return new PointF(point.X, point.Y);
+		}
+
+		public static sd.PointF ToSD(this PointF point)
+		{
+			return new sd.PointF(point.X, point.Y);
+		}
+
+		public static sd.Point ToSDPoint(this PointF point)
+		{
+			return new sd.Point((int)point.X, (int)point.Y);
+		}
+
+		public static Size ToEto(this sd.Size size)
+		{
+			return new Size(size.Width, size.Height);
+		}
+
+		public static sd.Size ToSD(this Size size)
+		{
+			return new sd.Size(size.Width, size.Height);
+		}
+
+		public static Size ToEtoF(this sd.SizeF size)
+		{
+			return new Size((int)size.Width, (int)size.Height);
+		}
+
+		public static SizeF ToEto(this sd.SizeF size)
+		{
+			return new SizeF(size.Width, size.Height);
+		}
+
+		public static sd.SizeF ToSD(this SizeF size)
+		{
+			return new sd.SizeF(size.Width, size.Height);
+		}
+
+		public static Rectangle ToEto(this sd.Rectangle rect)
+		{
+			return new Rectangle(rect.X, rect.Y, rect.Width, rect.Height);
+		}
+
+		public static RectangleF ToEto(this sd.RectangleF rect)
+		{
+			return new RectangleF(rect.X, rect.Y, rect.Width, rect.Height);
+		}
+
+		public static sd.Rectangle ToSD(this Rectangle rect)
+		{
+			return new sd.Rectangle(rect.X, rect.Y, rect.Width, rect.Height);
+		}
+
+		public static sd.RectangleF ToSD(this RectangleF rect)
+		{
+			return new sd.RectangleF(rect.X, rect.Y, rect.Width, rect.Height);
+		}
+
+		public static sd.Rectangle ToSDRectangle(this RectangleF rect)
+		{
+			return new sd.Rectangle((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height);
+		}
+
+		internal static sd.Point[] ToSD(this Point[] points)
+		{
+			var result =
+				new sd.Point[points.Length];
+
+			for (var i = 0;
+				i < points.Length;
+				++i)
+			{
+				var p = points[i];
+				result[i] =
+					new sd.Point(p.X, p.Y);
+			}
+
+			return result;
+		}
+
+		internal static sd.PointF[] ToSD(this PointF[] points)
+		{
+			var result =
+				new sd.PointF[points.Length];
+
+			for (var i = 0;
+				i < points.Length;
+				++i)
+			{
+				var p = points[i];
+				result[i] =
+					new sd.PointF(p.X, p.Y);
+			}
+
+			return result;
+		}
+
+		internal static PointF[] ToEto(this sd.PointF[] points)
+		{
+			var result =
+				new PointF[points.Length];
+
+			for (var i = 0;
+				i < points.Length;
+				++i)
+			{
+				var p = points[i];
+				result[i] =
+					new PointF(p.X, p.Y);
+			}
+
+			return result;
+		}
+	}
+}

--- a/Source/Eto.Wpf/Eto.Wpf - net45.csproj
+++ b/Source/Eto.Wpf/Eto.Wpf - net45.csproj
@@ -82,11 +82,17 @@
     <Compile Include="..\Eto.WinForms\CustomControls\TreeController.cs">
       <Link>CustomControls\TreeGridView\TreeController.cs</Link>
     </Compile>
+    <Compile Include="..\Eto.WinForms\KeyMap.cs">
+      <Link>WinForms\KeyMap.cs</Link>
+    </Compile>
     <Compile Include="..\Eto.WinForms\Win32.cs">
       <Link>Win32.cs</Link>
     </Compile>
     <Compile Include="..\Eto.WinForms\Win32.dpi.cs">
       <Link>Win32.dpi.cs</Link>
+    </Compile>
+    <Compile Include="..\Eto.WinForms\WinConversions.shared.cs">
+      <Link>WinConversions.shared.cs</Link>
     </Compile>
     <Compile Include="..\Shared\Conversions.cs">
       <Link>Conversions.cs</Link>
@@ -112,6 +118,7 @@
     <Compile Include="Forms\PerMonitorDpiHelper.cs" />
     <Compile Include="Forms\TrayIndicatorHandler.cs" />
     <Compile Include="Forms\VistaSelectFolderDialogHandler.cs" />
+    <Compile Include="Forms\WindowsFormsHostHandler.cs" />
     <Compile Include="Win32.dib.cs" />
     <Compile Include="WpfConversions.cs" />
     <Compile Include="CustomControls\EditableTextBlock.cs" />

--- a/Source/Eto.Wpf/Forms/WindowsFormsHostHandler.cs
+++ b/Source/Eto.Wpf/Forms/WindowsFormsHostHandler.cs
@@ -1,0 +1,191 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms.Integration;
+using swf = System.Windows.Forms;
+using Eto.Drawing;
+using Eto.Forms;
+
+namespace Eto.Wpf.Forms
+{
+	public abstract class WindowsFormsHostHandler<TControl, TWidget, TCallback> : WpfFrameworkElement<WindowsFormsHost, TWidget, TCallback>
+		where TControl : swf.Control
+		where TWidget : Control
+		where TCallback : Control.ICallback
+	{
+		public override bool UseKeyPreview => true;
+		public override bool UseMousePreview => true;
+
+		public override Color BackgroundColor
+		{
+			get { return WinFormsControl.BackColor.ToEto(); }
+			set { WinFormsControl.BackColor = value.ToSD(); }
+		}
+
+		public TControl WinFormsControl
+		{
+			get { return (TControl)Control.Child; }
+			set { Control.Child = value; }
+		}
+
+		public WindowsFormsHostHandler(TControl control)
+			: this()
+		{
+			Control.Child = control;
+		}
+
+		public WindowsFormsHostHandler()
+		{
+			Control = new WindowsFormsHost();
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Eto.Forms.Control.MouseMoveEvent:
+					WinFormsControl.MouseMove += WinFormsControl_MouseMove;
+					break;
+				case Eto.Forms.Control.MouseUpEvent:
+					WinFormsControl.MouseUp += WinFormsControl_MouseUp;
+					break;
+				case Eto.Forms.Control.MouseDownEvent:
+					WinFormsControl.MouseDown += WinFormsControl_MouseDown;
+					break;
+				case Eto.Forms.Control.MouseDoubleClickEvent:
+					WinFormsControl.MouseDoubleClick += WinFormsControl_MouseDoubleClick;
+					break;
+				case Eto.Forms.Control.MouseEnterEvent:
+					WinFormsControl.MouseEnter += WinFormsControl_MouseEnter;
+					break;
+				case Eto.Forms.Control.MouseLeaveEvent:
+					WinFormsControl.MouseLeave += WinFormsControl_MouseLeave;
+					break;
+				case Eto.Forms.Control.MouseWheelEvent:
+					WinFormsControl.MouseWheel += WinFormsControl_MouseWheel;
+					break;
+				case Eto.Forms.Control.KeyDownEvent:
+					WinFormsControl.KeyDown += WinFormsControl_KeyDown;
+					WinFormsControl.KeyPress += WinFormsControl_KeyPress;
+					break;
+				case Eto.Forms.Control.KeyUpEvent:
+					WinFormsControl.KeyUp += WinFormsControl_KeyUp;
+					break;
+				case TextControl.TextChangedEvent:
+					WinFormsControl.TextChanged += WinFormsControl_TextChanged;
+					break;
+				case Eto.Forms.Control.TextInputEvent:
+					HandleEvent(Eto.Forms.Control.KeyDownEvent);
+					break;
+				case Eto.Forms.Control.GotFocusEvent:
+					WinFormsControl.GotFocus += WinFormsControl_GotFocus;
+					break;
+				case Eto.Forms.Control.LostFocusEvent:
+					WinFormsControl.LostFocus += WinFormsControl_LostFocus;
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		Keys key;
+		bool handled;
+		char keyChar;
+		bool charPressed;
+		public Keys? LastKeyDown { get; set; }
+
+		void WinFormsControl_KeyDown(object sender, System.Windows.Forms.KeyEventArgs e)
+		{
+			charPressed = false;
+			handled = true;
+			key = e.KeyData.ToEto();
+
+			if (key != Keys.None && LastKeyDown != key)
+			{
+				var kpea = new KeyEventArgs(key, KeyEventType.KeyDown);
+				Callback.OnKeyDown(Widget, kpea);
+
+				handled = e.SuppressKeyPress = e.Handled = kpea.Handled;
+			}
+			else
+				handled = false;
+
+			if (!handled && charPressed)
+			{
+				// this is when something in the event causes messages to be processed for some reason (e.g. show dialog box)
+				// we want the char event to come after the dialog is closed, and handled is set to true!
+				var kpea = new KeyEventArgs(key, KeyEventType.KeyDown, keyChar);
+				Callback.OnKeyDown(Widget, kpea);
+				e.SuppressKeyPress = e.Handled = kpea.Handled;
+			}
+
+			LastKeyDown = null;
+		}
+
+		void WinFormsControl_KeyPress(object sender, System.Windows.Forms.KeyPressEventArgs e)
+		{
+			charPressed = true;
+			keyChar = e.KeyChar;
+			if (!handled)
+			{
+				if (!char.IsControl(e.KeyChar))
+				{
+					var tia = new TextInputEventArgs(keyChar.ToString());
+					Callback.OnTextInput(Widget, tia);
+					e.Handled = tia.Cancel;
+				}
+
+				if (!e.Handled)
+				{
+					var kpea = new KeyEventArgs(key, KeyEventType.KeyDown, keyChar);
+					Callback.OnKeyDown(Widget, kpea);
+					e.Handled = kpea.Handled;
+				}
+			}
+			else
+				e.Handled = true;
+		}
+
+
+		void WinFormsControl_KeyUp(object sender, System.Windows.Forms.KeyEventArgs e)
+		{
+			key = e.KeyData.ToEto();
+
+			var kpea = new KeyEventArgs(key, KeyEventType.KeyUp);
+			Callback.OnKeyUp(Widget, kpea);
+			e.Handled = kpea.Handled;
+		}
+
+		void WinFormsControl_TextChanged(object sender, EventArgs e)
+		{
+			var widget = Widget as TextControl;
+			if (widget != null)
+			{
+				var callback = (TextControl.ICallback)((ICallbackSource)widget).Callback;
+				callback.OnTextChanged(widget, e);
+			}
+		}
+
+		void WinFormsControl_MouseWheel(object sender, swf.MouseEventArgs e) => Callback.OnMouseWheel(Widget, e.ToEto(WinFormsControl));
+
+		void WinFormsControl_MouseLeave(object sender, EventArgs e) => Callback.OnMouseLeave(Widget, new MouseEventArgs(Mouse.Buttons, Keyboard.Modifiers, PointFromScreen(Mouse.Position)));
+
+		void WinFormsControl_MouseEnter(object sender, EventArgs e) => Callback.OnMouseEnter(Widget, new MouseEventArgs(Mouse.Buttons, Keyboard.Modifiers, PointFromScreen(Mouse.Position)));
+
+		void WinFormsControl_MouseDoubleClick(object sender, swf.MouseEventArgs e) => Callback.OnMouseDoubleClick(Widget, e.ToEto(WinFormsControl));
+
+		void WinFormsControl_MouseDown(object sender, swf.MouseEventArgs e) => Callback.OnMouseDown(Widget, e.ToEto(WinFormsControl));
+
+		void WinFormsControl_MouseUp(object sender, swf.MouseEventArgs e) => Callback.OnMouseUp(Widget, e.ToEto(WinFormsControl));
+
+		void WinFormsControl_MouseMove(object sender, swf.MouseEventArgs e) => Callback.OnMouseMove(Widget, e.ToEto(WinFormsControl));
+
+		void WinFormsControl_LostFocus(object sender, EventArgs e) => Callback.OnLostFocus(Widget, EventArgs.Empty);
+
+		void WinFormsControl_GotFocus(object sender, EventArgs e) => Callback.OnGotFocus(Widget, EventArgs.Empty);
+
+	}
+}


### PR DESCRIPTION
WindowsFormsHostHandler can be used to wire up windows forms controls easier while routing all mouse & keyboard events properly.