### PR TITLE
Add TextChangingEventArgs.NewText and OldText

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using Eto.Drawing;
 using System.Runtime.InteropServices;
@@ -109,8 +109,11 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				if (!e.Cancel)
 				{
-					var tia = new TextChangingEventArgs(e.Text, Handler.Selection);
-					Handler.Callback.OnTextChanging(Handler.Widget, tia);
+					var h = Handler;
+					if (h == null)
+						return;
+					var tia = new TextChangingEventArgs(e.Text, h.Selection);
+					h.Callback.OnTextChanging(h.Widget, tia);
 					e.Cancel = tia.Cancel;
 				}
 			}
@@ -118,8 +121,11 @@ namespace Eto.GtkSharp.Forms.Controls
 			[GLib.ConnectBefore]
 			public void HandleClipboardPasted(object sender, EventArgs e)
 			{
-				var tia = new TextChangingEventArgs(Clipboard.Text, Handler.Selection);
-				Handler.Callback.OnTextChanging(Handler.Widget, tia);
+				var h = Handler;
+				if (h == null)
+					return;
+				var tia = new TextChangingEventArgs(Clipboard.Text, h.Selection);
+				Handler.Callback.OnTextChanging(h.Widget, tia);
 				if (tia.Cancel)
 					NativeMethods.g_signal_stop_emission_by_name(Handler.Control.Handle, "paste-clipboard");
 			}
@@ -227,8 +233,14 @@ namespace Eto.GtkSharp.Forms.Controls
 			get { return Control.Text; }
 			set
 			{
-				Control.Text = value ?? string.Empty;
-				lastSelection = null;
+				var oldText = Control.Text;
+				var newText = value ?? string.Empty;
+				if (newText != oldText)
+				{
+					Callback.OnTextChanging(Widget, new TextChangingEventArgs(oldText, newText));
+					Control.Text = newText;
+					lastSelection = null;
+				}
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/MacText.cs
+++ b/src/Eto.Mac/Forms/Controls/MacText.cs
@@ -1,4 +1,4 @@
-﻿using Eto.Forms;
+using Eto.Forms;
 using Eto.Drawing;
 using Eto.Mac.Drawing;
 using System;
@@ -76,17 +76,23 @@ namespace Eto.Mac.Forms.Controls
 			set
 			{
 				var oldValue = Control.AttributedStringValue;
-				var val = value ?? string.Empty;
-				if (val != oldValue.Value)
+				var newText = value ?? string.Empty;
+				var oldText = oldValue.Value;
+				if (newText != oldText)
 				{
+					TextChanging(oldText, newText);
 					if (HasFont)
-						Control.AttributedStringValue = Font.AttributedString(val, oldValue);
+						Control.AttributedStringValue = Font.AttributedString(newText, oldValue);
 					else
-						Control.AttributedStringValue = oldValue.ToMutable(val);
+						Control.AttributedStringValue = oldValue.ToMutable(newText);
 					
 					Callback.OnTextChanged(Widget, EventArgs.Empty);
 				}
 			}
+		}
+
+		protected virtual void TextChanging(string oldText, string newText)
+		{
 		}
 
 		public virtual Color TextColor

--- a/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
@@ -188,5 +188,12 @@ namespace Eto.Mac.Forms.Controls
 		TextBox.ICallback IMacTextBoxHandler.Callback => Callback;
 
 		TextBox IMacTextBoxHandler.Widget => Widget;
+
+		protected override void TextChanging(string oldText, string newText)
+		{
+			base.TextChanging(oldText, newText);
+
+			Callback.OnTextChanging(Widget, new TextChangingEventArgs(oldText, newText));
+		}
 	}
 }

