### PR TITLE
RichTextArea TextChanged and SelectedText updates

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/RichTextAreaHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Linq;
 using Eto.Forms;
 using Eto.Drawing;
@@ -176,6 +176,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			});
 			SetUnderline(range, font.FontDecoration.HasFlag(FontDecoration.Underline));
 			SetStrikethrough(range, font.FontDecoration.HasFlag(FontDecoration.Strikethrough));
+			Callback.OnTextChanged(Widget, EventArgs.Empty);
 		}
 
 		public void SetFamily(Range<int> range, FontFamily family)
@@ -186,6 +187,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				tag.Family = pangoFamily;
 				tag.FamilySet = true;
 			});
+			Callback.OnTextChanged(Widget, EventArgs.Empty);
 		}
 
 		public void SetTypeface(Range<int> range, FontTypeface typeface)
@@ -196,6 +198,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				tag.Family = pangoFace.FaceName;
 				tag.FamilySet = true;
 			});
+			Callback.OnTextChanged(Widget, EventArgs.Empty);
 		}
 
 		public void SetForeground(Range<int> range, Color color)
@@ -205,6 +208,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				tag.ForegroundGdk = color.ToGdk();
 				tag.ForegroundSet = true;
 			});
+			Callback.OnTextChanged(Widget, EventArgs.Empty);
 		}
 
 		public void SetBackground(Range<int> range, Color color)
@@ -214,6 +218,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				tag.BackgroundGdk = color.ToGdk();
 				tag.BackgroundSet = true;
 			});
+			Callback.OnTextChanged(Widget, EventArgs.Empty);
 		}
 
 		public void SetBold(Range<int> range, bool bold)
@@ -224,6 +229,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				tag.Weight = weight;
 				tag.WeightSet = true;
 			});
+			Callback.OnTextChanged(Widget, EventArgs.Empty);
 		}
 
 		public void SetItalic(Range<int> range, bool italic)
@@ -234,6 +240,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				tag.Style = style;
 				tag.StyleSet = true;
 			});
+			Callback.OnTextChanged(Widget, EventArgs.Empty);
 		}
 
 		public void SetUnderline(Range<int> range, bool underline)
@@ -243,6 +250,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				tag.Underline = underline ? Pango.Underline.Single : Pango.Underline.None;
 				tag.UnderlineSet = true;
 			});
+			Callback.OnTextChanged(Widget, EventArgs.Empty);
 		}
 
 		public void SetStrikethrough(Range<int> range, bool strikethrough)
@@ -252,6 +260,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				tag.Strikethrough = strikethrough;
 				tag.StrikethroughSet = true;
 			});
+			Callback.OnTextChanged(Widget, EventArgs.Empty);
 		}
 
 		Gtk.TextIter SelectionIter
@@ -348,8 +357,20 @@ namespace Eto.GtkSharp.Forms.Controls
 					tag.StyleSet = true;
 				});
 
-				SelectionUnderline = value.FontDecoration.HasFlag(FontDecoration.Underline);
-				SelectionStrikethrough = value.FontDecoration.HasFlag(FontDecoration.Strikethrough);
+				var underline = value.FontDecoration.HasFlag(FontDecoration.Underline);
+				ApplySelectionTag(UnderlineTagPrefix, value.ToString(), tag =>
+				{
+					tag.Underline = underline ? Pango.Underline.Single : Pango.Underline.None;
+					tag.UnderlineSet = true;
+				});
+				var strikethrough = value.FontDecoration.HasFlag(FontDecoration.Strikethrough);
+				ApplySelectionTag(StrikethroughTagPrefix, value.ToString(), tag =>
+				{
+					tag.Strikethrough = strikethrough;
+					tag.StrikethroughSet = true;
+				});
+
+				Callback.OnTextChanged(Widget, EventArgs.Empty);
 			}
 		}
 
@@ -371,6 +392,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					tag.ForegroundGdk = value.ToGdk();
 					tag.ForegroundSet = true;
 				});
+				Callback.OnTextChanged(Widget, EventArgs.Empty);
 			}
 		}
 
@@ -392,6 +414,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					tag.BackgroundGdk = value.ToGdk();
 					tag.BackgroundSet = true;
 				});
+				Callback.OnTextChanged(Widget, EventArgs.Empty);
 			}
 		}
 
@@ -409,6 +432,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					tag.Weight = weight;
 					tag.WeightSet = true;
 				});
