### PR TITLE
Wpf: Avoid errors when using a native ParentWindow

### DIFF
--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -126,10 +126,7 @@ namespace Eto.WinForms.Forms
 
 		public string Title
 		{
-			get
-			{
-				throw new NotImplementedException();
-			}
+			get => Win32.GetWindowText(Control);
 			set
 			{
 				throw new NotImplementedException();
@@ -138,7 +135,13 @@ namespace Eto.WinForms.Forms
 
 		public Screen Screen
 		{
-			get { throw new NotImplementedException(); }
+			get
+			{
+				var swfscreen = swf.Screen.FromHandle(Control);
+				if (swfscreen == null)
+					return null;
+				return new Screen(new ScreenHandler(swfscreen));
+			}
 		}
 
 		public MenuBar Menu
@@ -400,22 +403,18 @@ namespace Eto.WinForms.Forms
 
 		public void OnPreLoad(EventArgs e)
 		{
-			throw new NotImplementedException();
 		}
 
 		public void OnLoad(EventArgs e)
 		{
-			throw new NotImplementedException();
 		}
 
 		public void OnLoadComplete(EventArgs e)
 		{
-			throw new NotImplementedException();
 		}
 
 		public void OnUnLoad(EventArgs e)
 		{
-			throw new NotImplementedException();
 		}
 
 		public void SetParent(Container parent)

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -2,6 +2,7 @@ using System;
 using System.Runtime.InteropServices;
 using System.Windows.Forms;
 using System.Drawing;
+using System.Text;
 
 namespace Eto
 {
@@ -313,6 +314,27 @@ namespace Eto
 			finally
 			{
 				FreeLibrary(moduleHandle);
+			}
+		}
+
+		[DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+		static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+		[DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Auto)]
+		static extern int GetWindowTextLength(IntPtr hWnd);
+
+		public static string GetWindowText(IntPtr hwnd)
+		{
+			try
+			{
+				var len = GetWindowTextLength(hwnd);
+				var sb = new StringBuilder(len + 1);
+				GetWindowText(hwnd, sb, sb.Capacity);
+				return sb.ToString();
+			}
+			catch
+			{
+				return null;
 			}
 		}
 	}

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -440,8 +440,9 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			get
 			{
-				if (Widget.ParentWindow != null)
-					return Control.HasFocus((sw.DependencyObject)Widget.ParentWindow.ControlObject);
+				var parent = Control.GetParent<sw.Window>();
+				if (parent != null)
+					return Control.HasFocus(parent);
 				return base.HasFocus;
 			}
 		}


### PR DESCRIPTION
- GridHandler.HasFocus assumed the ParentWindow was WPF
- Showing a message box with no caption uses ParentWindow.Title
- In some cases ParentWindow.Screen is used so it needs to return a value