### PR TITLE
Mac: Improve layout performance (greatly)

### DIFF
--- a/src/Eto.Mac/AsyncQueue.cs
+++ b/src/Eto.Mac/AsyncQueue.cs
@@ -1,6 +1,13 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using Eto.Forms;
+using Eto.Mac.Forms;
+#if XAMMAC2
+using AppKit;
+#else
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+#endif
 
 namespace Eto.Mac
 {
@@ -57,7 +64,11 @@ namespace Eto.Mac
 			if (_actionQueue.Count == 1)
 			{
 				// first one added, schedule a layout!
-				Application.Instance.AsyncInvoke(FlushQueue);
+#if XAMMAC1
+				NSApplication.SharedApplication.BeginInvokeOnMainThread(new NSAction(FlushQueue));
+#else
+				NSApplication.SharedApplication.BeginInvokeOnMainThread(FlushQueue);
+#endif
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
@@ -65,7 +65,7 @@ namespace Eto.Mac.Forms.Cells
 			}
 			Callback.OnConfigureCell(Widget, args, widthCell);
 
-			var result = widthCell.GetPreferredSize(SizeF.MaxValue).Width;
+			var result = widthCell.GetPreferredSize(SizeF.PositiveInfinity).Width;
 
 			widthCell.DataContext = null;
 			return result;

--- a/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
@@ -186,21 +186,21 @@ namespace Eto.Mac.Forms.Controls
 				{
 					Handler.Control.Add(NSObject.FromObject(item));
 				}
-				Handler.LayoutIfNeeded();
+				Handler.InvalidateMeasure();
 			}
 
 			public override void AddItem(object item)
 			{
 				var binding = Handler.Widget.ItemTextBinding;
 				Handler.Control.Add(NSObject.FromObject(binding.GetValue(item)));
-				Handler.LayoutIfNeeded();
+				Handler.InvalidateMeasure();
 			}
 
 			public override void InsertItem(int index, object item)
 			{
 				var binding = Handler.Widget.ItemTextBinding;
 				Handler.Control.Insert(NSObject.FromObject(binding.GetValue(item)), index);
-				Handler.LayoutIfNeeded();
+				Handler.InvalidateMeasure();
 			}
 
 			public override void RemoveItem(int index)
@@ -215,7 +215,7 @@ namespace Eto.Mac.Forms.Controls
 					if (index == Count)
 						Handler.Callback.OnSelectedIndexChanged(Handler.Widget, EventArgs.Empty);
 				}
-				Handler.LayoutIfNeeded();
+				Handler.InvalidateMeasure();
 			}
 
 			public override void RemoveAllItems()
@@ -227,7 +227,7 @@ namespace Eto.Mac.Forms.Controls
 					Handler.Control.StringValue = string.Empty;
 					Handler.SelectedIndex = -1;
 				}
-				Handler.LayoutIfNeeded();
+				Handler.InvalidateMeasure();
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -40,12 +40,9 @@ namespace Eto.Mac.Forms.Controls
 
 		public override NSView ContainerControl { get { return Control; } }
 
-		public class EtoDrawableView : MacEventView
+		public class EtoDrawableView : EtoPaddedPanel
 		{
-			DrawableHandler Drawable
-			{
-				get { return Handler as DrawableHandler; }
-			}
+			DrawableHandler Drawable => Handler as DrawableHandler;
 
 			public override void DrawRect(CGRect dirtyRect)
 			{

--- a/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
@@ -183,7 +183,7 @@ namespace Eto.Mac.Forms.Controls
 
 				if (oldIndex == -1)
 					control.SelectItem(-1);
-				Handler.LayoutIfNeeded();
+				Handler.InvalidateMeasure();
 			}
 
 			public override void AddItem(object item)
@@ -192,7 +192,7 @@ namespace Eto.Mac.Forms.Controls
 				Handler.Control.Menu.AddItem(CreateItem(item));
 				if (oldIndex == -1)
 					Handler.Control.SelectItem(-1);
-				Handler.LayoutIfNeeded();
+				Handler.InvalidateMeasure();
 			}
 
 			public override void InsertItem(int index, object item)
@@ -201,14 +201,14 @@ namespace Eto.Mac.Forms.Controls
 				Handler.Control.Menu.InsertItem(CreateItem(item), index);
 				if (oldIndex == -1)
 					Handler.Control.SelectItem(-1);
