### PR TITLE
RichTextArea FontTypeface implementation

### DIFF
--- a/src/Eto.Gtk/Drawing/FontsHandler.cs
+++ b/src/Eto.Gtk/Drawing/FontsHandler.cs
@@ -15,8 +15,8 @@ namespace Eto.GtkSharp.Drawing
 			get
 			{
 				if (context == null) {
-					var window = new Gtk.Window (string.Empty);
-					context = window.PangoContext;
+					var label = new Gtk.Label();
+					context = label.PangoContext;
 				}
 				return context;
 			}

--- a/src/Eto.Gtk/Eto.Gtk.csproj
+++ b/src/Eto.Gtk/Eto.Gtk.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.22.24.30" />
+    <PackageReference Include="GtkSharp" Version="3.22.24.35" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eto\Eto.csproj" />

--- a/src/Eto.Gtk/GtkConversions.cs
+++ b/src/Eto.Gtk/GtkConversions.cs
@@ -601,6 +601,13 @@ namespace Eto.GtkSharp
 			return ((FontFamilyHandler)family.Handler).Control;
 		}
 
+		public static Pango.FontFace ToPango(this FontTypeface typeface)
+		{
+			if (typeface == null)
+				return null;
+			return ((FontTypefaceHandler)typeface.Handler).Control;
+		}
+
 		public static Font ToEto(this Pango.FontDescription fontDesc, string familyName = null)
 		{
 			return fontDesc == null ? null : new Font(new FontHandler(fontDesc, familyName));

--- a/src/Eto.Mac/Drawing/FontTypefaceHandler.cs
+++ b/src/Eto.Mac/Drawing/FontTypefaceHandler.cs
@@ -56,8 +56,8 @@ namespace Eto.Mac.Drawing
 		{
 			PostScriptName = (string)Messaging.GetNSObject<NSString>(descriptor.ValueAt(0));
 			name = (string)Messaging.GetNSObject<NSString>(descriptor.ValueAt(1));
-			Weight = Messaging.GetNSObject<NSNumber>(descriptor.ValueAt(2)).Int32Value;
-			Traits = (NSFontTraitMask)Messaging.GetNSObject<NSNumber>(descriptor.ValueAt(3)).Int32Value;
+			Weight = Messaging.GetNSObject<NSNumber>(descriptor.ValueAt(2))?.Int32Value ?? 1;
+			Traits = (NSFontTraitMask)(Messaging.GetNSObject<NSNumber>(descriptor.ValueAt(3))?.Int32Value ?? 0);
 		}
 
 		public FontTypefaceHandler(NSFont font, NSFontTraitMask? traits = null)

--- a/src/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
@@ -77,6 +77,12 @@ namespace Eto.Mac.Forms.Controls
 			SetFontAttribute(range.ToNS(), true, font => NSFontManager.SharedFontManager.ConvertFontToFamily(font, familyName));
 		}
 
+		public void SetTypeface(Range<int> range, FontTypeface typeface)
+		{
+			var typefaceName = ((FontTypefaceHandler)typeface.Handler).Name;
+			SetFontAttribute(range.ToNS(), true, font => NSFontManager.SharedFontManager.ConvertFont(font, typefaceName));
+		}
+
 		public void SetForeground(Range<int> range, Color color)
 		{
 			Control.TextStorage.AddAttribute(NSStringAttributeKey.ForegroundColor, color.ToNSUI(), range.ToNS());
@@ -258,8 +264,22 @@ namespace Eto.Mac.Forms.Controls
 			get { return GetSelectedTextAttribute<NSFont>(NSStringAttributeKey.Font).ToEto().Family; }
 			set
 			{
+				if (value == null)
+					return;
 				var familyName = ((FontFamilyHandler)value.Handler).MacName;
 				SetSelectedFontAttribute(true, f => NSFontManager.SharedFontManager.ConvertFontToFamily(f, familyName));
+			}
+		}
+
+		public FontTypeface SelectionTypeface
+		{
+			get { return GetSelectedTextAttribute<NSFont>(NSStringAttributeKey.Font).ToEto().Typeface; }
+			set
+			{
+				if (value == null)
+					return;
+				var typefaceName = ((FontTypefaceHandler)value?.Handler)?.PostScriptName;
+				SetSelectedFontAttribute(true, f => NSFontManager.SharedFontManager.ConvertFont(f, typefaceName));
 			}
 		}
 