+				Callback.OnTextChanged(Widget, EventArgs.Empty);
 			}
 		}
 
@@ -426,6 +450,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					tag.Style = style;
 					tag.StyleSet = true;
 				});
+				Callback.OnTextChanged(Widget, EventArgs.Empty);
 			}
 		}
 
@@ -439,6 +464,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					tag.Underline = value ? Pango.Underline.Single : Pango.Underline.None;
 					tag.UnderlineSet = true;
 				});
+				Callback.OnTextChanged(Widget, EventArgs.Empty);
 			}
 		}
 
@@ -452,6 +478,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					tag.Strikethrough = value;
 					tag.StrikethroughSet = true;
 				});
+				Callback.OnTextChanged(Widget, EventArgs.Empty);
 			}
 		}
 
@@ -475,6 +502,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					tag.Family = pangoFamily;
 					tag.FamilySet = true;
 				});
+				Callback.OnTextChanged(Widget, EventArgs.Empty);
 			}
 		}
 
@@ -506,6 +534,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					tag.Stretch = pangoDesc.Stretch;
 					tag.StretchSet = true;
 				});
+				Callback.OnTextChanged(Widget, EventArgs.Empty);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
@@ -177,7 +177,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				{
 					return Control.Buffer.GetText(start, end, false);
 				}
