### PR TITLE
Mac: Fire SizeChanged events for controls that override SetFrameSize

### DIFF
--- a/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
@@ -103,11 +103,18 @@ namespace Eto.Mac.Forms.Controls
 			public override void SetFrameSize(CGSize newSize)
 			{
 				base.SetFrameSize(newSize);
+				var h = Handler;
+				if (h == null)
+					return;
+				
 				if (setBezel)
 				{
 					setBezel = false;
-					Handler.SetBezel();
+					h.SetBezel();
 				}
+
+				h.OnSizeChanged(EventArgs.Empty);
+				h.Callback.OnSizeChanged(h.Widget, EventArgs.Empty);
 			}
 
 			public EtoButton()

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -45,9 +45,9 @@ using nnint = System.UInt32;
 
 namespace Eto.Mac.Forms.Controls
 {
-	public interface IGridHandler
+	public interface IGridHandler : IMacViewHandler
 	{
-		Grid Widget { get; }
+		new Grid Widget { get; }
 
 		NSTableView Table { get; }
 
@@ -65,11 +65,16 @@ namespace Eto.Mac.Forms.Controls
 		public override void SetFrameSize(CGSize newSize)
 		{
 			base.SetFrameSize(newSize);
+			var h = Handler;
+			if (h == null)
+				return;
 
 			if (!autoSized)
 			{
-				autoSized = Handler.AutoSizeColumns(false);
+				autoSized = h.AutoSizeColumns(false);
 			}
+			h.OnSizeChanged(EventArgs.Empty);
+			h.Callback.OnSizeChanged(h.Widget, EventArgs.Empty);
 		}
 	}
 
@@ -508,10 +513,7 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		Grid IGridHandler.Widget
-		{
-			get { return Widget; }
-		}
+		Grid IGridHandler.Widget => Widget;
 
 		public CGRect GetVisibleRect()
 		{

--- a/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
@@ -75,6 +75,14 @@ namespace Eto.Mac.Forms.Controls
 					base.BorderType = _borderType.Value;
 			}
 			base.SetFrameSize(newSize);
+
+
+			var h = Handler as IMacViewHandler;
+			if (h == null)
+				return;
+
+			h.OnSizeChanged(EventArgs.Empty);
+			h.Callback.OnSizeChanged(h.Widget, EventArgs.Empty);
 		}
 	}
 

--- a/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
@@ -81,6 +81,13 @@ namespace Eto.Mac.Forms.Controls
 				text.SetFrameSize(new CGSize((float)(newSize.Width - splitter.Frame.Width), (float)text.Frame.Height));
 				offset = (newSize.Height - splitter.Frame.Height) / 2;
 				splitter.SetFrameOrigin(new CGPoint(newSize.Width - splitter.Frame.Width, offset));
+
+				var h = WeakHandler?.Target as IMacViewHandler;
+				if (h == null)
+					return;
+				
+				h.OnSizeChanged(EventArgs.Empty);
+				h.Callback.OnSizeChanged(h.Widget, EventArgs.Empty);
 			}
 
 			public EtoNumericStepperView(NumericStepperHandler handler)


### PR DESCRIPTION
- GridView, TreeGridView, TreeView, ListBox, Button, and NumericStepper didn't fire these events.