### PR TITLE
Drag 'n Drop fixes

### DIFF
--- a/Source/Eto.Gtk/NativeMethods.cs
+++ b/Source/Eto.Gtk/NativeMethods.cs
@@ -23,7 +23,7 @@ namespace Eto.GtkSharp
 			const string plat = "";
 #endif
 			const string ext = "-0.dll";
-			const string libgobject = "libgobject-" + ver + ext;
+			const string libgobject = "libgobject-2.0" + ext;
 			const string libgtk = "libgtk-" + plat + ver + ext;
 			const string libgdk = "libgdk-" + plat + ver + ext;
 			const string libwebkit = "libwebkit2gtk-4.0.so.37";
@@ -169,7 +169,7 @@ namespace Eto.GtkSharp
 			const string plat = "";
 #endif
 			const string ext = ".so.0";
-			const string libgobject = "libgobject-" + ver + ext;
+			const string libgobject = "libgobject-2.0" + ext;
 			const string libgtk = "libgtk-" + plat + ver + ext;
 			const string libgdk = "libgdk-" + plat + ver + ext;
 			const string libwebkit = "libwebkit2gtk-4.0.so.37";
@@ -315,7 +315,7 @@ namespace Eto.GtkSharp
 			const string plat = "";
 #endif
 			const string ext = ".dylib";
-			const string libgobject = "libgobject-" + ver + ext;
+			const string libgobject = "libgobject-2.0" + ext;
 			const string libgtk = "libgtk-" + plat + ver + ext;
 			const string libgdk = "libgdk-" + plat + ver + ext;
 			const string libwebkit = "libwebkit2gtk-4.0.so.37";

--- a/Source/Eto.Gtk/NativeMethods.tt
+++ b/Source/Eto.Gtk/NativeMethods.tt
@@ -101,7 +101,7 @@ namespace Eto.GtkSharp
 			const string plat = "";
 #endif
 			const string ext = "<#= ext[i] #>";
-			const string libgobject = "libgobject-" + ver + ext;
+			const string libgobject = "libgobject-2.0" + ext;
 			const string libgtk = "libgtk-" + plat + ver + ext;
 			const string libgdk = "libgdk-" + plat + ver + ext;
 			const string libwebkit = "libwebkit2gtk-4.0.so.37";

--- a/Source/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -183,13 +183,20 @@ namespace Eto.Mac.Forms.Controls
 				if (e.AllowedEffects.HasFlag(e.Effects))
 				{
 					var idx = etoInfo.Index;
-					var pos = etoInfo.Position;
-					if (pos == GridDragPosition.After)
+					if (idx >= 0)
 					{
-						pos = GridDragPosition.Before;
-						idx++;
+						var pos = etoInfo.Position;
+						if (pos == GridDragPosition.After)
+						{
+							pos = GridDragPosition.Before;
+							idx++;
+						}
+						tableView.SetDropRowDropOperation((nint)idx, pos == GridDragPosition.Over ? NSTableViewDropOperation.On : NSTableViewDropOperation.Above);
 					}
-					tableView.SetDropRowDropOperation((nint)idx, pos == GridDragPosition.Over ? NSTableViewDropOperation.On : NSTableViewDropOperation.Above);
+					else
+					{
+						tableView.SetDropRowDropOperation(-1, NSTableViewDropOperation.On);
+					}
 
 					return e.Effects.ToNS();
 				}
@@ -219,7 +226,7 @@ namespace Eto.Mac.Forms.Controls
 							row--;
 					}
 				}
-				var item = h.GetItem((int)row);
+				var item = row >= 0 ? h.GetItem((int)row) : null;
 
 				return new GridViewDragInfo(h.Widget, item, (int)row, position);
 			}

--- a/Source/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/Source/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -376,10 +376,15 @@ namespace Eto.Mac.Forms.Controls
 								if (index > 0)
 								{
 									childItem = outlineView.DataSource.GetChild(outlineView, index - 1, item);
+									if (outlineView.RespondsToSelector(selGetChildIndex)) // 10.11+
+										childIndex = (int?)outlineView.GetChildIndex(childItem);
+									else
+										childIndex = null;
 								}
 								else
 								{
 									childItem = null;
+									childIndex = -1;
 								}
 								position = GridDragPosition.After;
 							}
