### PR TITLE
Make it easier to create custom controls

### DIFF
--- a/build/MacTemplate/MacTemplate.targets
+++ b/build/MacTemplate/MacTemplate.targets
@@ -49,6 +49,9 @@
 			
 			<LauncherExecutable Condition="'$(LauncherExecutable)' == '' AND $(MacArch)=='x86_64'">$(ReferenceFiles)\Launcher64</LauncherExecutable>
 			<LauncherExecutable Condition="'$(LauncherExecutable)' == '' AND $(MacArch)=='i386'">$(ReferenceFiles)\Launcher32</LauncherExecutable>
+
+			<XamarinMacAssembly Condition="$(XamarinMacAssembly) == '' AND Exists('$(ReferenceFiles)\Xamarin.Mac.dll')">$(ReferenceFiles)\Xamarin.Mac.dll</XamarinMacAssembly>
+			<XamarinMacAssembly Condition="$(XamarinMacAssembly) == '' AND Exists('\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\lib\x86_64\full\Xamarin.Mac.dll')">\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\lib\x86_64\full\Xamarin.Mac.dll</XamarinMacAssembly>
 		</PropertyGroup>
 
 		<Message Text="Creating $(MacBundleName).app in target directory" Importance="high" />
@@ -62,7 +65,7 @@
 		<Copy SourceFiles="$(InputAppPath)\**\*.*" DestinationFolder="$(OutputContents)" SkipUnchangedFiles="true" Condition="Exists('$(InputAppPath)')" />
 		<Copy SourceFiles="$(LauncherExecutable)" DestinationFiles="$(LauncherFileWithPath)" SkipUnchangedFiles="true" />
 		<Copy SourceFiles="$(InputPListFile)" DestinationFiles="$(OutputPListFile)" Condition="!Exists('$(OutputPListFile)')" />
-		<Copy SourceFiles="$(ReferenceFiles)\Xamarin.Mac.dll" DestinationFolder="$(OutputMonoBundlePath)" SkipUnchangedFiles="true" Condition="$(HasXamMac) == 'True'" />
+		<Copy SourceFiles="$(XamarinMacAssembly)" DestinationFolder="$(OutputMonoBundlePath)" SkipUnchangedFiles="true" Condition="$(HasXamMac) == 'True'" />
 
 		<FindUnderPath  
             Files="@(FileWrites)"  

--- a/src/Eto.Direct2D/Platform.cs
+++ b/src/Eto.Direct2D/Platform.cs
@@ -8,10 +8,7 @@ namespace Eto.Direct2D
 {
 	public class Platform : Eto.WinForms.Platform
 	{
-		public override string ID
-		{
-			get { return Platforms.Direct2D; }
-		}
+		public override string ID => "Direct2D";
 
 		public override PlatformFeatures SupportedFeatures =>
 			base.SupportedFeatures & ~ PlatformFeatures.DrawableWithTransparentContent;

--- a/src/Eto.Gtk/Platform.cs
+++ b/src/Eto.Gtk/Platform.cs
@@ -48,14 +48,18 @@ namespace Eto.GtkSharp
 			}
 		}
 
-		#if GTK2
-		public override string ID { get { return "gtk2"; } }
-		#else
-		public override string ID { get { return "gtk3"; } }
+#if GTK2
+		public override string ID => "Gtk2";
+#else
+#if GTKCORE
+		public override string ID => "Gtk";
+#else
+		public override string ID => "Gtk3";
+#endif
 
 		public override PlatformFeatures SupportedFeatures => PlatformFeatures.DrawableWithTransparentContent;
 
