### PR TITLE
Add ContextMenu.Closing event and Show() overrides for positioning

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/ExpanderHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ExpanderHandler.cs
@@ -67,7 +67,7 @@ namespace Eto.Wpf.Forms.Controls
 			switch (id)
 			{
 				case Expander.ExpandedChangedEvent:
-					PropertyChangeNotifier.Register(swc.Expander.IsExpandedProperty, HandleIsExpandedChanged, Control);
+					Widget.Properties.Set(swc.Expander.IsExpandedProperty, PropertyChangeNotifier.Register(swc.Expander.IsExpandedProperty, HandleIsExpandedChanged, Control));
 					break;
 				default:
 					base.AttachEvent(id);

--- a/src/Eto.Wpf/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/SplitterHandler.cs
@@ -85,8 +85,8 @@ namespace Eto.Wpf.Forms.Controls
 			switch (id)
 			{
 				case Splitter.PositionChangedEvent:
-					PropertyChangeNotifier.Register(swc.RowDefinition.HeightProperty, HandlePositionChanged, Control.RowDefinitions[0]);
-					PropertyChangeNotifier.Register(swc.ColumnDefinition.WidthProperty, HandlePositionChanged, Control.ColumnDefinitions[0]);
+					Widget.Properties.Set(swc.RowDefinition.HeightProperty, PropertyChangeNotifier.Register(swc.RowDefinition.HeightProperty, HandlePositionChanged, Control.RowDefinitions[0]));
+					Widget.Properties.Set(swc.ColumnDefinition.WidthProperty, PropertyChangeNotifier.Register(swc.ColumnDefinition.WidthProperty, HandlePositionChanged, Control.ColumnDefinitions[0]));
 					break;
 				default:
 					base.AttachEvent(id);

--- a/src/Eto.Wpf/Forms/Menu/CheckMenuItemHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/CheckMenuItemHandler.cs
@@ -29,7 +29,7 @@ namespace Eto.Wpf.Forms.Menu
 			switch (id)
 			{
 				case CheckMenuItem.CheckedChangedEvent:
-					PropertyChangeNotifier.Register(swc.MenuItem.IsCheckedProperty, HandleIsCheckedChanged, Control);
+					Widget.Properties.Set(swc.MenuItem.IsCheckedProperty, PropertyChangeNotifier.Register(swc.MenuItem.IsCheckedProperty, HandleIsCheckedChanged, Control));
                     break;
 				default:
 					base.AttachEvent(id);

--- a/src/Eto.Wpf/Forms/Menu/RadioMenuItemHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/RadioMenuItemHandler.cs
@@ -69,7 +69,7 @@ namespace Eto.Wpf.Forms.Menu
 			switch (id)
 			{
 				case RadioMenuItem.CheckedChangedEvent:
-					PropertyChangeNotifier.Register(swc.MenuItem.IsCheckedProperty, HandleIsCheckedChanged, Control);
+					Widget.Properties.Set(swc.MenuItem.IsCheckedProperty, PropertyChangeNotifier.Register(swc.MenuItem.IsCheckedProperty, HandleIsCheckedChanged, Control));
 					break;
 				default:
 					base.AttachEvent(id);

--- a/src/Eto.Wpf/PropertyChangeNotifier.cs
+++ b/src/Eto.Wpf/PropertyChangeNotifier.cs
@@ -20,7 +20,7 @@ namespace Eto.Wpf
 		public static PropertyChangeNotifier Register(sw.DependencyProperty property, EventHandler handler, sw.DependencyObject propertySource = null)
 		{
 			var notifier = new PropertyChangeNotifier(property);
-			notifier.ValueChanged += handler; // creates a reference to where we bind to
+			notifier.ValueChanged += handler;
 			if (propertySource != null)
 				notifier.PropertySource = propertySource;
 			return notifier;
@@ -29,6 +29,11 @@ namespace Eto.Wpf
 		public PropertyChangeNotifier(sw.DependencyProperty property)
 		: this(new sw.PropertyPath(property))
 		{
+		}
+
+		~PropertyChangeNotifier()
+		{
+			Console.WriteLine($"WAGABAGABOO! {_property?.PathParameters[0]}");
 		}
 
 		public PropertyChangeNotifier(sw.PropertyPath property)

--- a/src/Eto/Forms/Menu/ContextMenu.cs
+++ b/src/Eto/Forms/Menu/ContextMenu.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Eto.Drawing;
 
 namespace Eto.Forms
 {
@@ -78,16 +79,40 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Show the context menu relative to the specified control
+		/// Show the context menu at the current mouse position.
+		/// </summary>
+		public void Show() => Show(null, null);
+
+		/// <summary>
+		/// Show the context menu for the specified control, usually at the current mouse position.
 		/// </summary>
 		/// <param name="relativeTo">Control to show the menu relative to</param>
-		public void Show(Control relativeTo)
+		public void Show(Control relativeTo) => Show(relativeTo, null);
+
+		/// <summary>
+		/// Shows the context menu at the specified screen co-ordinates
+		/// </summary>
+		/// <remarks>
+		/// Note that the operating system may move the location of the menu to make it fully visible.
+		/// </remarks>
+		/// <param name="location">Location in screen co-ordinates to place the context menu</param>
+		public void Show(PointF location) => Show(null, location);
+
+		/// <summary>
+		/// Shows the context menu at the specified location relative to a control.
+		/// </summary>
+		/// <remarks>
+		/// Note that the operating system may move the context menu to make it fully visible.
+		/// </remarks>
+		/// <param name="relativeTo">Control to show the menu relative to, or null to use screen co-ordinates for <paramref name="location"/></param>
+		/// <param name="location">Location to place the upper left of the context menu, or null to use the mouse position</param>
+		public void Show(Control relativeTo, PointF? location)
 		{
 			if (Trim)
 				Items.Trim();
 			OnPreLoad(EventArgs.Empty);
 			OnLoad(EventArgs.Empty);
-			Handler.Show(relativeTo);
+			Handler.Show(relativeTo, location);
 		}
 
 		/// <summary>
@@ -109,7 +134,7 @@ namespace Eto.Forms
 		{
 			base.OnUnLoad(e);
 			foreach (var item in Items)
-				item.OnLoad(e);
+				item.OnUnLoad(e);
 		}
 
 		/// <summary>
@@ -141,7 +166,8 @@ namespace Eto.Forms
 		public const string ClosedEvent = "ContextMenu.Closed";
 
 		/// <summary>
-		/// Occurs when the context menu is closed/dismissed.
+		/// Occurs when the context menu is closed/dismissed, after the menu item has been selected and its click 
+		/// event is triggered.
 		/// </summary>
 		public event EventHandler<EventArgs> Closed
 		{
@@ -156,6 +182,30 @@ namespace Eto.Forms
 		protected virtual void OnClosed(EventArgs e)
 		{
 			Properties.TriggerEvent(ClosedEvent, this, e);
+		}
+
+		/// <summary>
+		/// Event identifier for handlers when attaching the <see cref="Closing"/> event.
+		/// </summary>
+		public const string ClosingEvent = "ContextMenu.Closing";
+
+		/// <summary>
+		/// Occurs before the context menu is closed/dismissed when the user clicks an item, but before the menu item's
+		/// click event is triggered.
+		/// </summary>
+		public event EventHandler<EventArgs> Closing
+		{
+			add { Properties.AddHandlerEvent(ClosingEvent, value); }
+			remove { Properties.RemoveEvent(ClosingEvent, value); }
+		}
+
+		/// <summary>
+		/// Raises the <see cref="Closing"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnClosing(EventArgs e)
+		{
+			Properties.TriggerEvent(ClosingEvent, this, e);
 		}
 
 		static readonly object callback = new Callback();
@@ -183,6 +233,11 @@ namespace Eto.Forms
 			/// Raises the <see cref="Closed"/> event.
 			/// </summary>
 			void OnClosed(ContextMenu widget, EventArgs e);
+
+			/// <summary>
+			/// Raises the <see cref="Closing"/> event.
+			/// </summary>
+			void OnClosing(ContextMenu widget, EventArgs e);
 		}
 
 		/// <summary>
@@ -207,6 +262,15 @@ namespace Eto.Forms
 				using (widget.Platform.Context)
 					widget.OnClosed(e);
 			}
+
+			/// <summary>
+			/// Raises the <see cref="Closing"/> event.
+			/// </summary>
+			public void OnClosing(ContextMenu widget, EventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnClosing(e);
+			}
 		}
 
 		/// <summary>
@@ -217,8 +281,9 @@ namespace Eto.Forms
 			/// <summary>
 			/// Show the context menu relative to the specified control
 			/// </summary>
-			/// <param name="relativeTo">Control to show the menu relative to</param>
-			void Show(Control relativeTo);
+			/// <param name="relativeTo">Control to show the menu relative to, or null to use screen co-ordinates for <paramref name="location"/></param>
+			/// <param name="location">Location to place the upper left of the context menu, or null to use the mouse position</param>
+			void Show(Control relativeTo, PointF? location);
 		}
 	}
 }

--- a/test/Eto.Test/Sections/Behaviors/ContextMenuSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ContextMenuSection.cs
@@ -1,67 +1,113 @@
 using Eto.Forms;
 using Eto.Drawing;
 using System.Linq;
+using System;
 
 namespace Eto.Test.Sections.Behaviors
 {
 	[Section("Behaviors", "ContextMenu")]
 	public class ContextMenuSection : Panel
 	{
+		public bool RelativeToLabel { get; set; }
+		public bool UseLocation { get; set; }
+
+		PointF location = new PointF(100, 100);
+
 		public ContextMenuSection()
 		{
+			var relativeToLabelCheckBox = new CheckBox { Text = "Relative to label" };
+			relativeToLabelCheckBox.CheckedBinding.Bind(this, c => c.RelativeToLabel);
+
+			var useLocationCheckBox = new CheckBox { Text = "Use Location" };
+			useLocationCheckBox.CheckedBinding.Bind(this, c => c.UseLocation);
+
+			var locationInput = PointControl(() => location, p => location = p);
+
+			var contextMenuLabel = CreateContextMenuLabel();
+
+			// layout
+
 			var layout = new DynamicLayout();
 
-			layout.Add(null, null, true);
+			layout.BeginCentered();
+			layout.Add(relativeToLabelCheckBox);
+			layout.AddSeparateRow(useLocationCheckBox, locationInput);
+			layout.EndCentered();
 
-			layout.AddRow(null, ContextMenuPanel(), null);
-
-			layout.Add(null, null, true);
+			layout.AddCentered(contextMenuLabel, yscale: true);
 
 			Content = layout;
 		}
 
-		ContextMenu menu;
+		Control PointControl(Func<PointF> getValue, Action<PointF> setValue)
+		{
+			var xpoint = new NumericStepper();
+			xpoint.ValueBinding.Bind(() => getValue().X, v =>
+			{
+				var p = getValue();
+				p.X = (float)v;
+				setValue(p);
+			});
+
+			var ypoint = new NumericStepper();
+			ypoint.ValueBinding.Bind(() => getValue().Y, v =>
+			{
+				var p = getValue();
+				p.Y = (float)v;
+				setValue(p);
+			});
+
+			return new StackLayout
+			{
+				Orientation = Orientation.Horizontal,
+				Items = { "X:", xpoint, "Y:", ypoint }
+			};
+		}
+
+
+		ContextMenu _menu;
 
 		ContextMenu CreateMenu()
 		{
-			if (menu != null)
-				return menu;
+			if (_menu != null)
+				return _menu;
 			
-			menu = new ContextMenu();
+			_menu = new ContextMenu();
 
-			menu.Opening += (sender, e) => Log.Write(sender, "Opening");
-			menu.Closed += (sender, e) => Log.Write(sender, "Closed");
+			_menu.Opening += (sender, e) => Log.Write(sender, "Opening");
+			_menu.Closed += (sender, e) => Log.Write(sender, "Closed");
+			_menu.Closing += (sender, e) => Log.Write(sender, "Closing");
 
-			menu.Items.Add(new ButtonMenuItem { Text = "Item 1" });
-			menu.Items.Add(new ButtonMenuItem { Text = "Item 2", Shortcut = Keys.Control | Keys.I });
-			menu.Items.Add(new ButtonMenuItem { Text = "Item 3", Shortcut = Keys.Shift | Keys.I });
-			menu.Items.Add(new ButtonMenuItem { Text = "Item 4", Shortcut = Keys.Alt | Keys.I });
+			_menu.Items.Add(new ButtonMenuItem { Text = "Item 1" });
+			_menu.Items.Add(new ButtonMenuItem { Text = "Item 2", Shortcut = Keys.Control | Keys.I });
+			_menu.Items.Add(new ButtonMenuItem { Text = "Item 3", Shortcut = Keys.Shift | Keys.I });
+			_menu.Items.Add(new ButtonMenuItem { Text = "Item 4", Shortcut = Keys.Alt | Keys.I });
 
-			var subMenu = menu.Items.GetSubmenu("Sub Menu");
+			var subMenu = _menu.Items.GetSubmenu("Sub Menu");
 			subMenu.Items.Add(new ButtonMenuItem { Text = "Item 5", Shortcut = Keys.Application | Keys.I });
 			subMenu.Items.Add(new ButtonMenuItem { Text = "Item 6", Shortcut = Keys.I });
 
-			menu.Items.AddSeparator();
+			_menu.Items.AddSeparator();
 			RadioMenuItem radioController;
-			menu.Items.Add(radioController = new RadioMenuItem { Text = "Radio 1" });
-			menu.Items.Add(new RadioMenuItem(radioController) { Text = "Radio 2", Checked = true });
-			menu.Items.Add(new RadioMenuItem(radioController) { Text = "Radio 3", Shortcut = Keys.R });
-			menu.Items.Add(new RadioMenuItem(radioController) { Text = "Radio 4" });
+			_menu.Items.Add(radioController = new RadioMenuItem { Text = "Radio 1" });
+			_menu.Items.Add(new RadioMenuItem(radioController) { Text = "Radio 2", Checked = true });
+			_menu.Items.Add(new RadioMenuItem(radioController) { Text = "Radio 3", Shortcut = Keys.R });
+			_menu.Items.Add(new RadioMenuItem(radioController) { Text = "Radio 4" });
 
-			menu.Items.AddSeparator();
-			menu.Items.Add(new CheckMenuItem { Text = "Check 1" });
-			menu.Items.Add(new CheckMenuItem { Text = "Check 2", Shortcut = Keys.Control | Keys.Alt | Keys.G, Checked = true });
-			menu.Items.Add(new CheckMenuItem { Text = "Check 3", Shortcut = Keys.Control | Keys.Shift | Keys.G });
-			menu.Items.Add(new CheckMenuItem { Text = "Check 4", Shortcut = Keys.Control | Keys.Application | Keys.G });
-			menu.Items.Add(new CheckMenuItem { Text = "Check 5", Shortcut = Keys.Shift | Keys.Alt | Keys.G });
-			menu.Items.Add(new CheckMenuItem { Text = "Check 6", Shortcut = Keys.Shift | Keys.Application | Keys.G });
-			menu.Items.Add(new CheckMenuItem { Text = "Check 7", Shortcut = Keys.Alt | Keys.Application | Keys.G });
+			_menu.Items.AddSeparator();
+			_menu.Items.Add(new CheckMenuItem { Text = "Check 1" });
+			_menu.Items.Add(new CheckMenuItem { Text = "Check 2", Shortcut = Keys.Control | Keys.Alt | Keys.G, Checked = true });
+			_menu.Items.Add(new CheckMenuItem { Text = "Check 3", Shortcut = Keys.Control | Keys.Shift | Keys.G });
+			_menu.Items.Add(new CheckMenuItem { Text = "Check 4", Shortcut = Keys.Control | Keys.Application | Keys.G });
+			_menu.Items.Add(new CheckMenuItem { Text = "Check 5", Shortcut = Keys.Shift | Keys.Alt | Keys.G });
+			_menu.Items.Add(new CheckMenuItem { Text = "Check 6", Shortcut = Keys.Shift | Keys.Application | Keys.G });
+			_menu.Items.Add(new CheckMenuItem { Text = "Check 7", Shortcut = Keys.Alt | Keys.Application | Keys.G });
 
-			LogEvents(menu);
-			return menu;
+			LogEvents(_menu);
+			return _menu;
 		}
 
-		Control ContextMenuPanel()
+		Control CreateContextMenuLabel()
 		{
 			var label = new Label
 			{
@@ -75,7 +121,18 @@ namespace Eto.Test.Sections.Behaviors
 			label.MouseDown += (sender, e) =>
 			{
 				var menu = CreateMenu();
-				menu.Show(label);
+
+				if (UseLocation)
+				{
+					if (RelativeToLabel)
+						menu.Show(label, location);
+					else
+						menu.Show(location);
+				}
+				else if (RelativeToLabel)
+					menu.Show(label);
+				else
+					menu.Show();
 			};
 			return label;
 		}


### PR DESCRIPTION
Closed event now triggers *after* the menu item's click event, whereas the new Closing event works as Closed did before where it triggers before the menu item's click event.

Also added ability to specify a location relative to the control, or relative to the screen.  Fixes #834