### PR TITLE
Wpf: Fix using a CustomCell as the first column

### DIFF
--- a/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
@@ -122,7 +122,7 @@ namespace Eto.Wpf.Forms.Cells
 			static void HandleControlDataContextChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
 			{
 				var ctl = sender as EtoBorder;
-				var cell = ctl?.Parent as swc.DataGridCell;
+				var cell = ctl?.GetParent<swc.DataGridCell>();
 				var col = cell?.Column as Column;
 				var handler = col?.Handler;
 				if (handler == null)


### PR DESCRIPTION
Direct parent will not be the DataGridCell as we need to add the expander.