### PR TITLE
Addressing Issues 1076 and 1080

### DIFF
--- a/build/MacTemplate/MacTemplate.targets
+++ b/build/MacTemplate/MacTemplate.targets
@@ -112,6 +112,9 @@
 		<!--
 			Add any missing keys to the PListFile
 		-->
+		<Warning Text="A reference to the NuGet package RoslynCodeTaskFactory is required in this project" 
+				 Condition=" '$(RoslynCodeTaskFactory)' == '' " /> 
+		
 		<_UpdatePList 
 			PListFile="$(OutputPListFile)"
 			TargetFileName="$(TargetFileName)"
@@ -130,14 +133,8 @@
 		<!-- Set executable bit on launcher if on *nix -->
 		<Exec Command="chmod +x &quot;$(LauncherFileWithPath)&quot;" Condition="'$(OS)'=='Unix'" />
 	</Target>
-	<UsingTask TaskName="_UpdatePList" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
-		<ParameterGroup>
-			<PListFile ParameterType="System.String" Required="true" />
-			<TargetFileName ParameterType="System.String" Required="true" />
-			<MacBundleName ParameterType="System.String" Required="true" />
-			<LauncherFile ParameterType="System.String" Required="true" />
-			<IconFile ParameterType="System.String" Output="true" />
-		</ParameterGroup>
+	<UsingTask TaskName="_UpdatePList" TaskFactory="CodeTaskFactory"  AssemblyFile="$(RoslynCodeTaskFactory)"
+               Condition=" '$(RoslynCodeTaskFactory)' != '' ">
 		<Task>
 			<Reference Include="System.Xml" />
 			<Using Namespace="System" />
@@ -161,7 +158,7 @@
                 public string MacBundleName { get; set; }
 				[Required]
                 public string LauncherFile { get; set; }
-
+                [Output]
 				public string IconFile { get; set; }
 
                 XmlDocument xml;

--- a/build/MacTemplate/MacTemplate.targets
+++ b/build/MacTemplate/MacTemplate.targets
@@ -12,7 +12,8 @@
 		<OutputAppPath Condition="'$(OutputAppPath)'==''">$(TargetDir)\$(MacBundleName).app</OutputAppPath>
 		<MacSetDefaultRunConfiguration Condition="'$(MacSetDefaultTarget)' == ''">True</MacSetDefaultRunConfiguration>
 		<MacBuildBundle Condition="$(MacBuildBundle) == '' and $(ProjectTypeGuids) == ''">True</MacBuildBundle>
-		<RoslynCodeTaskProps>$(MSBuildThisFileDirectory)..\..\..\roslyncodetaskfactory\2.0.7\Sdk\Sdk.props</RoslynCodeTaskProps>
+		<RoslynCodeTaskFactoryVersion Condition="'$(RoslynCodeTaskFactoryVersion)' ==''">2.0.7</RoslynCodeTaskFactoryVersion>		
+		<RoslynCodeTaskProps>$(MSBuildThisFileDirectory)../../../roslyncodetaskfactory\$(RoslynCodeTaskFactoryVersion)/Sdk/Sdk.props</RoslynCodeTaskProps>
 	</PropertyGroup>
 
 	<Import Project="RunConfiguration.Default.targets" Condition="$(MacSetDefaultRunConfiguration) == 'True' AND $(IsMac) == 'True' AND $(MacBuildBundle) == 'True'" />

--- a/build/MacTemplate/MacTemplate.targets
+++ b/build/MacTemplate/MacTemplate.targets
@@ -12,10 +12,12 @@
 		<OutputAppPath Condition="'$(OutputAppPath)'==''">$(TargetDir)\$(MacBundleName).app</OutputAppPath>
 		<MacSetDefaultRunConfiguration Condition="'$(MacSetDefaultTarget)' == ''">True</MacSetDefaultRunConfiguration>
 		<MacBuildBundle Condition="$(MacBuildBundle) == '' and $(ProjectTypeGuids) == ''">True</MacBuildBundle>
+		<RoslynCodeTaskProps>$(MSBuildThisFileDirectory)..\..\..\roslyncodetaskfactory\2.0.7\Sdk\Sdk.props</RoslynCodeTaskProps>
 	</PropertyGroup>
 
 	<Import Project="RunConfiguration.Default.targets" Condition="$(MacSetDefaultRunConfiguration) == 'True' AND $(IsMac) == 'True' AND $(MacBuildBundle) == 'True'" />
 	<Import Project="RunConfiguration.Mac.targets" Condition="$(MacSetDefaultRunConfiguration) != 'True' AND $(IsMac) == 'True' AND $(MacBuildBundle) == 'True'" />
