### PR TITLE
Fix bugs with TextBox.TextChanging

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
@@ -237,7 +237,10 @@ namespace Eto.GtkSharp.Forms.Controls
 				var newText = value ?? string.Empty;
 				if (newText != oldText)
 				{
-					Callback.OnTextChanging(Widget, new TextChangingEventArgs(oldText, newText));
+					var args = new TextChangingEventArgs(oldText, newText);
+					Callback.OnTextChanging(Widget, args);
+					if (args.Cancel)
+						return;
 					Control.Text = newText;
 					lastSelection = null;
 				}

--- a/src/Eto.Mac/Forms/Controls/MacText.cs
+++ b/src/Eto.Mac/Forms/Controls/MacText.cs
@@ -80,7 +80,8 @@ namespace Eto.Mac.Forms.Controls
 				var oldText = oldValue.Value;
 				if (newText != oldText)
 				{
-					TextChanging(oldText, newText);
+					if (TextChanging(oldText, newText))
+						return;
 					if (HasFont)
 						Control.AttributedStringValue = Font.AttributedString(newText, oldValue);
 					else
@@ -91,8 +92,9 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		protected virtual void TextChanging(string oldText, string newText)
+		protected virtual bool TextChanging(string oldText, string newText)
 		{
+			return false;
 		}
 
 		public virtual Color TextColor

--- a/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
@@ -189,11 +189,11 @@ namespace Eto.Mac.Forms.Controls
 
 		TextBox IMacTextBoxHandler.Widget => Widget;
 
-		protected override void TextChanging(string oldText, string newText)
+		protected override bool TextChanging(string oldText, string newText)
 		{
-			base.TextChanging(oldText, newText);
-
-			Callback.OnTextChanging(Widget, new TextChangingEventArgs(oldText, newText));
+			var args = new TextChangingEventArgs(oldText, newText);
+			Callback.OnTextChanging(Widget, args);
+			return args.Cancel;
 		}
 	}
 }