--- a/src/Eto.WinForms/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/RichTextAreaHandler.cs
@@ -125,15 +125,21 @@ namespace Eto.WinForms.Forms.Controls
 
 		public FontFamily SelectionFamily
 		{
-			get
-			{
-				var font = Control.SelectionFont;
-				return font != null ? font.FontFamily.ToEto() : null;
-			}
+			get => Control.SelectionFont?.FontFamily.ToEto();
 			set
 			{
 				var family = value.ToSD();
 				SetSelectionFontStyle(font => new sd.Font(family, font.Size, font.Style));
+			}
+		}
+
+		public FontTypeface SelectionTypeface
+		{
+			get => SelectionFont.Typeface;
+			set
+			{
+				var fontStyle = value.ToSD();
+				SetSelectionFontStyle(font => new sd.Font(font.FontFamily, font.Size, fontStyle));
 			}
 		}
 

--- a/src/Eto.WinForms/WinConversions.cs
+++ b/src/Eto.WinForms/WinConversions.cs
@@ -209,6 +209,11 @@ namespace Eto.WinForms
 			return ((FontFamilyHandler)family.Handler).Control;
 		}
 
+		public static sd.FontStyle ToSD(this FontTypeface typeface)
+		{
+			return FontTypefaceHandler.GetControl(typeface);
+		}
+
 		public static sd.Font ToSD(this SystemFont systemFont)
 		{
 			switch (systemFont)

--- a/src/Eto.Wpf/CustomControls/FontDialog/fontchooser.xaml
+++ b/src/Eto.Wpf/CustomControls/FontDialog/fontchooser.xaml
@@ -176,7 +176,7 @@
         <!-- Row 3: OK and Cancel buttons -->
         <StackPanel Grid.Column="0" Grid.Row="4" Orientation="Horizontal" HorizontalAlignment="Right" Margin="0,12,0,0" Width="196">
             <Button Content="OK" Width="86" IsDefault="True" Click="OnOKButtonClicked" Margin="6,0"/>
-            <Button Content="Cancel" Width="86" Click="OnCancelButtonClicked" Margin="6,0"/>
+            <Button Content="Cancel" Width="86" Click="OnCancelButtonClicked" Margin="6,0" IsCancel="True"/>
         </StackPanel>
 
     </Grid>

--- a/src/Eto.Wpf/CustomControls/FontDialog/fontchooser.xaml.cs
+++ b/src/Eto.Wpf/CustomControls/FontDialog/fontchooser.xaml.cs
@@ -10,10 +10,13 @@ using System.Windows.Threading;
 
 namespace Eto.Wpf.CustomControls.FontDialog
 {
-    /// <summary>
-    /// Interaction logic for FontChooser.xaml
-    /// </summary>
-    public partial class FontChooser : Window
+	/// <summary>
+	/// Interaction logic for FontChooser.xaml
+	/// </summary>
+	/// <remarks>
+	/// Initially from https://github.com/Microsoft/WPF-Samples, MIT license.
+	/// </remarks>
+	public partial class FontChooser : Window
     {
         #region Private fields and types
 
@@ -1254,16 +1257,16 @@ namespace Eto.Wpf.CustomControls.FontDialog
             {
                 ICollection<Typeface> faceCollection = family.GetTypefaces();
 
-                var items = new TypefaceListItem[faceCollection.Count];
-
-                int i = 0;
+				var items = new List<TypefaceListItem>(faceCollection.Count);
 
                 foreach (Typeface face in faceCollection)
                 {
-                    items[i++] = new TypefaceListItem(face);
+					if (!Drawing.FontHandler.ShowSimulatedFonts && (face.IsBoldSimulated || face.IsObliqueSimulated))
+						continue;
+                    items.Add(new TypefaceListItem(face));
                 }
 
-                Array.Sort<TypefaceListItem>(items);
+				items.Sort();
 
                 foreach (TypefaceListItem item in items)
                 {

--- a/src/Eto.Wpf/Drawing/FontFamilyHandler.cs
+++ b/src/Eto.Wpf/Drawing/FontFamilyHandler.cs
@@ -55,15 +55,19 @@ namespace Eto.Wpf.Drawing
 
 		public string Name { get; set; }
 
+
+		static readonly object LocalizedName_Key = new object();
+
 		public string LocalizedName
 		{
 			get
 			{
-				var lang = sw.Markup.XmlLanguage.GetLanguage(CultureInfo.CurrentUICulture.Name);
-				string name;
-				if (!Control.FamilyNames.TryGetValue(lang, out name))
-					name = Name;
-				return name;
+				if (Widget.Properties.ContainsKey(LocalizedName_Key))
+					return Widget.Properties.Get<string>(LocalizedName_Key);
+
+				var localizedName = CustomControls.FontDialog.NameDictionaryHelper.GetDisplayName(Control.FamilyNames);
+				Widget.Properties.Set(LocalizedName_Key, localizedName);
+				return localizedName;
 			}
 		}
 
@@ -71,19 +75,11 @@ namespace Eto.Wpf.Drawing
 		{
 			get {
 				foreach (var type in Control.GetTypefaces ()) {
+					if (!FontHandler.ShowSimulatedFonts && (type.IsBoldSimulated || type.IsObliqueSimulated))
+						continue;
 					yield return new FontTypeface(Widget, new FontTypefaceHandler (type));
 				}
 			}
-		}
-
-		public FontTypeface GetFamilyTypeface (sw.FontStyle fontStyle, sw.FontWeight fontWeight)
-		{
-			var typefaces = Control.GetTypefaces ();
-			foreach (var type in typefaces) {
-				if (type.Style == fontStyle && type.Weight == fontWeight)
-					return new FontTypeface(Widget, new FontTypefaceHandler (type));
-			}
-			return new FontTypeface(Widget, new FontTypefaceHandler (typefaces.First ()));
 		}
 
 		public void Apply(sw.Documents.TextRange control)

--- a/src/Eto.Wpf/Drawing/FontHandler.cs
+++ b/src/Eto.Wpf/Drawing/FontHandler.cs
@@ -15,10 +15,13 @@ namespace Eto.Wpf.Drawing
 		FontDecoration decoration;
 		sd.Font sdfont;
 
+		public static bool ShowSimulatedFonts = false;
+
 		public void Apply(swc.Control control, Action<sw.TextDecorationCollection> setDecorations)
 		{
 			control.FontFamily = WpfFamily;
 			control.FontStyle = WpfFontStyle;
+			control.FontStretch = WpfFontStretch;
 			control.FontWeight = WpfFontWeight;
 			control.FontSize = PixelSize;
 			if (setDecorations != null && WpfTextDecorationsFrozen != null)
@@ -31,6 +34,7 @@ namespace Eto.Wpf.Drawing
 		{
 			control.FontFamily = WpfFamily;
 			control.FontStyle = WpfFontStyle;
+			control.FontStretch = WpfFontStretch;
 			control.FontWeight = WpfFontWeight;
 			control.FontSize = PixelSize;
 			if (setDecorations != null && WpfTextDecorationsFrozen != null)
@@ -43,6 +47,7 @@ namespace Eto.Wpf.Drawing
 		{
 			control.FontFamily = WpfFamily;
 			control.FontStyle = WpfFontStyle;
+			control.FontStretch = WpfFontStretch;
 			control.FontWeight = WpfFontWeight;
 			control.FontSize = PixelSize;
 			if (setDecorations != null && WpfTextDecorationsFrozen != null)
@@ -55,6 +60,7 @@ namespace Eto.Wpf.Drawing
 		{
 			control.ApplyPropertyValue(swd.TextElement.FontFamilyProperty, WpfFamily);
 			control.ApplyPropertyValue(swd.TextElement.FontStyleProperty, WpfFontStyle);
+			control.ApplyPropertyValue(swd.TextElement.FontStretchProperty, WpfFontStretch);
 			control.ApplyPropertyValue(swd.TextElement.FontWeightProperty, WpfFontWeight);
 			control.ApplyPropertyValue(swd.TextElement.FontSizeProperty, PixelSize);
 			control.ApplyPropertyValue(swd.Inline.TextDecorationsProperty, WpfTextDecorationsFrozen);
@@ -116,6 +122,8 @@ namespace Eto.Wpf.Drawing
 
 		public sw.FontStyle WpfFontStyle { get; private set; }
 
+		public sw.FontStretch WpfFontStretch { get; private set; }
+
 		sw.TextDecorationCollection WpfTextDecorations { get; set; }
 
 		public sw.TextDecorationCollection WpfTextDecorationsFrozen { get; private set; }
@@ -135,6 +143,7 @@ namespace Eto.Wpf.Drawing
 			this.Family = new FontFamily(new FontFamilyHandler(control.FontFamily));
 			this.Size = PixelsToPoints(control.FontSize, control);
 			this.WpfFontStyle = control.FontStyle;
+			this.WpfFontStretch = control.FontStretch;
 			this.WpfFontWeight = control.FontWeight;
 		}
 
@@ -143,6 +152,7 @@ namespace Eto.Wpf.Drawing
 			this.Family = new FontFamily(new FontFamilyHandler(control.FontFamily));
 			this.Size = PixelsToPoints(control.FontSize, control);
 			this.WpfFontStyle = control.FontStyle;
+			this.WpfFontStretch = control.FontStretch;
 			this.WpfFontWeight = control.FontWeight;
 			var decorations = control.TextDecorations;
 			if (decorations != null)
@@ -158,6 +168,7 @@ namespace Eto.Wpf.Drawing
 			this.Family = new FontFamily(new FontFamilyHandler(wpfFamily));
 			Size = PixelsToPoints(range.GetPropertyValue(swd.TextElement.FontSizeProperty) as double? ?? swd.TextElement.GetFontSize(control));
 			this.WpfFontStyle = range.GetPropertyValue(swd.TextElement.FontStyleProperty) as sw.FontStyle? ?? swd.TextElement.GetFontStyle(control);
+			this.WpfFontStretch = range.GetPropertyValue(swd.TextElement.FontStretchProperty) as sw.FontStretch? ?? swd.TextElement.GetFontStretch(control);
 			this.WpfFontWeight = range.GetPropertyValue(swd.TextElement.FontWeightProperty) as sw.FontWeight? ?? swd.TextElement.GetFontWeight(control);
 			var decorations = range.GetPropertyValue(swd.Inline.TextDecorationsProperty) as sw.TextDecorationCollection;
 			if (decorations != null)
@@ -167,11 +178,12 @@ namespace Eto.Wpf.Drawing
 			}
 		}
 
-		public FontHandler(swm.FontFamily family, double size, sw.FontStyle style, sw.FontWeight weight)
+		public FontHandler(swm.FontFamily family, double size, sw.FontStyle style, sw.FontWeight weight, sw.FontStretch stretch)
 		{
 			Family = new FontFamily(new FontFamilyHandler(family));
 			Size = size;
 			WpfFontStyle = style;
+			WpfFontStretch = stretch;
 			WpfFontWeight = weight;
 		}
 
@@ -189,6 +201,7 @@ namespace Eto.Wpf.Drawing
 			Family = typeface.Family;
 			Size = size;
 			WpfFontWeight = WpfTypeface.Weight;
+			WpfFontStretch = WpfTypeface.Stretch;
 			WpfFontStyle = WpfTypeface.Style;
 			SetDecorations(decoration);
 		}
@@ -198,6 +211,8 @@ namespace Eto.Wpf.Drawing
 			WpfFontWeight = style.HasFlag(FontStyle.Bold) ? sw.FontWeights.Bold : sw.FontWeights.Normal;
 
 			WpfFontStyle = style.HasFlag(FontStyle.Italic) ? sw.FontStyles.Italic : sw.FontStyles.Normal;
+
+			WpfFontStretch = sw.FontStretches.Normal;
 		}
 
 		void SetDecorations(FontDecoration decoration)
@@ -213,6 +228,7 @@ namespace Eto.Wpf.Drawing
 
 		public void Create(SystemFont systemFont, float? size, FontDecoration decoration)
 		{
+			WpfFontStretch = sw.FontStretches.Normal;
 			switch (systemFont)
 			{
 				case SystemFont.Label:
@@ -266,7 +282,7 @@ namespace Eto.Wpf.Drawing
 			{
 				if (typeface == null)
 				{
-					typeface = new FontTypeface(Family, new FontTypefaceHandler(new swm.Typeface(WpfFamily, WpfFontStyle, WpfFontWeight, sw.FontStretches.Normal)));
+					typeface = new FontTypeface(Family, new FontTypefaceHandler(new swm.Typeface(WpfFamily, WpfFontStyle, WpfFontWeight, WpfFontStretch)));
 				}
 				return typeface;
 			}

--- a/src/Eto.Wpf/Drawing/FontTypefaceHandler.cs
+++ b/src/Eto.Wpf/Drawing/FontTypefaceHandler.cs
@@ -3,6 +3,7 @@ using System.Globalization;
 using System.Linq;
 using swm = System.Windows.Media;
 using sw = System.Windows;
+using swd = System.Windows.Documents;
 
 namespace Eto.Wpf.Drawing
 {
@@ -15,15 +16,29 @@ namespace Eto.Wpf.Drawing
 			this.Control = type;
 		}
 
+		public FontTypefaceHandler(swd.TextSelection range, sw.Controls.RichTextBox control)
+		{
+			var family = range.GetPropertyValue(swd.TextElement.FontFamilyProperty) as swm.FontFamily ?? swd.TextElement.GetFontFamily(control);
+			var style = range.GetPropertyValue(swd.TextElement.FontStyleProperty) as sw.FontStyle? ?? swd.TextElement.GetFontStyle(control);
+			var weight = range.GetPropertyValue(swd.TextElement.FontWeightProperty) as sw.FontWeight? ?? swd.TextElement.GetFontWeight(control);
+			var stretch = range.GetPropertyValue(swd.TextElement.FontStretchProperty) as sw.FontStretch? ?? swd.TextElement.GetFontStretch(control);
+			Control = new swm.Typeface(family, style, weight, stretch);
+		}
+
+		public void Apply(swd.TextRange range)
+		{
+			range.ApplyPropertyValue(swd.TextElement.FontFamilyProperty, Control.FontFamily);
+			range.ApplyPropertyValue(swd.TextElement.FontStyleProperty, Control.Style);
+			range.ApplyPropertyValue(swd.TextElement.FontStretchProperty, Control.Stretch);
+			range.ApplyPropertyValue(swd.TextElement.FontWeightProperty, Control.Weight);
+		}
+
 		public string Name
 		{
 			get
 			{
 				if (name == null) {
-					var lang = sw.Markup.XmlLanguage.GetLanguage (CultureInfo.CurrentUICulture.IetfLanguageTag);
-					if (!Control.FaceNames.TryGetValue (lang, out name)) {
-						name = Control.FaceNames.First ().Value;
-					}
+					name = CustomControls.FontDialog.NameDictionaryHelper.GetDisplayName(Control.FaceNames);
 				}
 				return name;
 			}

--- a/src/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
@@ -395,6 +395,7 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				var handler = ((FontHandler)value?.Handler);
 				SetSelectionAttribute(swd.TextElement.FontFamilyProperty, handler?.WpfFamily);
+				SetSelectionAttribute(swd.TextElement.FontStretchProperty, handler?.WpfFontStretch);
 				SetSelectionAttribute(swd.TextElement.FontStyleProperty, handler?.WpfFontStyle);
 				SetSelectionAttribute(swd.TextElement.FontWeightProperty, handler?.WpfFontWeight);
 				SetSelectionAttribute(swd.TextElement.FontSizeProperty, handler?.PixelSize);
@@ -408,6 +409,19 @@ namespace Eto.Wpf.Forms.Controls
 			set
 			{
 				SetSelectionAttribute(swd.TextElement.FontFamilyProperty, ((FontFamilyHandler)value?.Handler)?.Control);
+			}
+		}
+
+		public FontTypeface SelectionTypeface
+		{
+			get { return new FontTypeface(SelectionFamily, new FontTypefaceHandler(Control.Selection, Control)); }
+			set
+			{
+				var typeface = (value?.Handler as FontTypefaceHandler)?.Control;
+				SetSelectionAttribute(swd.TextElement.FontFamilyProperty, typeface?.FontFamily ?? Control.FontFamily);
+				SetSelectionAttribute(swd.TextElement.FontStyleProperty, typeface?.Style);
+				SetSelectionAttribute(swd.TextElement.FontStretchProperty, typeface?.Stretch);
+				SetSelectionAttribute(swd.TextElement.FontWeightProperty, typeface?.Weight);
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/FontDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/FontDialogHandler.cs
@@ -41,24 +41,26 @@ namespace Eto.Wpf.Forms
 				Control.Owner = owner;
 				Control.WindowStartupLocation = sw.WindowStartupLocation.CenterOwner;
 			}
-			if (Font != null)
+
+			if (Font?.Handler is FontHandler fontHandler)
 			{
-				var fontHandler = (FontHandler)Font.Handler;
 				Control.SelectedFontFamily = fontHandler.WpfFamily;
 				Control.SelectedFontPointSize = fontHandler.Size;
 				Control.SelectedFontStyle = fontHandler.WpfFontStyle;
 				Control.SelectedFontWeight = fontHandler.WpfFontWeight;
+				Control.SelectedFontStretch = fontHandler.WpfFontStretch;
 			}
 			var result = Control.ShowDialog();
 
 			if (result == true)
 			{
-				var fontHandler = new FontHandler(Control.SelectedFontFamily, Control.SelectedFontPointSize, Control.SelectedFontStyle, Control.SelectedFontWeight);
+				fontHandler = new FontHandler(Control.SelectedFontFamily, Control.SelectedFontPointSize, Control.SelectedFontStyle, Control.SelectedFontWeight, Control.SelectedFontStretch);
 				Font = new Font(fontHandler);
 				Callback.OnFontChanged(Widget, EventArgs.Empty);
+				return DialogResult.Ok;
 			}
 
-			return result != null && result.Value ? DialogResult.Ok : DialogResult.Cancel;
+			return DialogResult.Cancel;
 		}
 	}
 }

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -179,7 +179,7 @@ namespace Eto.Wpf.Forms
 					}
 					SetupPerMonitorDpi();
 					if (dpiHelper != null)
-						dpiHelper.ScaleChanged += (sender, e) => Callback.OnLogicalPixelSizeChanged(Widget, EventArgs.Empty);
+						dpiHelper.ScaleChanged += HandleLogicalPixelSizeChanged;
 					break;
 				default:
 					base.AttachEvent(id);
@@ -187,9 +187,21 @@ namespace Eto.Wpf.Forms
 			}
 		}
 
+		static readonly object LastPixelSize_Key = new object();
+
+		float LastPixelSize
+		{
+			get => Widget.Properties.Get<float>(LastPixelSize_Key);
+			set => Widget.Properties.Set(LastPixelSize_Key, value);
+		}
+
 		void HandleLogicalPixelSizeChanged(object sender, EventArgs e)
 		{
-			Callback.OnLogicalPixelSizeChanged(Widget, EventArgs.Empty);
+			if (LastPixelSize != LogicalPixelSize)
+			{
+				Callback.OnLogicalPixelSizeChanged(Widget, EventArgs.Empty);
+				LastPixelSize = LogicalPixelSize;
+			}
 		}
 
 		static bool IsApplicationClosing { get; set; }

--- a/src/Eto/Drawing/FontTypeface.cs
+++ b/src/Eto/Drawing/FontTypeface.cs
@@ -14,7 +14,7 @@ namespace Eto.Drawing
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	public class FontTypeface : Widget
 	{
-		new IHandler Handler  { get { return (IHandler)base.Handler; } }
+		new IHandler Handler { get { return (IHandler)base.Handler; } }
 
 		/// <summary>
 		/// Gets the family of this typeface
@@ -42,7 +42,7 @@ namespace Eto.Drawing
 		/// </summary>
 		public bool Bold
 		{
-			get { return FontStyle.HasFlag (FontStyle.Bold); }
+			get { return FontStyle.HasFlag(FontStyle.Bold); }
 		}
 
 		/// <summary>
@@ -50,7 +50,7 @@ namespace Eto.Drawing
 		/// </summary>
 		public bool Italic
 		{
-			get { return FontStyle.HasFlag (FontStyle.Italic); }
+			get { return FontStyle.HasFlag(FontStyle.Italic); }
 		}
 
 		/// <summary>
@@ -72,9 +72,73 @@ namespace Eto.Drawing
 		/// Gets a string representation of this typeface
 		/// </summary>
 		/// <returns>A string representation of this typeface</returns>
-		public override string ToString ()
+		public override string ToString()
 		{
 			return Name;
+		}
+
+		/// <summary>
+		/// Tests this instance for equality with another font typeface
+		/// </summary>
+		/// <remarks>
+		/// Font typefaces are considered equal if the names are the same
+		/// </remarks>
+		/// <param name="other">Other font typeface to test</param>
+		/// <returns>True if the typefaces are equal, false otherwise</returns>
+		public bool Equals(FontTypeface other)
+		{
+			return other == this;
+		}
+
+		/// <summary>
+		/// Tests two FontTypeface objects for equality
+		/// </summary>
+		/// <remarks>
+		/// Font typefaces are considered equal if the names and font typefaces are the same
+		/// </remarks>
+		/// <param name="value1">First font typeface to test</param>
+		/// <param name="value2">Second font typeface to test</param>
+		/// <returns>True if the font families are equal, false otherwise</returns>
+		public static bool operator ==(FontTypeface value1, FontTypeface value2)
+		{
+			if (ReferenceEquals(value1, value2))
+				return true;
+			if (ReferenceEquals(value1, null) || ReferenceEquals(value2, null))
+				return false;
+			return value1.Name == value2.Name;
+		}
+
+		/// <summary>
+		/// Tests two FontTypeface objects for inequality
+		/// </summary>
+		/// <param name="value1">First font typeface to test</param>
+		/// <param name="value2">Second font typeface to test</param>
+		/// <returns>True if the font typefaces are not equal, false otherwise</returns>
+		public static bool operator !=(FontTypeface value1, FontTypeface value2)
+		{
+			return !(value1 == value2);
+		}
+
+		/// <summary>
+		/// Gets the hash code for this instance
+		/// </summary>
+		/// <returns>Hash code for this instance</returns>
+		public override int GetHashCode()
+		{
+			var hash = 23;
+			hash = hash * 31 + Family.GetHashCode();
+			hash = hash * 31 & Name.GetHashCode();
+			return hash;
+		}
+
+		/// <summary>
+		/// Tests if this instance is equal to the specified object
+		/// </summary>
+		/// <param name="obj">Object to test with</param>
+		/// <returns>True if the specified object is a FontTypeface and is equal to this instance</returns>
+		public override bool Equals(object obj)
+		{
+			return this == obj as FontTypeface;
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/Binding/PropertyBinding.cs
+++ b/src/Eto/Forms/Binding/PropertyBinding.cs
@@ -75,19 +75,14 @@ namespace Eto.Forms
 				)
 			{
 				var dataItemType = dataItem.GetType();
-				// find public property
-				descriptor = dataItemType.GetRuntimeProperty(Property);
-				if (descriptor == null)
+				// iterate to find non-public properties or with different case
+				var comparison = IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+				foreach (var prop in dataItemType.GetRuntimeProperties())
 				{
-					// iterate to find non-public properties or with different case
-					var comparison = IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-					foreach (var prop in dataItemType.GetRuntimeProperties())
+					if (string.Equals(prop.Name, Property, comparison))
 					{
-						if (string.Equals(prop.Name, Property, comparison))
-						{
-							descriptor = prop;
-							break;
-						}
+						descriptor = prop;
+						break;
 					}
 				}
 				declaringType = descriptor?.DeclaringType ?? dataItemType;

--- a/src/Eto/Forms/Controls/FontPicker.cs
+++ b/src/Eto/Forms/Controls/FontPicker.cs
@@ -83,7 +83,23 @@ namespace Eto.Forms
 			Properties.TriggerEvent(ValueChangedEvent, this, e);
 		}
 
-		// Events
+		/// <summary>
+		/// Gets a new binding for the <see cref="Value"/> property.
+		/// </summary>
+		/// <value>A new value binding.</value>
+		public BindableBinding<FontPicker, Font> ValueBinding
+		{
+			get
+			{
+				return new BindableBinding<FontPicker, Font>(
+					this,
+					c => c.Value,
+					(c, v) => c.Value = v,
+					(c, h) => c.ValueChanged += h,
+					(c, h) => c.ValueChanged -= h
+				);
+			}
+		}
 
 		/// <summary>
 		/// Callback interface for handlers of the <see cref="FontPicker"/>.

--- a/src/Eto/Forms/Controls/RichTextArea.cs
+++ b/src/Eto/Forms/Controls/RichTextArea.cs
@@ -250,6 +250,16 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Gets or sets the font typeface of the selected text or insertion point.
+		/// </summary>
+		/// <value>The font typeface of the selected text.</value>
+		public FontTypeface SelectionTypeface
+		{
+			get { return Handler.SelectionTypeface; }
+			set { Handler.SelectionTypeface = value; }
+		}
+
+		/// <summary>
 		/// Gets the formatted text buffer to set formatting and load/save to file.
 		/// </summary>
 		/// <remarks>
@@ -335,6 +345,12 @@ namespace Eto.Forms
 			/// </summary>
 			/// <value>The font family of the selected text.</value>
 			FontFamily SelectionFamily { get; set; }
+
+			/// <summary>
+			/// Gets or sets the font typeface of the selected text or insertion point.
+			/// </summary>
+			/// <value>The font typeface of the selected text.</value>
+			FontTypeface SelectionTypeface { get; set; }
 		}
 	}
 }

