### PR TITLE
Mac: Prevent crash when disposing an Image in use by ImageView

### DIFF
--- a/src/Eto.Mac/Forms/Controls/ImageViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ImageViewHandler.cs
@@ -62,7 +62,8 @@ namespace Eto.Mac.Forms.Controls
 
 		protected override SizeF GetNaturalSize(SizeF availableSize)
 		{
-			return image == null ? Size.Empty : image.Size;
+			// handler will be null if it was disposed while still in use.
+			return image == null || image.Handler == null ? Size.Empty : image.Size;
 		}
 
 		public Image Image


### PR DESCRIPTION
- Not really good to dispose of an image when it is currently being displayed by a user, but this prevents a crash from bad code.