-				Handler.LayoutIfNeeded();
+				Handler.InvalidateMeasure();
 			}
 
 			public override void RemoveItem(int index)
 			{
 				var selected = Handler.SelectedIndex;
 				Handler.Control.RemoveItem(index);
-				Handler.LayoutIfNeeded();
+				Handler.InvalidateMeasure();
 				if (Handler.Widget.Loaded && selected == index)
 				{
 					Handler.Control.SelectItem(-1);
@@ -220,7 +220,7 @@ namespace Eto.Mac.Forms.Controls
 			{
 				var change = Handler.SelectedIndex != -1;
 				Handler.Control.RemoveAllItems();
-				Handler.LayoutIfNeeded();
+				Handler.InvalidateMeasure();
 				if (Handler.Widget.Loaded && change)
 				{
 					Handler.Control.SelectItem(-1);

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -432,7 +432,7 @@ namespace Eto.Mac.Forms.Controls
 			set
 			{
 				ScrollView.BorderType = value.ToNS();
-				LayoutIfNeeded();
+				InvalidateMeasure();
 			}
 		}
 
@@ -579,7 +579,8 @@ namespace Eto.Mac.Forms.Controls
 		void IDataViewHandler.OnCellEdited(GridViewCellEventArgs e)
 		{
 			SetIsEditing(false);
-			Callback.OnCellEdited(Widget, e);
+			if (e.Item != null)
+				Callback.OnCellEdited(Widget, e);
 		}
 
 		Grid IDataViewHandler.Widget

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -160,6 +160,8 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void SetObjectValue(NSTableView tableView, NSObject theObject, NSTableColumn tableColumn, nint row)
 			{
+				if (row >= Handler.collection.Count)
+					return;
 				var item = Handler.collection.ElementAt((int)row);
 				var colHandler = Handler.GetColumn(tableColumn);
 				if (colHandler != null && Handler.SuppressUpdate == 0)

--- a/src/Eto.Mac/Forms/Controls/ImageViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ImageViewHandler.cs
@@ -73,10 +73,9 @@ namespace Eto.Mac.Forms.Controls
 			{
 				if (image != value)
 				{
-					var oldSize = GetPreferredSize(Size.MaxValue);
 					image = value;
 					Control.Image = image.ToNS();
-					LayoutIfNeeded(oldSize);
+					InvalidateMeasure();
 				}
 			}
 		}

--- a/src/Eto.Mac/Forms/Controls/MacButton.cs
+++ b/src/Eto.Mac/Forms/Controls/MacButton.cs
@@ -33,9 +33,9 @@ namespace Eto.Mac.Forms.Controls
 			set
 			{
 				Widget.Properties[textKey] = value;
-				var oldSize = GetPreferredSize(Size.MaxValue);
+				var oldSize = GetPreferredSize(SizeF.PositiveInfinity);
 				SetText(value);
-				LayoutIfNeeded(oldSize);
+				InvalidateMeasure();
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/MacControl.cs
+++ b/src/Eto.Mac/Forms/Controls/MacControl.cs
@@ -46,7 +46,7 @@ namespace Eto.Mac.Forms.Controls
 				{
 					Control.Font = value.ToNS();
 					Control.AttributedStringValue = value.AttributedString(Control.AttributedStringValue);
-					LayoutIfNeeded();
+					InvalidateMeasure();
 				});
 			}
 		}

--- a/src/Eto.Mac/Forms/Controls/MacLabel.cs
+++ b/src/Eto.Mac/Forms/Controls/MacLabel.cs
@@ -140,23 +140,40 @@ namespace Eto.Mac.Forms.Controls
 		readonly NSMutableAttributedString str;
 		readonly NSMutableParagraphStyle paragraphStyle;
 		int underlineIndex;
-		SizeF availableSizeCached;
+		Size availableSizeCached;
+		SizeF? naturalSizeInfinity;
 		SizeF lastSize;
 		bool isSizing;
 
-		public override NSView ContainerControl { get { return Control; } }
+		public override NSView ContainerControl => Control;
 
 		protected override SizeF GetNaturalSize(SizeF availableSize)
 		{
-			if (Widget.Loaded && Wrap != WrapMode.None && Size.Width > 0 && availableSize.Width < int.MaxValue)
-				availableSize.Width = Math.Max(Size.Width, availableSize.Width);
-
-			availableSize = new SizeF((float)Math.Truncate(availableSize.Width), (float)Math.Truncate(availableSize.Height));
-			if (NaturalSize == null || availableSizeCached != availableSize)
+			if (float.IsPositiveInfinity(availableSize.Width))
 			{
-				var size = Control.Cell.CellSizeForBounds(new CGRect(CGPoint.Empty, availableSize.ToNS())).ToEto();
+				if (naturalSizeInfinity != null)
+					return naturalSizeInfinity.Value;
+
+				var size = Control.Cell.CellSizeForBounds(new CGRect(0, 0, int.MaxValue, int.MaxValue)).ToEto();
+				naturalSizeInfinity = Size.Ceiling(size);
+				return naturalSizeInfinity.Value;
+			}
+
+			if (Widget.Loaded && Wrap != WrapMode.None && Size.Width > 0)
+			{
+				/*if (!float.IsPositiveInfinity(availableSize.Width))
+					availableSize.Width = Math.Max(Size.Width, availableSize.Width);
+				else*/
+					availableSize.Width = Size.Width;
+				availableSize.Height = float.PositiveInfinity;
+			}
+
+			var availableSizeTruncated = availableSize.TruncateInfinity();
+			if (NaturalSize == null || availableSizeCached != availableSizeTruncated)
+			{
+				var size = Control.Cell.CellSizeForBounds(new CGRect(CGPoint.Empty, availableSizeTruncated.ToNS())).ToEto();
 				NaturalSize = Size.Ceiling(size);
-				availableSizeCached = availableSize;
+				availableSizeCached = availableSizeTruncated;
 			}
 
 			return NaturalSize.Value;
@@ -169,13 +186,13 @@ namespace Eto.Mac.Forms.Controls
 				return;
 			isSizing = true;
 			var size = Size;
-			if (Wrap != WrapMode.None && lastSize != size)
+			if (Wrap != WrapMode.None && lastSize.Width != size.Width)
 			{
 				// when wrapping we use the current size, if it changes we check if we need another layout pass
 				// this is needed when resizing a form/label so it can wrap correctly as GetNaturalSize()
 				// will use the old size first, and won't necessarily know the final size of the label.
 				lastSize = size;
-				LayoutIfNeeded();
+				InvalidateMeasure();
 			}
 			isSizing = false;
 		}
@@ -261,7 +278,7 @@ namespace Eto.Mac.Forms.Controls
 						throw new NotSupportedException();
 				}
 				SetAttributes();
