### PR TITLE
Wpf: Fix Graphics.ImageInterpolation

### DIFF
--- a/src/Eto.Wpf/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Wpf/Drawing/GraphicsHandler.cs
@@ -388,9 +388,13 @@ namespace Eto.Wpf.Drawing
 			get { return Widget.Properties.Get<ImageInterpolation>(ImageInterpolation_Key); }
 			set
 			{
-				Widget.Properties.Set(ImageInterpolation_Key, value, () => {
-					swm.RenderOptions.SetBitmapScalingMode(visual, value.ToWpf());
-				});
+				if (value != ImageInterpolation)
+				{
+					CloseGroup();
+					CreateGroup();
+					Widget.Properties.Set(ImageInterpolation_Key, value);
+					swm.RenderOptions.SetBitmapScalingMode(group, value.ToWpf());
+				}
 			}
 		}
 

--- a/test/Eto.Test/UnitTests/Drawing/GraphicsTests.cs
+++ b/test/Eto.Test/UnitTests/Drawing/GraphicsTests.cs
@@ -1,4 +1,4 @@
-﻿using Eto.Drawing;
+using Eto.Drawing;
 using NUnit.Framework;
 using System;
 using System.Collections.Generic;
@@ -51,6 +51,99 @@ namespace Eto.Test.UnitTests.Drawing
 				Assert.AreEqual(Colors.Green, bd.GetPixel(10, 0), "#2");
 				Assert.AreEqual(Colors.Blue, bd.GetPixel(20, 0), "#3");
 				Assert.AreEqual(Colors.Yellow, bd.GetPixel(30, 0), "#4");
+			}
+		}
+
+		/// <summary>
+		/// Ensure that ImageInterpolation can be set to different values in one context
+		/// </summary>
+		[Test]
+		public void ImageInterpolationShouldBeIndependent()
+		{
+			// let's create a teeny tiny bitmap
+			var bmp = new Bitmap(2, 2, PixelFormat.Format32bppRgb);
+			using (var bd = bmp.Lock())
+			{
+				// b b
+				// r b
+				bd.SetPixel(0, 0, Colors.Blue);
+				bd.SetPixel(1, 0, Colors.Blue);
+				bd.SetPixel(1, 1, Colors.Blue);
+				bd.SetPixel(0, 1, Colors.Red);
+			}
+
+			// now, let's draw it and ensure it isn't interpolated
+			var bmp2 = new Bitmap(200, 200, PixelFormat.Format32bppRgb);
+			using (var g = new Graphics(bmp2))
+			{
+				g.PixelOffsetMode = PixelOffsetMode.None;
+				g.ImageInterpolation = ImageInterpolation.Default;
+				g.DrawImage(bmp, 0, 0, 100, 100);
+				g.ImageInterpolation = ImageInterpolation.None;
+				g.DrawImage(bmp, 100, 0, 100, 100);
+				g.ImageInterpolation = ImageInterpolation.Default;
+				g.DrawImage(bmp, 0, 100, 100, 100);
+				g.ImageInterpolation = ImageInterpolation.None;
+				g.DrawImage(bmp, 100, 100, 100, 100);
+			}
+
+			void hasBlue(Color c)
+			{
+				Assert.Greater(c.B, 0);
+				Assert.AreEqual(0, c.G);
+				Assert.AreEqual(0, c.R);
+			}
+
+			void hasRed(Color c)
+			{
+				Assert.AreEqual(0, c.B);
+				Assert.AreEqual(0, c.G);
+				Assert.Greater(c.R, 0);
+			}
+
+			void hasRedAndBlue(Color c)
+			{
+				Assert.Greater(c.B, 0);
+				Assert.AreEqual(0, c.G);
+				Assert.Greater(c.R, 0);
+			}
+
+			void checkInterpolated(BitmapData bd, int x, int y)
+			{
+				// upper left should be blue ish
+				hasBlue(bd.GetPixel(x + 0, y + 0));
+				hasBlue(bd.GetPixel(x + 99, y + 0));
+
+				// check the middle (ish) of the lower left corner which should both red and blue components
+				hasRedAndBlue(bd.GetPixel(x + 25, y + 75));
+
+				hasRed(bd.GetPixel(x + 0, y + 99));
+			}
+
+			void checkNonInterpolated(BitmapData bd, int x, int y)
+			{
+				Assert.AreEqual(Colors.Blue, bd.GetPixel(x + 0, y + 0));
+				Assert.AreEqual(Colors.Blue, bd.GetPixel(x + 99, y + 0));
+				Assert.AreEqual(Colors.Blue, bd.GetPixel(x + 50, y + 50));
+				Assert.AreEqual(Colors.Blue, bd.GetPixel(x + 50, y + 49));
+				Assert.AreEqual(Colors.Blue, bd.GetPixel(x + 49, y + 49));
+				Assert.AreEqual(Colors.Red, bd.GetPixel(x + 49, y + 51));
+				Assert.AreEqual(Colors.Red, bd.GetPixel(x + 0, y + 99));
+			}
+
+			using (var bd = bmp2.Lock())
+			{
+				// default, should be interpolated 50,50 is somewhere inbetween red and blue
+				checkInterpolated(bd, 0, 0);
+
+				// no interpolation in upper right
+				checkNonInterpolated(bd, 100, 0);
+
+				// default again, should be interpolated 50,150 is somewhere inbetween red and blue
+				checkInterpolated(bd, 0, 100);
+
+				// no interpolation again in lower right
+				checkNonInterpolated(bd, 100, 100);
 			}
 		}
 	}


### PR DESCRIPTION
- It applied to all drawing operations so changing it to draw a single image didn't work
- Add unit test