--- a/src/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
@@ -316,9 +316,15 @@ namespace Eto.WinForms.Forms.Controls
 			get { return base.Text; }
 			set
 			{
-				base.Text = value;
-				if (AutoSelectMode == AutoSelectMode.Never)
-					Selection = new Range<int>(value.Length, value.Length - 1);
+				var oldText = Text;
+				var newText = value ?? string.Empty;
+				if (newText != oldText)
+				{
+					Callback.OnTextChanging(Widget, new TextChangingEventArgs(oldText, newText));
+					base.Text = value;
+					if (AutoSelectMode == AutoSelectMode.Never)
+						Selection = new Range<int>(value.Length, value.Length - 1);
+				}
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using swc = System.Windows.Controls;
 using sw = System.Windows;
 using mwc = Xceed.Wpf.Toolkit;
@@ -235,7 +235,13 @@ namespace Eto.Wpf.Forms.Controls
 			get { return TextBox.Text; }
 			set
 			{
-				TextBox.Text = value;
+				var oldText = TextBox.Text;
+				var newText = value ?? string.Empty;
+				if (newText != oldText)
+				{
+					Callback.OnTextChanging(Widget, new TextChangingEventArgs(oldText, newText));
+					TextBox.Text = newText;
+				}
 				if (value != null && AutoSelectMode == AutoSelectMode.Never && !HasFocus)
 				{
 					TextBox.SelectionStart = value.Length;

--- a/src/Eto/Forms/Controls/TextBox.cs
+++ b/src/Eto/Forms/Controls/TextBox.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 
 namespace Eto.Forms
@@ -328,6 +328,8 @@ namespace Eto.Forms
 			/// </summary>
 			public void OnTextChanging(TextBox widget, TextChangingEventArgs e)
 			{
+				if (e.NeedsOldText)
+					e.SetOldText(widget.Text);
 				using (widget.Platform.Context)
 					widget.OnTextChanging(e);
 			}

--- a/src/Eto/Forms/Controls/TextChangingEventArgs.cs
+++ b/src/Eto/Forms/Controls/TextChangingEventArgs.cs
@@ -11,11 +11,20 @@ namespace Eto.Forms
 	/// </remarks>
 	public class TextChangingEventArgs : CancelEventArgs
 	{
+		string newText;
+		string oldText;
+		string text;
+		Range<int>? range;
+
+		internal bool NeedsOldText => oldText == null;
+
+		internal void SetOldText(string oldText) => this.oldText = oldText;
+
 		/// <summary>
 		/// Gets the text that is to be inserted at the given <see cref="Range"/>, or string.Empty if text will be deleted.
 		/// </summary>
 		/// <value>The text to be inserted.</value>
-		public string Text { get; private set; }
+		public string Text => text ?? (text = GetText());
 
 		/// <summary>
 		/// Gets the range that the text will be replaced or deleted.
@@ -26,7 +35,22 @@ namespace Eto.Forms
 		/// Note that the length of the <see cref="Text"/> will not necessarily match the length of the range. 
 		/// </remarks>
 		/// <value>The range.</value>
-		public Range<int> Range { get; private set; }
+		public Range<int> Range => range ?? (range = GetRange()).Value;
+
+		/// <summary>
+		/// Gets the entire old text for the control.
+		/// </summary>
+		/// <remarks>
+		/// This is the same as the <see cref="TextControl.Text"/> property of the control.
+		/// </remarks>
+		/// <value>The old text value.</value>
+		public string OldText => oldText;
+
+		/// <summary>
+		/// Gets the new text the control will contain after the change.
+		/// </summary>
+		/// <value>The new text.</value>
+		public string NewText => newText ?? (newText = GetNewText());
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Eto.Forms.TextChangingEventArgs"/> class.
@@ -35,9 +59,71 @@ namespace Eto.Forms
 		/// <param name="range">Range of text to be effected.</param>
 		public TextChangingEventArgs(string text, Range<int> range)
 		{
-			Text = text;
-			Range = range;
+			this.text = text;
+			this.range = range;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.TextChangingEventArgs"/> class.
+		/// </summary>
+		/// <param name="text">Text to be replaced in the range.</param>
+		/// <param name="range">Range of text to be effected.</param>
+		/// <param name="oldText">Current text in the control.</param>
+		public TextChangingEventArgs(string text, Range<int> range, string oldText)
+		{
+			this.text = text;
+			this.range = range;
+			this.oldText = oldText;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.TextChangingEventArgs"/> class.
+		/// </summary>
+		/// <param name="newText">Old text for the control</param>
+		/// <param name="oldText">New text for the control</param>
+		public TextChangingEventArgs(string oldText, string newText)
+		{
+			this.oldText = oldText;
+			this.newText = newText;
+		}
+
+		Range<int> GetRange()
+		{
+			var old = OldText;
+			int start = 0;
+			for (int i = 0; i < old.Length; i++)
+			{
+				if (i >= newText.Length || old[i] != newText[i])
+					break;
+				start++;
+			}
+
+			int end = old.Length - 1;
+			for (int i = newText.Length - 1; i >= 0; i--)
+			{
+				if (end == 0 || old[end] != newText[i])
+					break;
+				end--;
+			}
+
+			return new Range<int>(start, end);
+		}
+
+		string GetNewText()
+		{
+			var old = OldText;
+			var r = Range;
+			var start = old.Substring(0, r.Start);
+			var end = old.Substring(r.End + 1);
+			return start + text + end;
+		}
+
+		string GetText()
+		{
+			var r = Range;
+			if (r.Length() <= 0)
+				return string.Empty;
+			return newText.Substring(r.Start, newText.Length - (OldText.Length - r.End - 1) - r.Start);
 		}
 	}
-	
 }

--- a/test/Eto.Test/UnitTests/Forms/Controls/TextChangingEventArgsTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TextChangingEventArgsTests.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections.Generic;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	[TestFixture]
+	public class TextChangingEventArgsTests
+	{
+		public static IEnumerable<object[]> GetTextChangingCases()
+		{
+			yield return new object[] { "some old text", "some new text", "new", 5, 3 };
+			yield return new object[] { "some old", "some new text", "new text", 5, 3 };
+			yield return new object[] { "some old text", "some new", "new", 5, 8 };
+			yield return new object[] { "some old text", "new text", "new", 0, 8 };
+			yield return new object[] { "some old and boring text", "some new text", "new", 5, 14 };
+		}
+
+		[TestCaseSource(nameof(GetTextChangingCases))]
+		public void OldAndNewTextShouldCalculateRangeAndText(string oldText, string newText, string text, int rangeStart, int rangeLength)
+		{
+			var args = new TextChangingEventArgs(oldText, newText);
+
+			Assert.AreEqual(oldText, args.OldText);
+			Assert.AreEqual(newText, args.NewText);
+			Assert.AreEqual(Range.FromLength(rangeStart, rangeLength), args.Range, "#1");
+			Assert.AreEqual(text, args.Text, "#2");
+		}
+
+		[TestCaseSource(nameof(GetTextChangingCases))]
+		public void OldAndRangeShouldCalculateNewText(string oldText, string newText, string text, int rangeStart, int rangeLength)
+		{
+			var args = new TextChangingEventArgs(text, Range.FromLength(rangeStart, rangeLength), oldText);
+
+			Assert.AreEqual(oldText, args.OldText);
+			Assert.AreEqual(newText, args.NewText);
+			Assert.AreEqual(Range.FromLength(rangeStart, rangeLength), args.Range, "#1");
+			Assert.AreEqual(text, args.Text, "#2");
+		}
+	}
+}


### PR DESCRIPTION
- TextChangingEventArgs can be created either with a range or with new/old text
- Trigger TextBox.TextChanging when setting the Text property programatically
- Calculate range/text/newtext based on the information supplied

Fixes #866