### PR TITLE
[WPF] fix for issue #1041: Corresponds to SynchronizationContext at the Application creation stage.

### DIFF
--- a/src/Eto.Wpf/Forms/ApplicationHandler.cs
+++ b/src/Eto.Wpf/Forms/ApplicationHandler.cs
@@ -83,6 +83,9 @@ namespace Eto.Wpf.Forms
 
 		protected override void Initialize()
 		{
+			if (SynchronizationContext.Current == null)
+				SynchronizationContext.SetSynchronizationContext(new DispatcherSynchronizationContext());
+
 			Control = sw.Application.Current;
 			if (Control == null)
 			{


### PR DESCRIPTION
In WPF, DispatcherSynchronizationContext is normally set in Application.Run() ( or Dispatcher.Run()). However, if you do a process that depends on SynchronizationContext before that, we will get unintended behavior. So we fixed it to set it at initialization of Eto.Forms.Application.

Although 'Launching a WPF Window in a Separate Thread'[1] talks about a new thread, it is in the same state as immediately after the main function is started.

## Reference
[1] [Launching a WPF Window in a Separate Thread, Part 1](http://reedcopsey.com/2011/11/28/launching-a-wpf-window-in-a-separate-thread-part-1/)