### PR TITLE
Wpf: Fix possible stack overflow with logical screen locations

### DIFF
--- a/src/Eto.WinForms/Eto.WinForms.csproj
+++ b/src/Eto.WinForms/Eto.WinForms.csproj
@@ -60,6 +60,9 @@
     <Compile Include="..\Eto.Wpf\Forms\VistaSelectFolderDialogHandler.cs">
       <Link>Forms\VistaSelectFolderDialogHandler.cs</Link>
     </Compile>
+    <Compile Include="..\Eto.Wpf\LogicalScreenHelper.cs">
+      <Link>LogicalScreenHelper.cs</Link>
+    </Compile>
     <Compile Include="..\Eto.Wpf\Win32.dib.cs">
       <Link>Win32.dib.cs</Link>
     </Compile>
@@ -349,7 +352,7 @@
     <EmbeddedResource Include="CustomControls\CalendarPicker.png" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.WindowsAPICodePack-Shell">
+    <PackageReference Include="Windows7APICodePack-Shell">
       <Version>1.1.0</Version>
       <IncludeAssets>compile</IncludeAssets>
       <ExcludeAssets>none</ExcludeAssets>

--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -91,7 +91,7 @@ namespace Eto.WinForms.Forms
 				var screen = swf.Screen.FromHandle(Control);
 				if (screen == null)
 					return 1;
-				return screen.GetDpi() / 96f;
+				return screen.GetLogicalPixelSize();
 			}
 		}
 

--- a/src/Eto.WinForms/Win32.dpi.cs
+++ b/src/Eto.WinForms/Win32.dpi.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using System.Windows;
 using swf = System.Windows.Forms;
 using sd = System.Drawing;
+using Eto.Drawing;
 #if WPF
 using Eto.Wpf.Forms;
 #elif WINFORMS
@@ -67,30 +68,6 @@ namespace Eto
 			return dpiX;
 		}
 
-		static swf.Screen FindLeftScreen(this swf.Screen screen) =>
-			swf.Screen.AllScreens
-			.Where(r => r.Bounds.X >= 0 && r.Bounds.Right == screen.Bounds.X)
-			.OrderBy(r => r.GetDpi())
-			.FirstOrDefault();
-
-		static swf.Screen FindRightScreen(this swf.Screen screen) => 
-			swf.Screen.AllScreens
-			.Where(r => r.Bounds.X < 0 && r.Bounds.X == screen.Bounds.Right)
-			.OrderBy(r => r.GetDpi())
-			.FirstOrDefault();
-
-		static swf.Screen FindTopScreen(this swf.Screen screen) =>
-			swf.Screen.AllScreens
-			.Where(r => r.Bounds.Y >= 0 && r.Bounds.Bottom == screen.Bounds.Y)
-			.OrderBy(r => r.GetDpi())
-			.FirstOrDefault();
-
-		static swf.Screen FindBottomScreen(this swf.Screen screen) =>
-			swf.Screen.AllScreens
-			.Where(r => r.Bounds.Y < 0 && r.Bounds.Y == screen.Bounds.Bottom)
-			.OrderBy(r => r.GetDpi())
-			.FirstOrDefault();
-
 		public static Eto.Drawing.Point LogicalToScreen(this Eto.Drawing.PointF point)
 		{
 			var screen = Eto.Forms.Screen.FromPoint(point);
@@ -137,76 +114,50 @@ namespace Eto
 				);
 		}
 
-		public static float GetMaxLogicalPixelSize() => swf.Screen.AllScreens.Max(r => r.GetLogicalPixelSize());
+		public static float GetMaxLogicalPixelSize() => locationHelper.GetMaxLogicalPixelSize();
 
 		public static Eto.Drawing.RectangleF GetLogicalBounds(this swf.Screen screen)
 		{
 			return new Eto.Drawing.RectangleF(GetLogicalLocation(screen), GetLogicalSize(screen));
 		}
 
