### PR TITLE
Fix regression when binding to internal properties

### DIFF
--- a/src/Eto/Forms/Binding/PropertyBinding.cs
+++ b/src/Eto/Forms/Binding/PropertyBinding.cs
@@ -21,6 +21,7 @@ namespace Eto.Forms
 	{
 #if PCL
 		PropertyInfo descriptor;
+		Type declaringType;
 #else
 		PropertyDescriptor descriptor;
 #endif
@@ -65,20 +66,31 @@ namespace Eto.Forms
 		void EnsureProperty(object dataItem)
 		{
 #if PCL
-			if (dataItem != null && (descriptor == null || !descriptor.DeclaringType.IsInstanceOfType(dataItem)))
+			if (dataItem != null 
+				&& (
+					// if not found previously, don't always try to find it if the declaring type is the same
+					(descriptor == null && declaringType == null)
+				    // found previously but incompatible type
+					|| !declaringType.IsInstanceOfType(dataItem))
+				)
 			{
-				descriptor = dataItem.GetType().GetRuntimeProperty(Property);
-				if (descriptor == null && IgnoreCase)
+				var dataItemType = dataItem.GetType();
+				// find public property
+				descriptor = dataItemType.GetRuntimeProperty(Property);
+				if (descriptor == null)
 				{
-					foreach (var prop in dataItem.GetType().GetRuntimeProperties())
+					// iterate to find non-public properties or with different case
+					var comparison = IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+					foreach (var prop in dataItemType.GetRuntimeProperties())
 					{
-						if (string.Equals(prop.Name, Property, StringComparison.OrdinalIgnoreCase))
+						if (string.Equals(prop.Name, Property, comparison))
 						{
 							descriptor = prop;
 							break;
 						}
 					}
 				}
+				declaringType = descriptor?.DeclaringType ?? dataItemType;
 			}
 #else
 			if (dataItem != null && (descriptor == null || !descriptor.ComponentType.IsInstanceOfType(dataItem)))

--- a/test/Eto.Test/UnitTests/Forms/Binding/ObjectBindingChangedTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Binding/ObjectBindingChangedTests.cs
@@ -90,6 +90,17 @@ namespace Eto.Test.UnitTests.Forms.Binding
 			}
 		}
 
+		string internalStringProperty;
+		internal string InternalStringProperty
+		{
+			get { return internalStringProperty; }
+			set
+			{
+				internalStringProperty = value;
+				OnPropertyChanged(nameof(InternalStringProperty));
+			}
+		}
+
 		public event PropertyChangedEventHandler PropertyChanged;
 
 		protected void OnPropertyChanged(string propertyName)

--- a/test/Eto.Test/UnitTests/Forms/Binding/PropertyBindingTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Binding/PropertyBindingTests.cs
@@ -127,5 +127,23 @@ namespace Eto.Test.UnitTests.Forms.Binding
 			Assert.DoesNotThrow(() => binding.SetValue(item, 123));
 			binding.RemoveValueChangedHandler(changeReference, valueChanged);
 		}
+
+		[Test]
+		public void InternalPropertyShouldBeAccessible()
+		{
+			var item = new BindObject { InternalStringProperty = "some value" };
+			var binding = Eto.Forms.Binding.Property<string>("InternalStringProperty");
+
+			int changed = 0;
+			EventHandler<EventArgs> valueChanged = (sender, e) => changed++;
+			var changeReference = binding.AddValueChangedHandler(item, valueChanged);
+
+			Assert.AreEqual(0, changed);
+			Assert.AreEqual("some value", binding.GetValue(item));
+			Assert.DoesNotThrow(() => binding.SetValue(item, "some other value"));
+			Assert.AreEqual(1, changed);
+			Assert.AreEqual("some other value", binding.GetValue(item));
+			binding.RemoveValueChangedHandler(changeReference, valueChanged);
+		}
 	}
 }


### PR DESCRIPTION
- It worked before even though probably not correct, and don't want to break existing code.
- Also optimize when property is not found to only search once, unless the dataItem type has changed.