### PR TITLE
Few fixes for .NET Core & Gtk

### DIFF
--- a/src/Shared/PlatformDetect.cs
+++ b/src/Shared/PlatformDetect.cs
@@ -23,7 +23,7 @@ namespace Eto
 			{
 				buf = Marshal.AllocHGlobal(8192);
 				if (uname(buf) == 0)
-					osName = Marshal.PtrToStringAuto(buf);
+					osName = Marshal.PtrToStringAnsi(buf);
 			}
 			// Analysis disable once EmptyGeneralCatchClause
 			catch
@@ -40,7 +40,7 @@ namespace Eto
 #if GTK3
 		public static Assembly GetCallingAssembly()
 		{
-			return (new StackTrace()).GetFrame(5).GetMethod().DeclaringType.Assembly;
+			return (new StackTrace()).GetFrame(4).GetMethod().DeclaringType.Assembly;
 		}
 #endif
 	}

--- a/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj
+++ b/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj
@@ -16,6 +16,13 @@
     <Optimize>true</Optimize>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
+    <StartAction>Project</StartAction>
+    <ExternalConsole>false</ExternalConsole>
+    <EnvironmentVariables>
+      <Variable name="DYLD_FALLBACK_LIBRARY_PATH" value="/usr/local/lib" />
+    </EnvironmentVariables>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Eto.Gtk\Eto.Gtk.csproj" />
     <ProjectReference Include="..\..\src\Eto\Eto.csproj" />


### PR DESCRIPTION
- Fix platform detection on .NET Core
- Fix getting (proper) calling assembly on Gtk platform
- Set up library fallback path so we can run Eto.Test.Gtk on macOS