### PR TITLE
Fix a warning (error in Release) with Xamarin.Mac

### DIFF
--- a/src/Eto.Mac/Forms/ApplicationHandler.cs
+++ b/src/Eto.Mac/Forms/ApplicationHandler.cs
@@ -174,7 +174,9 @@ namespace Eto.Mac.Forms
 
 		public void RunIteration()
 		{
+#pragma warning disable 0618 // for some reason we get a warning (error in Release) here even though we aren't using an obsolete api.
 			NSApplication.SharedApplication.NextEvent(NSEventMask.AnyEvent, NSDate.DistantFuture, NSRunLoop.NSDefaultRunLoopMode, true);
+#pragma warning restore 0618
 		}
 
 		public void Attach(object context)


### PR DESCRIPTION
Ignore it for now.  For some reason even though NSRunLoop.NSDefaultRunLoopMode returns NSString, it gives a warning about using the NextEvent method with string.  Perhaps because it is implicitly converted.