-		public static Eto.Drawing.PointF GetLogicalLocation(this swf.Screen screen)
+		class ScreenHelper : LogicalScreenHelper<swf.Screen>
 		{
-			var bounds = screen.Bounds;
-			float x, y;
-			if (bounds.X > 0)
-			{
-				var left = screen.FindLeftScreen();
-				if (left != null)
-					x = GetLogicalLocation(left).X + GetLogicalSize(left).Width;
-				else
-					x = bounds.X / GetMaxLogicalPixelSize();
-			}
-			else if (bounds.X < 0)
-			{
-				var right = screen.FindRightScreen();
-				if (right != null)
-					x = GetLogicalLocation(right).X - GetLogicalSize(screen).Width;
-				else
-					x = bounds.X / screen.GetLogicalPixelSize();
-			}
-			else x = bounds.X;
-			if (bounds.Y > 0)
-			{
-				var top = screen.FindTopScreen();
-				if (top != null)
-					y = GetLogicalLocation(top).Y + GetLogicalSize(top).Height;
-				else
-					y = bounds.Y / GetMaxLogicalPixelSize();
-			}
-			else if (bounds.Y < 0)
-			{
-				var bottom = screen.FindBottomScreen();
-				if (bottom != null)
-					y = GetLogicalLocation(bottom).Y - GetLogicalSize(screen).Height;
-				else
-					y = bounds.Y / screen.GetLogicalPixelSize();
-			}
-			else y = bounds.Y;
-			return new Eto.Drawing.PointF(x, y);
-		}
+			public override IEnumerable<swf.Screen> AllScreens => swf.Screen.AllScreens;
 
-		public static Eto.Drawing.SizeF GetLogicalSize(this swf.Screen screen) => (Eto.Drawing.SizeF)screen.Bounds.Size.ToEto() / screen.GetLogicalPixelSize();
+			public override swf.Screen PrimaryScreen => swf.Screen.PrimaryScreen;
 
-		public static float GetLogicalPixelSize(this swf.Screen screen) => GetDpi(screen) / 96f;
+			public override sd.Rectangle GetBounds(swf.Screen screen) => screen.Bounds;
 
-		public static uint GetDpi(this System.Windows.Forms.Screen screen)
-		{
-			if (!MonitorDpiSupported)
+			public override float GetLogicalPixelSize(swf.Screen screen)
 			{
-				// fallback to slow method if we can't get the dpi from the system
-				using (var form = new System.Windows.Forms.Form { Bounds = screen.Bounds })
-				using (var graphics = form.CreateGraphics())
+				if (!MonitorDpiSupported)
 				{
-					return (uint)graphics.DpiY;
+					// fallback to slow method if we can't get the dpi from the system
+					using (var form = new System.Windows.Forms.Form { Bounds = screen.Bounds })
+					using (var graphics = form.CreateGraphics())
+					{
+						return (uint)graphics.DpiY / 96f;
+					}
 				}
+
+				var pnt = new System.Drawing.Point(screen.Bounds.Left + 1, screen.Bounds.Top + 1);
+				var mon = MonitorFromPoint(pnt, MONITOR.DEFAULTTONEAREST);
+				uint dpiX, dpiY;
+				GetDpiForMonitor(mon, MDT.EFFECTIVE_DPI, out dpiX, out dpiY);
+				return dpiX / 96f;
 			}
 
-			var pnt = new System.Drawing.Point(screen.Bounds.Left + 1, screen.Bounds.Top + 1);
-			var mon = MonitorFromPoint(pnt, MONITOR.DEFAULTTONEAREST);
-			uint dpiX, dpiY;
-			GetDpiForMonitor(mon, MDT.EFFECTIVE_DPI, out dpiX, out dpiY);
-			return dpiX;
+			public override SizeF GetLogicalSize(swf.Screen screen) => (SizeF)screen.Bounds.Size.ToEto() / screen.GetLogicalPixelSize();
 		}
