### PR TITLE
DPI scaling fix in Direct2D engine, ClipBounds property fix in Direct2D and WinForms

### DIFF
--- a/src/Eto.Direct2D/2DConversions.cs
+++ b/src/Eto.Direct2D/2DConversions.cs
@@ -86,9 +86,9 @@ namespace Eto.Direct2D
 			return new s.Size2F(value.Width, value.Height);
 		}
 
-		public static Point ToEto(this s.Vector2 value)
+		public static PointF ToEto(this s.Vector2 value)
 		{
-			return new Point((int)value.X, (int)value.Y);
+			return new PointF(value.X, value.Y);
 		}
 
 		public static s.Vector2 ToDx(this PointF value)

--- a/src/Eto.Direct2D/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Direct2D/Drawing/GraphicsHandler.cs
@@ -130,8 +130,10 @@ namespace Eto.Direct2D.Drawing
 		{
 			var renderProp = new sd.RenderTargetProperties
 			{
-				DpiX = 0,
-				DpiY = 0,
+				/* Direct2D rendering engine does not perform DPI virtualization like WPF and Logical pixel size is always 1
+				   In order to prevent SharpDX from using real screen DPI, we fix the scale ratio to 1 */
+				DpiX = 96,
+				DpiY = 96,
 				MinLevel = sd.FeatureLevel.Level_DEFAULT,
 				Type = sd.RenderTargetType.Default,
 				Usage = sd.RenderTargetUsage.None

--- a/src/Eto.Direct2D/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Direct2D/Drawing/GraphicsHandler.cs
@@ -202,11 +202,11 @@ namespace Eto.Direct2D.Drawing
 				if (Control != null)
 				{
 					// not very efficient, but works
-					s.Matrix3x2 transform = Control.Transform;
+					s.Matrix3x2 transform = currentTransform;
 					transform.Invert();
-					var start = s.Matrix3x2.TransformPoint(transform, clipBounds.Location.ToDx()).ToEto();
-					var end = s.Matrix3x2.TransformPoint(transform, clipBounds.EndLocation.ToDx()).ToEto();
-					return new RectangleF(start, end);
+					var topleft = s.Matrix3x2.TransformPoint(transform, clipBounds.TopLeft.ToDx()).ToEto();
+					var bottomright = s.Matrix3x2.TransformPoint(transform, clipBounds.BottomRight.ToDx()).ToEto();
+					return RectangleF.FromSides(topleft.X, topleft.Y, bottomright.X, bottomright.Y);
 				}
 				else
 					return new RectangleF();

--- a/src/Eto.WinForms/Drawing/GraphicsHandler.cs
+++ b/src/Eto.WinForms/Drawing/GraphicsHandler.cs
@@ -427,8 +427,11 @@ namespace Eto.WinForms.Drawing
 		{
 			get
 			{
+				var oldValue = this.Control.PixelOffsetMode;
 				this.Control.PixelOffsetMode = sdd.PixelOffsetMode.None;
-				return this.Control.ClipBounds.ToEto();
+				var result = this.Control.ClipBounds.ToEto();
+				this.Control.PixelOffsetMode = oldValue;
+				return result;
 			}
 		}
 

--- a/src/Eto.WinForms/Drawing/GraphicsHandler.cs
+++ b/src/Eto.WinForms/Drawing/GraphicsHandler.cs
@@ -425,7 +425,11 @@ namespace Eto.WinForms.Drawing
 
 		public RectangleF ClipBounds
 		{
-			get { return this.Control.ClipBounds.ToEto(); }
+			get
+			{
+				this.Control.PixelOffsetMode = sdd.PixelOffsetMode.None;
+				return this.Control.ClipBounds.ToEto();
+			}
 		}
 
 		public void SetClip(RectangleF rectangle)


### PR DESCRIPTION
It's a fix to an issue #1141.

1. Direct2D: `ClipBounds` value was incorrect when DPI scaling was on due to rounding and logical problems.
2. WinForms: `ClipBounds` should not depend on PixelOffsetMode value.
3. Direct2D: since the control size is physical size regardess of screen DPI, there is no need to scale WicRenderTarget.