### PR TITLE
Mac: fix broken compatibility with some 3rd party libs

### DIFF
--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -768,7 +768,7 @@ namespace Eto.Mac.Forms
 			}
 		}
 
-		public bool Enabled
+		public virtual bool Enabled
 		{
 			get => ControlEnabled;
 			set => SetEnabled(ParentEnabled, value);


### PR DESCRIPTION
- MacView.Enabled was abstract so it was required to be overridden.  Change to virtual so things still work, even though the 3rd party libs will need to be updated to use ControlEnabled instead to inherit Enabled from parent.