### PR TITLE
Wpf: Fix crash with RichTextArea when setting text decorations

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
@@ -351,7 +351,12 @@ namespace Eto.Wpf.Forms.Controls
 					decorations = new sw.TextDecorationCollection(decorations);
 				selectionAttributes[swd.Inline.TextDecorationsProperty] = decorations;
 			}
-			else decorations = (sw.TextDecorationCollection)decorationsObj;
+			else
+			{
+				decorations = (sw.TextDecorationCollection)decorationsObj;
+				if (decorations.IsFrozen)
+					decorations = new sw.TextDecorationCollection(decorations);
+			}
 
 			foreach (var decoration in setDecorations)
 			{


### PR DESCRIPTION
Create a copy of the decorations if they are frozen as we are modifying it.