### PR TITLE
Remove all PCL!

### DIFF
--- a/build/Build.proj
+++ b/build/Build.proj
@@ -7,7 +7,7 @@
         <NugetDir Condition="$(NugetDir) == ''">$(SourceDir)</NugetDir>
         <ArtifactsDir Condition="$(BuildOutoutDir) == ''">$(BaseDir)\artifacts</ArtifactsDir>
 		<ArtifactsNet45Dir Condition="$(ArtifactsNet45Dir) == ''">$(ArtifactsDir)\core\$(Configuration)\net45</ArtifactsNet45Dir>
-		<ArtifactsNetStandard13Dir Condition="$(ArtifactsNetStandard13Dir) == ''">$(ArtifactsDir)\core\$(Configuration)\netstandard1.3</ArtifactsNetStandard13Dir>
+		<ArtifactsNetStandard10Dir Condition="$(ArtifactsNetStandard10Dir) == ''">$(ArtifactsDir)\core\$(Configuration)\netstandard1.0</ArtifactsNetStandard10Dir>
 		<ArtifactsNetStandard20Dir Condition="$(ArtifactsNetStandard20Dir) == ''">$(ArtifactsDir)\core\$(Configuration)\netstandard2.0</ArtifactsNetStandard20Dir>
 		<ArtifactsModernDir Condition="$(ArtifactsModernDir) == ''">$(ArtifactsDir)\core\$(Configuration)\modern</ArtifactsModernDir>
 		<PackageTargets Condition="$(PackageTargets) == ''">Build</PackageTargets>
@@ -169,10 +169,10 @@
 		</Package>
 		-->
 		<Package Include="Eto.Serialization.Json">
-			<Assembly>$(ArtifactsNetStandard13Dir)\Eto.Serialization.Json.dll</Assembly>
+			<Assembly>$(ArtifactsNetStandard10Dir)\Eto.Serialization.Json.dll</Assembly>
 		</Package>
 		<Package Include="Eto.Serialization.Xaml">
-			<Assembly>$(ArtifactsNetStandard13Dir)\publish\Eto.Serialization.Xaml.dll</Assembly>
+			<Assembly>$(ArtifactsNetStandard10Dir)\publish\Eto.Serialization.Xaml.dll</Assembly>
 		</Package>
 	</ItemGroup>
 	

--- a/build/MacTemplate/MacTemplate.targets
+++ b/build/MacTemplate/MacTemplate.targets
@@ -11,12 +11,13 @@
 		<InputAppPath Condition="'$(InputAppPath)'==''">$(MSBuildProjectDirectory)\Mac\</InputAppPath>
 		<OutputAppPath Condition="'$(OutputAppPath)'==''">$(TargetDir)\$(MacBundleName).app</OutputAppPath>
 		<MacSetDefaultRunConfiguration Condition="'$(MacSetDefaultTarget)' == ''">True</MacSetDefaultRunConfiguration>
+		<MacBuildBundle Condition="$(MacBuildBundle) == '' and $(ProjectTypeGuids) == ''">True</MacBuildBundle>
 	</PropertyGroup>
 
-	<Import Project="RunConfiguration.Default.targets" Condition="$(MacSetDefaultRunConfiguration) == 'True' AND $(IsMac) == 'True'" />
-	<Import Project="RunConfiguration.Mac.targets" Condition="$(MacSetDefaultRunConfiguration) != 'True' AND $(IsMac) == 'True'" />
+	<Import Project="RunConfiguration.Default.targets" Condition="$(MacSetDefaultRunConfiguration) == 'True' AND $(IsMac) == 'True' AND $(MacBuildBundle) == 'True'" />
+	<Import Project="RunConfiguration.Mac.targets" Condition="$(MacSetDefaultRunConfiguration) != 'True' AND $(IsMac) == 'True' AND $(MacBuildBundle) == 'True'" />
 
