### PR TITLE
Wpf: Fix RichTextArea saving RTF with different font weights

### DIFF
--- a/src/Eto.Wpf/CustomControls/FontDialog/namedictionaryhelper.cs
+++ b/src/Eto.Wpf/CustomControls/FontDialog/namedictionaryhelper.cs
@@ -8,11 +8,21 @@ namespace Eto.Wpf.CustomControls.FontDialog
 {
     static class NameDictionaryHelper
     {
-        public static string GetDisplayName(LanguageSpecificStringDictionary nameDictionary)
+		public static string GetEnglishName(LanguageSpecificStringDictionary nameDictionary)
+		{
+			return GetName(nameDictionary, "en-us");
+		}
+
+		public static string GetDisplayName(LanguageSpecificStringDictionary nameDictionary)
+		{
+			return GetName(nameDictionary, CultureInfo.CurrentUICulture.IetfLanguageTag);
+		}
+
+		public static string GetName(LanguageSpecificStringDictionary nameDictionary, string ietfLanguageTag)
         {
             // Look up the display name based on the UI culture, which is the same culture
             // used for resource loading.
-            var userLanguage = XmlLanguage.GetLanguage(CultureInfo.CurrentUICulture.IetfLanguageTag);
+            var userLanguage = XmlLanguage.GetLanguage(ietfLanguageTag);
 
             // Look for an exact match.
             string name;

--- a/test/Eto.Test/Sections/Controls/RichTextAreaSection.cs
+++ b/test/Eto.Test/Sections/Controls/RichTextAreaSection.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using Eto.Drawing;
 using System.IO;
@@ -10,9 +10,9 @@ namespace Eto.Test.Sections.Controls
 	[Section("Controls", typeof(RichTextArea))]
 	public class RichTextAreaSection : Panel
 	{
-		const string LoremText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+		string LoremText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 
-		const string RtfString = "{\\rtf1\\ansi\\ansicpg1252\\cocoartf1343\\cocoasubrtf160\r\n{\\fonttbl\\f0\\fswiss\\fcharset0 Helvetica;}\r\n{\\colortbl;\\red255\\green255\\blue255;}\r\n\\margl1440\\margr1440\\vieww10800\\viewh8400\\viewkind0\r\n\\pard\\tx566\\tx1133\\tx1700\\tx2267\\tx2834\\tx3401\\tx3968\\tx4535\\tx5102\\tx5669\\tx6236\\tx6803\\pardirnatural\r\n\r\n\\f0\\fs24 \\cf0 This is some \r\n\\b bold\r\n\\b0 , \r\n\\i italic\r\n\\i0 , and \\ul underline\\ulnone  text! \\\r\n\\\r\n\\pard\\tx566\\tx1133\\tx1700\\tx2267\\tx2834\\tx3401\\tx3968\\tx4535\\tx5102\\tx5669\\tx6236\\tx6803\\pardirnatural\\qr\r\n\\cf0 Some other text}";
+		string RtfString = "{\\rtf1\\ansi\\ansicpg1252\\cocoartf1343\\cocoasubrtf160\r\n{\\fonttbl\\f0\\fswiss\\fcharset0 Helvetica;}\r\n{\\colortbl;\\red255\\green255\\blue255;}\r\n\\margl1440\\margr1440\\vieww10800\\viewh8400\\viewkind0\r\n\\pard\\tx566\\tx1133\\tx1700\\tx2267\\tx2834\\tx3401\\tx3968\\tx4535\\tx5102\\tx5669\\tx6236\\tx6803\\pardirnatural\r\n\r\n\\f0\\fs24 \\cf0 This is some \r\n\\b bold\r\n\\b0 , \r\n\\i italic\r\n\\i0 , and \\ul underline\\ulnone  text! \\\r\n\\\r\n\\pard\\tx566\\tx1133\\tx1700\\tx2267\\tx2834\\tx3401\\tx3968\\tx4535\\tx5102\\tx5669\\tx6236\\tx6803\\pardirnatural\\qr\r\n\\cf0 Some other text}";
 
 		public RichTextAreaSection()
 		{
@@ -123,6 +123,10 @@ namespace Eto.Test.Sections.Controls
 				var stream = new MemoryStream();
 				buffer.Save(stream, formatEnum.SelectedValue);
 				stream.Position = 0;
+				if (formatEnum.SelectedValue == RichTextAreaFormat.Rtf)
+					RtfString = Encoding.UTF8.GetString(stream.ToArray());
+				else
+					LoremText = Encoding.UTF8.GetString(stream.ToArray());
 				Log.Write(richText, "Saved {0}:\n{1}", formatEnum.SelectedValue, new StreamReader(stream).ReadToEnd());
 			};
 


### PR DESCRIPTION
- It only worked with bold, but light, ultralight, semibold, black, etc wouldn't save correctly.
- Updated RichTextArea test so save will update text that will be used for loading