### PR TITLE
Properly handle Reset for FilterCollection

### DIFF
--- a/src/Eto/CollectionChangedHandler.cs
+++ b/src/Eto/CollectionChangedHandler.cs
@@ -242,6 +242,21 @@ namespace Eto
 				RemoveItem(item);
 		}
 
+		/// <summary>
+		/// Resets the collection when it is dramatically changed
+		/// </summary>
+		/// <remarks>
+		/// By default this removes all items and adds all items back (if Collection is an IEnumerable{T})
+		/// Platform implementations can override this to do something more efficient if needed.
+		/// </remarks>
+		public virtual void Reset()
+		{
+			RemoveAllItems();
+			var items = Collection as IEnumerable<TItem>;
+			if (items != null)
+				AddRange(items);
+		}
+
 		void CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			switch (e.Action)
@@ -292,7 +307,7 @@ namespace Eto
 					}
 					break;
 				case NotifyCollectionChangedAction.Reset:
-					RemoveAllItems();
+					Reset();
 					break;
 			}
 		}

--- a/src/Eto/Forms/FilterCollection.cs
+++ b/src/Eto/Forms/FilterCollection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Linq;
@@ -684,6 +684,19 @@ namespace Eto.Forms
 					List.items.Clear();
 					List.filtered?.Clear();
 					List.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+				}
+			}
+
+			public override void Reset()
+			{
+				if (List.updating)
+					return;
+				using (List.CreateChange())
+				{
+					List.items.Clear();
+					if (Collection != null)
+				    	List.items.AddRange(Collection);
+					List.Refresh();
 				}
 			}
 		}

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
@@ -1,9 +1,12 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using Eto.Forms;
 using System.Collections.Generic;
 using System.Runtime.ExceptionServices;
 using Eto.Drawing;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {
@@ -104,6 +107,42 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			}, -1);
 			if (exception != null)
 				ExceptionDispatchInfo.Capture(exception).Throw();
+		}
+
+		class MyCollection : ObservableCollection<DataItem>
+		{
+			public void AddRange(IEnumerable<DataItem> items)
+			{
+				foreach (var item in items)
+					Items.Add(item);
+				OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+			}
+		}
+
+		[Test, ManualTest]
+		public void CollectionChangedWithResetShouldShowItems()
+		{
+			var count = 10;
+			ManualForm($"GridView should show {count} items", form =>
+			{
+				var collection = new MyCollection();
+				var filterCollection = new FilterCollection<DataItem>(collection);
+				var myGridView = new GridView
+				{
+					Size = new Size(200, 260),
+					DataStore = filterCollection,
+					Columns = {
+						new GridColumn {
+							DataCell = new TextBoxCell { Binding = Eto.Forms.Binding.Property((DataItem m) => m.Id.ToString()) }
+						}
+					}
+				};
+				collection.Clear();
+				collection.AddRange(Enumerable.Range(1, count).Select(r => new DataItem(r)));
+
+				return myGridView;
+			});
+
 		}
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/FilterCollectionTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/FilterCollectionTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using Eto.Forms;
 using System.Collections.Generic;
@@ -345,6 +345,32 @@ namespace Eto.Test.UnitTests.Forms
 			Assert.AreEqual(model.Count, filtered.Count, "#4-3 Count in filtered does not match model");
 			Assert.AreEqual(1000, filtered[filtered.Count - 2].Id, "#4-1 Item 1000 was not added in the correct location");
 			Assert.AreEqual(1001, filtered[filtered.Count - 1].Id, "#4-2 Item 1001 was not added in the correct location");
+		}
+
+		class MyCollection : ObservableCollection<DataItem>
+		{
+			public void AddRange(IEnumerable<DataItem> items)
+			{
+				foreach (var item in items)
+					Items.Add(item);
+				OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+			}
+		}
+
+
+		[Test]
+		public void ResetShouldAddCurrentItemsToFilteredList()
+		{
+			var collection = new MyCollection();
+			var filterCollection = new FilterCollection<DataItem>(collection);
+
+			collection.AddRange(Enumerable.Range(1, 10).Select(r => new DataItem(r)));
+
+			Assert.AreEqual(10, filterCollection.Count, "FilterCollection.Count should be equal to 10 after adding items in bulk");
+
+			collection.AddRange(Enumerable.Range(1, 10).Select(r => new DataItem(r)));
+
+			Assert.AreEqual(20, filterCollection.Count, "FilterCollection.Count should be equal to 20 after adding more items in bulk");
 		}
 	}
 }


### PR DESCRIPTION
- When responding to NotifyCollectionChangedAction.Reset, the CollectionChangedHandler only removed all items, but should add existing items back.
- Add CollectionChangedHandler.Reset() so that implementations can override and provide a more efficient way (e.g. if you don't need to remove and re-add)
- Added tests for FilterCollection and GridView to ensure the items are indeed shown correctly.