### PR TITLE
[Gtk] Fix setting messagebox text

### DIFF
--- a/src/Eto.Gtk/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/MessageBoxHandler.cs
@@ -23,7 +23,8 @@ namespace Eto.GtkSharp.Forms
 			if (parent != null && parent.ParentWindow != null)
 				parentWindow = parent.ParentWindow.ControlObject as Gtk.Window;
 
-			control = new Gtk.MessageDialog(parentWindow, Gtk.DialogFlags.Modal, Type.ToGtk(), Buttons.ToGtk(), false, Text);
+			control = new Gtk.MessageDialog(parentWindow, Gtk.DialogFlags.Modal, Type.ToGtk(), Buttons.ToGtk(), false, string.Empty);
+			control.Text = Text;
 			control.TypeHint = Gdk.WindowTypeHint.Dialog;
 			var caption = Caption ?? ((parent != null && parent.ParentWindow != null) ? parent.ParentWindow.Title : null);
 			if (!string.IsNullOrEmpty(caption))


### PR DESCRIPTION
The constructor for the messagedialog does not take in a text param, but instead a string format. In case you were to use `{ }` in any way this would cause a crash.