### PR TITLE
Update nuspec files to use proper path separators, now that it works on macOS.

### DIFF
--- a/build/nuspec/Eto.Platform.Direct2D.nuspec
+++ b/build/nuspec/Eto.Platform.Direct2D.nuspec
@@ -31,7 +31,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts/core/$configuration$/net45/Eto.Direct2D.dll" target="lib\net45" />
+		<file src="artifacts\core\$configuration$\net45\Eto.Direct2D.dll" target="lib\net45" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Platform.Gtk.nuspec
+++ b/build/nuspec/Eto.Platform.Gtk.nuspec
@@ -28,7 +28,7 @@ On Linux, mono framework 2.10 or higher and gtk-sharp2 are required.
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts/core/$configuration$/net45/Eto.Gtk2.dll" target="lib\net45" />
+		<file src="artifacts\core\$configuration$\net45\Eto.Gtk2.dll" target="lib\net45" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Platform.Gtk3.nuspec
+++ b/build/nuspec/Eto.Platform.Gtk3.nuspec
@@ -28,7 +28,7 @@ On Linux, mono framework 2.10 or higher and gtk-sharp2 are required.
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts/core/$configuration$/net45/Eto.Gtk3.dll" target="lib\net45" />
+		<file src="artifacts\core\$configuration$\net45\Eto.Gtk3.dll" target="lib\net45" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Platform.Mac.nuspec
+++ b/build/nuspec/Eto.Platform.Mac.nuspec
@@ -32,11 +32,11 @@ You do not need to use any of the classes of this assembly (unless customizing t
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="lib/MonoMac/MonoMac.dll" target="lib/net45" />
-		<file src="lib/MonoMac/MonoMac-License.txt" target="MonoMac-License.txt" />
-		<file src="artifacts/core/$configuration$/net45/Eto.Mac.dll" target="lib/net45" />
+		<file src="lib\MonoMac\MonoMac.dll" target="lib\net45" />
+		<file src="lib\MonoMac\MonoMac-License.txt" target="MonoMac-License.txt" />
+		<file src="artifacts\core\$configuration$\net45\Eto.Mac.dll" target="lib\net45" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
-		<file src="build/MacTemplate/*" target="build/" />
-		<file src="build/nuspec/Mac.targets" target="build/Eto.Platform.Mac.targets" />
+		<file src="build\MacTemplate\*.*" target="build" />
+		<file src="build\nuspec\Mac.targets" target="build\Eto.Platform.Mac.targets" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Platform.Mac64.nuspec
+++ b/build/nuspec/Eto.Platform.Mac64.nuspec
@@ -34,11 +34,11 @@ You do not need to use any of the classes of this assembly (unless customizing t
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="lib/MonoMac64/MonoMac.dll" target="lib\net45" />
-		<file src="lib/MonoMac64/MonoMac-License.txt" target="MonoMac-License.txt" />
-		<file src="artifacts/core/$configuration$/net45/Eto.Mac64.dll" target="lib\net45" />
+		<file src="lib\MonoMac64\MonoMac.dll" target="lib\net45" />
+		<file src="lib\MonoMac64\MonoMac-License.txt" target="MonoMac-License.txt" />
+		<file src="artifacts\core\$configuration$\net45\Eto.Mac64.dll" target="lib\net45" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
-		<file src="build/MacTemplate/*" target="build/" />
-		<file src="build/nuspec/Mac.targets" target="build/Eto.Platform.Mac64.targets" />
+		<file src="build\MacTemplate\*.*" target="build" />
+		<file src="build\nuspec\Mac.targets" target="build\Eto.Platform.Mac64.targets" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Platform.WinRT.nuspec
+++ b/build/nuspec/Eto.Platform.WinRT.nuspec
@@ -31,7 +31,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts/$configuration$/portable259/Eto.WinRT.dll" target="lib\netcore45" />
+		<file src="artifacts\$configuration$\portable259\Eto.WinRT.dll" target="lib\netcore45" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Platform.Windows.nuspec
+++ b/build/nuspec/Eto.Platform.Windows.nuspec
@@ -26,7 +26,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts/core/$configuration$/net45/Eto.WinForms.dll" target="lib\net45" />
+		<file src="artifacts\core\$configuration$\net45\Eto.WinForms.dll" target="lib\net45" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Platform.Wpf.nuspec
+++ b/build/nuspec/Eto.Platform.Wpf.nuspec
@@ -26,7 +26,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts/core/$configuration$/net45/Eto.Wpf.dll" target="lib\net45" />
+		<file src="artifacts\core\$configuration$\net45\Eto.Wpf.dll" target="lib\net45" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Platform.XamMac.nuspec
+++ b/build/nuspec/Eto.Platform.XamMac.nuspec
@@ -30,7 +30,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts/core/$configuration$/net45/Eto.XamMac.dll" target="lib\net45" />
+		<file src="artifacts\core\$configuration$\net45\Eto.XamMac.dll" target="lib\net45" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Platform.XamMac2.nuspec
+++ b/build/nuspec/Eto.Platform.XamMac2.nuspec
@@ -30,8 +30,8 @@ Using Eto.Platform.Mac instead uses the open source MonoMac, which allows you to
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts/core/$configuration$/modern/Eto.XamMac2.dll" target="lib\xamarin.mac2" />
-		<file src="artifacts/core/$configuration$/net45/Eto.XamMac2.dll" target="lib\net45" />
+		<file src="artifacts\core\$configuration$\modern\Eto.XamMac2.dll" target="lib\xamarin.mac2" />
+		<file src="artifacts\core\$configuration$\net45\Eto.XamMac2.dll" target="lib\net45" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Platform.iOS.nuspec
+++ b/build/nuspec/Eto.Platform.iOS.nuspec
@@ -26,7 +26,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts/$configuration$/netstandard1.3/Eto.iOS.dll" target="lib\monotouch" />
+		<file src="artifacts\$configuration$\netstandard1.3\Eto.iOS.dll" target="lib\monotouch" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Serialization.Json.nuspec
+++ b/build/nuspec/Eto.Serialization.Json.nuspec
@@ -27,8 +27,8 @@ https://github.com/picoe/Eto/wiki
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts/core/$configuration$/netstandard1.3/Eto.Serialization.Json.dll" target="lib\netstandard1.3" />
-		<file src="artifacts/core/$configuration$/portable-net45+win8+wpa81+wp8/Eto.Serialization.Json.dll" target="lib\portable-net45+win8+wpa81+wp8" />
+		<file src="artifacts\core\$configuration$\netstandard1.3\Eto.Serialization.Json.dll" target="lib\netstandard1.3" />
+		<file src="artifacts\core\$configuration$\portable-net45+win8+wpa81+wp8\Eto.Serialization.Json.dll" target="lib\portable-net45+win8+wpa81+wp8" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Serialization.Xaml.nuspec
+++ b/build/nuspec/Eto.Serialization.Xaml.nuspec
@@ -27,8 +27,8 @@ https://github.com/picoe/Eto/wiki
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts/core/$configuration$/netstandard1.3/Eto.Serialization.Xaml.dll" target="lib\netstandard1.3" />
-		<file src="artifacts/core/$configuration$/portable-net45+win8+wpa81+wp8/Eto.Serialization.Xaml.dll" target="lib\portable-net45+win8+wpa81+wp8" />
+		<file src="artifacts\core\$configuration$\netstandard1.3\Eto.Serialization.Xaml.dll" target="lib\netstandard1.3" />
+		<file src="artifacts\core\$configuration$\portable-net45+win8+wpa81+wp8\Eto.Serialization.Xaml.dll" target="lib\portable-net45+win8+wpa81+wp8" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>


### PR DESCRIPTION


Fixes generating nupkg files on windows.