--- a/src/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
@@ -320,7 +320,10 @@ namespace Eto.WinForms.Forms.Controls
 				var newText = value ?? string.Empty;
 				if (newText != oldText)
 				{
-					Callback.OnTextChanging(Widget, new TextChangingEventArgs(oldText, newText));
+					var args = new TextChangingEventArgs(oldText, newText);
+					Callback.OnTextChanging(Widget, args);
+					if (args.Cancel)
+						return;
 					base.Text = value;
 					if (AutoSelectMode == AutoSelectMode.Never)
 						Selection = new Range<int>(value.Length, value.Length - 1);

--- a/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -239,7 +239,10 @@ namespace Eto.Wpf.Forms.Controls
 				var newText = value ?? string.Empty;
 				if (newText != oldText)
 				{
-					Callback.OnTextChanging(Widget, new TextChangingEventArgs(oldText, newText));
+					var args = new TextChangingEventArgs(oldText, newText);
+					Callback.OnTextChanging(Widget, args);
+					if (args.Cancel)
+						return;
 					TextBox.Text = newText;
 				}
 				if (value != null && AutoSelectMode == AutoSelectMode.Never && !HasFocus)

--- a/src/Eto/Forms/Controls/TextBox.cs
+++ b/src/Eto/Forms/Controls/TextBox.cs
@@ -38,6 +38,14 @@ namespace Eto.Forms
 	[Handler(typeof(TextBox.IHandler))]
 	public class TextBox : TextControl
 	{
+		static readonly object SuppressTextChangingKey = new object();
+
+		int SuppressTextChanging
+		{
+			get => Properties.Get<int>(SuppressTextChangingKey);
+			set => Properties.Set(SuppressTextChanging, value);
+		}
+
 		new IHandler Handler { get { return (IHandler)base.Handler; } }
 
 		#region Events
@@ -323,15 +331,22 @@ namespace Eto.Forms
 		/// </summary>
 		protected new class Callback : TextControl.Callback, ICallback
 		{
+
+			
 			/// <summary>
 			/// Raises the text changed event.
 			/// </summary>
 			public void OnTextChanging(TextBox widget, TextChangingEventArgs e)
 			{
-				if (e.NeedsOldText)
-					e.SetOldText(widget.Text);
-				using (widget.Platform.Context)
-					widget.OnTextChanging(e);
+				if (widget.SuppressTextChanging == 0)
+				{
+					widget.SuppressTextChanging++;
+					if (e.NeedsOldText)
+						e.SetOldText(widget.Text);
+					using (widget.Platform.Context)
+						widget.OnTextChanging(e);
+					widget.SuppressTextChanging--;
+				}
 			}
 		}
 

--- a/src/Eto/Forms/Controls/TextChangingEventArgs.cs
+++ b/src/Eto/Forms/Controls/TextChangingEventArgs.cs
@@ -18,7 +18,7 @@ namespace Eto.Forms
 
 		internal bool NeedsOldText => oldText == null;
 
-		internal void SetOldText(string oldText) => this.oldText = oldText;
+		internal void SetOldText(string oldText) => this.oldText = oldText ?? string.Empty;
 
 		/// <summary>
 		/// Gets the text that is to be inserted at the given <see cref="Range"/>, or string.Empty if text will be deleted.
@@ -59,7 +59,7 @@ namespace Eto.Forms
 		/// <param name="range">Range of text to be effected.</param>
 		public TextChangingEventArgs(string text, Range<int> range)
 		{
-			this.text = text;
+			this.text = text ?? string.Empty;
 			this.range = range;
 		}
 
@@ -71,9 +71,9 @@ namespace Eto.Forms
 		/// <param name="oldText">Current text in the control.</param>
 		public TextChangingEventArgs(string text, Range<int> range, string oldText)
 		{
-			this.text = text;
+			this.text = text ?? string.Empty;
 			this.range = range;
-			this.oldText = oldText;
+			this.oldText = oldText ?? string.Empty;
 		}
 
 		/// <summary>
@@ -83,25 +83,26 @@ namespace Eto.Forms
 		/// <param name="oldText">New text for the control</param>
 		public TextChangingEventArgs(string oldText, string newText)
 		{
-			this.oldText = oldText;
-			this.newText = newText;
+			this.oldText = oldText ?? string.Empty;
+			this.newText = newText ?? string.Empty;
 		}
 
 		Range<int> GetRange()
 		{
-			var old = OldText;
+			var ot = OldText;
+			var nt = NewText;
 			int start = 0;
-			for (int i = 0; i < old.Length; i++)
+			for (int i = 0; i < ot.Length; i++)
 			{
-				if (i >= newText.Length || old[i] != newText[i])
+				if (i >= nt.Length || ot[i] != nt[i])
 					break;
 				start++;
 			}
 
-			int end = old.Length - 1;
-			for (int i = newText.Length - 1; i >= 0; i--)
+			int end = ot.Length - 1;
+			for (int i = nt.Length - 1; i >= 0; i--)
 			{
-				if (end == 0 || old[end] != newText[i])
+				if (end <= 0 || ot[end] != nt[i])
 					break;
 				end--;
 			}
@@ -121,7 +122,7 @@ namespace Eto.Forms
 		string GetText()
 		{
 			var r = Range;
-			if (r.Length() <= 0)
+			if (r.Length() < 0 || newText == null)
 				return string.Empty;
 			return newText.Substring(r.Start, newText.Length - (OldText.Length - r.End - 1) - r.Start);
 		}

--- a/test/Eto.Test/UnitTests/Forms/Controls/TextBoxTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TextBoxTests.cs
@@ -143,8 +143,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				tb.Text = newText;
 
 				Assert.IsNotNull(args, "#1");
-				Assert.AreEqual(oldText, args.OldText, "#2");
-				Assert.AreEqual(newText, args.NewText, "#3");
+				Assert.AreEqual(oldText ?? string.Empty, args.OldText, "#2");
+				Assert.AreEqual(newText ?? string.Empty, args.NewText, "#3");
 				Assert.AreEqual(text, args.Text, "#4");
 				Assert.AreEqual(Range.FromLength(rangeStart, rangeLength), args.Range, "#5");
 

--- a/test/Eto.Test/UnitTests/Forms/Controls/TextChangingEventArgsTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TextChangingEventArgsTests.cs
@@ -10,6 +10,10 @@ namespace Eto.Test.UnitTests.Forms.Controls
 	{
 		public static IEnumerable<object[]> GetTextChangingCases()
 		{
+			yield return new object[] { "", "some new text", "some new text", 0, 0 };
+			yield return new object[] { null, "some new text", "some new text", 0, 0 };
+			yield return new object[] { "some old text", "", "", 0, 13 };
+			yield return new object[] { "some old text", null, "", 0, 13 };
 			yield return new object[] { "some old text", "some new text", "new", 5, 3 };
 			yield return new object[] { "some old", "some new text", "new text", 5, 3 };
 			yield return new object[] { "some old text", "some new", "new", 5, 8 };
@@ -22,10 +26,10 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			var args = new TextChangingEventArgs(oldText, newText);
 
-			Assert.AreEqual(oldText, args.OldText);
-			Assert.AreEqual(newText, args.NewText);
-			Assert.AreEqual(Range.FromLength(rangeStart, rangeLength), args.Range, "#1");
-			Assert.AreEqual(text, args.Text, "#2");
+			Assert.AreEqual(oldText ?? string.Empty, args.OldText, "#1");
+			Assert.AreEqual(newText ?? string.Empty, args.NewText, "#2");
+			Assert.AreEqual(Range.FromLength(rangeStart, rangeLength), args.Range, "#3");
+			Assert.AreEqual(text, args.Text, "#4");
 		}
 
 		[TestCaseSource(nameof(GetTextChangingCases))]
@@ -33,10 +37,10 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			var args = new TextChangingEventArgs(text, Range.FromLength(rangeStart, rangeLength), oldText);
 
-			Assert.AreEqual(oldText, args.OldText);
-			Assert.AreEqual(newText, args.NewText);
-			Assert.AreEqual(Range.FromLength(rangeStart, rangeLength), args.Range, "#1");
-			Assert.AreEqual(text, args.Text, "#2");
+			Assert.AreEqual(oldText ?? string.Empty, args.OldText, "#1");
+			Assert.AreEqual(newText ?? string.Empty, args.NewText, "#2");
+			Assert.AreEqual(Range.FromLength(rangeStart, rangeLength), args.Range, "#3");
+			Assert.AreEqual(text, args.Text, "#4");
 		}
 	}
 }


### PR DESCRIPTION
- Going from blank to a string would crash
- Can now cancel the change when changed programatically
- Don't allow the TextChanging property to fire recursively (might want to add a general capability for this later)