+    <Import Project="$(RoslynCodeTaskProps)" Condition=" '$(RoslynCodeTaskFactory)' == '' AND Exists($(RoslynCodeTaskProps))" />
 
 	<Target Name="_TouchApp" Condition="$(MacBuildBundle) == 'True'">
 		<!-- This makes it so we can debug in VS for Mac right away without building first -->

--- a/build/MacTemplate/MacTemplate.targets
+++ b/build/MacTemplate/MacTemplate.targets
@@ -12,13 +12,10 @@
 		<OutputAppPath Condition="'$(OutputAppPath)'==''">$(TargetDir)\$(MacBundleName).app</OutputAppPath>
 		<MacSetDefaultRunConfiguration Condition="'$(MacSetDefaultTarget)' == ''">True</MacSetDefaultRunConfiguration>
 		<MacBuildBundle Condition="$(MacBuildBundle) == '' and $(ProjectTypeGuids) == ''">True</MacBuildBundle>
-		<RoslynCodeTaskFactoryVersion Condition="'$(RoslynCodeTaskFactoryVersion)' ==''">2.0.7</RoslynCodeTaskFactoryVersion>		
-		<RoslynCodeTaskProps>$(MSBuildThisFileDirectory)../../../roslyncodetaskfactory/$(RoslynCodeTaskFactoryVersion)/Sdk/Sdk.props</RoslynCodeTaskProps>
 	</PropertyGroup>
 
 	<Import Project="RunConfiguration.Default.targets" Condition="$(MacSetDefaultRunConfiguration) == 'True' AND $(IsMac) == 'True' AND $(MacBuildBundle) == 'True'" />
 	<Import Project="RunConfiguration.Mac.targets" Condition="$(MacSetDefaultRunConfiguration) != 'True' AND $(IsMac) == 'True' AND $(MacBuildBundle) == 'True'" />
-    <Import Project="$(RoslynCodeTaskProps)" Condition=" '$(RoslynCodeTaskFactory)' == '' AND Exists($(RoslynCodeTaskProps))" />
 
 	<Target Name="_TouchApp" Condition="$(MacBuildBundle) == 'True'">
 		<!-- This makes it so we can debug in VS for Mac right away without building first -->

--- a/build/MacTemplate/MacTemplate.targets
+++ b/build/MacTemplate/MacTemplate.targets
@@ -13,7 +13,7 @@
 		<MacSetDefaultRunConfiguration Condition="'$(MacSetDefaultTarget)' == ''">True</MacSetDefaultRunConfiguration>
 		<MacBuildBundle Condition="$(MacBuildBundle) == '' and $(ProjectTypeGuids) == ''">True</MacBuildBundle>
 		<RoslynCodeTaskFactoryVersion Condition="'$(RoslynCodeTaskFactoryVersion)' ==''">2.0.7</RoslynCodeTaskFactoryVersion>		
-		<RoslynCodeTaskProps>$(MSBuildThisFileDirectory)../../../roslyncodetaskfactory\$(RoslynCodeTaskFactoryVersion)/Sdk/Sdk.props</RoslynCodeTaskProps>
+		<RoslynCodeTaskProps>$(MSBuildThisFileDirectory)../../../roslyncodetaskfactory/$(RoslynCodeTaskFactoryVersion)/Sdk/Sdk.props</RoslynCodeTaskProps>
 	</PropertyGroup>
 
 	<Import Project="RunConfiguration.Default.targets" Condition="$(MacSetDefaultRunConfiguration) == 'True' AND $(IsMac) == 'True' AND $(MacBuildBundle) == 'True'" />

--- a/build/nuspec/Eto.Platform.Mac.nuspec
+++ b/build/nuspec/Eto.Platform.Mac.nuspec
@@ -28,6 +28,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
 		<dependencies>
 			<group>
 				<dependency id="Eto.Forms" version="[$version$]" />
+				<dependency id="RoslynCodeTaskFactory" version="2.0.7" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/build/nuspec/Eto.Platform.Mac64.nuspec
+++ b/build/nuspec/Eto.Platform.Mac64.nuspec
@@ -26,6 +26,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
 		<dependencies>
 			<group>
 				<dependency id="Eto.Forms" version="[$version$]" />
+				<dependency id="RoslynCodeTaskFactory" version="2.0.7" />
 			</group>
 		</dependencies>
 	</metadata>