-				LayoutIfNeeded();
+				InvalidateMeasure();
 			}
 		}
 
@@ -272,7 +289,6 @@ namespace Eto.Mac.Forms.Controls
 			get { return str.Value; }
 			set
 			{
-				var oldSize = GetPreferredSize(Size.MaxValue);
 				if (string.IsNullOrEmpty(value))
 				{
 					str.SetString(new NSMutableAttributedString());
@@ -297,7 +313,7 @@ namespace Eto.Mac.Forms.Controls
 					}
 				}
 				SetAttributes();
-				LayoutIfNeeded(oldSize);
+				InvalidateMeasure();
 			}
 		}
 
@@ -308,7 +324,7 @@ namespace Eto.Mac.Forms.Controls
 			{
 				paragraphStyle.Alignment = value.ToNS();
 				SetAttributes();
-				LayoutIfNeeded();
+				InvalidateMeasure();
 			}
 		}
 
@@ -322,10 +338,10 @@ namespace Eto.Mac.Forms.Controls
 			{
 				if (Widget.Properties.Get<Font>(MacLabel.FontKey) != value)
 				{
-					var oldSize = GetPreferredSize(Size.MaxValue);
+					var oldSize = GetPreferredSize(SizeF.PositiveInfinity);
 					Widget.Properties[MacLabel.FontKey] = value;
 					SetAttributes();
-					LayoutIfNeeded(oldSize);
+					InvalidateMeasure();
 				}
 			}
 		}
@@ -379,6 +395,12 @@ namespace Eto.Mac.Forms.Controls
 					return col.Value.ToNSUI();
 				return null; 
 			}
+		}
+
+		public override void InvalidateMeasure()
+		{
+			base.InvalidateMeasure();
+			naturalSizeInfinity = null;
 		}
 
 		public override void OnLoad(EventArgs e)

--- a/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
@@ -188,7 +188,7 @@ namespace Eto.Mac.Forms.Controls
 		protected override void Initialize()
 		{
 			base.Initialize();
-			var size = GetNaturalSize(Size.MaxValue);
+			var size = GetNaturalSize(SizeF.PositiveInfinity);
 			Control.Frame = new CGRect(0, 0, size.Width, size.Height);
 			HandleEvent(Eto.Forms.Control.KeyDownEvent);
 			Widget.LostFocus += (sender, e) =>
@@ -371,7 +371,7 @@ namespace Eto.Mac.Forms.Controls
 				{
 					TextField.Font = value.ToNS();
 					TextField.SizeToFit();
-					LayoutIfNeeded();
+					InvalidateMeasure();
 				});
 			}
 		}

--- a/src/Eto.Mac/Forms/Controls/PanelHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/PanelHandler.cs
@@ -1,4 +1,6 @@
+using System;
 using Eto.Forms;
+using Eto.Drawing;
 #if XAMMAC2
 using AppKit;
 using Foundation;
@@ -15,17 +17,40 @@ using MonoMac.CoreAnimation;
 
 namespace Eto.Mac.Forms.Controls
 {
-	public class PanelHandler : MacPanel<NSView, Panel, Panel.ICallback>, Panel.IHandler
+	public class EtoPaddedPanel : MacEventView
 	{
-		class EtoPanel : MacEventView
+		new Panel.IHandler Handler => base.Handler as Panel.IHandler;
+
+		public EtoPaddedPanel(IntPtr handle) : base(handle)
 		{
 		}
 
-		protected override NSView CreateControl()
+		public EtoPaddedPanel()
 		{
-			return new EtoPanel { Handler = this };
+			AutoresizesSubviews = false;
 		}
+
+		public override void Layout()
+		{
+			base.Layout();
+			var subviews = Subviews;
+			if (subviews.Length == 1)
+			{
+				var view = subviews[0];
+				view.Frame = Bounds.WithPadding(Handler?.Padding ?? Padding.Empty);
+			}
+		}
+	}
+	public class PanelHandler : MacPanel<NSView, Panel, Panel.ICallback>, Panel.IHandler
+	{
+		protected override NSView CreateControl() => new EtoPaddedPanel();
 		
-		public override NSView ContainerControl { get { return Control; } }
+		public override NSView ContainerControl => Control;
+
+		public override void InvalidateMeasure()
+		{
+			base.InvalidateMeasure();
+			Control.NeedsLayout = true;
+		}
 	}
 }

--- a/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -34,13 +34,6 @@ namespace Eto.Mac.Forms.Controls
 {
 	public class SplitterHandler : MacContainer<NSSplitView, Splitter, Splitter.ICallback>, Splitter.IHandler
 	{
-
-		public override void LayoutParent(bool updateSize = true)
-		{
-			UpdatePosition();
-			base.LayoutParent(updateSize);
-		}
-
 		double relative = double.NaN;
 
 		double GetRelativePosition()
@@ -365,13 +358,16 @@ namespace Eto.Mac.Forms.Controls
 				    || cursor == NSCursor.ResizeUpCursor || cursor == NSCursor.ResizeDownCursor || cursor == NSCursor.ResizeUpDownCursor)
 					base.MouseUp(theEvent);
 			}
+
+			public override void Layout()
+			{
+				base.Layout();
+				Handler?.UpdatePosition();
+			}
 		}
 
 