-		#endif
+#endif
 		public Platform()
 		{
 			if (EtoEnvironment.Platform.IsWindows && Environment.Is64BitProcess)

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -42,10 +42,14 @@ namespace Eto.Mac
 
 		public override bool IsMac { get { return true; } }
 
-#if XAMMAC
-		public override string ID { get { return "xammac"; } }
+#if XAMMAC2
+		public override string ID { get { return "XamMac2"; } }
+#elif XAMMAC1
+		public override string ID { get { return "XamMac"; } }
+#elif Mac64
+		public override string ID { get { return "Mac64"; } }
 #else
-		public override string ID { get { return "mac"; } }
+		public override string ID { get { return "Mac"; } }
 #endif
 
 		public override PlatformFeatures SupportedFeatures =>

--- a/src/Eto.WinForms/Platform.cs
+++ b/src/Eto.WinForms/Platform.cs
@@ -22,7 +22,7 @@ namespace Eto.WinForms
 
 		public override bool IsWinForms { get { return true; } }
 
-		public override string ID { get { return "winforms"; } }
+		public override string ID => "WinForms";
 
 		public override PlatformFeatures SupportedFeatures =>
 			PlatformFeatures.DrawableWithTransparentContent;

--- a/src/Eto.Wpf/Platform.cs
+++ b/src/Eto.Wpf/Platform.cs
@@ -19,7 +19,7 @@ namespace Eto.Wpf
 {
 	public class Platform : Eto.Platform
 	{
-		public override string ID { get { return "wpf"; } }
+		public override string ID => "Wpf";
 
 		public override bool IsDesktop { get { return true; } }
 

--- a/src/Eto/ExportHandlerAttribute.cs
+++ b/src/Eto/ExportHandlerAttribute.cs
@@ -1,0 +1,50 @@
+using System;
+namespace Eto
+{
+	/// <summary>
+	/// Exports a handler from a 3rd party assembly.
+	/// </summary>
+	/// <remarks>
+	/// Use this to register a custom control from your custom assembly.
+	/// 
+	/// Use <see cref="ExportInitializerAttribute"/> when registering a lot of controls or to perform additional logic.
+	/// </remarks>
+	[System.AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = true)]
+	public sealed class ExportHandlerAttribute : PlatformExtensionAttribute
+	{
+		/// <summary>
+		/// Gets the type of the widget or handler interface to map to
+		/// </summary>
+		/// <value>The type of the widget or handler.</value>
+		public Type WidgetType { get; private set; }
+
+		/// <summary>
+		/// Gets the type of the handler to instantiate
+		/// </summary>
+		/// <value>The type of the handler for the widget.</value>
+		public Type HandlerType { get; private set; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.ExportHandlerAttribute"/> class.
+		/// </summary>
+		/// <param name="widgetType">Widget or handler interface type.</param>
+		/// <param name="handlerType">Handler that implements the widget's handler interface.</param>
+		public ExportHandlerAttribute(Type widgetType, Type handlerType)
+		{
+			WidgetType = widgetType ?? throw new ArgumentNullException(nameof(widgetType));
+			HandlerType = handlerType ?? throw new ArgumentNullException(nameof(handlerType));
+		}
+
+		/// <summary>
+		/// Registers the extension with the specified platform
+		/// </summary>
+		/// <returns><c>true</c>, if the extension was applied, <c>false</c> otherwise.</returns>
+		/// <param name="platform">Platform to register this extension with.</param>
+		public override void Register(Platform platform)
+		{
+			platform.Add(WidgetType, CreateHandler);
+		}
+
+		object CreateHandler() => Activator.CreateInstance(HandlerType);
+	}
+}

--- a/src/Eto/PlatformExtension.cs
+++ b/src/Eto/PlatformExtension.cs
@@ -1,0 +1,174 @@
+using System;
+using System.Reflection;
+namespace Eto
+{
+	/// <summary>
+	/// Attribute to apply to 3rd party assemblies to load additional controls or functionality.
+	/// </summary>
+	/// <remarks>
+	/// This can be used by both by the cross platform control library, and in each of the platform-specific libraries.
+	/// </remarks>
+	/// <example>
+	/// For example, say you want to create a new control, called <code>MyControl</code>, you would have a shared assembly, plus implementation assemblies for each platform.
+	/// 
+	/// MyControls.dll:
+	/// <code>
+	/// using Eto;
+	/// using Eto.Forms;
+	/// 
+	/// namespace MyControls
+	/// {
+	/// 	[Handler(typeof(IHandler))]
+	/// 	public class MyControl : Control
+	/// 	{
+	/// 		new IHandler Handler => base.Handler as IHandler;
+	/// 
+	/// 		public bool SomeProperty
+	/// 		{
+	/// 			get { return Handler.SomeProperty; }
+	/// 			set { Handler.SomeProperty = value; }
+	/// 		}
+	/// 
+	/// 		public new interface IHandler : IHandler
+	/// 		{
+	/// 			bool SomeProperty { get; set; }
+	/// 		}
+	/// 	}
+	/// }
+	/// </code>
+	/// 
+	/// MyControls.Wpf.dll:
+	/// <code>
+	/// using Eto;
+	/// using Eto.Forms;
+	/// using Eto.Wpf.Forms;
+	/// 
+	/// [assembly:ExportInitializer(typeof(MyControls.Wpf.MyPlatform))]
+	/// 
+	/// namespace MyControls.Wpf
+	/// {
+	/// 	class MyPlatform : IPlatformExtension
+	/// 	{
+	/// 		public Initialize(Platform platform)
+	/// 		{
+	/// 			platform.Add&lt;MyControl.IHandler&gt;(() => new MyControlHandler());
+	/// 		}
+	/// 	}
+	/// 
+	/// 	public class MyControlHandler : WpfFrameworkElement&lt;SomeWpfControl, MyControl, MyControl.ICallback>, MyControl.IHandler
+	/// 	{
+	/// 		public MyControlHandler()
+	/// 		{
+	/// 			Control = new SomeWpfControl();
+	/// 		}
+	/// 
+	/// 		// TODO:
+	/// 		public bool SomeProperty
+	/// 		{
+	/// 			get { return false; }
+	/// 			set { }
+	/// 		}
+	/// 	}
+	/// }
+	/// </code>
+	/// </example>
+	[System.AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = true)]
+	public sealed class ExportInitializerAttribute : PlatformExtensionAttribute
+	{
+		/// <summary>
+		/// Type of the extension class to instantiate when the assembly this attribute is supplied on is loaded by the platform.
+		/// </summary>
+		/// <remarks>
+		/// This type should usually implement <see cref="IPlatformInitializer"/> so that it can know what platform it is being loaded on.
+		/// </remarks>
+		/// <value>The type of the extension.</value>
+		public Type InitializerType { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the PlatformInitializerAttribute class
+		/// </summary>
+		/// <param name="initializerType">Type of the initializer to create</param>
+		public ExportInitializerAttribute(Type initializerType)
+		{
+			InitializerType = initializerType ?? throw new ArgumentNullException(nameof(initializerType));
+		}
+
+		/// <summary>
+		/// Registers the extension with the specified platform
+		/// </summary>
+		/// <returns><c>true</c>, if the extension was applied, <c>false</c> otherwise.</returns>
+		/// <param name="platform">Platform to register this extension with.</param>
+		public override void Register(Platform platform)
+		{
+			var extension = Activator.CreateInstance(InitializerType) as IPlatformInitializer;
+			extension?.Initialize(platform);
+			platform.SetSharedProperty(this, extension);
+		}
+	}
+
+	/// <summary>
+	/// Platform extension for 3rd party libraries to provide additional controls or functionality
+	/// </summary>
+	/// <remarks>
+	/// This is implemented for types that are referenced using the <see cref="ExportInitializerAttribute"/>.
+	/// </remarks>
+	public interface IPlatformInitializer
+	{
+		/// <summary>
+		/// Called to add specific functionality to the specified <paramref name="platform"/>
+		/// </summary>
+		/// <param name="platform">Platform to add the extension to</param>
+		void Initialize(Platform platform);
+	}
+
+	/// <summary>
+	/// Base extension attribute to wire up 3rd party controls and native handler implementations.
+	/// </summary>
+	/// <remarks>
+	/// All extensions are loaded via <see cref="Platform.LoadAssembly(Assembly)"/>.  
+	/// 
+	/// Use the <see cref="PlatformID"/> property to specify which platform the extension applies to.
+	/// </remarks>
+	[System.AttributeUsage(AttributeTargets.Assembly, Inherited = false, AllowMultiple = true)]
+	public abstract class PlatformExtensionAttribute : Attribute
+	{
+		/// <summary>
+		/// Gets or sets the platform identifier this extension should be loaded on, or null to load for all platforms.
+		/// </summary>
+		/// <value>The platform identifier.</value>
+		public string PlatformID { get; set; }
+
+		/// <summary>
+		/// Gets a value indicating that this extension supports the specified platform.
+		/// </summary>
+		/// <remarks>
+		/// <see cref="Register"/> will only be called if this returns <c>true</c>.
+		/// </remarks>
+		/// <returns><c>true</c>, if this extension supports the specified platform, <c>false</c> otherwise.</returns>
+		/// <param name="platform">Platform to determine if this extension applies.</param>
+		public virtual bool Supports(Platform platform)
+		{
+			if (string.IsNullOrEmpty(PlatformID) || platform.ID == PlatformID)
+				return true;
+			// support using the Eto.Platforms.* values
+			var type = platform.GetType();
+			while (type != null)
+			{
+				if (type.AssemblyQualifiedName == PlatformID)
+					return true;
+				type = type.GetBaseType();
+			}
+			return false;
+		}
+
+		/// <summary>
+		/// Registers the extension with the specified platform
+		/// </summary>
+		/// <returns><c>true</c>, if the extension was applied, <c>false</c> otherwise.</returns>
+		/// <param name="platform">Platform to register this extension with.</param>
+		public abstract void Register(Platform platform);
+	}
+
+	
+
+}


### PR DESCRIPTION
- Automatically register custom control assembly and platform-specific assembly, if found
- Platform ID's now need to match the platform suffix (e.g. Wpf, WinForms, Mac, XamMac2, etc).
- Added new ExportHandlerAttribute and ExportInitializerAttribute to register handlers and perform logic when loaded with a platform