+
+		static ScreenHelper locationHelper = new ScreenHelper();
+
+		public static Eto.Drawing.PointF GetLogicalLocation(this swf.Screen screen) => locationHelper.GetLogicalLocation(screen);
+
+		public static Eto.Drawing.SizeF GetLogicalSize(this swf.Screen screen) => locationHelper.GetLogicalSize(screen);
+
+		public static float GetLogicalPixelSize(this swf.Screen screen) => locationHelper.GetLogicalPixelSize(screen);
 
 		[DllImport("User32.dll")]
 		public static extern IntPtr MonitorFromPoint(System.Drawing.Point pt, MONITOR dwFlags);

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -96,6 +96,7 @@
     <Compile Include="Drawing\SystemColorsHandler.cs" />
     <Compile Include="Forms\Controls\ExpanderHandler.cs" />
     <Compile Include="Forms\Cells\CustomCellHandler.cs" />
+    <Compile Include="LogicalScreenHelper.cs" />
     <Compile Include="PropertyChangeNotifier.cs" />
     <Compile Include="Forms\Controls\TextStepperHandler.cs" />
     <Compile Include="Forms\Controls\StepperHandler.cs" />

--- a/src/Eto.Wpf/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/NumericStepperHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Drawing;
 using swc = System.Windows.Controls;
 using sw = System.Windows;
@@ -34,13 +34,20 @@ namespace Eto.Wpf.Forms.Controls
 			var trimmedText = text;
 			if (h?.HasFormatString == true && trimmedText != null)
 				trimmedText = Regex.Replace(trimmedText, $@"(?!\d|{Regex.Escape(h.CultureInfo.NumberFormat.NumberDecimalSeparator)}|{Regex.Escape(h.CultureInfo.NumberFormat.NegativeSign)}).", ""); // strip any non-numeric value
-			var result = base.ConvertTextToValue(trimmedText);
+			try
+			{
+				var result = base.ConvertTextToValue(trimmedText);
 
-			// test if the text matches the negative format
-			if (h.HasFormatString && result > 0 && NumberStringsMatch((-result.Value).ToString(FormatString, CultureInfo), text))
-				result = -result;
+				// test if the text matches the negative format
+				if (h.HasFormatString && result > 0 && NumberStringsMatch((-result.Value).ToString(FormatString, CultureInfo), text))
+					result = -result;
 
-			return result;
+				return result;
+			}
+			catch
+			{
+				return null;
+			}
 		}
 
 		protected override string ConvertValueToText()

--- a/src/Eto.Wpf/Forms/ScreenHandler.cs
+++ b/src/Eto.Wpf/Forms/ScreenHandler.cs
@@ -42,7 +42,7 @@ namespace Eto.Wpf.Forms
 
 			if (realScale == null)
 			{
-				realScale = Control.GetDpi() / 96f;
+				realScale = Control.GetLogicalPixelSize();
 			}
 			return realScale ?? 1f;
 		}