-		protected override NSSplitView CreateControl()
-		{
-			return new EtoSplitView(this);
-		}
+		protected override NSSplitView CreateControl() => new EtoSplitView(this);
 
 		protected override void Initialize()
 		{
@@ -490,11 +486,11 @@ namespace Eto.Mac.Forms.Controls
 				{
 					case SplitterFixedPanel.None:
 					case SplitterFixedPanel.Panel1:
-						var size1 = panel1.GetPreferredSize(SizeF.MaxValue);
+						var size1 = panel1.GetPreferredSize(SizeF.PositiveInfinity);
 						position = (int)(Orientation == Orientation.Horizontal ? size1.Width : size1.Height);
 						break;
 					case SplitterFixedPanel.Panel2:
-						var size2 = panel2.GetPreferredSize(SizeF.MaxValue);
+						var size2 = panel2.GetPreferredSize(SizeF.PositiveInfinity);
 						if (Orientation == Orientation.Horizontal)
 							position = (int)(Control.Frame.Width - size2.Width - Control.DividerThickness);
 						else
@@ -621,6 +617,12 @@ namespace Eto.Mac.Forms.Controls
 				size.Width = Math.Max(size1.Width, size2.Width);
 			}
 			return size;
+		}
+
+		public override void InvalidateMeasure()
+		{
+			base.InvalidateMeasure();
+			Control.NeedsLayout = true;
 		}
 
 		void UpdatePosition()

--- a/src/Eto.Mac/Forms/Controls/TabControlHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TabControlHandler.cs
@@ -95,10 +95,11 @@ namespace Eto.Mac.Forms.Controls
 
 		public void InsertTab(int index, TabPage page)
 		{
+			var tabViewItem = ((TabPageHandler)page.Handler).Control;
 			if (index == -1)
-				Control.Add(((TabPageHandler)page.Handler).Control);
+				Control.Add(tabViewItem);
 			else
-				Control.Insert(((TabPageHandler)page.Handler).Control, index);
+				Control.Insert(tabViewItem, index);
 		}
 
 		public void ClearTabs()
@@ -127,6 +128,10 @@ namespace Eto.Mac.Forms.Controls
 
 		protected override SizeF GetNaturalSize(SizeF availableSize)
 		{
+			var naturalSize = NaturalSize;
+			if (naturalSize != null)
+				return naturalSize.Value;
+			
 			var size = base.GetNaturalSize(availableSize);
 			var borderSize = Control.Frame.Size.ToEto() - Control.ContentRect.Size.ToEto();
 
@@ -134,7 +139,9 @@ namespace Eto.Mac.Forms.Controls
 			{
 				size = SizeF.Max(size, tab.GetPreferredSize(availableSize));
 			}
-			return size + borderSize;
+			naturalSize = size + borderSize;
+			NaturalSize = naturalSize;
+			return naturalSize.Value;
 		}
 
 		public DockPosition TabPosition

--- a/src/Eto.Mac/Forms/Controls/TabPageHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TabPageHandler.cs
@@ -56,12 +56,12 @@ namespace Eto.Mac.Forms.Controls
 						nsimage.Draw(new CGRect(labelRect.X, labelRect.Y, labelRect.Height, labelRect.Height), new CGRect(CGPoint.Empty, nsimage.Size), NSCompositingOperation.SourceOver, 1, true, null);
 					else
 					{
-						#pragma warning disable 618
+#pragma warning disable 618
 						nsimage.Flipped = View.IsFlipped;
-						#pragma warning restore 618
+#pragma warning restore 618
 						nsimage.Draw(new CGRect(labelRect.X, labelRect.Y, labelRect.Height, labelRect.Height), new CGRect(CGPoint.Empty, nsimage.Size), NSCompositingOperation.SourceOver, 1);
 					}
-					
+
 					labelRect.X += labelRect.Height + ICON_PADDING;
 					labelRect.Width -= labelRect.Height + ICON_PADDING;
 					base.DrawLabel(shouldTruncateLabel, labelRect);
@@ -69,10 +69,11 @@ namespace Eto.Mac.Forms.Controls
 				base.DrawLabel(shouldTruncateLabel, labelRect);
 			}
 
-			public override CGSize SizeOfLabel (bool computeMin)
+			public override CGSize SizeOfLabel(bool computeMin)
 			{
-				var size = base.SizeOfLabel (computeMin);
-				if (Handler.image != null) {
+				var size = base.SizeOfLabel(computeMin);
+				if (Handler.image != null)
+				{
 					size.Width += size.Height + ICON_PADDING;
 				}
 				return size;
@@ -81,19 +82,14 @@ namespace Eto.Mac.Forms.Controls
 			public EtoTabViewItem(IMacViewHandler handler)
 			{
 				Identifier = new NSString(Guid.NewGuid().ToString());
-				View = new MacEventView { Handler = handler };
+				View = new EtoPaddedPanel { Handler = handler };
 			}
 		}
+
 
 		protected override NSTabViewItem CreateControl()
 		{
 			return new EtoTabViewItem(this);
-		}
-
-		protected override void Initialize()
-		{
-			Enabled = true;
-			base.Initialize();
 		}
 
 		public string Text
@@ -114,11 +110,8 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		public override NSView ContentControl
-		{
-			get { return Control.View; }
-		}
+		public override NSView ContentControl => Control.View;
 
-		public override bool Enabled { get; set; }
+		public override bool Enabled { get; set; } = true;
 	}
 }

