### PR TITLE
Remove use of deprecated AppKit API

### DIFF
--- a/src/Eto.Mac/Forms/Controls/MacButton.cs
+++ b/src/Eto.Mac/Forms/Controls/MacButton.cs
@@ -55,7 +55,7 @@ namespace Eto.Mac.Forms.Controls
 
 		void SetText(string text)
 		{
-			Control.SetTitleWithMnemonic(text ?? string.Empty);
+			Control.Title = MacConversions.StripAmpersands(text ?? string.Empty);
 			var color = Widget.Properties.Get<Color?>(textColorKey);
 			if (color != null)
 			{

--- a/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
@@ -72,7 +72,16 @@ namespace Eto.Mac.Forms.Menu
 			set
 			{ 
 				text = value;
-				Control.SetTitleWithMnemonic(value ?? string.Empty);
+
+				string title = value ?? string.Empty;
+				if (title.Length > 0)
+				{
+					title = title.Replace("&&", "\x01");
+					title = title.Replace("&", "");
+					title = title.Replace("\x01", "&");
+				}
+
+				Control.Title = title;
 				if (Control.HasSubmenu)
 					Control.Submenu.Title = Control.Title;
 			}

--- a/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
@@ -73,15 +73,7 @@ namespace Eto.Mac.Forms.Menu
 			{ 
 				text = value;
 
-				string title = value ?? string.Empty;
-				if (title.Length > 0)
-				{
-					title = title.Replace("&&", "\x01");
-					title = title.Replace("&", "");
-					title = title.Replace("\x01", "&");
-				}
-
-				Control.Title = title;
+				Control.Title = MacConversions.StripAmpersands(value ?? string.Empty);
 				if (Control.HasSubmenu)
 					Control.Submenu.Title = Control.Title;
 			}

--- a/src/Eto.Mac/Forms/Menu/CheckMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/CheckMenuItemHandler.cs
@@ -44,7 +44,18 @@ namespace Eto.Mac.Forms.Menu
 		public string Text
 		{
 			get	{ return Control.Title; }
-			set { Control.SetTitleWithMnemonic(value ?? string.Empty); }
+			set
+			{
+				string title = value ?? string.Empty;
+				if (title.Length > 0)
+				{
+					title = title.Replace("&&", "\x01");
+					title = title.Replace("&", "");
+					title = title.Replace("\x01", "&");
+				}
+
+				Control.Title = title;
+			}
 		}
 
 		public string ToolTip

--- a/src/Eto.Mac/Forms/Menu/CheckMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/CheckMenuItemHandler.cs
@@ -44,18 +44,7 @@ namespace Eto.Mac.Forms.Menu
 		public string Text
 		{
 			get	{ return Control.Title; }
-			set
-			{
-				string title = value ?? string.Empty;
-				if (title.Length > 0)
-				{
-					title = title.Replace("&&", "\x01");
-					title = title.Replace("&", "");
-					title = title.Replace("\x01", "&");
-				}
-
-				Control.Title = title;
-			}
+			set { Control.Title = MacConversions.StripAmpersands(value ?? string.Empty); }
 		}
 
 		public string ToolTip

--- a/src/Eto.Mac/Forms/Menu/RadioMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/RadioMenuItemHandler.cs
@@ -71,18 +71,7 @@ namespace Eto.Mac.Forms.Menu
 		public string Text
 		{
 			get	{ return Control.Title; }
-			set
-			{
-				string title = value ?? string.Empty;
-				if (title.Length > 0)
-				{
-					title = title.Replace("&&", "\x01");
-					title = title.Replace("&", "");
-					title = title.Replace("\x01", "&");
-				}
-
-				Control.Title = title;
-			}
+			set => Control.Title = MacConversions.StripAmpersands(value ?? string.Empty);
 		}
 
 		public string ToolTip

--- a/src/Eto.Mac/Forms/Menu/RadioMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/RadioMenuItemHandler.cs
@@ -71,7 +71,18 @@ namespace Eto.Mac.Forms.Menu
 		public string Text
 		{
 			get	{ return Control.Title; }
-			set { Control.SetTitleWithMnemonic(value ?? string.Empty); }
+			set
+			{
+				string title = value ?? string.Empty;
+				if (title.Length > 0)
+				{
+					title = title.Replace("&&", "\x01");
+					title = title.Replace("&", "");
+					title = title.Replace("\x01", "&");
+				}
+
+				Control.Title = title;
+			}
 		}
 
 		public string ToolTip

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -522,5 +522,15 @@ namespace Eto.Mac
 		}
 
 		public static NSMenu ToNS(this ContextMenu menu) => ContextMenuHandler.GetControl(menu);
+
+		internal static string StripAmpersands(string text)
+		{
+			if (string.IsNullOrEmpty(text)) return text;
+
+			text = text.Replace("&&", "\x01");
+			text = text.Replace("&", "");
+			text = text.Replace("\x01", "&");
+			return text;
+		}
 	}
 }


### PR DESCRIPTION
Use of such APIs may be cause for rejection if submitting to the Mac App Store.

Note that I copy/pasted the ampersand-removal algorithm into the three places where it was needed. If you have a better idea of a better, more common location, please let me know. Thanks!