--- a/src/Eto.Wpf/LogicalScreenHelper.cs
+++ b/src/Eto.Wpf/LogicalScreenHelper.cs
@@ -1,0 +1,206 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using sd = System.Drawing;
+#if WPF
+#elif WINFORMS
+using Eto.WinForms.Forms;
+#endif
+
+namespace Eto
+{
+	public abstract class LogicalScreenHelper<T>
+	{
+		public abstract IEnumerable<T> AllScreens { get; }
+
+		public abstract T PrimaryScreen { get; }
+
+		public abstract sd.Rectangle GetBounds(T screen);
+
+		public abstract Eto.Drawing.SizeF GetLogicalSize(T screen);
+
+		public abstract float GetLogicalPixelSize(T screen);
+
+		public virtual float GetMaxLogicalPixelSize() => AllScreens.Max((Func<T, float>)GetLogicalPixelSize);
+
+		T FindLeftScreen(T screen) =>
+			AllScreens
+			.Where(r => GetBounds(r).X >= 0 && GetBounds(r).Right == GetBounds(screen).X)
+			.OrderBy(r => GetLogicalPixelSize(r))
+			.FirstOrDefault();
+
+		T FindRightScreen(T screen) =>
+			AllScreens
+			.Where(r => GetBounds(r).X < 0 && GetBounds(r).X == GetBounds(screen).Right)
+			.OrderBy(r => GetLogicalPixelSize(r))
+			.FirstOrDefault();
+
+		T FindTopScreen(T screen) =>
+			AllScreens
+			.Where(r => GetBounds(r).Y >= 0 && GetBounds(r).Bottom == GetBounds(screen).Y)
+			.OrderBy(r => GetLogicalPixelSize(r))
+			.FirstOrDefault();
+
+		T FindBottomScreen(T screen) =>
+			AllScreens
+			.Where(r => GetBounds(r).Y < 0 && GetBounds(r).Y == GetBounds(screen).Bottom)
+			.OrderBy(r => GetLogicalPixelSize(r))
+			.FirstOrDefault();
+
+		public Eto.Drawing.PointF GetLogicalLocation(T screen)
+		{
+			/**/
+			var bounds = GetBounds(screen);
+			var primaryScreen = PrimaryScreen;
+			if (screen.Equals(primaryScreen))
+				return bounds.Location.ToEto();
+			var primaryBounds = GetBounds(primaryScreen);
+			Eto.Drawing.PointF location = primaryBounds.Location.ToEto();
+
+			// this finds all adjacent screens between the primary screen and the specified screen
+			// to calculate it's logical position
+
+			// if it is not adjacent, we use the maximum pixel size to figure out its position.
+
+			if (bounds.X < primaryBounds.X)
+			{
+				var adjacentScreen = primaryScreen;
+				foreach (var scn in AllScreens.OrderByDescending(s => GetBounds(s).X))
+				{
+					var scnBounds = GetBounds(scn);
+					if (scnBounds.X > primaryBounds.X || (!scn.Equals(screen) && bounds.Right > scnBounds.X))
+						continue;
+					if (scnBounds.X < bounds.X)
+						break;
+					if (scnBounds.Right == GetBounds(adjacentScreen).X)
+					{
+						var logicalSize = GetLogicalSize(scn);
+						location.X -= logicalSize.Width;
+						adjacentScreen = scn;
+					}
+					if (scn.Equals(screen))
+						break;
+				}
+				if (!adjacentScreen.Equals(screen))
+				{
+					location.X = bounds.X / GetMaxLogicalPixelSize();
+				}
+			}
+			else if (bounds.X > primaryBounds.X)
+			{
+				var adjacentScreen = primaryScreen;
+				foreach (var scn in AllScreens.OrderBy(s => GetBounds(s).X))
+				{
+					var scnBounds = GetBounds(scn);
+					if (scnBounds.X < primaryBounds.X || (!scn.Equals(screen) && bounds.X < scnBounds.Right))
+						continue;
+					if (scnBounds.X > bounds.X)
+						break;
+					if (scnBounds.X == GetBounds(adjacentScreen).Right)
+					{
+						var logicalSize = GetLogicalSize(adjacentScreen);
+						location.X += logicalSize.Width;
+						adjacentScreen = scn;
+					}
+					if (scn.Equals(screen))
+						break;
+				}
+				if (!adjacentScreen.Equals(screen))
+				{
+					location.X = bounds.X / GetMaxLogicalPixelSize();
+				}
+			}
+
+			if (bounds.Y < primaryBounds.Y)
+			{
+				var adjacentScreen = primaryScreen;
+				foreach (var scn in AllScreens.OrderByDescending(s => GetBounds(s).Y))
+				{
+					var scnBounds = GetBounds(scn);
+					if (scnBounds.Y > primaryBounds.Y || (!scn.Equals(screen) && bounds.Bottom > scnBounds.Y))
+						continue;
+					if (scnBounds.Y < bounds.Y)
+						break;
+					if (scnBounds.Bottom == GetBounds(adjacentScreen).Y)
+					{
+						var logicalSize = GetLogicalSize(scn);
+						location.Y -= logicalSize.Height;
+						adjacentScreen = scn;
+					}
+					if (scn.Equals(screen))
+						break;
+				}
+				if (!adjacentScreen.Equals(screen))
+				{
+					location.Y = bounds.Y / GetMaxLogicalPixelSize();
+				}
+			}
+			else if (bounds.Y > primaryBounds.Y)
+			{
+				var adjacentScreen = primaryScreen;
+				foreach (var scn in AllScreens.OrderBy(s => GetBounds(s).Y))
+				{
+					var scnBounds = GetBounds(scn);
+					if (scnBounds.Y < primaryBounds.Y || (!scn.Equals(screen) && bounds.Y < scnBounds.Bottom))
+						continue;
+					if (scnBounds.Y > bounds.Y)
+						break;
+					if (scnBounds.Y == GetBounds(adjacentScreen).Bottom)
+					{
+						var logicalSize = GetLogicalSize(adjacentScreen);
+						location.Y += logicalSize.Height;
+						adjacentScreen = scn;
+					}
+					if (scn.Equals(screen))
+						break;
+				}
+				if (!adjacentScreen.Equals(screen))
+				{
+					location.Y = bounds.Y / GetMaxLogicalPixelSize();
+				}
+			}
+
+			return location;
+			/**
+
+			var bounds = GetBounds(screen);
+			float x, y;
+			if (bounds.X > 0)
+			{
+				var left = FindLeftScreen(screen);
+				if (left != null)
+					x = GetLogicalLocation(left).X + GetLogicalSize(left).Width;
+				else
+					x = bounds.X / GetMaxLogicalPixelSize();
+			}
+			else if (bounds.X < 0)
+			{
+				var right = FindRightScreen(screen);
+				if (right != null)
+					x = GetLogicalLocation(right).X - GetLogicalSize(screen).Width;
+				else
+					x = bounds.X / GetLogicalPixelSize(screen);
+			}
+			else x = bounds.X;
+			if (bounds.Y > 0)
+			{
+				var top = FindTopScreen(screen);
+				if (top != null)
+					y = GetLogicalLocation(top).Y + GetLogicalSize(top).Height;
+				else
+					y = bounds.Y / GetMaxLogicalPixelSize();
+			}
+			else if (bounds.Y < 0)
+			{
+				var bottom = FindBottomScreen(screen);
+				if (bottom != null)
+					y = GetLogicalLocation(bottom).Y - GetLogicalSize(screen).Height;
+				else
+					y = bounds.Y / GetLogicalPixelSize(screen);
+			}
+			else y = bounds.Y;
+			return new Eto.Drawing.PointF(x, y);
+			/**/
+		}
+	}
+}

