### PR TITLE
[Gtk] Fix clipboard content getting lost after app quits (fixes #1063)

### DIFF
--- a/src/Eto.Gtk/Eto.Gtk.csproj
+++ b/src/Eto.Gtk/Eto.Gtk.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.22.24.35" />
+    <PackageReference Include="GtkSharp" Version="3.22.24.36" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eto\Eto.csproj" />

--- a/src/Eto.Gtk/Forms/ClipboardHandler.cs
+++ b/src/Eto.Gtk/Forms/ClipboardHandler.cs
@@ -49,6 +49,10 @@ namespace Eto.GtkSharp.Forms
 			{
 
 			});
+			
+#if GTKCORE
+			Control.CanStore = (Gtk.TargetEntry[])targets;
+#endif
 		}
 
 		void AddEntry(string type, object data, GetClipboardData getData)


### PR DESCRIPTION
By default Gtk only copies a pointer to the data, and not the actual data.