### PR TITLE
Mac: Fix Tree/GridView.ContextMenu when changing the menu when being opened.

### DIFF
--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -577,19 +577,20 @@ namespace Eto.Mac.Forms.Controls
 				if (old != null)
 				{
 					old.Opening -= ContextMenu_Opening;
-					old.Closed -= ContextMenu_Closed;
 				}
 				base.ContextMenu = value;
 				if (value != null)
 				{
 					value.Opening += ContextMenu_Opening;
-					value.Closed += ContextMenu_Closed;
 				}
 			}
 		}
 
 		void ContextMenu_Closed(object sender, EventArgs e)
 		{
+			var menu = (ContextMenu)sender;
+			menu.Closed -= ContextMenu_Closed;
+
 			// action is called after this, so we can't clear selected rows immediately
 			if (CustomSelectedRows != null)
 			{
@@ -606,6 +607,8 @@ namespace Eto.Mac.Forms.Controls
 			var row = (int)Control.ClickedRow;
 			if (!SelectedRows.Contains(row))
 			{
+				var menu = (ContextMenu)sender;
+				menu.Closed += ContextMenu_Closed;
 				CustomSelectedRows = new[] { row };
 				Callback.OnSelectionChanged(Widget, EventArgs.Empty);
 			}

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -950,19 +950,20 @@ namespace Eto.Mac.Forms.Controls
 				if (old != null)
 				{
 					old.Opening -= ContextMenu_Opening;
-					old.Closed -= ContextMenu_Closed;
 				}
 				base.ContextMenu = value;
 				if (value != null)
 				{
 					value.Opening += ContextMenu_Opening;
-					value.Closed += ContextMenu_Closed;
 				}
 			}
 		}
 
 		void ContextMenu_Closed(object sender, EventArgs e)
 		{
+			var menu = (ContextMenu)sender;
+			menu.Closed -= ContextMenu_Closed;
+
 			// action is called after this, so we can't clear selected items immediately
 			if (CustomSelectedItems != null)
 			{
@@ -979,6 +980,8 @@ namespace Eto.Mac.Forms.Controls
 			var row = (int)Control.ClickedRow;
 			if (!SelectedRows.Contains(row))
 			{
+				var menu = (ContextMenu)sender;
+				menu.Closed += ContextMenu_Closed;
 				CustomSelectedItems = new[] { GetItem(row) };
 				Callback.OnSelectionChanged(Widget, EventArgs.Empty);
 			}


### PR DESCRIPTION
It would keep the last selection and not respond to selection changes anymore.