-				return null;
+				return string.Empty;
 			}
 			set
 			{

--- a/src/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using Eto.Drawing;
 using Eto.Mac.Drawing;
@@ -148,7 +148,10 @@ namespace Eto.Mac.Forms.Controls
 		{
 			var range = Control.SelectedRange;
 			if (range.Length > 0)
+			{
 				Control.TextStorage.AddAttribute(attribute, value, range);
+				Control.DidChangeText();
+			}
 			else
 			{
 				var mutableAttributes = new NSMutableDictionary(Control.TypingAttributes);
@@ -217,13 +220,13 @@ namespace Eto.Mac.Forms.Controls
 
 		public Color SelectionForeground
 		{
-			get { return GetSelectedTextAttribute<NSColor>(NSStringAttributeKey.ForegroundColor).ToEto(); }
+			get { return GetSelectedTextAttribute<NSColor>(NSStringAttributeKey.ForegroundColor).ToEto(false); }
 			set { SetSelectedAttribute(NSStringAttributeKey.ForegroundColor, value.ToNSUI()); }
 		}
 
 		public Color SelectionBackground
 		{
-			get { return GetSelectedTextAttribute<NSColor>(NSStringAttributeKey.BackgroundColor).ToEto(); }
+			get { return GetSelectedTextAttribute<NSColor>(NSStringAttributeKey.BackgroundColor).ToEto(false); }
 			set { SetSelectedAttribute(NSStringAttributeKey.BackgroundColor, value.ToNSUI()); }
 		}
 

--- a/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -334,7 +334,7 @@ namespace Eto.Mac.Forms.Controls
 				var range = Control.SelectedRange;
 				if (range.Location >= 0 && range.Length > 0)
 					return Control.Value.Substring((int)range.Location, (int)range.Length);
-				return null;
+				return string.Empty;
 			}
 			set
 			{

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -43,9 +43,13 @@ namespace Eto.Mac
 {
 	public static partial class MacConversions
 	{
-		public static NSColor ToNSUI(this Color color)
+		public static NSColor ToNSUI(this Color color) => NSColor.FromDeviceRgba(color.R, color.G, color.B, color.A);
+
+		public static NSColor ToNSUI(this Color color, bool calibrated)
 		{
-			return NSColor.FromDeviceRgba(color.R, color.G, color.B, color.A);
+			return calibrated
+				? NSColor.FromCalibratedRgba(color.R, color.G, color.B, color.A)
+				: NSColor.FromDeviceRgba(color.R, color.G, color.B, color.A);
 		}
 
 		public static Color ToEto(this NSColor color, bool calibrated = true)

--- a/test/Eto.Test/UnitTests/Forms/Controls/RichTextAreaTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/RichTextAreaTests.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using NUnit.Framework;
+using Eto.Drawing;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {
@@ -103,6 +104,66 @@ namespace Eto.Test.UnitTests.Forms.Controls
 
 				richText.Text = val = $"This is{nl}some text{nl}";
 				Assert.AreEqual(val, richText.Text, "#2");
+			});
+		}
+
+		[Test]
+		public void SelectionBoldItalicUnderlineShouldTriggerTextChanged()
+		{
+			Invoke(() =>
+			{
+				int textChangedCount = 0;
+				var richText = new RichTextArea();
+				richText.TextChanged += (sender, e) => textChangedCount++;
+
+				string text = "This is some underline, strikethrough, bold, and italic text. This is green, background blue text.";
+
+				Range<int> GetRange(string s) => Range.FromLength(text.IndexOf(s, StringComparison.Ordinal), s.Length);
+
+				richText.Text = text;
+				Assert.AreEqual(1, textChangedCount);
+
+				richText.Selection = GetRange("underline");
+				richText.SelectionUnderline = true;
+				Assert.AreEqual(2, textChangedCount, "RichTextArea.TextChanged did not fire when setting SelectionUnderline");
+				Assert.AreEqual(true, richText.SelectionUnderline);
+				Assert.AreEqual(false, richText.SelectionStrikethrough);
+				Assert.AreEqual(false, richText.SelectionBold);
+				Assert.AreEqual(false, richText.SelectionItalic);
+
+				richText.Selection = GetRange("strikethrough");
+				richText.SelectionStrikethrough = true;
+				Assert.AreEqual(3, textChangedCount, "RichTextArea.TextChanged did not fire when setting SelectionStrikethrough");
+				Assert.AreEqual(false, richText.SelectionUnderline);
+				Assert.AreEqual(true, richText.SelectionStrikethrough);
+				Assert.AreEqual(false, richText.SelectionBold);
+				Assert.AreEqual(false, richText.SelectionItalic);
+
+				richText.Selection = GetRange("bold");
+				richText.SelectionBold = true;
+				Assert.AreEqual(4, textChangedCount, "RichTextArea.TextChanged did not fire when setting SelectionBold");
+				Assert.AreEqual(false, richText.SelectionUnderline);
+				Assert.AreEqual(false, richText.SelectionStrikethrough);
+				Assert.AreEqual(true, richText.SelectionBold);
+				Assert.AreEqual(false, richText.SelectionItalic);
+
+				richText.Selection = GetRange("italic");
+				richText.SelectionItalic = true;
+				Assert.AreEqual(5, textChangedCount, "RichTextArea.TextChanged did not fire when setting SelectionItalic");
+				Assert.AreEqual(false, richText.SelectionUnderline);
+				Assert.AreEqual(false, richText.SelectionStrikethrough);
+				Assert.AreEqual(false, richText.SelectionBold);
+				Assert.AreEqual(true, richText.SelectionItalic);
+
+				richText.Selection = GetRange("green");
+				richText.SelectionForeground = Colors.Green;
+				Assert.AreEqual(6, textChangedCount, "RichTextArea.TextChanged did not fire when setting SelectionForeground");
+				Assert.AreEqual(Colors.Green, richText.SelectionForeground);
+
+				richText.Selection = GetRange("green");
+				richText.SelectionBackground = Colors.Blue;
+				Assert.AreEqual(7, textChangedCount, "RichTextArea.TextChanged did not fire when setting SelectionBackground");
+				Assert.AreEqual(Colors.Blue, richText.SelectionBackground);
 			});
 		}
 	}

--- a/test/Eto.Test/UnitTests/Forms/Controls/TextAreaTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TextAreaTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using NUnit.Framework;
 
@@ -103,6 +103,18 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				Assert.AreEqual(5, selectionChangedCount, "#7-2");
 				Assert.AreEqual("Hello friend", textArea.Text.TrimEnd(), "#7-3");
 				Assert.AreEqual(Range.FromLength(6, 0), textArea.Selection, "#7-4");
+			});
+		}
+
+		[Test]
+		public void InitialValueOfSelectedTextShouldBeEmptyInsteadOfNull()
+		{
+			Invoke(() =>
+			{
+				var textArea = new T();
+				Assert.AreEqual(string.Empty, textArea.SelectedText, "SelectedText should be empty not null before setting any text");
+				textArea.Text = "Hello!";
+				Assert.AreEqual(string.Empty, textArea.SelectedText, "SelectedText should *still* be empty not null after setting text");
 			});
 		}
 	}


### PR DESCRIPTION
Make the behaviour consistent across platforms.

- TextChanged should fire when setting RichTextArea.Selection* properties.
- SelectedText should return an empty string when no text is selected.