### PR TITLE
Make GridColumn.Sortable consistent across platforms

### DIFF
--- a/src/Eto.WinForms/Forms/Controls/GridHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridHandler.cs
@@ -219,7 +219,11 @@ namespace Eto.WinForms.Forms.Controls
 			switch (id)
 			{
 				case Grid.ColumnHeaderClickEvent:
-					Control.ColumnHeaderMouseClick += (sender, e) => Callback.OnColumnHeaderClick(Widget, new GridColumnEventArgs(Widget.Columns[e.ColumnIndex]));
+					Control.ColumnHeaderMouseClick += (sender, e) =>
+					{
+						if (e.ColumnIndex >= 0 && columns.Collection[e.ColumnIndex].Sortable)
+							Callback.OnColumnHeaderClick(Widget, new GridColumnEventArgs(Widget.Columns[e.ColumnIndex]));
+					};
 					break;
 				case Grid.CellEditingEvent:
 					Control.CellBeginEdit += (sender, e) =>

--- a/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
@@ -29,6 +29,7 @@ namespace Eto.Wpf.Forms.Controls
 			base.Initialize();
 			DataCell = new TextBoxCell();
 			Editable = false;
+			Sortable = false;
 		}
 
 		public string HeaderText


### PR DESCRIPTION
Should be false by default, which should also not trigger GridView.ColumnHeaderClick when false.

Fixes #894 
