### PR TITLE
Mac: WeakHandler can be null (e.g. control disposed or other cases)

### DIFF
--- a/src/Eto.Mac/MacHelpers.cs
+++ b/src/Eto.Mac/MacHelpers.cs
@@ -145,8 +145,8 @@ namespace Eto.Forms
 			var control = client as IMacControl;
 			if (control != null)
 			{
-				var childHandler = control.WeakHandler.Target as IMacViewHandler;
-				if (childHandler != null)
+				var childHandler = control.WeakHandler?.Target as IMacViewHandler;
+				if (childHandler?.Widget != null)
 				{
 					var fieldEditor = childHandler.Widget.Properties.Get<NSObject>(FieldEditor_Key);
 					if (fieldEditor == null)


### PR DESCRIPTION
- Fixes issue when integrating into a native window and you want to get the field editor for the control.