-	<Target Name="_TouchApp">
+	<Target Name="_TouchApp" Condition="$(MacBuildBundle) == 'True'">
 		<!-- This makes it so we can debug in VS for Mac right away without building first -->
 		<MakeDir Directories="$(OutputAppPath)" Condition="$(IsMac) == 'True' AND $(VisualStudioVersion) != ''" />
 	</Target>
@@ -25,7 +26,7 @@
 		<RemoveDir Directories="$(OutputAppPath)"/>
 	</Target>
 	
-	<Target Name="_BuildAppBundle" AfterTargets="AfterBuild">
+	<Target Name="_BuildAppBundle" AfterTargets="AfterBuild" Condition="$(MacBuildBundle) == 'True'">
 		<PropertyGroup>
 			<OutputContents>$(OutputAppPath)\Contents</OutputContents>
 			<OutputMonoBundlePath>$(OutputContents)\MonoBundle</OutputMonoBundlePath>

--- a/build/MacTemplate/MacTemplate.targets
+++ b/build/MacTemplate/MacTemplate.targets
@@ -34,8 +34,10 @@
 			<LauncherFile>$([System.IO.Path]::GetFileNameWithoutExtension('$(TargetFileName)'))</LauncherFile>
 			<LauncherFileWithPath>$(OutputContents)\MacOS\$(LauncherFile)</LauncherFileWithPath>
 
+			<HasXamMac>@(ReferenceCopyLocalPaths->AnyHaveMetadataValue('Filename', 'Eto.XamMac2'))</HasXamMac>
 			<Has32Bit>@(ReferenceCopyLocalPaths->AnyHaveMetadataValue('Filename', 'Eto.Mac'))</Has32Bit>
 			<Has64Bit>@(ReferenceCopyLocalPaths->AnyHaveMetadataValue('Filename', 'Eto.Mac64'))</Has64Bit>
+			<Has64Bit Condition="$(Has64Bit) != 'True'">$(HasXamMac)</Has64Bit>
 			<MacIncludeSymbols Condition="'$(MacIncludeSymbols)' == ''">true</MacIncludeSymbols>
 			<MacArch Condition="'$(MacArch)'=='' AND $(Has64Bit)=='true'">x86_64</MacArch>
 			<MacArch Condition="'$(MacArch)'==''">i386</MacArch>
@@ -60,6 +62,7 @@
 		<Copy SourceFiles="$(InputAppPath)\**\*.*" DestinationFolder="$(OutputContents)" SkipUnchangedFiles="true" Condition="Exists('$(InputAppPath)')" />
 		<Copy SourceFiles="$(LauncherExecutable)" DestinationFiles="$(LauncherFileWithPath)" SkipUnchangedFiles="true" />
 		<Copy SourceFiles="$(InputPListFile)" DestinationFiles="$(OutputPListFile)" Condition="!Exists('$(OutputPListFile)')" />
+		<Copy SourceFiles="$(ReferenceFiles)\Xamarin.Mac.dll" DestinationFolder="$(OutputMonoBundlePath)" SkipUnchangedFiles="true" Condition="$(HasXamMac) == 'True'" />
 
 		<FindUnderPath  
             Files="@(FileWrites)"  
@@ -83,7 +86,6 @@
 				and %(Filename) != 'Eto.WinRT'
 				and %(Filename) != 'Eto.Android'
 				and %(Filename) != 'Eto.XamMac'
-				and %(Filename) != 'Eto.XamMac2'
 				and (
 					$(MacIncludeSymbols) == 'True'
 					or (
@@ -91,8 +93,9 @@
 						and %(Extension) != '.mdb'
 					)
 				)
-				and ($(MacArch) == 'i386' or %(Filename) != 'Eto.Mac')
-				and ($(MacArch) == 'x86_64' or %(Filename) != 'Eto.Mac64')
+				and (($(HasXamMac) != 'True' and $(Has32Bit) == 'True') or %(Filename) != 'Eto.Mac')
+				and (($(HasXamMac) != 'True' and $(Has64Bit) == 'True') or %(Filename) != 'Eto.Mac64')
+				and ($(HasXamMac) == 'True' or %(Filename) != 'Eto.XamMac2')
 				" />
 
 			<ResourceFiles Include="@(BundleResource)" />