--- a/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -301,7 +301,7 @@ namespace Eto.Mac.Forms.Controls
 				Widget.Properties.Set(Font_Key, value, () =>
 				{
 					Control.Font = value.ToNS() ?? NSFont.SystemFontOfSize(NSFont.SystemFontSize);
-					LayoutIfNeeded();
+					InvalidateMeasure();
 				});
 			}
 		}

--- a/src/Eto.Mac/Forms/MacBase.cs
+++ b/src/Eto.Mac/Forms/MacBase.cs
@@ -27,8 +27,6 @@ namespace Eto.Mac.Forms
 	{
 		NSView ContainerControl { get; }
 
-		Size PositionOffset { get; }
-
 		Size MinimumSize { get; set; }
 
 		bool IsEventHandled(string eventName);
@@ -44,6 +42,8 @@ namespace Eto.Mac.Forms
 		SizeF GetPreferredSize(SizeF availableSize);
 
 		void RecalculateKeyViewLoop(ref NSView last);
+
+		void InvalidateMeasure();
 	}
 
 	[Register("ObserverHelper")]

--- a/src/Eto.Mac/Forms/MacControlExtensions.cs
+++ b/src/Eto.Mac/Forms/MacControlExtensions.cs
@@ -67,17 +67,6 @@ namespace Eto.Mac.Forms
 
 		}
 
-		public static IMacContainer GetMacContainer(this Control control)
-		{
-			if (control == null)
-				return null;
-			var container = control.Handler as IMacContainer;
-			if (container != null)
-				return container;
-			var child = control.ControlObject as Control;
-			return child == null ? null : child.GetMacContainer();
-		}
-
 		public static IMacViewHandler GetMacViewHandler(this Control control)
 		{
 			if (control == null)

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -198,13 +198,13 @@ namespace Eto.Mac.Forms
 		public virtual Size MinimumSize
 		{
 			get { return Widget.Properties.Get<Size?>(MacView.MinimumSize_Key) ?? DefaultMinimumSize; }
-			set { Widget.Properties[MacView.MinimumSize_Key] = value; NaturalSize = null; }
+			set { Widget.Properties[MacView.MinimumSize_Key] = value; InvalidateMeasure(); }
 		}
 
 		public virtual SizeF MaximumSize
 		{
 			get { return Widget.Properties.Get<SizeF?>(MacView.MaximumSize_Key) ?? SizeF.MaxValue; }
-			set { Widget.Properties[MacView.MaximumSize_Key] = value; }
+			set { Widget.Properties[MacView.MaximumSize_Key] = value; InvalidateMeasure(); }
 		}
 
 		public Size? PreferredSize
@@ -223,29 +223,32 @@ namespace Eto.Mac.Forms
 			}
 			set
 			{
-				var oldSize = GetPreferredSize(Size.MaxValue);
+				AutoSize = value.Width == -1 || value.Height == -1;
+				if (!Widget.Loaded)
+				{
+					if (PreferredSize != value)
+					{
+						PreferredSize = value;
+						Callback.OnSizeChanged(Widget, EventArgs.Empty);
+					}
+					return;
+				}
 				PreferredSize = value;
 
 				var oldFrameSize = ContainerControl.Frame.Size;
 				var newSize = oldFrameSize;
 				if (value.Width >= 0)
 					newSize.Width = value.Width;
-				else if (!Widget.Loaded)
-					newSize.Width = oldSize.Width;
-				
 				if (value.Height >= 0)
 					newSize.Height = value.Height;
-				else if (!Widget.Loaded)
-					newSize.Height = oldSize.Height;
 
 				// this doesn't get to our overridden method to handle the event (since it calls [super setFrameSize:]) so trigger event manually.
 				ContainerControl.SetFrameSize(newSize);
 				if (oldFrameSize != newSize)
 					Callback.OnSizeChanged(Widget, EventArgs.Empty);
 
-				AutoSize = value.Width == -1 || value.Height == -1;
 				CreateTracking();
-				LayoutIfNeeded(oldSize);
+				InvalidateMeasure();
 			}
 		}
 
@@ -255,22 +258,15 @@ namespace Eto.Mac.Forms
 			set { Widget.Properties[MacView.NaturalSize_Key] = value; }
 		}
 
-		protected virtual bool LayoutIfNeeded(SizeF? oldPreferredSize = null, bool force = false)
+
+		public virtual void InvalidateMeasure()
 		{
 			NaturalSize = null;
-			if (Widget.Loaded)
-			{
-				var oldSize = oldPreferredSize ?? ContainerControl.Frame.Size.ToEtoSize();
-				var newSize = GetPreferredSize(Size.MaxValue);
-				if (newSize != oldSize || force)
-				{
-					var container = Widget.VisualParent.GetMacContainer();
-					if (container != null)
-						container.LayoutParent();
-					return true;
-				}
-			}
-			return false;
+
+			if (!Widget.Loaded)
+				return;
+
+			Widget.VisualParent.GetMacControl()?.InvalidateMeasure();
 		}
 
 		protected virtual SizeF GetNaturalSize(SizeF availableSize)
@@ -278,14 +274,10 @@ namespace Eto.Mac.Forms
 			var naturalSize = NaturalSize;
 			if (naturalSize != null)
 				return naturalSize.Value;
