### PR TITLE
Fix autosizing with multiple scaled rows/columns

### DIFF
--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -251,14 +251,14 @@ namespace Eto.GtkSharp.Forms
 
 		public virtual bool Visible
 		{
-			get { return Control.Visible; }
+			get { return ContainerControl.Visible; }
 			set
 			{ 
-				Control.Visible = value;
-				Control.NoShowAll = !value;
+				ContainerControl.Visible = value;
+				ContainerControl.NoShowAll = !value;
 				if (value && Widget.Loaded)
 				{
-					Control.ShowAll();
+					ContainerControl.ShowAll();
 				}
 			}
 		}

--- a/src/Eto.Mac/Forms/TableLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/TableLayoutHandler.cs
@@ -178,6 +178,7 @@ namespace Eto.Mac.Forms
 
 			// now, calculate any scaled control(s) now that we have the remaining space available
 			var availableControlSize = new SizeF();
+			var maxScaledSize = new SizeF();
 			for (int y = 0; y < heights.Length; y++)
 			{
 				var yscaled = y == lastyscale || yscaling[y];
@@ -197,21 +198,32 @@ namespace Eto.Mac.Forms
 					if (view != null && view.Visible)
 					{
 						var size = view.GetPreferredSize(availableControlSize);
+						if (xscaled)
+						{
+							maxScaledSize.Width = Math.Max(maxScaledSize.Width, size.Width);
+						}
 						if (size.Width > widths[x])
 						{
-							if (!final || !xscaled)
+							if (!xscaled)
 								required.Width += size.Width - widths[x];
 							widths[x] = size.Width;
 						}
+						if (yscaled)
+						{
+							maxScaledSize.Height = Math.Max(maxScaledSize.Height, size.Height);
+						}
 						if (size.Height > heights[y])
 						{
-							if (!final || !yscaled)
+							if (!yscaled)
 								required.Height += size.Height - heights[y];
 							heights[y] = size.Height;
 						}
 					}
 				}
 			}
+
+			if (!final)
+				required += maxScaledSize * numscaled;
 
 
 			if (final)

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -272,6 +272,34 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="themes\royale.normalcolor.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="themes\luna.homestead.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="themes\luna.metallic.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="themes\luna.normalcolor.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="themes\classic.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="themes\aero2.normalcolor.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
+    <Page Include="themes\aero.normalcolor.xaml">
+      <Generator>MSBuild:Compile</Generator>
+      <SubType>Designer</SubType>
+    </Page>
     <Page Include="themes\generic.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>

--- a/src/Eto.Wpf/themes/aero.normalcolor.xaml
+++ b/src/Eto.Wpf/themes/aero.normalcolor.xaml
@@ -1,0 +1,6 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:s="clr-namespace:System;assembly=mscorlib">
+
+
+</ResourceDictionary>

--- a/src/Eto.Wpf/themes/aero2.normalcolor.xaml
+++ b/src/Eto.Wpf/themes/aero2.normalcolor.xaml
@@ -1,0 +1,9 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:s="clr-namespace:System;assembly=mscorlib">
+
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/aero.normalcolor.xaml" />
+    </ResourceDictionary.MergedDictionaries>
+
+</ResourceDictionary>

--- a/src/Eto.Wpf/themes/classic.xaml
+++ b/src/Eto.Wpf/themes/classic.xaml
@@ -1,0 +1,29 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:r="clr-namespace:Eto.Wpf.CustomControls.TreeGridView"
+    >
+
+    <!-- use +/- for expanders -->
+    <Style TargetType="{x:Type r:TreeToggleButton}">
+        <Setter Property="UIElement.Focusable" Value="False" />
+        <Setter Property="FrameworkElement.Width" Value="19" />
+        <Setter Property="FrameworkElement.Height" Value="13" />
+        <Setter Property="Template">
+            <Setter.Value>
+                <ControlTemplate TargetType="{x:Type r:TreeToggleButton}">
+                    <Border Height="13" Width="19" Background="#00FFFFFF">
+                        <Border Height="9" BorderBrush="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" Width="9" BorderThickness="1,1,1,1" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" SnapsToDevicePixels="True">
+                            <Path Margin="1,1,1,1" Data="M0,2L0,3 2,3 2,5 3,5 3,3 5,3 5,2 3,2 3,0 2,0 2,2z" Fill="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" Name="ExpandPath" />
+                        </Border>
+                    </Border>
+                    <ControlTemplate.Triggers>
+                        <Trigger Property="ToggleButton.IsChecked" Value="True">
+                            <Setter Property="Path.Data" TargetName="ExpandPath" Value="M0,2L0,3 5,3 5,2z" />
+                        </Trigger>
+                    </ControlTemplate.Triggers>
+                </ControlTemplate>
+            </Setter.Value>
+        </Setter>
+    </Style>
+
+</ResourceDictionary>

