### PR TITLE
Wpf: Fix setting ImageView.Image after window is closed.

### DIFF
--- a/src/Eto.Wpf/Drawing/IconHandler.cs
+++ b/src/Eto.Wpf/Drawing/IconHandler.cs
@@ -116,14 +116,16 @@ namespace Eto.Wpf.Drawing
 
 		static swmi.BitmapFrame Resize(swmi.BitmapSource image, float scale, int width, int height, swm.BitmapScalingMode scalingMode)
 		{
+			width = (int)Math.Round(width * scale);
+			height = (int)Math.Round(height * scale);
+			if (width <= 0 || height <= 0)
+				return null;
 			var group = new swm.DrawingGroup();
 			swm.RenderOptions.SetBitmapScalingMode(group, scalingMode);
 			group.Children.Add(new swm.ImageDrawing(image, new sw.Rect(0, 0, width, height)));
 			var targetVisual = new swm.DrawingVisual();
 			var targetContext = targetVisual.RenderOpen();
 			targetContext.DrawDrawing(group);
-			width = (int)Math.Round(width * scale);
-			height = (int)Math.Round(height * scale);
 			var target = new swmi.RenderTargetBitmap(width, height, 96 * scale, 96 * scale, swm.PixelFormats.Default);
 			targetContext.Close();
 			target.Render(targetVisual);
@@ -137,10 +139,15 @@ namespace Eto.Wpf.Drawing
 			var wpfBitmap = frame.ToWpf(scale);
 			if ((wpfBitmap.Width == size.Width && wpfBitmap.Height == size.Height)
 				|| size.Height == 0
-				|| size.Width == 0)
+				|| size.Width == 0
+				|| scale <= 0)
 				return wpfBitmap;
 
-			return Resize(wpfBitmap, scale, size.Width, size.Height, swm.BitmapScalingMode.Linear);
+			var resizedBitmap = Resize(wpfBitmap, scale, size.Width, size.Height, swm.BitmapScalingMode.Linear);
+			// will be null if size * scale is too small
+			if (resizedBitmap != null)
+				return resizedBitmap;
+			return wpfBitmap;
 			/*
 			if (width == null)
 				return GetLargestIcon().ToWpf();

--- a/src/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
@@ -48,7 +48,7 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				// use actual size of the control to get the correct image
 				var size = Size;
-				if (!size.IsEmpty)
+				if (size.Width > 0 && size.Height > 0)
 					fittingSize = size;
 			}
 			Control.Source = image.ToWpf(ParentScale, fittingSize);

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -723,7 +723,13 @@ namespace Eto.Wpf.Forms
 
 		public float LogicalPixelSize
 		{
-			get { return (float)(dpiHelper?.Scale ?? (sw.PresentationSource.FromVisual(Control)?.CompositionTarget.TransformToDevice.M11 ?? 1.0)); }
+			get {
+				var scale = (float)(dpiHelper?.Scale ?? sw.PresentationSource.FromVisual(Control)?.CompositionTarget.TransformToDevice.M11 ?? 1.0);
+				// will be zero after the window is closed, but should always be a positive number
+				if (scale <= 0)
+					return 1f;
+				return scale;
+			}
 		}
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/Controls/ImageViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ImageViewTests.cs
@@ -40,6 +40,34 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			});
 		}
 
+		[Test]
+		public void IconShouldNotCrashInEventsOrAfterClosed()
+		{
+			Form(form =>
+			{
+				// shouldn't really be setting ImageView.Image after the form is closed (as you can't re-open the form),
+				// but with complex code this may happen so we should protect from crashing.
+				var imageView = new ImageView { Width = 64, Height = 64 };
+				form.Content = new StackLayout { Items = { imageView } };
+				imageView.Image = TestIcons.Logo;
+				form.Load += (sender, e) => imageView.Image = TestIcons.TestIcon;
+				form.LoadComplete += (sender, e) => imageView.Image = TestIcons.TestIcon;
+				form.Closing += (sender, e) =>
+				{
+					imageView.Image = TestIcons.Logo;
+				};
+				form.Closed += (sender, e) =>
+				{
+					imageView.Image = TestIcons.Logo;
+				};
+				form.Shown += (sender, e) => Application.Instance.AsyncInvoke(() =>
+				{
+					form.Close();
+					imageView.Image = TestIcons.Logo;
+				});
+			});
+		}
+
 		static IEnumerable<object[]> GetImageSizeTests()
 		{
 			var logo = TestIcons.Logo;


### PR DESCRIPTION
Not a typical case, but should not crash.  Happened due to Window.LogicalPixelSize reporting 0 when trying to resize the image.

Also added checks to ensure that it won't crash with negative values (e.g. Size = -1, -1), or if scale * size = 0.