-			var control = Control as NSControl;
+			var control = ContainerControl as NSView;
 			if (control != null)
 			{
-				var size = (Widget.Loaded) ? (CGSize?)control.Frame.Size : null;
-				control.SizeToFit();
-				naturalSize = control.Frame.Size.ToEto();
-				if (size != null)
-					control.SetFrameSize(size.Value);
+				naturalSize = control.FittingSize.ToEto();
 				NaturalSize = naturalSize;
 				return naturalSize.Value;
 			}
@@ -317,10 +309,10 @@ namespace Eto.Mac.Forms
 			}
 			else
 				size = GetNaturalSize(availableSize);
-			return SizeF.Min(SizeF.Max(size, MinimumSize), MaximumSize);
-		}
+			size =  SizeF.Min(SizeF.Max(size, MinimumSize), MaximumSize);
 
-		public virtual Size PositionOffset { get { return Size.Empty; } }
+			return size;
+		}
 
 		void CreateTracking()
 		{
@@ -661,12 +653,14 @@ namespace Eto.Mac.Forms
 				if (!args.Delta.IsZero)
 				{
 					handler.Callback.OnMouseWheel(handler.Widget, args);
-					if (!args.Handled)
-					{
-						Messaging.void_objc_msgSendSuper_IntPtr(obj.SuperHandle, sel, e);
-					}
+				}
+				if (!args.Handled)
+				{
+					Messaging.void_objc_msgSendSuper_IntPtr(obj.SuperHandle, sel, e);
 				}
 			}
+			else
+				Messaging.void_objc_msgSendSuper_IntPtr(obj.SuperHandle, sel, e);
 		}
 
 		public virtual void OnSizeChanged(EventArgs e)
@@ -692,8 +686,6 @@ namespace Eto.Mac.Forms
 
 		public virtual void ResumeLayout()
 		{
-			if (!Widget.IsSuspended && Widget.Loaded)
-				LayoutIfNeeded();
 		}
 
 
@@ -716,9 +708,12 @@ namespace Eto.Mac.Forms
 			get { return Widget.Properties.Get<Color?>(MacView.BackgroundColorKey) ?? Colors.Transparent; }
 			set
 			{
-				Widget.Properties[MacView.BackgroundColorKey] = value;
-				if (Widget.Loaded)
-					SetBackgroundColor(value);
+				if (value != BackgroundColor)
+				{
+					Widget.Properties[MacView.BackgroundColorKey] = value;
+					if (Widget.Loaded)
+						SetBackgroundColor(value);
+				}
 			}
 		}
 
@@ -739,13 +734,16 @@ namespace Eto.Mac.Forms
 			Messaging.void_objc_msgSendSuper_CGRect(control.SuperHandle, sel, rect);
 		}
 
+		bool drawRectAdded;
+
 		protected virtual void SetBackgroundColor(Color? color)
 		{
 			if (color != null)
 			{
-				if (color.Value.A > 0)
+				if (color.Value.A > 0 && !drawRectAdded)
 				{
 					AddMethod(MacView.selDrawRect, new Action<IntPtr, IntPtr, CGRect>(DrawBackgroundRect), EtoEnvironment.Is64BitProcess ? "v@:{CGRect=dddd}" : "v@:{CGRect=ffff}", ContainerControl);
+					drawRectAdded = true;
 				}
 				ContainerControl.SetNeedsDisplay();
 			}
@@ -774,9 +772,8 @@ namespace Eto.Mac.Forms
 			{
 				if (ContainerControl.Hidden == value)
 				{
-					var oldSize = GetPreferredSize(Size.MaxValue);
 					ContainerControl.Hidden = !value;
-					LayoutIfNeeded(oldSize, true);
+					InvalidateMeasure();
 					if (Widget.Loaded && value)
 						FireOnShown();
 				}

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -106,7 +106,7 @@ namespace Eto.Mac.Forms
 		public WeakReference WeakHandler { get; set; }
 	}
 
-	public interface IMacWindow : IMacContainer
+	public interface IMacWindow : IMacControlHandler
 	{
 		Rectangle? RestoreBounds { get; set; }
 
@@ -132,7 +132,7 @@ namespace Eto.Mac.Forms
 		public static IntPtr selSetMainMenu = Selector.GetHandle("setMainMenu:");
 	}
 
-	public abstract class MacWindow<TControl, TWidget, TCallback> : MacPanel<TControl, TWidget, TCallback>, Window.IHandler, IMacContainer, IMacWindow
+	public abstract class MacWindow<TControl, TWidget, TCallback> : MacPanel<TControl, TWidget, TCallback>, Window.IHandler, IMacWindow
 		where TControl: NSWindow
 		where TWidget: Window
 		where TCallback: Window.ICallback
@@ -847,7 +847,7 @@ namespace Eto.Mac.Forms
 
 		#region IMacContainer implementation
 
-		public override void SetContentSize(CGSize contentSize)
+		void SetContentSize(CGSize contentSize)
 		{
 			if (MinimumSize != Size.Empty)
 			{
@@ -891,22 +891,13 @@ namespace Eto.Mac.Forms
 			}
 		}
 
-		Window IMacWindow.Widget
-		{
-			get { return Widget; }
-		}
+		Window IMacWindow.Widget => Widget;
 
-		NSWindow IMacWindow.Control
-		{
-			get { return Control; }
-		}
+		NSWindow IMacWindow.Control => Control;
 
 		#endregion
 
-		public Screen Screen
-		{
-			get { return new Screen(new ScreenHandler(Control.Screen)); }
-		}
+		public Screen Screen => new Screen(new ScreenHandler(Control.Screen));
 
 		public override PointF PointFromScreen(PointF point)
 		{
@@ -955,9 +946,6 @@ namespace Eto.Mac.Forms
 		{
 		}
 
-		public float LogicalPixelSize
-		{
-			get { return Screen?.LogicalPixelSize ?? 1f; }
-		}
+		public float LogicalPixelSize => Screen?.LogicalPixelSize ?? 1f;
 	}
 }