--- a/src/Eto.Wpf/themes/generic.xaml
+++ b/src/Eto.Wpf/themes/generic.xaml
@@ -9,19 +9,56 @@
 
     <Style TargetType="{x:Type r:TreeToggleButton}">
         <Setter Property="UIElement.Focusable" Value="False" />
-        <Setter Property="FrameworkElement.Width" Value="19" />
-        <Setter Property="FrameworkElement.Height" Value="13" />
+        <Setter Property="FrameworkElement.Width" Value="16" />
+        <Setter Property="FrameworkElement.Height" Value="16" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type r:TreeToggleButton}">
-                    <Border Height="13" Width="19" Background="#00FFFFFF">
-                        <Border Height="9" BorderBrush="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" Width="9" BorderThickness="1,1,1,1" Background="{DynamicResource {x:Static SystemColors.WindowBrushKey}}" SnapsToDevicePixels="True">
-                            <Path Margin="1,1,1,1" Data="M0,2L0,3 2,3 2,5 3,5 3,3 5,3 5,2 3,2 3,0 2,0 2,2z" Fill="{DynamicResource {x:Static SystemColors.WindowTextBrushKey}}" Name="ExpandPath" />
-                        </Border>
+                    <Border Height="16" Width="16" Background="#00FFFFFF" Padding="5,5,5,5">
+                        <Path Fill="#00FFFFFF" Name="ExpandPath" Stroke="#FF989898">
+                            <Path.Data>
+                                <PathGeometry Figures="M0,0L0,6L6,0z" />
+                            </Path.Data>
+                            <Path.RenderTransform>
+                                <RotateTransform CenterX="3" Angle="135" CenterY="3" />
+                            </Path.RenderTransform>
+                        </Path>
                     </Border>
                     <ControlTemplate.Triggers>
-                        <Trigger Property="ToggleButton.IsChecked" Value="True">
-                            <Setter Property="Path.Data" TargetName="ExpandPath" Value="M0,2L0,3 5,3 5,2z" />
+                        <Trigger Property="UIElement.IsMouseOver">
+                            <Setter Property="Shape.Stroke" TargetName="ExpandPath">
+                                <Setter.Value>
+                                    <SolidColorBrush>#FF1BBBFA</SolidColorBrush>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="Shape.Fill" TargetName="ExpandPath">
+                                <Setter.Value>
+                                    <SolidColorBrush>#00FFFFFF</SolidColorBrush>
+                                </Setter.Value>
+                            </Setter>
+                            <Trigger.Value>
+                                <s:Boolean>True</s:Boolean>
+                            </Trigger.Value>
+                        </Trigger>
+                        <Trigger Property="ToggleButton.IsChecked">
+                            <Setter Property="UIElement.RenderTransform" TargetName="ExpandPath">
+                                <Setter.Value>
+                                    <RotateTransform CenterX="3" Angle="180" CenterY="3" />
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="Shape.Fill" TargetName="ExpandPath">
+                                <Setter.Value>
+                                    <SolidColorBrush>#FF595959</SolidColorBrush>
+                                </Setter.Value>
+                            </Setter>
+                            <Setter Property="Shape.Stroke" TargetName="ExpandPath">
+                                <Setter.Value>
+                                    <SolidColorBrush>#FF262626</SolidColorBrush>
+                                </Setter.Value>
+                            </Setter>
+                            <Trigger.Value>
+                                <s:Boolean>True</s:Boolean>
+                            </Trigger.Value>
                         </Trigger>
                     </ControlTemplate.Triggers>
                 </ControlTemplate>