--- a/src/Eto/Forms/ThemedControls/ThemedFontPickerHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedFontPickerHandler.cs
@@ -1,4 +1,6 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
+using System.Text;
 using Eto.Drawing;
 
 namespace Eto.Forms.ThemedControls
@@ -38,7 +40,27 @@ namespace Eto.Forms.ThemedControls
 
 		private void Refresh()
 		{
-			Control.Text = font == null ? "None" : font.FamilyName + " " + font.Size;
+			Control.Text = GetText();
+		}
+
+		static List<string> defaultNames = new List<string> { "Normal", "Regular", "None" };
+
+		private string GetText()
+		{
+			if (font == null)
+				return "None";
+
+			var sb = new StringBuilder();
+			sb.Append(font.Family.LocalizedName);
+			var typeface = font.Typeface;
+			if (!defaultNames.Contains(typeface.Name))
+			{
+				sb.Append(" ");
+				sb.Append(typeface.Name);
+			}
+			sb.Append(" ");
+			sb.Append(font.Size);
+			return sb.ToString();
 		}
 
 		private void Control_Click(object sender, EventArgs e)

--- a/test/Eto.Test/Sections/Controls/RichTextAreaSection.cs
+++ b/test/Eto.Test/Sections/Controls/RichTextAreaSection.cs
@@ -77,32 +77,34 @@ namespace Eto.Test.Sections.Controls
 			foregroundButton.ValueBinding.Bind(richText, r => r.SelectionForeground);
 			foregroundButton.ValueChanged += (sender, e) => richText.Focus();
 