--- a/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
@@ -7,12 +7,28 @@ using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
+using CoreImage;
 #else
 using MonoMac.AppKit;
 using MonoMac.Foundation;
 using MonoMac.CoreGraphics;
 using MonoMac.ObjCRuntime;
 using MonoMac.CoreAnimation;
+using MonoMac.CoreImage;
+#if Mac64
+using nfloat = System.Double;
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nfloat = System.Single;
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
 #endif
 
 namespace Eto.Mac.Forms.Menu

--- a/src/Eto.Mac/Mac64Extensions.cs
+++ b/src/Eto.Mac/Mac64Extensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Drawing;
 using System.Runtime.InteropServices;
 #if IOS
@@ -168,6 +168,29 @@ namespace Eto.Mac
 		{
 			frame.Size = size.ToNS();
 			return frame;
+		}
+
+		public static CGRect WithPadding(this CGRect frame, Padding padding)
+		{
+			frame.X += padding.Left;
+			frame.Width -= padding.Horizontal;
+			frame.Y += padding.Bottom;
+			frame.Height -= padding.Vertical;
+			return frame;
+		}
+
+		public static Size TruncateInfinity(this SizeF size)
+		{
+			var result = new Size();
+			if (float.IsPositiveInfinity(size.Width))
+				result.Width = int.MaxValue;
+			else
+				result.Width = (int)Math.Truncate(size.Width);
+			if (float.IsPositiveInfinity(size.Height))
+				result.Height = int.MaxValue;
+			else
+				result.Height = (int)Math.Truncate(size.Height);
+			return result;
 		}
 	}
 }

--- a/src/Eto.Mac/MacHelpers.cs
+++ b/src/Eto.Mac/MacHelpers.cs
@@ -49,7 +49,7 @@ namespace Eto.Forms
 				control.AttachNative();
 				var macControl = control.GetMacControl();
 				if (macControl != null && macControl.AutoSize)
-					macControl.ContainerControl.SetFrameSize(macControl.GetPreferredSize(SizeF.MaxValue).ToNS());
+					macControl.ContainerControl.SetFrameSize(macControl.GetPreferredSize(SizeF.PositiveInfinity).ToNS());
 			}
 			return control.GetContainerView();
 		}

--- a/src/Eto/Drawing/SizeF.cs
+++ b/src/Eto/Drawing/SizeF.cs
@@ -70,6 +70,16 @@ namespace Eto.Drawing
 		public static readonly SizeF MinValue = new SizeF (float.MinValue, float.MinValue);
 
 		/// <summary>
+		/// A SizeF with the width and height set to float.PositiveInfinity
+		/// </summary>
+		public static readonly SizeF PositiveInfinity = new SizeF (float.PositiveInfinity, float.PositiveInfinity);
+
+		/// <summary>
+		/// A SizeF with the width and height set to float.NegativeInfinity
+		/// </summary>
+		public static readonly SizeF NegativeInfinity = new SizeF (float.NegativeInfinity, float.NegativeInfinity);
+
+		/// <summary>
 		/// Initializes a new SizeF class with the specified width and height
 		/// </summary>
 		/// <param name="width">Initial width of the size</param>

--- a/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
@@ -404,6 +404,7 @@ namespace Eto.Test.Sections.Behaviors
 			}
 
 			layout.Add(null);
+			child.Padding = 20;
 			child.Content = layout;
 
 			child.OwnerChanged += child_OwnerChanged;

