### PR TITLE
[Gtk] Fix Linux NotificationHandler

### DIFF
--- a/src/Eto.Gtk/Eto.Gtk.csproj
+++ b/src/Eto.Gtk/Eto.Gtk.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.22.24.29" />
+    <PackageReference Include="GtkSharp" Version="3.22.24.30" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eto\Eto.csproj" />

--- a/src/Eto.Gtk/Forms/LinuxNotificationHandler.cs
+++ b/src/Eto.Gtk/Forms/LinuxNotificationHandler.cs
@@ -10,6 +10,7 @@ namespace Eto.GtkSharp.Forms
 {
 	class NotificationWrapper : GLib.Object
 	{
+#if !GTK2
 		public delegate void ClosedHandler(object o, EventArgs args);
         public event ClosedHandler Closed
         {
@@ -22,11 +23,14 @@ namespace Eto.GtkSharp.Forms
                 this.RemoveSignalHandler("closed", value);
             }
         }
+#endif
 
 		public NotificationWrapper(IntPtr handle) : base(handle)
 		{
-
+			
 		}
+
+
 	}
 
     public class LinuxNotificationHandler : WidgetHandler<IntPtr, Notification, Notification.ICallback>, Notification.IHandler
@@ -150,11 +154,13 @@ namespace Eto.GtkSharp.Forms
 			// Empty string will show the default icon, while an incorrect one will show no icon			
 			var notification = new NotificationWrapper(notify_notification_new(Title, Message, iconPath ?? "???"));
 			var data = Marshal.StringToHGlobalUni(ID + (char)1 + UserData);
+#if !GTK2
 			notification.Closed += (sender, e) =>
 			{
 				Marshal.FreeHGlobal(data);
 				notification.Dispose();
 			};
+#endif
 
 			if (allowactions)
 			{


### PR DESCRIPTION
Stuff done:
- fix up a crash where the object could get disposed before the activate event occurred 
- don't use generics for Delegate marshaling (does not work with .NET Core it seems)
- create a separate notification object for each notification so that something like this does not happen:
```c#
var n = new Notification();
n.ID = 4;
n.Show();
n.ID = 6;
// activate the existing notification, ID is 6
```