--- a/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
+++ b/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
@@ -38,6 +38,7 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Data" />
+    <Reference Include="System.Drawing" />
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
     <Reference Include="Microsoft.CSharp" />
@@ -56,6 +57,7 @@
     <Compile Include="Startup.cs" />
     <Compile Include="UnitTests\DataContextTests.cs" />
     <Compile Include="UnitTests\MenuBarTests.cs" />
+    <Compile Include="UnitTests\ScreenTests.cs" />
     <Compile Include="UnitTests\ScrollableTests.cs" />
     <Compile Include="UnitTests\TransformStackTest.cs" />
   </ItemGroup>

--- a/test/Eto.Test.Wpf/UnitTests/ScreenTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/ScreenTests.cs
@@ -1,0 +1,184 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Eto.Drawing;
+using NUnit.Framework;
+using sd = System.Drawing;
+
+namespace Eto.Test.Wpf.UnitTests
+{
+	[TestFixture]
+	public class ScreenTests
+	{
+		public class TestScreen
+		{
+			public sd.Rectangle Bounds { get; set; }
+
+			public sd.SizeF LogicalSize => new sd.SizeF(Bounds.Width / LogicalPixelSize, Bounds.Height / LogicalPixelSize);
+
+			public float LogicalPixelSize { get; set; } = 1f;
+		}
+
+		public class TestLogicalScreenHelper : LogicalScreenHelper<TestScreen>
+		{
+			public List<TestScreen> Screens { get; } = new List<TestScreen>();
+
+			public TestScreen Primary { get; set; }
+
+			public override IEnumerable<TestScreen> AllScreens => Screens;
+
+			public override TestScreen PrimaryScreen => Primary;
+
+			public override sd.Rectangle GetBounds(TestScreen screen) => screen.Bounds;
+
+			public override float GetLogicalPixelSize(TestScreen screen) => screen.LogicalPixelSize;
+
+			public override SizeF GetLogicalSize(TestScreen screen) => screen.LogicalSize.ToEto();
+		}
+
+		static IEnumerable<object[]> ThreeMonitorSource()
+		{
+			for (int x = 1; x < 4; x++)
+				for (int y = 1; y < 4; y++)
+					for (int z = 1; z < 4; z++)
+						yield return new object[] { x, y, z };
+		}
+
+		static IEnumerable<object[]> TwoMonitorSource()
+		{
+			for (int x = 1; x < 4; x++)
+				for (int y = 1; y < 4; y++)
+					yield return new object[] { x, y };
+		}
+
+		[TestCaseSource(nameof(ThreeMonitorSource))]
+		public void ScreenLocationsShouldBeCorrect1(float pixelSize1, float pixelSize2, float pixelSize3)
+		{
+			//                --------------
+			//  -------------| 1.           |
+			// | 3.          |              |
+			// |             |              |
+			// |             |--------------
+			// |------------- 
+			// | 2.          |
+			// |             |
+			// |             |
+			//  -------------
+
+			var helper = new TestLogicalScreenHelper();
+			helper.Screens.Add(helper.Primary = new TestScreen { Bounds = new sd.Rectangle(0, 0, 1000, 1000), LogicalPixelSize = pixelSize1 });
+			helper.Screens.Add(new TestScreen { Bounds = new sd.Rectangle(-1000, 10, 1000, 1000), LogicalPixelSize = pixelSize3 });
+			helper.Screens.Add(new TestScreen { Bounds = new sd.Rectangle(-500, 1010, 500, 500), LogicalPixelSize = pixelSize2 });
+
+			Assert.AreEqual(new PointF(0, 0), helper.GetLogicalLocation(helper.Screens[0]));
+			Assert.AreEqual(new PointF(-1000 / pixelSize3, 10 / helper.GetMaxLogicalPixelSize()), helper.GetLogicalLocation(helper.Screens[1]));
+			Assert.AreEqual(new PointF(-500 / pixelSize2, 1010 / helper.GetMaxLogicalPixelSize()), helper.GetLogicalLocation(helper.Screens[2]));
+		}
+
+		[TestCaseSource(nameof(ThreeMonitorSource))]
+		public void ScreenLocationsShouldBeCorrect2(float pixelSize1, float pixelSize2, float pixelSize3)
+		{
+			//  ------------- --------------
+			// | 3.          | 1.           |
+			// |             |              |
+			// |             |              |
+			// |------------- --------------
+			// | 2.          |
+			// |             |
+			// |             |
+			//  -------------
+
+			var helper = new TestLogicalScreenHelper();
+			helper.Screens.Add(helper.Primary = new TestScreen { Bounds = new sd.Rectangle(0, 0, 1000, 1000), LogicalPixelSize = pixelSize1 });
+			helper.Screens.Add(new TestScreen { Bounds = new sd.Rectangle(-500, 1000, 500, 500), LogicalPixelSize = pixelSize2 });
+			helper.Screens.Add(new TestScreen { Bounds = new sd.Rectangle(-1000, 0, 1000, 1000), LogicalPixelSize = pixelSize3 });
+
+			Assert.AreEqual(new PointF(0, 0), helper.GetLogicalLocation(helper.Screens[0]));
+			Assert.AreEqual(new PointF(-500 / pixelSize2, 1000 / pixelSize1), helper.GetLogicalLocation(helper.Screens[1]));
+			Assert.AreEqual(new PointF(-1000 / pixelSize3, 0), helper.GetLogicalLocation(helper.Screens[2]));
+		}
+
+		[TestCaseSource(nameof(ThreeMonitorSource))]
+		public void ScreenLocationsShouldBeCorrect3(float pixelSize1, float pixelSize2, float pixelSize3)
+		{
+			//  ------------- --------------
+			// | 2.          | 3.           |
+			// |             |              |
+			// |             |              |
+			// |------------- --------------
+			// | 1.          |
+			// |             |
+			// |             |
+			//  -------------
+
+			var helper = new TestLogicalScreenHelper();
+			helper.Screens.Add(helper.Primary = new TestScreen { Bounds = new sd.Rectangle(0, 0, 1000, 1000), LogicalPixelSize = pixelSize1 });
+			helper.Screens.Add(new TestScreen { Bounds = new sd.Rectangle(0, -500, 500, 500), LogicalPixelSize = pixelSize2 });
+			helper.Screens.Add(new TestScreen { Bounds = new sd.Rectangle(1000, -1000, 1000, 1000), LogicalPixelSize = pixelSize3 });
+
+			Assert.AreEqual(new PointF(0, 0), helper.GetLogicalLocation(helper.Screens[0]));
+			Assert.AreEqual(new PointF(0, -500 / pixelSize2), helper.GetLogicalLocation(helper.Screens[1]));
+			Assert.AreEqual(new PointF(1000 / pixelSize1, -1000 / pixelSize3), helper.GetLogicalLocation(helper.Screens[2]));
+		}
+
+		[TestCaseSource(nameof(ThreeMonitorSource))]
+		public void ScreenLocationsShouldBeCorrect4(float pixelSize1, float pixelSize2, float pixelSize3)
+		{
+			//  -------------
+			// | 1.          |
+			// |             |
+			// |             |
+			//  ------------- --------------
+			// | 2.          | 3.           |
+			// |             |              |
+			// |             |              |
+			//  ------------- --------------
+
+			var helper = new TestLogicalScreenHelper();
+			helper.Screens.Add(helper.Primary = new TestScreen { Bounds = new sd.Rectangle(0, 0, 1000, 1000), LogicalPixelSize = pixelSize1 });
+			helper.Screens.Add(new TestScreen { Bounds = new sd.Rectangle(0, 1000, 500, 500), LogicalPixelSize = pixelSize2 });
+			helper.Screens.Add(new TestScreen { Bounds = new sd.Rectangle(1000, 1000, 1000, 1000), LogicalPixelSize = pixelSize3 });
+
+			Assert.AreEqual(new PointF(0, 0), helper.GetLogicalLocation(helper.Screens[0]));
+			Assert.AreEqual(new PointF(0, 1000 / pixelSize1), helper.GetLogicalLocation(helper.Screens[1]));
+			Assert.AreEqual(new PointF(1000 / pixelSize1, 1000 / pixelSize1), helper.GetLogicalLocation(helper.Screens[2]));
+		}
+
+
+		[TestCaseSource(nameof(TwoMonitorSource))]
+		public void ScreenLocationsShouldBeCorrect5(float pixelSize1, float pixelSize2)
+		{
+			//  ------------- --------------
+			// | 1.          | 2.           |
+			// |             |              |
+			// |             |              |
+			//  ------------- --------------
+
+			var helper = new TestLogicalScreenHelper();
+			helper.Screens.Add(helper.Primary = new TestScreen { Bounds = new sd.Rectangle(0, 0, 1000, 1000), LogicalPixelSize = pixelSize1 });
+			helper.Screens.Add(new TestScreen { Bounds = new sd.Rectangle(1000, 0, 1000, 1000), LogicalPixelSize = pixelSize2 });
+
+			Assert.AreEqual(new PointF(0, 0), helper.GetLogicalLocation(helper.Screens[0]));
+			Assert.AreEqual(new PointF(1000 / pixelSize1, 0), helper.GetLogicalLocation(helper.Screens[1]));
+		}
+
+		[TestCaseSource(nameof(TwoMonitorSource))]
+		public void ScreenLocationsShouldBeCorrect6(float pixelSize1, float pixelSize2)
+		{
+			//  ------------- --------------
+			// | 2.          | 1.           |
+			// |             |              |
+			// |             |              |
+			//  ------------- --------------
+
+			var helper = new TestLogicalScreenHelper();
+			helper.Screens.Add(helper.Primary = new TestScreen { Bounds = new sd.Rectangle(0, 0, 1000, 1000), LogicalPixelSize = pixelSize1 });
+			helper.Screens.Add(new TestScreen { Bounds = new sd.Rectangle(-1000, 0, 1000, 1000), LogicalPixelSize = pixelSize2 });
+
+			Assert.AreEqual(new PointF(0, 0), helper.GetLogicalLocation(helper.Screens[0]));
+			Assert.AreEqual(new PointF(-1000 / pixelSize2, 0), helper.GetLogicalLocation(helper.Screens[1]));
+		}
+	}
+}

