### PR TITLE
DropDown should keep selection when changing DataStore

### DIFF
--- a/build/Build.props
+++ b/build/Build.props
@@ -1,13 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 	<PropertyGroup>
+        <OSPlatform Condition="$(OSPlatform) == '' and '$(OS)' == 'Unix' and !Exists('/Library/Frameworks')">Linux</OSPlatform>
+        <OSPlatform Condition="$(OSPlatform) == '' and '$(OS)' == 'Unix' and Exists('/Library/Frameworks')">Mac</OSPlatform>
+        <OSPlatform Condition="$(OSPlatform) == '' and '$(OS)' != 'Unix'">Windows</OSPlatform>
+
 		<XamarinMacPath>\Library\Frameworks\Xamarin.Mac.framework\Versions\Current</XamarinMacPath>
 		<XamarinMacLibPath>$(XamarinMacPath)\lib\mono</XamarinMacLibPath>
 		<ReferencePath Condition="$(ReferencePath) == '' and Exists('$(XamarinMacLibPath)')">$(XamarinMacLibPath)</ReferencePath>
 		<!-- Prevent VS2015 from copying files from the GAC to the output folder -->
 		<DoNotCopyLocalIfInGac>true</DoNotCopyLocalIfInGac>
 		<BasePath>$(MSBuildThisFileDirectory)..\</BasePath>
-		<BaseIntermediateOutputPath>$(BasePath)artifacts\obj\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
+		<BaseIntermediateOutputPath>$(BasePath)artifacts\obj\$(OSPlatform)\$(MSBuildProjectName)\</BaseIntermediateOutputPath>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<Deterministic>False</Deterministic>
 		<!-- RestoreProjectStyle will be supported in VS for Mac 7.4 -->