@@ -389,12 +394,6 @@ namespace Eto.Mac.Forms.Controls
 							}
 
 							etoitem = h.GetEtoItem(childItem);
-							if (childItem == null)
-								childIndex = -1;
-							else if (outlineView.RespondsToSelector(selGetChildIndex)) // 10.11+
-								childIndex = (int?)outlineView.GetChildIndex(childItem);
-							else
-								childIndex = null;
 						}
 					}
 					else

--- a/Source/Eto.Test/Eto.Test/Sections/Behaviors/DragDropSection.cs
+++ b/Source/Eto.Test/Eto.Test/Sections/Behaviors/DragDropSection.cs
@@ -22,7 +22,7 @@ namespace Eto.Test.Sections.Behaviors
 			var includeImageCheck = new CheckBox { Text = "Include Image" };
 			var textBox = new TextBox { Text = "Some text" };
 			var allowedEffectDropDown = new EnumDropDown<DragEffects> { SelectedValue = DragEffects.All };
-			dragOverEffect = new EnumDropDown<DragEffects> { SelectedValue = DragEffects.Link };
+			dragOverEffect = new EnumDropDown<DragEffects> { SelectedValue = DragEffects.Copy };
 
 			var htmlTextArea = new TextArea();
 			var selectFilesButton = new Button { Text = "Select Files" };

--- a/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/Source/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -480,24 +480,34 @@ namespace Eto.Wpf.Forms
 		private void Control_DragEnter(object sender, sw.DragEventArgs e)
 		{
 			IsDragLeaving = false;
+			var args = GetDragEventArgs(e, null);
 			if (!IsDragEntered)
 			{
 				IsDragEntered = true;
-				HandleDragEnter(e, GetDragEventArgs(e, null));
+				HandleDragEnter(e, args);
+			}
+			else
+			{
+				// we re-entered, treat as another drag over so we can set the proper drag effect again
+				HandleDragOver(e, args);
 			}
 		}
 
 		void Control_DragLeave(object sender, sw.DragEventArgs e)
 		{
-			IsDragLeaving = true;
-			Control.Dispatcher.BeginInvoke(new Action(() =>
+			if (IsDragEntered)
 			{
-				if (IsDragLeaving)
+				IsDragLeaving = true;
+				Control.Dispatcher.BeginInvoke(new Action(() =>
 				{
-					IsDragEntered = false;
-					HandleDragLeave(e, GetDragEventArgs(e, null));
-				}
-			}));
+					if (IsDragLeaving)
+					{
+						IsDragEntered = false;
+						HandleDragLeave(e, GetDragEventArgs(e, null));
+					}
+				}));
+				e.Handled = true;
+			}
 		}
 
 		static readonly object IsDragEntered_Key = new object();
@@ -522,15 +532,15 @@ namespace Eto.Wpf.Forms
 			IsDragEntered = false;
 			Callback.OnDragLeave(Widget, args);
 			Callback.OnDragDrop(Widget, args);
-			e.Handled = args.Effects != DragEffects.None;
 			e.Effects = args.Effects.ToWpf();
+			e.Handled = true;
 		}
 
 		protected virtual void HandleDragEnter(sw.DragEventArgs e, DragEventArgs args)
 		{
 			Callback.OnDragEnter(Widget, args);
-			e.Handled = args.Effects != DragEffects.None;
 			e.Effects = args.Effects.ToWpf();
+			e.Handled = true;
 		}
 
 		protected virtual void HandleDragLeave(sw.DragEventArgs e, DragEventArgs args)
@@ -541,8 +551,8 @@ namespace Eto.Wpf.Forms
 		protected virtual void HandleDragOver(sw.DragEventArgs e, DragEventArgs args)
 		{
 			Callback.OnDragOver(Widget, args);
-			e.Handled = args.Effects != DragEffects.None;
 			e.Effects = args.Effects.ToWpf();
+			e.Handled = true;
 		}
 
 


### PR DESCRIPTION
Wpf: Fix constant flashing of drag cursor for TreeGridView/GridView. Fixes #932
Gtk: Clear out old DragArgs so one operation doesn't affect another
Mac: Fix setting indicator for GridView in some cases