### PR TITLE
Mac: copy files to the correct subdirectory when building .app bundle

### DIFF
--- a/build/MacTemplate/MacTemplate.targets
+++ b/build/MacTemplate/MacTemplate.targets
@@ -109,7 +109,7 @@
 		</ItemGroup>
 
 		<!-- copy executable files -->
-		<Copy SourceFiles="@(ExecutableFiles)" DestinationFolder="$(OutputMonoBundlePath)\%(RecursiveDir)" />
+		<Copy SourceFiles="@(ExecutableFiles)" DestinationFolder="$(OutputMonoBundlePath)\%(ExecutableFiles.DestinationSubDirectory)" />
 		<Copy SourceFiles="@(ResourceFiles)" DestinationFolder="$(OutputResourcesPath)\%(RecursiveDir)" SkipUnchangedFiles="true" />
 
 		<!--


### PR DESCRIPTION
Fixes #1092