### PR TITLE
WinForms: Fix getting parent window

### DIFF
--- a/src/Eto.WinForms/Eto.WinForms.csproj
+++ b/src/Eto.WinForms/Eto.WinForms.csproj
@@ -79,6 +79,7 @@
     <Compile Include="Forms\Controls\TextStepperHandler.cs" />
     <Compile Include="Forms\Controls\StepperHandler.cs" />
     <Compile Include="Forms\DataObjectHandler.cs" />
+    <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="Forms\TrayIndicatorHandler.cs" />
     <Compile Include="Win32.dpi.cs" />
     <Compile Include="WinConversions.cs" />

--- a/src/Eto.WinForms/Forms/NativeFormHandler.cs
+++ b/src/Eto.WinForms/Forms/NativeFormHandler.cs
@@ -1,0 +1,21 @@
+using System;
+using Eto.Forms;
+using Eto.Drawing;
+using swf = System.Windows.Forms;
+
+namespace Eto.WinForms.Forms
+{
+	public class NativeFormHandler : WindowHandler<swf.Form, Form, Form.ICallback>, Form.IHandler
+	{
+		public override bool IsAttached => true;
+
+		public bool ShowActivated { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+		public bool CanFocus { get => Control.CanFocus; set => throw new NotImplementedException(); }
+
+		public NativeFormHandler(swf.Form form)
+		{
+			Control = form;
+		}
+		public void Show() => Control.Show();
+	}
+}

--- a/src/Eto.WinForms/Forms/WindowHandler.cs
+++ b/src/Eto.WinForms/Forms/WindowHandler.cs
@@ -32,6 +32,7 @@ namespace Eto.WinForms.Forms
 		bool clientWidthSet;
 		bool clientHeightSet;
 
+		public virtual bool IsAttached => false;
 		public override swf.Control ContainerContentControl
 		{
 			get { return content; }
@@ -82,6 +83,8 @@ namespace Eto.WinForms.Forms
 
 		protected override void Initialize()
 		{
+			if (IsAttached)
+				return;
 			Control.KeyPreview = !ApplicationHandler.BubbleKeyEvents;
 			Control.FormBorderStyle = DefaultWindowStyle;
 			resizable = Control.FormBorderStyle.IsResizable();
@@ -155,6 +158,8 @@ namespace Eto.WinForms.Forms
 
 		public override void OnLoadComplete(EventArgs e)
 		{
+			if (IsAttached)
+				return;
 			base.OnLoadComplete(e);
 
 			if ((!clientWidthSet || !clientHeightSet))// && Control.AutoSize)

--- a/src/Eto.WinForms/WinFormsHelpers.cs
+++ b/src/Eto.WinForms/WinFormsHelpers.cs
@@ -63,7 +63,7 @@ namespace Eto.Forms
 		{
 			if (window == null)
 				return null;
-			return new Form(new FormHandler(window));
+			return new Form(new NativeFormHandler(window));
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -1094,7 +1094,7 @@ namespace Eto.Forms
 					var window = c as Window;
 					if (window != null)
 						return window;
-					c = c.Parent;
+					c = c.VisualParent;
 				}
 				return Handler.GetNativeParentWindow();
 			}


### PR DESCRIPTION
Also, fix getting parent window of a themed control for any platform.

Fixes #1225