### PR TITLE
Wpf: Add helpers to convert WinForms controls and forms to Eto.

### DIFF
--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -109,6 +109,7 @@
     <Compile Include="Forms\VistaSelectFolderDialogHandler.cs" />
     <Compile Include="Forms\WindowsFormsHostHandler.cs" />
     <Compile Include="Win32.dib.cs" />
+    <Compile Include="WinFormsHelpers.cs" />
     <Compile Include="WpfConversions.cs" />
     <Compile Include="CustomControls\EditableTextBlock.cs" />
     <Compile Include="CustomControls\FontDialog\fontchooser.xaml.cs">

--- a/src/Eto.Wpf/Forms/WindowsFormsHostHandler.cs
+++ b/src/Eto.Wpf/Forms/WindowsFormsHostHandler.cs
@@ -10,7 +10,7 @@ using Eto.Forms;
 
 namespace Eto.Wpf.Forms
 {
-	public abstract class WindowsFormsHostHandler<TControl, TWidget, TCallback> : WpfFrameworkElement<WindowsFormsHost, TWidget, TCallback>
+	public class WindowsFormsHostHandler<TControl, TWidget, TCallback> : WpfFrameworkElement<WindowsFormsHost, TWidget, TCallback>
 		where TControl : swf.Control
 		where TWidget : Control
 		where TCallback : Control.ICallback

--- a/src/Eto.Wpf/WinFormsHelpers.cs
+++ b/src/Eto.Wpf/WinFormsHelpers.cs
@@ -1,0 +1,51 @@
+using Eto.Forms;
+using Eto.Wpf.Forms;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using swf = System.Windows.Forms;
+
+namespace Eto.Wpf
+{
+	public static class WinFormsHelpers
+	{
+		/// <summary>
+		/// Wraps a Windows Forms control into an Eto control so it can be added to an Eto container.
+		/// </summary>
+		/// <param name="control">Windows Forms control to wrap</param>
+		/// <returns>An Eto control wrapper</returns>
+		public static Control ToEto(this swf.Control control)
+		{
+			return new Control(new WindowsFormsHostHandler<swf.Control, Control, Control.ICallback>(control));
+		}
+
+		/// <summary>
+		/// Wraps a native win32 window in an Eto control so it can be used as a parent when showing dialogs, etc.
+		/// </summary>
+		/// <remarks>
+		/// This is useful when your application is fully native and does not use WinForms or Wpf.
+		/// </remarks>
+		/// <returns>The eto window wrapper around the win32 window with the specified handle.</returns>
+		/// <param name="windowHandle">Handle of the win32 window.</param>
+		public static Window ToEtoWindow(IntPtr windowHandle)
+		{
+			return new Form(new HwndFormHandler(windowHandle));
+		}
+
+		static readonly object Form_Key = new object();
+
+		/// <summary>
+		/// Wraps a Windows Forms Form to an Eto window to use for parenting of Eto dialogs and forms
+		/// </summary>
+		/// <param name="form">Windows Forms Form to wrap</param>
+		/// <returns>Wrapped Eto window</returns>
+		public static Window ToEto(swf.Form form)
+		{
+			var etoForm = new Form(new HwndFormHandler(form.Handle));
+			etoForm.Properties[Form_Key] = form;
+			return etoForm;
+		}
+	}
+}


### PR DESCRIPTION
- Even though Eto is using WPF, this helps integrate with existing Windows Forms UI.
- Make WindowsFormsHostHandler non-abstract