-			var fontButton = new Button();
-			fontButton.Bind(c => c.Text, new DelegateBinding<string>(() =>
+			var fontButton = new FontPicker();
+			fontButton.ValueBinding.Bind(richText, r => r.SelectionFont);
+			fontButton.ValueChanged += (sender, e) =>
 			{
-				var font = richText.SelectionFont;
-				if (font == null)
-					return "<No Font>";
-				return string.Format("{0}, {1}, {2:0.00}pt", font.FamilyName, font.Typeface.Name, font.Size);
-			}));
-			var fd = new FontDialog();
-			fontButton.Click += (sender, e) =>
+				richText.Focus();
+				UpdateBindings(BindingUpdateMode.Destination);
+			};
+
+			var typefaceDropDown = new DropDown();
+			typefaceDropDown.ItemKeyBinding = Binding.Property((FontTypeface f) => f.Name);
+			typefaceDropDown.DataStore = richText.SelectionFamily.Typefaces;
+			var tyepfaceBinding = typefaceDropDown.SelectedValueBinding.Bind(richText, r => r.SelectionTypeface);
+			typefaceDropDown.SelectedValueChanged += (sender, e) =>
 			{
-				fd.Font = richText.SelectionFont;
-				fd.FontChanged += (s, ee) =>
-				{
-					richText.SelectionFont = fd.Font;
-					UpdateBindings(BindingUpdateMode.Destination);
-				};
-				if (fd.ShowDialog(this) == DialogResult.Ok)
-					richText.Focus();
+				richText.Focus();
+				UpdateBindings(BindingUpdateMode.Destination);
 			};
 
 			var familyDropDown = new DropDown();
