### PR TITLE
Font handling updates

### DIFF
--- a/src/Eto.Mac/Drawing/FontHandler.cs
+++ b/src/Eto.Mac/Drawing/FontHandler.cs
@@ -62,6 +62,12 @@ namespace Eto.Mac.Drawing
 			Control = font;
 		}
 
+		public FontHandler(NSFont font, FontDecoration decoration)
+		{
+			Control = font;
+			this.decoration = decoration;
+		}
+
 		public FontHandler(NSFont font, FontStyle style)
 		{
 			Control = font;

--- a/src/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
@@ -404,8 +404,13 @@ namespace Eto.Wpf.Forms.Controls
 				// very odd, considering WPF's available font families only lists "Arial", you'd think this would be handled
 				// by the rtf processor.
 				var faceName = CustomControls.FontDialog.NameDictionaryHelper.GetEnglishName(typeface.FaceNames);
-				family = new swm.FontFamily(family.Source + " " + faceName);
-				weight = sw.FontWeights.Normal;
+				// special case, sometimes the weight of the "Regular" or "Normal" font is not exact
+				if (!string.Equals(faceName, "Regular", StringComparison.Ordinal)
+					&& !string.Equals(faceName, "Normal", StringComparison.Ordinal))
+				{
+					family = new swm.FontFamily(family.Source + " " + faceName);
+					weight = sw.FontWeights.Normal;
+				}
 			}
 
 			SetSelectionAttribute(swd.TextElement.FontFamilyProperty, family);

--- a/src/Eto.Wpf/WpfConversions.cs
+++ b/src/Eto.Wpf/WpfConversions.cs
@@ -877,5 +877,20 @@ namespace Eto.Wpf
 
 			return System.Drawing.Icon.FromHandle(image.ToSD().GetHicon());
 		}
+
+		public static string GetEnglishName(this swm.LanguageSpecificStringDictionary nameDictionary)
+		{
+			return CustomControls.FontDialog.NameDictionaryHelper.GetEnglishName(nameDictionary);
+		}
+
+		public static string GetDisplayName(this swm.LanguageSpecificStringDictionary nameDictionary)
+		{
+			return CustomControls.FontDialog.NameDictionaryHelper.GetDisplayName(nameDictionary);
+		}
+
+		public static string GetName(this swm.LanguageSpecificStringDictionary nameDictionary, string ietfLanguageTag)
+		{
+			return CustomControls.FontDialog.NameDictionaryHelper.GetName(nameDictionary, ietfLanguageTag);
+		}
 	}
 }


### PR DESCRIPTION
Wpf: Fix using Regular or Normal font faces in RichTextArea when the weight is not exactly equal.
Wpf: Added extensions to get the name from a System.Windows.Media.LanguageSpecificStringDictionary
Mac: Add constructor for FontHandler that take an NSFont and FontDecorations.