### PR TITLE
Direct2D: fix a problem with bitmap freezing in Graphics.DrawImage

### DIFF
--- a/src/Eto.Direct2D/Drawing/BitmapHandler.cs
+++ b/src/Eto.Direct2D/Drawing/BitmapHandler.cs
@@ -58,6 +58,7 @@ namespace Eto.Direct2D.Drawing
 
         public void Unlock(BitmapData bitmapData)
         {
+			Reset();
         }
 	}
 }


### PR DESCRIPTION
Problem: `Graphics.DrawImage` paints old contents of `Bitmap` instance in Direct2D enging.

How to reproduce:
1. Create `Bitmap` object.
2. Paint on bitmap (any way).
3. Call `Graphics.DrawImage(bitmap, ...)`.
4. Update bitmap contents using `bitmap.Lock()`.
5. Call `Graphics.DrawImage(bitmap, ...)`. 

Expected result: updated bitmap content.
Actual result: old bitmap content is drawn.

Problem: a caching object `targetBitmap` is created at `DrawImage` but it is not destroyed after bitmap lock-unlock.

Solution: call `ImageHandler.Reset` in `Unlock` method.

Note: when the bitmap is updated using `new Graphics(bitmap)`, the `Reset` method is called as expected.