### PR TITLE
Mac: Fix issue with WebView on Mojave.

### DIFF
--- a/test/Eto.Test.Mac/Info.plist
+++ b/test/Eto.Test.Mac/Info.plist
@@ -14,5 +14,14 @@
 	<string>10.7</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+		<key>NSAllowsArbitraryLoadsInWebContent</key>
+		<true/>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
 </dict>
 </plist>

--- a/test/Eto.Test/Sections/Controls/WebViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/WebViewSection.cs
@@ -381,7 +381,7 @@ namespace Eto.Test.Sections.Controls
 						dialog.MinimumSize = new Size(300, 0);
 
 					var layout = new DynamicLayout();
-					var textBox = new TextBox { Text = "http://google.com" };
+					var textBox = new TextBox { Text = "https://google.com" };
 					var goButton = new Button { Text = "Go" };
 					dialog.DefaultButton = goButton;
 					goButton.Click += (sender, e) => dialog.Close(true);
@@ -405,7 +405,7 @@ namespace Eto.Test.Sections.Controls
 					}
 				}
 				else
-					webView.Url = new Uri("http://google.com");
+					webView.Url = new Uri("https://google.com");
 			};
 			return control;
 		}


### PR DESCRIPTION
Switch to a custom implementation of the delegates instead of events as using events causes all delegate methods to be "implemented" (by obj-c standards).