### PR TITLE
Mac/Wpf updates for parent windows

### DIFF
--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -291,8 +291,15 @@ namespace Eto
 		[DllImport("kernel32.dll", CharSet = CharSet.Ansi, BestFitMapping = false, SetLastError = true, ExactSpelling = true)]
 		static extern IntPtr GetProcAddress(IntPtr moduleHandle, string method);
 
+		public enum GA : uint
+		{
+			GA_PARENT = 1,
+			GA_ROOT = 2,
+			GA_ROOTOWNER = 3
+		}
+
 		[DllImport("user32.dll")]
-		public static extern IntPtr GetParent(IntPtr hwnd);
+		public static extern IntPtr GetAncestor(IntPtr hwnd, GA gaFlags);
 
 		public static bool MethodExists(string module, string method)
 		{

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -812,14 +812,13 @@ namespace Eto.Wpf.Forms
 				return null;
 
 			IntPtr parentHandle = presentationSource.Handle;
-			IntPtr handle = parentHandle;
+			if (parentHandle == IntPtr.Zero)
+				return null;
 
-			// traverse the hwnds until we get the top level
-			while (parentHandle != IntPtr.Zero)
-			{
-				handle = parentHandle;
-				parentHandle = Win32.GetParent(parentHandle);
-			}
+			// get the root window (without traversing owners)
+			IntPtr handle = Win32.GetAncestor(parentHandle, Win32.GA.GA_ROOT);
+			if (handle == IntPtr.Zero)
+				return null;
 
 			// if it's a windows forms control, use that
 			var winform = swf.Control.FromHandle(handle) as swf.Form;


### PR DESCRIPTION
Mac: When hosted in an NSWindow that can't become main (e.g. an NSPanel), it should show dialogs as attached so the panel does not lose key focus.
Wpf: Update to the ParentWindow native wrapper so it returns the root window without traversing owner windows when hosted in win32 or winforms windows.