### PR TITLE
[Gtk] Remove redundant setting of minimal size

### DIFF
--- a/src/Eto.Gtk/Forms/Cells/CheckBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/CheckBoxCellHandler.cs
@@ -36,8 +36,6 @@ namespace Eto.GtkSharp.Forms.Cells
 			protected override void OnGetPreferredHeight(Gtk.Widget widget, out int minimum_size, out int natural_size)
 			{
 				base.OnGetPreferredHeight(widget, out minimum_size, out natural_size);
-
-				minimum_size = Math.Max(minimum_size, Handler.Source.RowHeight);
 				natural_size = Handler.Source.RowHeight;
 			}
 #endif

--- a/src/Eto.Gtk/Forms/Cells/ComboBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ComboBoxCellHandler.cs
@@ -41,8 +41,6 @@ namespace Eto.GtkSharp.Forms.Cells
 			protected override void OnGetPreferredHeight(Gtk.Widget widget, out int minimum_size, out int natural_size)
 			{
 				base.OnGetPreferredHeight(widget, out minimum_size, out natural_size);
-
-				minimum_size = Math.Max(minimum_size, Handler.Source.RowHeight);
 				natural_size = Handler.Source.RowHeight;
 			}
 #endif

--- a/src/Eto.Gtk/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/CustomCellHandler.cs
@@ -136,8 +136,6 @@ namespace Eto.GtkSharp.Forms.Cells
 			protected override void OnGetPreferredHeight(Gtk.Widget widget, out int minimum_size, out int natural_size)
 			{
 				base.OnGetPreferredHeight(widget, out minimum_size, out natural_size);
-
-				minimum_size = Math.Max(minimum_size, Handler.Source.RowHeight);
 				natural_size = Handler.Source.RowHeight;
 			}
 			

--- a/src/Eto.Gtk/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/DrawableCellHandler.cs
@@ -47,8 +47,6 @@ namespace Eto.GtkSharp.Forms.Cells
 			protected override void OnGetPreferredHeight(Gtk.Widget widget, out int minimum_size, out int natural_size)
 			{
 				base.OnGetPreferredHeight(widget, out minimum_size, out natural_size);
-
-				minimum_size = Math.Max(minimum_size, Handler.Source.RowHeight);
 				natural_size = Handler.Source.RowHeight;
 			}
 			

--- a/src/Eto.Gtk/Forms/Cells/ImageViewCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ImageViewCellHandler.cs
@@ -34,8 +34,6 @@ namespace Eto.GtkSharp.Forms.Cells
 			protected override void OnGetPreferredHeight(Gtk.Widget widget, out int minimum_size, out int natural_size)
 			{
 				base.OnGetPreferredHeight(widget, out minimum_size, out natural_size);
-
-				minimum_size = Math.Max(minimum_size, Handler.Source.RowHeight);
 				natural_size = Handler.Source.RowHeight;
 			}
 #endif

--- a/src/Eto.Gtk/Forms/Cells/ProgressCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ProgressCellHandler.cs
@@ -46,8 +46,6 @@ namespace Eto.GtkSharp.Forms.Cells
 			protected override void OnGetPreferredHeight(Gtk.Widget widget, out int minimum_size, out int natural_size)
 			{
 				base.OnGetPreferredHeight(widget, out minimum_size, out natural_size);
-
-				minimum_size = Math.Max(minimum_size, Handler.Source.RowHeight);
 				natural_size = Handler.Source.RowHeight;
 			}
 

--- a/src/Eto.Gtk/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/TextBoxCellHandler.cs
@@ -97,8 +97,6 @@ namespace Eto.GtkSharp.Forms.Cells
 			protected override void OnGetPreferredHeight(Gtk.Widget widget, out int minimum_size, out int natural_size)
 			{
 				base.OnGetPreferredHeight(widget, out minimum_size, out natural_size);
-
-				minimum_size = Math.Max(minimum_size, Handler.Source.RowHeight);
 				natural_size = Handler.Source.RowHeight;
 			}
 #endif


### PR DESCRIPTION
We were either setting it to itself or the default size value which it will be autosized to anyways.