### PR TITLE
Protect from NRE crash in DropDown/ComboBox

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
@@ -88,6 +88,8 @@ namespace Eto.Wpf.Forms.Controls
 			foreach (var item in Items)
 			{
 				var comboBoxItem = (swc.ComboBoxItem)ItemContainerGenerator.ContainerFromItem(item);
+				if (comboBoxItem == null)
+					continue;
 				comboBoxItem.Measure(WpfConversions.PositiveInfinitySize);
 				maxWidth = Math.Max(maxWidth, comboBoxItem.DesiredSize.Width);
 			}


### PR DESCRIPTION
In some cases the comboBoxItem is null when updating the list dynamically.