--- a/build/nuspec/Eto.Forms.nuspec
+++ b/build/nuspec/Eto.Forms.nuspec
@@ -19,7 +19,7 @@ The goal of this framework is to expose a common API that can be used to build f
 
 For advanced scenarios, you can take advantage of each platform's capabilities by wrapping your common UI in a larger application, or even create your own high-level controls with a custom implementations per platform.
 
-This framework currently supports creating Desktop applications that work across Windows Forms, WPF, MonoMac/Xamarin.Mac, and GTK#.
+This framework currently supports creating Desktop applications that work across Windows Forms, WPF, MonoMac, Xamarin.Mac, and GTK#.
 
 In order to run your Eto.Forms based application, you must also install one (or more) of the following packages:
 
@@ -27,11 +27,12 @@ In order to run your Eto.Forms based application, you must also install one (or 
 - Eto.Platform.Windows
 - Eto.Platform.Direct2D
 - Eto.Platform.Gtk
+- Eto.Platform.Gtk2
 - Eto.Platform.Gtk3
 - Eto.Platform.Mac
 - Eto.Platform.Mac64
 - Eto.Platform.XamMac  * requires Visual Studio for Mac
-- Eto.Platform.XamMac2  * requires Visual Studio for Mac
+- Eto.Platform.XamMac2
 
 To get more information about how to get started, read the wiki:
 

--- a/build/nuspec/Eto.Forms.nuspec
+++ b/build/nuspec/Eto.Forms.nuspec
@@ -41,8 +41,9 @@ https://github.com/picoe/Eto/wiki
 		<tags>cross platform gui ui framework desktop winforms wpf mac osx gtk eto.forms</tags>
 	</metadata>
 	<files>
-		<file src="artifacts/core/$configuration$/netstandard1.0/Eto.dll" target="lib\netstandard1.0" />
-		<file src="artifacts/core/$configuration$/netstandard1.0/Eto.xml" target="lib\netstandard1.0" />
+		<file src="artifacts\core\$configuration$\netstandard1.0\Eto.dll" target="lib\netstandard1.0" />
+		<file src="artifacts\core\$configuration$\netstandard1.0\Eto.xml" target="lib\netstandard1.0" />
+		<file src="build\nuspec\Eto.Forms.targets" target="build\" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Forms.targets
+++ b/build/nuspec/Eto.Forms.targets
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
+
+  <ItemGroup>
+    <Compile Update="**\*.eto.cs">
+      <DependentUpon>$([System.String]::Copy('%(Filename)').Replace('.eto', ''))%(Extension)</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/build/nuspec/Eto.Platform.Mac.nuspec
+++ b/build/nuspec/Eto.Platform.Mac.nuspec
@@ -11,15 +11,15 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<summary>$description$</summary>
 		<description>
-This is the MonoMac platform for Eto.Forms UI Framework.
-    	
-Include this along with your Eto.Forms application to provide an OS X interface for Mac users.
-    	
-Eto.Platform.Mac uses the open source MonoMac, which allows you to create OS X Applications with no cost.  However, it does require mono to be installed.
+This package is deprecated and should not be used in new projects, please use Eto.Platform.Mac64 or Eto.Platform.XamMac2 instead.
 
-Using Eto.Platform.XamMac instead allows you to bundle mono inside your .app, however it requires purchasing Xamarin.Mac and using Xamarin Studio on OS X.
+This is the 32-bit MonoMac platform for Eto.Forms UI Framework.
     	
-You can create your own .app bundle to run your app on OS X, without using a Mac. Use the Eto.Platform.Mac.Template nuget package to build one for your app automatically.
+Include this along with your Eto.Forms application to provide a native interface for Mac users.
+    	
+Eto.Platform.Mac uses the open source MonoMac, which allows you to create macOS application bundles from any platform.  However, it does require mono to be installed when running on macOS.
+
+Use Eto.Platform.XamMac2 if you want to bundle mono inside your .app, however it requires Visual Studio on a Mac.
     	
 You do not need to use any of the classes of this assembly (unless customizing the MonoMac functionality of the platform), and should just use the UI controls from the Eto assembly.
 		</description>

--- a/build/nuspec/Eto.Platform.Mac64.nuspec
+++ b/build/nuspec/Eto.Platform.Mac64.nuspec
@@ -11,15 +11,11 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<summary>$description$</summary>
 		<description>
-This is the MonoMac 64-bit platform for Eto.Forms UI Framework.
+This is the 64-bit MonoMac platform for Eto.Forms UI Framework.
     	
-This is used only when running a 64-bit version of mono, which is typically useful for embedding scenarios as the default mono on OS X is only 32-bit currently.
+Eto.Platform.Mac64 uses a modified version of the open source MonoMac for 64-bit, which allows you to create macOS application bundles from any platform.  However, it does require mono to be installed when running on macOS.
     	
-Eto.Platform.Mac64 uses a modified version of the open source MonoMac for 64-bit, which allows you to create OS X Applications at no cost.  However, it does require 64-bit mono to be installed.
-    	
-If you want to run using the standard mono install for OS X, use Eto.Platform.Mac.
-
-Using Eto.Platform.XamMac instead allows you to bundle mono inside your .app, however it requires purchasing Xamarin.Mac and using Xamarin Studio on OS X.
+Use Eto.Platform.XamMac2 if you want to bundle mono inside your .app, however it requires Visual Studio on a Mac.
     	
 You can create your own .app bundle to run your app on OS X, without an OS X machine. This is included as the MyApp.app folder. Read MyApp.app\Contents\MonoBundle\README.txt for instructions on next steps.
     	

--- a/build/nuspec/Eto.Platform.XamMac.nuspec
+++ b/build/nuspec/Eto.Platform.XamMac.nuspec
@@ -11,13 +11,15 @@
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
 		<summary>$description$</summary>
 		<description>
-This is the Xamarin.Mac platform for Eto.Forms UI Framework.
+This package is deprecated and should not be used in new projects, please use Eto.Platform.XamMac2 instead.
+		
+This is the Xamarin.Mac Classic platform for Eto.Forms UI Framework.
     	
 Include this along with your Eto.Forms application to provide an OS X interface for Mac users.
     	
-* Note: You should only use this package from an Xamarin.Mac project created with Xamarin Studio on OS X. Xamarin.Mac allows you to bundle mono inside your .app, however it requires purchasing Xamarin.Mac.
+* Note: You should only use this package from an Xamarin.Mac project created with Visual Studio on OS X. Xamarin.Mac allows you to bundle mono inside your .app.
 
-Using Eto.Platform.Mac instead uses the open source MonoMac, which allows you to create OS X Applications with no cost.  However, it does require mono to be installed for the app to run.
+Using Eto.Platform.Mac64 instead uses the open source MonoMac, which allows you to create macOS application bundles from any platform.  However, it does require mono to be installed when running on macOS.
     	
 You do not need to use any of the classes of this assembly (unless customizing the Xamarin.Mac functionality of the platform), and should just use the UI controls from the Eto assembly.
 		</description>

--- a/build/nuspec/Eto.Platform.XamMac2.nuspec
+++ b/build/nuspec/Eto.Platform.XamMac2.nuspec
@@ -13,13 +13,13 @@
 		<description>
 This is the Xamarin.Mac2 (unified) platform for Eto.Forms UI Framework.
     	
-Include this along with your Eto.Forms application to provide an OS X interface for Mac users using the 64-bit compatible Xamarin.Mac.
-    	
-* Note: You should only use this package from an Xamarin.Mac project created with Xamarin Studio on OS X. Xamarin.Mac allows you to bundle mono inside your .app, however it requires purchasing Xamarin.Mac.
+Include this along with your Eto.Forms application to provide an macOS interface for Mac users.
 
-Using Eto.Platform.Mac instead uses the open source MonoMac, which allows you to create OS X Applications with no cost.  However, it does require mono to be installed for the app to run.
+When used in a desktop project, this package will automatically create a macOS application bundle to run on a Mac.  However, it will require mono to be installed when running on macOS.
     	
-    	You do not need to use any of the classes of this assembly (unless customizing the Xamarin.Mac functionality of the platform), and should just use the UI controls from the Eto assembly.
+In order to bundle mono with your application, you must create a Xamarin.Mac project using Visual Studio on Mac.
+
+You do not need to use any of the classes of this assembly (unless customizing the Xamarin.Mac functionality of the platform), and should just use the UI controls from the Eto assembly.
 		</description>
 		<copyright>$copyright$</copyright>
 		<tags>cross platform gui ui framework desktop osx xamarin.mac mac eto.forms</tags>
@@ -33,5 +33,8 @@ Using Eto.Platform.Mac instead uses the open source MonoMac, which allows you to
 		<file src="artifacts\core\$configuration$\modern\Eto.XamMac2.dll" target="lib\xamarin.mac2" />
 		<file src="artifacts\core\$configuration$\net45\Eto.XamMac2.dll" target="lib\net45" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
+		<file src="/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/x86_64/full/Xamarin.Mac.dll" target="build" />
+		<file src="build\MacTemplate\*" target="build" />
+		<file src="build\nuspec\Mac.targets" target="build\Eto.Platform.XamMac2.targets" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Serialization.Json.nuspec
+++ b/build/nuspec/Eto.Serialization.Json.nuspec
@@ -28,7 +28,7 @@ https://github.com/picoe/Eto/wiki
 	</metadata>
 	<files>
 		<file src="artifacts\core\$configuration$\netstandard1.0\Eto.Serialization.Json.dll" target="lib\netstandard1.0" />
-		<file src="build\nuspec\Eto.Serialization.Xaml.targets" target="build\" />
+		<file src="build\nuspec\Eto.Serialization.Json.targets" target="build\" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Serialization.Json.nuspec
+++ b/build/nuspec/Eto.Serialization.Json.nuspec
@@ -27,8 +27,8 @@ https://github.com/picoe/Eto/wiki
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts\core\$configuration$\netstandard1.3\Eto.Serialization.Json.dll" target="lib\netstandard1.3" />
-		<file src="artifacts\core\$configuration$\portable-net45+win8+wpa81+wp8\Eto.Serialization.Json.dll" target="lib\portable-net45+win8+wpa81+wp8" />
+		<file src="artifacts\core\$configuration$\netstandard1.0\Eto.Serialization.Json.dll" target="lib\netstandard1.0" />
+		<file src="build\nuspec\Eto.Serialization.Xaml.targets" target="build\" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Serialization.Json.targets
+++ b/build/nuspec/Eto.Serialization.Json.targets
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
+
+  <ItemGroup Condition=" '$(EnableDefaultCompileItems)' == 'true' ">
+    <None Remove="**\*.jeto" />
+    <EmbeddedResource Include="**\*.jeto" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="**\*.jeto.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/build/nuspec/Eto.Serialization.Xaml.nuspec
+++ b/build/nuspec/Eto.Serialization.Xaml.nuspec
@@ -22,13 +22,13 @@ https://github.com/picoe/Eto/wiki
 		<dependencies>
 			<group>
 				<dependency id="Eto.Forms" version="[$version$]" />
-				<dependency id="Portable.Xaml" version="0.20.0" />
+				<dependency id="Portable.Xaml" version="0.21.0" />
 			</group>
 		</dependencies>
 	</metadata>
 	<files>
-		<file src="artifacts\core\$configuration$\netstandard1.3\Eto.Serialization.Xaml.dll" target="lib\netstandard1.3" />
-		<file src="artifacts\core\$configuration$\portable-net45+win8+wpa81+wp8\Eto.Serialization.Xaml.dll" target="lib\portable-net45+win8+wpa81+wp8" />
+		<file src="artifacts\core\$configuration$\netstandard1.0\Eto.Serialization.Xaml.dll" target="lib\netstandard1.0" />
+		<file src="build\nuspec\Eto.Serialization.Xaml.targets" target="build\" />
 		<file src="LICENSE.txt" target="LICENSE.txt" />
 	</files>
 </package>

--- a/build/nuspec/Eto.Serialization.Xaml.targets
+++ b/build/nuspec/Eto.Serialization.Xaml.targets
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
+
+  <ItemGroup Condition=" '$(EnableDefaultCompileItems)' == 'true' ">
+    <None Remove="**\*.xeto" />
+    <EmbeddedResource Include="**\*.xeto" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Update="**\*.xeto.cs">
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+</Project>

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -42,32 +42,41 @@ namespace Eto.Mac
 
 		public override bool IsMac { get { return true; } }
 
-		#if XAMMAC
+#if XAMMAC
 		public override string ID { get { return "xammac"; } }
-		#else
+#else
 		public override string ID { get { return "mac"; } }
 #endif
 
 		public override PlatformFeatures SupportedFeatures =>
 			PlatformFeatures.DrawableWithTransparentContent
-            | PlatformFeatures.CustomCellSupportsControlView
+			| PlatformFeatures.CustomCellSupportsControlView
 			| PlatformFeatures.TabIndexWithCustomContainers;
 
 		public Platform()
 		{
-			#if Mac64
+#if Mac64
 			unsafe
 			{
 				if (sizeof(IntPtr) != 8)
 					throw new InvalidOperationException(string.Format(System.Globalization.CultureInfo.CurrentCulture, "You can only run this platform in 64-bit mode. Use the 32-bit Eto.Mac platform instead."));
 			}
-			#endif
+#endif
 			if (!initialized)
 			{
 				var appType = typeof(NSApplication);
 				var initField = appType.GetField("initialized", BindingFlags.Static | BindingFlags.NonPublic);
 				if (initField == null || Equals(initField.GetValue(null), false))
+				{
+#if XAMMAC
+					// with out this, Xamarin.Mac borks on netstandard.dll due to System.IO.Compression.FileSystem.dll
+					// at least when run with system mono
+					// let's be forgiving until that is fixed so we can actually use .net standard!
+					NSApplication.IgnoreMissingAssembliesDuringRegistration = true;
+#endif
+
 					NSApplication.Init();
+				}
 				// until everything is marked as thread safe correctly in monomac
 				// e.g. overriding NSButtonCell.DrawBezelWithFrame will throw an exception
 				NSApplication.CheckForIllegalCrossThreadCalls = false;

--- a/src/Eto.Serialization.Json/Eto.Serialization.Json.csproj
+++ b/src/Eto.Serialization.Json/Eto.Serialization.Json.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <!-- Use this when multi-targeting works in VS for Mac (it works with msbuild though!)
     <TargetFrameworks>netstandard1.3;portable-net45+win8+wpa81+wp8</TargetFrameworks>
     -->

--- a/src/Eto.Serialization.Xaml/Eto.Serialization.Xaml.csproj
+++ b/src/Eto.Serialization.Xaml/Eto.Serialization.Xaml.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.3</TargetFramework>
+    <TargetFramework>netstandard1.0</TargetFramework>
     <!-- Use this when multi-targeting works in VS for Mac (it works with msbuild though!)
-    <TargetFrameworks>netstandard1.3;portable-net45+win8+wpa81+wp8</TargetFrameworks>
+    <TargetFrameworks>netstandard1.0;netstandard1.3</TargetFrameworks>
     -->
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -18,9 +18,10 @@
     <Compile Include="..\Eto\TypeHelper.cs" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Portable.Xaml" Version="0.20.0" />
+    <ProjectReference Include="..\Eto\Eto.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\Eto\Eto.csproj" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
+    <PackageReference Include="Portable.Xaml" Version="0.21.0" />
   </ItemGroup>
 </Project>

--- a/src/Eto.Serialization.Xaml/EtoXamlType.cs
+++ b/src/Eto.Serialization.Xaml/EtoXamlType.cs
@@ -9,11 +9,7 @@ using Eto.Forms;
 #if PORTABLE
 using Portable.Xaml;
 using Portable.Xaml.Schema;
-#if NETSTANDARD1_3
 using cm = System.ComponentModel;
-#else
-using cm = Portable.Xaml.ComponentModel;
-#endif
 
 #if NET40
 using EtoTypeConverter = System.ComponentModel.TypeConverter;
@@ -21,7 +17,6 @@ using EtoTypeConverterAttribute = System.ComponentModel.TypeConverterAttribute;
 #else
 using EtoTypeConverter = Eto.TypeConverter;
 using EtoTypeConverterAttribute = Eto.TypeConverterAttribute;
-using Portable.Xaml.ComponentModel;
 #endif
 #else
 using System.Xaml;
@@ -49,7 +44,7 @@ namespace Eto.Serialization.Xaml
 	#endif
 
 	#if PORTABLE || NET45
-	class TypeConverterConverter : IXamlTypeConverter
+	class TypeConverterConverter : cm.TypeConverter
 	{
 		readonly EtoTypeConverter etoConverter;
 
@@ -58,35 +53,35 @@ namespace Eto.Serialization.Xaml
 			this.etoConverter = etoConverter;
 		}
 
-		public bool CanConvertFrom(object context, Type sourceType)
+		public override bool CanConvertFrom(cm.ITypeDescriptorContext context, Type sourceType)
 		{
 			return etoConverter.CanConvertFrom(sourceType);
 		}
 
-		public bool CanConvertTo(object context, Type destinationType)
+		public override bool CanConvertTo(cm.ITypeDescriptorContext context, Type destinationType)
 		{
 			return etoConverter.CanConvertTo(destinationType);
 		}
 
-		public object ConvertFrom(object context, System.Globalization.CultureInfo culture, object value)
+		public override object ConvertFrom(cm.ITypeDescriptorContext context, CultureInfo culture, object value)
 		{
 			return etoConverter.ConvertFrom(null, culture, value);
 		}
 
-		public object ConvertTo(object context, System.Globalization.CultureInfo culture, object value, Type destinationType)
+		public override object ConvertTo(cm.ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
 		{
 			return etoConverter.ConvertTo(null, culture, value, destinationType);
 		}
 	}
 
-	class EtoValueConverter : XamlValueConverter<IXamlTypeConverter>
+	class EtoValueConverter : XamlValueConverter<cm.TypeConverter>
 	{
 		public EtoValueConverter(Type converterType, XamlType targetType)
 			: base(converterType, targetType)
 		{
 		}
 
-		protected override IXamlTypeConverter CreateInstance()
+		protected override cm.TypeConverter CreateInstance()
 		{
 			var etoConverter = Activator.CreateInstance(ConverterType) as EtoTypeConverter;
 			return new TypeConverterConverter(etoConverter);
@@ -149,10 +144,10 @@ namespace Eto.Serialization.Xaml
 		}
 
 		#if PORTABLE || NET45
-		XamlValueConverter<IXamlTypeConverter> typeConverter;
+		XamlValueConverter<cm.TypeConverter> typeConverter;
 		bool gotTypeConverter;
 
-		protected override XamlValueConverter<IXamlTypeConverter> LookupXamlTypeConverter()
+		protected override XamlValueConverter<cm.TypeConverter> LookupTypeConverter()
 		{
 			if (gotTypeConverter)
 				return typeConverter;
@@ -185,7 +180,7 @@ namespace Eto.Serialization.Xaml
 			}
 
 			if (typeConverter == null)
-				typeConverter = base.LookupXamlTypeConverter();
+				typeConverter = base.LookupTypeConverter();
 			return typeConverter;
 		}
 
@@ -199,7 +194,7 @@ namespace Eto.Serialization.Xaml
 
 			}
 
-			class EmptyConverter : IXamlTypeConverter
+			class EmptyConverter : cm.TypeConverter
 			{
 				public bool CanConvertFrom(object context, Type sourceType) => true;
 
@@ -210,9 +205,9 @@ namespace Eto.Serialization.Xaml
 				public object ConvertTo(object context, CultureInfo culture, object value, Type destinationType) => null;
 			}
 
-			protected override XamlValueConverter<IXamlTypeConverter> LookupXamlTypeConverter()
+			protected override XamlValueConverter<cm.TypeConverter> LookupTypeConverter()
 			{
-				return new XamlValueConverter<IXamlTypeConverter>(typeof(EmptyConverter), Type);
+				return new XamlValueConverter<cm.TypeConverter>(typeof(EmptyConverter), Type);
 			}
 		}
 

--- a/src/Eto.sln
+++ b/src/Eto.sln
@@ -61,10 +61,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{95227DFB
 		..\NuGet.Config = ..\NuGet.Config
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Serialization.Json-pcl", "Eto.Serialization.Json\Eto.Serialization.Json-pcl.csproj", "{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}"
-EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Serialization.Xaml-pcl", "Eto.Serialization.Xaml\Eto.Serialization.Xaml-pcl.csproj", "{3D896993-E11E-4F9A-8040-56D0BD03E6B4}"
-EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Gtk", "Eto.Gtk\Eto.Gtk.csproj", "{659873CA-9949-4353-B0AA-E0589D045584}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.Gtk", "..\test\Eto.Test.Gtk\Eto.Test.Gtk.csproj", "{063AF7E7-18BD-488F-85BF-53B6E3D75685}"
@@ -335,30 +331,6 @@ Global
 		{E381E8CA-0DE1-4792-88F9-AC1529E911DF}.Release|Mac.Build.0 = Release|Any CPU
 		{E381E8CA-0DE1-4792-88F9-AC1529E911DF}.Release|Windows.ActiveCfg = Release|Any CPU
 		{E381E8CA-0DE1-4792-88F9-AC1529E911DF}.Release|Windows.Build.0 = Release|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Debug|Linux.ActiveCfg = Debug|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Debug|Linux.Build.0 = Debug|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Debug|Mac.ActiveCfg = Debug|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Debug|Mac.Build.0 = Debug|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Debug|Windows.ActiveCfg = Debug|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Debug|Windows.Build.0 = Debug|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Release|Linux.ActiveCfg = Release|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Release|Linux.Build.0 = Release|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Release|Mac.ActiveCfg = Release|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Release|Mac.Build.0 = Release|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Release|Windows.ActiveCfg = Release|Any CPU
-		{CC6339A8-E217-4D5F-89F1-A2506CBBFC47}.Release|Windows.Build.0 = Release|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Debug|Linux.ActiveCfg = Debug|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Debug|Linux.Build.0 = Debug|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Debug|Mac.ActiveCfg = Debug|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Debug|Mac.Build.0 = Debug|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Debug|Windows.ActiveCfg = Debug|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Debug|Windows.Build.0 = Debug|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Release|Linux.ActiveCfg = Release|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Release|Linux.Build.0 = Release|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Release|Mac.ActiveCfg = Release|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Release|Mac.Build.0 = Release|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Release|Windows.ActiveCfg = Release|Any CPU
-		{3D896993-E11E-4F9A-8040-56D0BD03E6B4}.Release|Windows.Build.0 = Release|Any CPU
 		{659873CA-9949-4353-B0AA-E0589D045584}.Debug|Linux.ActiveCfg = Debug|Any CPU
 		{659873CA-9949-4353-B0AA-E0589D045584}.Debug|Linux.Build.0 = Debug|Any CPU
 		{659873CA-9949-4353-B0AA-E0589D045584}.Debug|Mac.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION
- Eto.Serialization.Json and Xaml are now both .NET Standard 1.0
- Include .targets for json/xaml to embed the necessary files (when using sdk style csproj's) and set up DependentUpon
- Only generate mac bundle if not using a specific xamarin.mac or monomac project type