-			familyDropDown.DataStore = Fonts.AvailableFontFamilies.OrderBy(r => r.Name);
+			familyDropDown.ItemTextBinding = Binding.Property((FontFamily f) => f.LocalizedName);
+			familyDropDown.DataStore = Fonts.AvailableFontFamilies.OrderBy(r => r.LocalizedName);
 			familyDropDown.SelectedValueBinding.Bind(richText, r => r.SelectionFamily);
 			familyDropDown.SelectedValueChanged += (sender, e) =>
 			{
+				var family = familyDropDown.SelectedValue as FontFamily;
+				//tyepfaceBinding.Mode = DualBindingMode.Manual;
+				typefaceDropDown.DataStore = family?.Typefaces;
+				//tyepfaceBinding.Mode = DualBindingMode.TwoWay;
 				richText.Focus();
 				UpdateBindings(BindingUpdateMode.Destination);
 			};
@@ -167,6 +169,7 @@ namespace Eto.Test.Sections.Controls
 				    null,
 				    fontButton,
 				    familyDropDown,
+					typefaceDropDown,
 				    null
 				}
 			};


### PR DESCRIPTION
Also includes:

- Fix PropertyBinding exception on a class that defines a new property with same name as base class
- Wpf: LogicalPixelSizeChanged should only be fired when the value changes.