### PR TITLE
Direct2D: fix memory leak in Graphics.DrawImage(Bitmap, ...)

### DIFF
--- a/src/Eto.Direct2D/Drawing/ImageHandler.cs
+++ b/src/Eto.Direct2D/Drawing/ImageHandler.cs
@@ -47,7 +47,10 @@ namespace Eto.Direct2D.Drawing
 		{
 			if (Control.PixelFormat == PixelFormat.Format24bppRgb.ToWic())
 			{
-				return sd.Bitmap.FromWicBitmap(target, Control.ToBitmap(PixelFormat.Format32bppRgb.ToWic()));
+				using (var wicBitmap = Control.ToBitmap(PixelFormat.Format32bppRgb.ToWic()))
+				{
+					return sd.Bitmap.FromWicBitmap(target, wicBitmap);
+				}
 			}
             return sd.Bitmap.FromWicBitmap(target, Control);
 		}


### PR DESCRIPTION
A temporary object created inside `Graphics.DrawImage` method was not cleared properly thus resulting in memory leak.
This pull request fixes the problem.