--- a/src/Eto.Wpf/themes/luna.homestead.xaml
+++ b/src/Eto.Wpf/themes/luna.homestead.xaml
@@ -1,0 +1,7 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:s="clr-namespace:System;assembly=mscorlib">
+
+    <!-- placeholder when using this theme -->
+
+</ResourceDictionary>

--- a/src/Eto.Wpf/themes/luna.metallic.xaml
+++ b/src/Eto.Wpf/themes/luna.metallic.xaml
@@ -1,0 +1,7 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:s="clr-namespace:System;assembly=mscorlib">
+
+    <!-- placeholder when using this theme -->
+
+</ResourceDictionary>

--- a/src/Eto.Wpf/themes/luna.normalcolor.xaml
+++ b/src/Eto.Wpf/themes/luna.normalcolor.xaml
@@ -1,0 +1,7 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:s="clr-namespace:System;assembly=mscorlib">
+
+    <!-- placeholder when using this theme -->
+
+</ResourceDictionary>

--- a/src/Eto.Wpf/themes/royale.normalcolor.xaml
+++ b/src/Eto.Wpf/themes/royale.normalcolor.xaml
@@ -1,0 +1,7 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:s="clr-namespace:System;assembly=mscorlib">
+
+    <!-- placeholder when using this theme -->
+
+</ResourceDictionary>

--- a/src/Eto/Forms/Binding/PropertyBinding.cs
+++ b/src/Eto/Forms/Binding/PropertyBinding.cs
@@ -75,6 +75,7 @@ namespace Eto.Forms
 				)
 			{
 				var dataItemType = dataItem.GetType();
+				descriptor = null;
 				// iterate to find non-public properties or with different case
 				var comparison = IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
 				foreach (var prop in dataItemType.GetRuntimeProperties())

--- a/test/Eto.Test.Mac/Eto.Test.Mac.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac.csproj
@@ -37,4 +37,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.9.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
@@ -37,4 +37,7 @@
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.9.0" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2-modern.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2-modern.csproj
@@ -96,4 +96,7 @@
   <ItemGroup>
     <Content Include="TestIcon.icns" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
 </Project>

--- a/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
+++ b/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
@@ -90,4 +90,7 @@
       <Version>3.9.0</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
 </Project>

--- a/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
+++ b/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
@@ -103,4 +103,7 @@
       <Version>3.9.0</Version>
     </PackageReference>
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
 </Project>

--- a/test/Eto.Test.Wpf/Startup.cs
+++ b/test/Eto.Test.Wpf/Startup.cs
@@ -12,7 +12,7 @@ namespace Eto.Test.Wpf
 			var platform = new Eto.Wpf.Platform();
 
 			// optional - enables GDI text display mode
-			/**/
+			/**
 			Style.Add<Eto.Wpf.Forms.FormHandler>(null, handler => TextOptions.SetTextFormattingMode(handler.Control, TextFormattingMode.Display));
 			Style.Add<Eto.Wpf.Forms.DialogHandler>(null, handler => TextOptions.SetTextFormattingMode(handler.Control, TextFormattingMode.Display));
 			/**/

--- a/test/Eto.Test/Eto.Test.csproj
+++ b/test/Eto.Test/Eto.Test.csproj
@@ -49,4 +49,7 @@
     <None Remove="Sections\Serialization\Xaml\Test.xeto" />
     <None Remove="Sections\Serialization\Json\Test.json" />
   </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
+  </ItemGroup>
 </Project>

--- a/test/Eto.Test/UnitTests/Forms/Layout/TableLayoutTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Layout/TableLayoutTests.cs
@@ -15,15 +15,15 @@ namespace Eto.Test.UnitTests.Forms.Layout
 			Invoke(() =>
 			{
 				var layout = new TableLayout(
-					            new TableRow(
-						            new Label(),
-						            new TextBox()
-					            ),
-					            new TableRow(
-						            new Label(),
-						            new TextBox()
-					            )
-				            );
+								new TableRow(
+									new Label(),
+									new TextBox()
+								),
+								new TableRow(
+									new Label(),
+									new TextBox()
+								)
+							);
 				Assert.AreEqual(layout.Dimensions, new Size(2, 2), "Table size should be 2x2");
 			});
 		}