--- a/test/Eto.Test/Sections/Controls/ImageViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/ImageViewSection.cs
@@ -28,7 +28,7 @@ namespace Eto.Test.Sections.Controls
 			var page = new TabPage { Text = "Fixed Size" };
 			page.Content = new Scrollable
 			{
-				Border = BorderType.None,
+				Border = BorderType.Bezel,
 				ExpandContentWidth = false,
 				ExpandContentHeight = false,
 				Content = layout

--- a/test/Eto.Test/Sections/Controls/LabelSection.cs
+++ b/test/Eto.Test/Sections/Controls/LabelSection.cs
@@ -127,7 +127,7 @@ namespace Eto.Test.Sections.Controls
 
 		Control WrapLabel()
 		{
-			const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum";
+			const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 			var label = new Label
 			{
 				Text = text
@@ -143,7 +143,7 @@ namespace Eto.Test.Sections.Controls
 			verticalAlignmentDropDown.SelectedValueBinding.Bind(label, l => l.VerticalAlignment);
 
 			var testVerticalAlignment = new CheckBox { Text = "Test VerticalAlignment" };
-			testVerticalAlignment.CheckedChanged += (sender, e) => label.Height = testVerticalAlignment.Checked == true ? 200 : -1;
+			testVerticalAlignment.CheckedChanged += (sender, e) => label.Size = new Size(-1, testVerticalAlignment.Checked == true ? 200 : -1);
 			testVerticalAlignment.CheckedBinding.Bind(verticalAlignmentDropDown, c => c.Enabled, DualBindingMode.OneWayToSource);
 
 			var fontSelector = new FontPicker();

--- a/test/Eto.Test/UnitTests/Drawing/IconTests.cs
+++ b/test/Eto.Test/UnitTests/Drawing/IconTests.cs
@@ -13,13 +13,14 @@ namespace Eto.Test.UnitTests.Drawing
 		[TestCase(1.5f, 1.5f)]
 		[TestCase(1.75f, 2f)]
 		[TestCase(2f, 2f)]
-		[TestCase(4f, 3f)]
+		[TestCase(4f, 4f)]
+		[TestCase(5f, 4f)]
 		public void IconShouldSupportMultipleResolutions(float scale, float expectedResult)
 		{
 			var icon = TestIcons.Logo;
 
 			Assert.IsNotNull(icon, "#1");
-			var expectedScales = new [] { 0.5f, 1f, 1.5f, 2f, 3f };
+			var expectedScales = new [] { 0.5f, 1f, 1.5f, 2f, 4f };
 
 			Assert.AreEqual(expectedScales.Length, icon.Frames.Count(), "#2 - Should be a representation for each image with @<scale>");
 

--- a/test/Eto.Test/UnitTests/Forms/ContainerTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ContainerTests.cs
@@ -1,0 +1,51 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms
+{
+	[TestFixture]
+	public class ContainerTests : TestBase
+	{
+		[TestCaseSource(nameof(GetPanelTypes)), ManualTest]
+		public void PanelPaddingShouldWork(Type panelType)
+		{
+			ManualForm(
+				"There should be 40px padding around the blue rectangle",
+				form =>
+				{
+					var panel = CreatePanelType(panelType, out var container);
+					Assert.IsNotNull(panel);
+
+					panel.Padding = 40;
+					panel.Content = new Panel
+					{
+						BackgroundColor = Colors.Blue,
+						Size = new Size(200, 200)
+					};
+					return container;
+				});
+		}
+
+		[TestCaseSource(nameof(GetPanelTypes)), ManualTest]
+		public void PanelPaddingBottomRightShouldWork(Type panelType)
+		{
+			ManualForm(
+				"There should be 40px padding at the bottom and right of the blue rectangle",
+				form =>
+				{
+					var panel = CreatePanelType(panelType, out var container);
+					Assert.IsNotNull(panel);
+
+					panel.Padding = new Padding(0, 0, 40, 40);
+					panel.Content = new Panel
+					{
+						BackgroundColor = Colors.Blue,
+						Size = new Size(200, 200)
+					};
+					return container;
+				});
+		}
+	}
+}

--- a/test/Eto.Test/UnitTests/Forms/Layout/StackLayoutTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Layout/StackLayoutTests.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using NUnit.Framework;
+using Eto.Drawing;
 
 namespace Eto.Test.UnitTests.Forms.Layout
 {
@@ -174,4 +175,3 @@ namespace Eto.Test.UnitTests.Forms.Layout
 		}
 	}
 }
-

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -280,7 +280,6 @@ namespace Eto.Test.UnitTests
 
 				form.Content = new StackLayout
 				{
-					Padding = 10,
 					Spacing = 10,
 					Items =
 					{
@@ -490,6 +489,7 @@ namespace Eto.Test.UnitTests
 				.OrderBy(r => r.FullName);
 		}
 
+
 		public static IEnumerable<Type> GetControlTypes()
 		{
 			return GetAllControlTypes()
@@ -499,6 +499,44 @@ namespace Eto.Test.UnitTests
 					return !typeof(Window).GetTypeInfo().IsAssignableFrom(ti)
 						&& !typeof(TabPage).GetTypeInfo().IsAssignableFrom(ti);
 				});
+		}
+
+		public static IEnumerable<Type> GetPanelTypes()
+		{
+			yield return typeof(Panel);
+			yield return typeof(Expander);
+			yield return typeof(GroupBox);
+			yield return typeof(TabPage);
+			yield return typeof(DocumentPage);
+			yield return typeof(Scrollable);
+			yield return typeof(Drawable);
+		}
+
+		public static Panel CreatePanelType(Type panelType, out Control container)
+		{
+			var panel = Activator.CreateInstance(panelType) as Panel;
+			container = panel;
+			if (panel is TabPage tabPage)
+			{
+				tabPage.Text = "TabPage";
+				container = new TabControl { Pages = { tabPage } };
+			}
+			else if (panel is DocumentPage documentPage)
+			{
+				documentPage.Text = "DocumentPage";
+				container = new DocumentControl { Pages = { documentPage } };
+			}
+			else if (panel is GroupBox groupBox)
+			{
+				groupBox.Text = "GroupBox";
+			}
+			else if (panel is Expander expander)
+			{
+				expander.Header = "Expander";
+				expander.Expanded = true;
+			}
+
+			return panel;
 		}
 	}
 }


### PR DESCRIPTION
- Fixes various layout bugs in Mac and improves performance dramatically when changing the properties of only a few controls in a large form.
- Rework the layout so that no calculations are done while changing properties of a control (Label being the biggest offender)
- Only perform layout once during NSView.Layout()
- SuspendLayout/ResumeLayout now do nothing on Mac as the layout isn't ever updated until everything is done.
- Padding now applied during layout vs. using autosizing
- Cache measure result of TableLayout so when we do another full layout it only recalculates what is necessary
- Use NSView.FittingSize vs. SizeToFit() and saving/restoring NSView.Frame to determine the natural size of a control
- Rework Scrollable for the new layout as it had various hacks to make it work properly.


Fixes #1081
Should also fix #925