--- a/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
@@ -147,12 +147,6 @@ namespace Eto.Mac.Forms.Controls
 		{
 			public DropDownHandler Handler { get; set; }
 
-			public override int IndexOf(object item)
-			{
-				var binding = Handler.Widget.ItemTextBinding;
-				return (int)Handler.Control.Menu.IndexOf(binding.GetValue(item));
-			}
-
 			NSMenuItem CreateItem(object dataItem)
 			{
 				var item = new NSMenuItem(Handler.Widget.ItemTextBinding?.GetValue(dataItem) ?? string.Empty);
@@ -209,7 +203,7 @@ namespace Eto.Mac.Forms.Controls
 				var selected = Handler.SelectedIndex;
 				Handler.Control.RemoveItem(index);
 				Handler.InvalidateMeasure();
-				if (Handler.Widget.Loaded && selected == index)
+				if (selected == index)
 				{
 					Handler.Control.SelectItem(-1);
 					Handler.Callback.OnSelectedIndexChanged(Handler.Widget, EventArgs.Empty);
@@ -221,7 +215,7 @@ namespace Eto.Mac.Forms.Controls
 				var change = Handler.SelectedIndex != -1;
 				Handler.Control.RemoveAllItems();
 				Handler.InvalidateMeasure();
-				if (Handler.Widget.Loaded && change)
+				if (change)
 				{
 					Handler.Control.SelectItem(-1);
 					Handler.Callback.OnSelectedIndexChanged(Handler.Widget, EventArgs.Empty);
@@ -234,10 +228,16 @@ namespace Eto.Mac.Forms.Controls
 			get { return collection == null ? null : collection.Collection; }
 			set
 			{
-				if (collection != null)
-					collection.Unregister();
+				var selected = Widget.SelectedValue;
+				Control.SelectItem(-1);
+				collection?.Unregister();
 				collection = new CollectionHandler { Handler = this };
 				collection.Register(value);
+				if (!ReferenceEquals(selected, null))
+				{
+					Control.SelectItem(collection.IndexOf(selected));
+					Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
+				}
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/ExpanderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ExpanderHandler.cs
@@ -100,6 +100,16 @@ namespace Eto.Mac.Forms.Controls
 			base.Initialize();
 		}
 
+		public override bool Enabled
+		{
+			get => base.Enabled;
+			set
+			{
+				base.Enabled = value;
+				disclosureButton.Enabled = value;
+			}
+		}
+
 		static void DisclosureButton_Activated(object sender, EventArgs e)
 		{
 			var handler = GetHandler((sender as NSView)?.Superview) as ExpanderHandler;

--- a/src/Eto.WinForms/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/DropDownHandler.cs
@@ -262,10 +262,17 @@ namespace Eto.WinForms.Forms.Controls
 			get { return collection != null ? collection.Collection : null; }
 			set
 			{
-				if (collection != null)
-					collection.Unregister();
+				var selected = Widget.SelectedValue;
+				collection?.Unregister();
 				collection = new CollectionHandler { Handler = this };
 				collection.Register(value);
+				if (!ReferenceEquals(selected, null))
+				{
+					var newSelectedIndex = collection.IndexOf(selected);
+					SelectedIndex = newSelectedIndex;
+					if (newSelectedIndex == -1)
+						Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
+				}
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
@@ -134,8 +134,12 @@ namespace Eto.Wpf.Forms.Controls
 			get { return store; }
 			set
 			{
+				var oldSelectedIndex = SelectedIndex;
 				store = value;
 				Control.ItemsSource = store;
+				// WPF only triggers a slection change when the item instance has changed
+				if (oldSelectedIndex != SelectedIndex && SelectedIndex >= 0)
+					Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
 			}
 		}
 

--- a/src/Eto/Forms/Controls/ListControl.cs
+++ b/src/Eto/Forms/Controls/ListControl.cs
@@ -166,6 +166,8 @@ namespace Eto.Forms
 			add { Properties.AddEvent(SelectedIndexChangedKey, value); }
 			remove { Properties.RemoveEvent(SelectedIndexChangedKey, value); }
 		}
+		object lastSelectedValue;
+		string lastSelectedKey;
 
 		/// <summary>
 		/// Raises the <see cref="SelectedIndexChanged"/> event.
@@ -174,8 +176,20 @@ namespace Eto.Forms
 		protected virtual void OnSelectedIndexChanged(EventArgs e)
 		{
 			Properties.TriggerEvent(SelectedIndexChangedKey, this, e);
-			OnSelectedValueChanged(e);
-			OnSelectedKeyChanged(e);
+			var newSelectedValue = SelectedValue;
+			if (lastSelectedValue != newSelectedValue)
+			{
+				lastSelectedValue = newSelectedValue;
+				OnSelectedValueChanged(e);
+			}
+
+			var newSelectedKey = SelectedKey;
+			if (lastSelectedKey != newSelectedKey)
+			{
+				lastSelectedKey = newSelectedKey;
+				OnSelectedKeyChanged(e);
+			}
+
 		}
 
 		static readonly object SelectedValueChangedKey = new object();

--- a/test/Eto.Test/Sections/Controls/ExpanderSection.cs
+++ b/test/Eto.Test/Sections/Controls/ExpanderSection.cs
@@ -10,6 +10,7 @@ namespace Eto.Test.Sections.Controls
 		public ExpanderSection()
 		{
 			var expandedCheckBox = new CheckBox { Text = "Expanded" };
+			var enabledCheckBox = new CheckBox { Text = "Enabled" };
 
 			var expander = new Expander
 			{
@@ -18,6 +19,7 @@ namespace Eto.Test.Sections.Controls
 			};
 
 			expandedCheckBox.CheckedBinding.Bind(expander, e => e.Expanded);
+			enabledCheckBox.CheckedBinding.Bind(expander, e => e.Enabled);
 
 			LogEvents(expander);
 
@@ -39,7 +41,13 @@ namespace Eto.Test.Sections.Controls
 				Padding = new Padding(10),
 				Items =
 				{
-					expandedCheckBox,
+					new StackLayout {
+						Orientation = Orientation.Horizontal,
+						Items = {
+							expandedCheckBox,
+							enabledCheckBox
+						}
+					},
 					expander,
 					expander2
 				}

--- a/test/Eto.Test/UnitTests/Forms/Controls/DropDownTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/DropDownTests.cs
@@ -1,0 +1,109 @@
+using System;
+using NUnit.Framework;
+using Eto.Forms;
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	[TestFixture]
+	public class DropDownTests : TestBase
+	{
+		static void TestDropDownSelection(DropDown dropDown, object item1, object item2, object item3, bool useIndex = false)
+		{
+			int selectedIndexChanged = 0;
+			int selectedValueChanged = 0;
+			int selectedKeyChanged = 0;
+
+			dropDown.SelectedIndexChanged += (sender, e) => selectedIndexChanged++;
+			dropDown.SelectedValueChanged += (sender, e) => selectedValueChanged++;
+			dropDown.SelectedKeyChanged += (sender, e) => selectedKeyChanged++;
+
+			// set up data
+			dropDown.DataStore = new[] { item1, item2, item3 };
+			if (useIndex)
+				dropDown.SelectedIndex = 1;
+			else
+				dropDown.SelectedValue = item2;
+
+			Assert.AreEqual(1, dropDown.SelectedIndex);
+			Assert.AreEqual(item2, dropDown.SelectedValue);
+			Assert.AreEqual(1, selectedIndexChanged);
+			Assert.AreEqual(1, selectedValueChanged);
+			Assert.AreEqual(1, selectedKeyChanged);
+
+			// change the list
+			dropDown.DataStore = new[] { item1, item3, item2 };
+			Assert.AreEqual(2, dropDown.SelectedIndex);
+			Assert.AreEqual(item2, dropDown.SelectedValue);
+			Assert.AreEqual(2, selectedIndexChanged);
+			Assert.AreEqual(1, selectedValueChanged);
+			Assert.AreEqual(1, selectedKeyChanged);
+
+			// change again, but selected value does not exist
+			dropDown.DataStore = new[] { item1, item3 };
+			Assert.AreEqual(-1, dropDown.SelectedIndex);
+			Assert.IsNull(dropDown.SelectedValue);
+			Assert.AreEqual(3, selectedIndexChanged);
+			Assert.AreEqual(2, selectedValueChanged);
+			Assert.AreEqual(2, selectedKeyChanged);
+
+			// add it back, still should not be selected now that it was deselected!
+			dropDown.DataStore = new[] { item2, item1, item3 };
+			Assert.AreEqual(-1, dropDown.SelectedIndex);
+			Assert.IsNull(dropDown.SelectedValue);
+			Assert.AreEqual(3, selectedIndexChanged);
+			Assert.AreEqual(2, selectedValueChanged);
+			Assert.AreEqual(2, selectedKeyChanged);
+		}
+
+		[Test]
+		public void DropDownShouldKeepSelectedValueWhenSettingDataStoreWithStrings()
+		{
+			Invoke(() =>
+			{
+				var item1 = "Item 1";
+				var item2 = "Item 2";
+				var item3 = "Item 3";
+
+				var dropDown = new DropDown();
+
+				TestDropDownSelection(dropDown, item1, item2, item3);
+			});
+		}
+
+		class CustomDropDownItem
+		{
+			public string Text { get; set; }
+		}
+
+		[Test]
+		public void DropDownShouldKeepSelectedValueWhenSettingDataStoreWithObjects()
+		{
+			Invoke(() =>
+			{
+				// text is same to make sure matching is based on equality, not value of text
+				var item1 = new CustomDropDownItem { Text = "Item" };
+				var item2 = new CustomDropDownItem { Text = "Item" };
+				var item3 = new CustomDropDownItem { Text = "Item" };
+
+				var dropDown = new DropDown();
+				dropDown.ItemTextBinding = Eto.Forms.Binding.Property((CustomDropDownItem i) => i.Text);
+
+				TestDropDownSelection(dropDown, item1, item2, item3);
+			});
+		}
+
+		[Test]
+		public void DropDownShouldKeepSelectedValueWhenSettingDataStoreWithSelectedIndex()
+		{
+			Invoke(() =>
+			{
+				var item1 = "Item 1";
+				var item2 = "Item 2";
+				var item3 = "Item 3";
+
+				var dropDown = new DropDown();
+
+				TestDropDownSelection(dropDown, item1, item2, item3, true);
+			});
+		}
+	}
+}


### PR DESCRIPTION
This makes DropDown work more consistently across platforms.  The selected item should be kept if it exists in the new data store, and fire appropriate changed events. Also, SelectedValueChanged and SelectedKeyChanged should only trigger if the value is indeed changed.

Also add OS to obj path so it doesn't conflict when using the same code on different platforms at the same time, since the generated .props files appear to save full paths.