### PR TITLE
Mac: calculate sizes correctly for autosized TableLayout cells

### DIFF
--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1011,7 +1011,7 @@ namespace Eto.Mac.Forms
 			}
 		}
 
-		protected void FireOnShown() => FireOnShown(Widget);
+		protected virtual void FireOnShown() => FireOnShown(Widget);
 
 		public bool AllowDrop
 		{

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -803,7 +803,7 @@ namespace Eto.Mac.Forms
 			if (AutoSize)
 			{
 				AutoSize = false;
-				var availableSize = Size.MaxValue;
+				var availableSize = SizeF.PositiveInfinity;
 				if (PreferredSize != null)
 				{
 					var borderSize = GetBorderSize();
@@ -826,6 +826,11 @@ namespace Eto.Mac.Forms
 			return Control.FrameRectFor(CGRect.Empty).Size.ToEtoSize();
 		}
 
+		protected override void FireOnShown()
+		{
+			Control.ContentView.LayoutSubtreeIfNeeded();
+			base.FireOnShown();
+		}
 
 		public override void OnLoadComplete(EventArgs e)
 		{

--- a/src/Eto.Mac/Forms/TableLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/TableLayoutHandler.cs
@@ -178,7 +178,7 @@ namespace Eto.Mac.Forms
 			{
 				var yscaled = y == lastyscale || yscaling[y];
 
-				availableControlSize.Height = yscaled ? remaining.Height : int.MaxValue;
+				availableControlSize.Height = yscaled ? remaining.Height : float.PositiveInfinity;
 
 				for (int x = 0; x < widths.Length; x++)
 				{	
@@ -187,7 +187,7 @@ namespace Eto.Mac.Forms
 					if (!xscaled && !yscaled)
 						continue;
 
-					availableControlSize.Width = xscaled ? remaining.Width : int.MaxValue;
+					availableControlSize.Width = xscaled ? remaining.Width : float.PositiveInfinity;
 
 					var view = views[y, x];
 					if (view != null && view.Visible)

--- a/test/Eto.Test/UnitTests/Forms/Layout/TableLayoutTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Layout/TableLayoutTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using Eto.Forms;
 using Eto.Drawing;
@@ -166,6 +166,32 @@ namespace Eto.Test.UnitTests.Forms.Layout
 						}
 					}
 				};
+			});
+		}
+
+		/// <summary>
+		/// Bug in macOS when sizing labels when parent size is fixed
+		/// </summary>
+		[Test]
+		public void LabelInAutoSizedColumnShouldHaveCorrectWidth()
+		{
+			Shown(form =>
+			{
+				var label = new Label { Text = "Hello Then" };
+
+				form.ClientSize = new Size(400, 200);
+				form.Content = new TableLayout
+				{
+					Rows = {
+						new TableRow(new TextBox(), label, null),
+						null
+					}
+				};
+				return label;
+			}, label =>
+			{
+				Assert.Greater(label.Width, 0, "Label didn't get correct width!");
+				Assert.Greater(label.Height, 0, "Label didn't get correct height!");
 			});
 		}
 	}


### PR DESCRIPTION
- Missed a few spots where PositiveInfinity is required vs. int.MaxValue.
- Ensure layout is performed before shown is fired when the form/dialog is not auto sized