--- a/test/Eto.Test/Sections/Behaviors/ScreenSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ScreenSection.cs
@@ -12,6 +12,7 @@ namespace Eto.Test.Sections.Behaviors
 		readonly Screen[] screens;
 		Window parentWindow;
 		Label windowPositionLabel;
+		Label mousePositionLabel;
 
 		public ScreenSection()
 		{
@@ -34,6 +35,7 @@ namespace Eto.Test.Sections.Behaviors
 			}
 			layout.EndVertical();
 			layout.Add(windowPositionLabel = new Label());
+			layout.Add(mousePositionLabel = new Label());
 			layout.EndCentered();
 
 			layout.Add(ScreenLayout());
@@ -63,6 +65,7 @@ namespace Eto.Test.Sections.Behaviors
 		protected override void OnMouseMove(MouseEventArgs e)
 		{
 			base.OnMouseMove(e);
+			mousePositionLabel.Text = $"Mouse Position: {Mouse.Position}";
 			Invalidate();
 		}
 

--- a/test/Eto.Test/Sections/UnitTestSection.cs
+++ b/test/Eto.Test/Sections/UnitTestSection.cs
@@ -26,13 +26,13 @@ namespace Eto.Test.Sections
 			if (!result.HasChildren)
 			{
 				if (!string.IsNullOrEmpty(result.Output))
-					Application.Instance.AsyncInvoke(() => Log.Write(null, result.Output));
+					Application.Instance.Invoke(() => Log.Write(null, result.Output));
 				if (result.FailCount > 0)
 				{
-					Application.AsyncInvoke(() => Log.Write(null, "Failed: {0}\n{1}", result.Message, result.StackTrace));
+					Application.Invoke(() => Log.Write(null, "Failed: {0}\n{1}", result.Message, result.StackTrace));
 				}
 				if (result.InconclusiveCount > 0)
-					Application.AsyncInvoke(() => Log.Write(null, "Inconclusive: {0}\n{1}", result.Message, result.StackTrace));
+					Application.Invoke(() => Log.Write(null, "Inconclusive: {0}\n{1}", result.Message, result.StackTrace));
 			}
 		}
 
@@ -43,7 +43,7 @@ namespace Eto.Test.Sections
 		public void TestStarted(ITest test)
 		{
 			if (!test.HasChildren)
-				Application.AsyncInvoke(() => Log.Write(null, test.FullName));
+				Application.Invoke(() => Log.Write(null, test.FullName));
 		}
 	}
 


### PR DESCRIPTION
- Remove recursive algorithm for calculating logical screen locations
- Add tests to verify behaviour
- Fix unit tests to properly show results after all test output
- WinForms should use same Windows 7 API code pack nuget as wpf, which is strong named.