@@ -33,7 +33,7 @@ namespace Eto.Test.UnitTests.Forms.Layout
 		{
 			Invoke(() =>
 			{
-				var rows = new [] {
+				var rows = new[] {
 					new TableRow(new Label(), new TextBox()),
 					new TableRow(new Label(), new TextBox())
 				};
@@ -87,7 +87,87 @@ namespace Eto.Test.UnitTests.Forms.Layout
 			});
 		}
 
+		[Test, ManualTest]
+		public void MultipleScaledRowsShouldAutoSizeCorrectly()
+		{
+			ManualForm("The two lines of text above should be fully visible and have equal space between them", form =>
+			{
+				return new TableLayout
+				{
+					Spacing = new Size(10, 10),
+					Rows =
+					{
+						new TableRow(new ProgressBar { Indeterminate = true }),
+						new TableRow(new Label { Text = "This is some text that should be fully visible" }) { ScaleHeight = true },
+						new TableRow(new Panel () ) { ScaleHeight = true },
+						new TableRow(new Label { Text = "This is some other text that should be fully visible" }) { ScaleHeight = true },
+					}
+				};
+			});
+		}
 
+		[Test, ManualTest]
+		public void ScaledRowsOfDifferentHeightShouldMakeAllRowsMaxHeight()
+		{
+			ManualForm("This form should be tall enough to make the blue box 80px high", form =>
+			{
+				var drawable = new Drawable();
+				drawable.Paint += (sender, e) =>
+				{
+					var p = new Pen(Colors.Red, 1);
+					e.Graphics.DrawRectangle(p, 0, 0, 79, 79);
+				};
+
+				var panel = new Panel { BackgroundColor = Colors.Blue, Content = drawable, Size = new Size(80, 80) };
+				drawable.MouseDown += (sender, e) => panel.Visible = false;
+
+				return new TableLayout
+				{
+					Spacing = new Size(10, 10),
+					Rows =
+					{
+						new TableRow(new ProgressBar { Indeterminate = true }),
+						new TableRow(new Panel { Content = new Label { Text = "There should be space below" } }) { ScaleHeight = true },
+						new TableRow(panel) { ScaleHeight = true },
+						new TableRow(new Panel { Content = new Label { Text = "And the blue box should be 80px high and show the red rectangle fully." } }) { ScaleHeight = true },
+					}
+				};
+			});
+		}
+
+		[Test, ManualTest]
+		public void ScaledRowSizeShouldChangeWhenInAScrollable()
+		{
+			ManualForm("This form should be tall enough to make the blue box 80px high, and should dissapear when clicked.", form =>
+			{
+				var drawable = new Drawable();
+				drawable.Paint += (sender, e) =>
+				{
+					var p = new Pen(Colors.Red, 1);
+					e.Graphics.DrawRectangle(p, 0, 0, 79, 79);
+				};
+
+				var panel = new Panel { BackgroundColor = Colors.Blue, Content = drawable, Size = new Size(80, 80) };
+				drawable.MouseDown += (sender, e) => panel.Visible = false;
+
+				return new Scrollable
+				{
+					ExpandContentWidth = false,
+					ExpandContentHeight = false,
+					Content = new TableLayout
+					{
+						Spacing = new Size(10, 10),
+						Rows =
+						{
+							new TableRow(new ProgressBar { Indeterminate = true }),
+							new TableRow(new Label { Text = "There should be space below" }) { ScaleHeight = true },
+							new TableRow(panel) { ScaleHeight = true },
+							new TableRow(new Label { Text = "And the blue box should be 80px high and show the red rectangle fully." }) { ScaleHeight = true },
+						}
+					}
+				};
+			});
+		}
 	}
 }
 


### PR DESCRIPTION
When using a TableLayout with multiple scaled rows/columns, the autosizing wouldn't be sufficient to show all the controls fully.

With this PR, it'll calculate the max width or height of the scaled control(s), and multiply that by the number of scaled rows/columns to get the correct height/width.

Now works correctly on Mac/Wpf/WinForms, but I can't seem to get Gtk to work properly as it sizes the controls based on their desired size, not dividing the space evenly between the rows/columns.

Hopefully Gtk.Grid supports this, which we need to migrate to anyway as Gtk.Table is deprecated.