### PR TITLE
Mac: Use FittingSize for native NSView's preferred size

### DIFF
--- a/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
@@ -51,7 +51,7 @@ namespace Eto.Mac.Forms.Controls
 
 		public override SizeF GetPreferredSize(SizeF availableSize)
 		{
-			return Control.Frame.Size.ToEto();
+			return Control.FittingSize.ToEto();
 		}
 
 		public NativeControlHandler(NSViewController nativeControl)


### PR DESCRIPTION
The NSView would never shrink back down if it is sized to a larger size.