--- a/samples/Tutorials/CSharp/Tutorial1/CS.Tutorial1.HelloWorld.csproj
+++ b/samples/Tutorials/CSharp/Tutorial1/CS.Tutorial1.HelloWorld.csproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
+    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/CSharp/Tutorial1/CS.Tutorial1.HelloWorld.csproj
+++ b/samples/Tutorials/CSharp/Tutorial1/CS.Tutorial1.HelloWorld.csproj
@@ -19,7 +19,6 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
-    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/CSharp/Tutorial2/CS.Tutorial2.MenusAndToolbars.csproj
+++ b/samples/Tutorials/CSharp/Tutorial2/CS.Tutorial2.MenusAndToolbars.csproj
@@ -18,7 +18,6 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
-    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/CSharp/Tutorial2/CS.Tutorial2.MenusAndToolbars.csproj
+++ b/samples/Tutorials/CSharp/Tutorial2/CS.Tutorial2.MenusAndToolbars.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
+    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/CSharp/Tutorial3/CS.Tutorial3.TableLayout.csproj
+++ b/samples/Tutorials/CSharp/Tutorial3/CS.Tutorial3.TableLayout.csproj
@@ -18,7 +18,6 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
-    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/CSharp/Tutorial3/CS.Tutorial3.TableLayout.csproj
+++ b/samples/Tutorials/CSharp/Tutorial3/CS.Tutorial3.TableLayout.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
+    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/CSharp/Tutorial4/CS.Tutorial4.Binding.csproj
+++ b/samples/Tutorials/CSharp/Tutorial4/CS.Tutorial4.Binding.csproj
@@ -18,7 +18,6 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
-    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/CSharp/Tutorial4/CS.Tutorial4.Binding.csproj
+++ b/samples/Tutorials/CSharp/Tutorial4/CS.Tutorial4.Binding.csproj
@@ -18,6 +18,7 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
+    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/FSharp/Tutorial1/FS.Tutorial1.HelloWorld.fsproj
+++ b/samples/Tutorials/FSharp/Tutorial1/FS.Tutorial1.HelloWorld.fsproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
+    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/FSharp/Tutorial1/FS.Tutorial1.HelloWorld.fsproj
+++ b/samples/Tutorials/FSharp/Tutorial1/FS.Tutorial1.HelloWorld.fsproj
@@ -19,7 +19,6 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
-    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/FSharp/Tutorial2/FS.Tutorial2.MenusAndToolbars.fsproj
+++ b/samples/Tutorials/FSharp/Tutorial2/FS.Tutorial2.MenusAndToolbars.fsproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
+    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/FSharp/Tutorial2/FS.Tutorial2.MenusAndToolbars.fsproj
+++ b/samples/Tutorials/FSharp/Tutorial2/FS.Tutorial2.MenusAndToolbars.fsproj
@@ -19,7 +19,6 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
-    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/FSharp/Tutorial3/FS.Tutorial3.TableLayout.fsproj
+++ b/samples/Tutorials/FSharp/Tutorial3/FS.Tutorial3.TableLayout.fsproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
+    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/FSharp/Tutorial3/FS.Tutorial3.TableLayout.fsproj
+++ b/samples/Tutorials/FSharp/Tutorial3/FS.Tutorial3.TableLayout.fsproj
@@ -19,7 +19,6 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
-    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/FSharp/Tutorial4/FS.Tutorial4.Binding.fsproj
+++ b/samples/Tutorials/FSharp/Tutorial4/FS.Tutorial4.Binding.fsproj
@@ -19,6 +19,7 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
+    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/samples/Tutorials/FSharp/Tutorial4/FS.Tutorial4.Binding.fsproj
+++ b/samples/Tutorials/FSharp/Tutorial4/FS.Tutorial4.Binding.fsproj
@@ -19,7 +19,6 @@
     <ProjectReference Include="..\..\..\..\src\Eto.Mac\Eto.Mac64.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto.WinForms\Eto.WinForms.csproj" />
     <ProjectReference Include="..\..\..\..\src\Eto\Eto.csproj" />
-    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 
 </Project>

--- a/test/Eto.Test.Mac/Eto.Test.Mac.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac.csproj
@@ -36,5 +36,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 </Project>

--- a/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
@@ -36,5 +36,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.9.0" />
+    <PackageReference Include="RoslynCodeTaskFactory" Version="2.0.7" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
This is the one about the lack of CodeTaskFactory for `dotnet build`, following the related thread for [MSBuild issue #616](https://github.com/Microsoft/msbuild/issues/616); so if the Roslyn version of the assembly is not present, a warning is emitted, otherwise use it to generate the task.  Manual testing (by patching the nuget package) allowed an application build and launch using `dotnet` (see [comment](https://github.com/picoe/Eto/issues/1080#issuecomment-388638019) on issue #1080)