### PR TITLE
Fix using font variants with RichTextArea

### DIFF
--- a/src/Eto.Mac/Drawing/EtoFontManager.cs
+++ b/src/Eto.Mac/Drawing/EtoFontManager.cs
@@ -1,0 +1,78 @@
+using System;
+#if XAMMAC2
+using AppKit;
+using Foundation;
+using ObjCRuntime;
+using CoreAnimation;
+using CoreImage;
+#elif OSX
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+using MonoMac.CoreGraphics;
+using MonoMac.ObjCRuntime;
+using MonoMac.CoreAnimation;
+using MonoMac.CoreImage;
+#if Mac64
+using nfloat = System.Double;
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nfloat = System.Single;
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
+#endif
+
+namespace Eto.Mac.Drawing
+{
+	public class EtoFontManager : NSFontManager
+	{
+		public EtoFontManager()
+		{
+		}
+
+		public EtoFontManager(IntPtr handle)
+			: base(handle)
+		{
+		}
+
+		public static void Install() => SetFontManagerFactory(new Class(typeof(EtoFontManager)));
+
+		public override NSFont ConvertFont(NSFont fontObj, NSFontTraitMask trait)
+		{
+			// be a little less conservative when converting fonts to use the name when translating to italics.
+			// e.g. 'Klavika Medium' translates to 'Klavika Italic' if adding italic trait, instead of
+			// 'Klavika Medium Italic'.
+			if (trait == NSFontTraitMask.Italic || trait == NSFontTraitMask.Unitalic)
+			{
+				var oldName = (string)FontTypefaceHandler.GetName(fontObj.Handle);
+				const string italicSuffix = " Italic";
+				string newName = null;
+				if (trait == NSFontTraitMask.Italic)
+					newName = oldName + italicSuffix;
+				else if (oldName.EndsWith(italicSuffix, StringComparison.OrdinalIgnoreCase))
+					newName = oldName.Substring(0, oldName.Length - italicSuffix.Length);
+
+				if (newName != null)
+				{
+					foreach (var descriptor in AvailableMembersOfFontFamily(fontObj.FamilyName))
+					{
+						var fontName = (string)Messaging.GetNSObject<NSString>(descriptor.ValueAt(1));
+						if (string.Equals(fontName, newName, StringComparison.OrdinalIgnoreCase))
+						{
+							var postScriptName = (string)Messaging.GetNSObject<NSString>(descriptor.ValueAt(0));
+							return NSFont.FromFontName(postScriptName, fontObj.PointSize);
+						}
+					}
+				}
+			}
+
+			return base.ConvertFont(fontObj, trait);
+		}
+	}
+}

--- a/src/Eto.Mac/Drawing/FontFamilyHandler.cs
+++ b/src/Eto.Mac/Drawing/FontFamilyHandler.cs
@@ -95,7 +95,7 @@ namespace Eto.Mac.Drawing
 		public FontTypeface GetFace(NSFont font, NSFontTraitMask? traits)
 		{
 			var postScriptName = font.FontDescriptor.PostscriptName;
-			var faceHandler = Typefaces.Select(r => r.Handler).OfType<FontTypefaceHandler>().FirstOrDefault(r => r.PostScriptName == postScriptName && r.Traits == traits);
+			var faceHandler = Typefaces.Select(r => r.Handler).OfType<FontTypefaceHandler>().FirstOrDefault(r => r.PostScriptName == postScriptName && (traits == null || r.Traits == traits));
 			if (faceHandler == null)
 				faceHandler = new FontTypefaceHandler(font, traits);
 			return new FontTypeface(Widget, faceHandler);

--- a/src/Eto.Mac/Drawing/FontHandler.cs
+++ b/src/Eto.Mac/Drawing/FontHandler.cs
@@ -138,9 +138,15 @@ namespace Eto.Mac.Drawing
 
 		#if OSX
 		NSFontTraitMask? traits;
+		[Obsolete]
 		public static NSFont CreateFont(FontFamilyHandler familyHandler, float size, NSFontTraitMask traits, int weight = 5)
 		{
-			var font = NSFontManager.SharedFontManager.FontWithFamily(familyHandler.MacName, traits, weight, size);
+			return CreateFont(familyHandler.MacName, size, traits, weight);
+		}
+
+		public static NSFont CreateFont(string familyName, nfloat size, NSFontTraitMask traits, int weight = 5)
+		{
+			var font = NSFontManager.SharedFontManager.FontWithFamily(familyName, traits, weight, size);
 			if (font == null)
 			{
 				if (traits.HasFlag(NSFontTraitMask.Italic))
@@ -153,7 +159,7 @@ namespace Eto.Mac.Drawing
 					italicTransform.TransformStruct = Matrix.FromSkew(0, kRotationForItalicText).ToCG();
 					fontTransform.AppendTransform(italicTransform);
 					traits &= ~NSFontTraitMask.Italic;
-					font = NSFontManager.SharedFontManager.FontWithFamily(familyHandler.MacName, traits, 5, size);
+					font = NSFontManager.SharedFontManager.FontWithFamily(familyName, traits, 5, size);
 					if (font != null)
 					{
 						font = NSFont.FromDescription(font.FontDescriptor, fontTransform);
@@ -172,7 +178,7 @@ namespace Eto.Mac.Drawing
 #if OSX
 			var familyHandler = (FontFamilyHandler)family.Handler;
 			traits = style.ToNS() & familyHandler.TraitMask;
-			var font = CreateFont(familyHandler, size, traits.Value);
+			var font = CreateFont(familyHandler.MacName, size, traits.Value);
 
 			if (font == null || font.Handle == IntPtr.Zero)
 				throw new ArgumentOutOfRangeException(string.Empty, string.Format(CultureInfo.CurrentCulture, "Could not allocate font with family {0}, traits {1}, size {2}", family.Name, traits, size));

--- a/src/Eto.Mac/Drawing/FontTypefaceHandler.cs
+++ b/src/Eto.Mac/Drawing/FontTypefaceHandler.cs
@@ -60,6 +60,12 @@ namespace Eto.Mac.Drawing
 			Traits = traits;
 		}
 
+		internal static NSString GetName(IntPtr fontHandle)
+		{
+			var namePtr = CTFontCopyName(fontHandle, CTFontNameKeySubFamily.Handle);
+			return Runtime.GetNSObject<NSString>(namePtr);
+		}
+
 		public string Name
 		{
 			get
@@ -68,8 +74,7 @@ namespace Eto.Mac.Drawing
 				{
 					if (font == null)
 						font = CreateFont(10);
-					var namePtr = CTFontCopyName(font.Handle, CTFontNameKeySubFamily.Handle);
-					name = Runtime.GetNSObject<NSString>(namePtr);
+					name = GetName(font.Handle);
 
 					/*
 					var manager = NSFontManager.SharedFontManager;
@@ -113,8 +118,12 @@ namespace Eto.Mac.Drawing
 
 		public NSFont CreateFont(float size)
 		{
+			// we have a postcript name, use that to create the font
+			if (!string.IsNullOrEmpty(PostScriptName))
+				return NSFont.FromFontName(PostScriptName, size);
+
 			var family = (FontFamilyHandler)Widget.Family.Handler;
-			return FontHandler.CreateFont(family, size, Traits, Weight);
+			return FontHandler.CreateFont(family.MacName, size, Traits, Weight);
 		}
 	}
 }

--- a/src/Eto.Mac/Eto.Mac.csproj
+++ b/src/Eto.Mac/Eto.Mac.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Forms\TrayIndicatorHandler.cs" />
     <Compile Include="AsyncQueue.cs" />
     <Compile Include="Forms\MacFieldEditor.cs" />
+    <Compile Include="Drawing\EtoFontManager.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Eto.Mac/Eto.Mac64.csproj
+++ b/src/Eto.Mac/Eto.Mac64.csproj
@@ -226,6 +226,7 @@
     <Compile Include="Forms\TrayIndicatorHandler.cs" />
     <Compile Include="AsyncQueue.cs" />
     <Compile Include="Forms\MacFieldEditor.cs" />
+    <Compile Include="Drawing\EtoFontManager.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Eto.Mac/Eto.XamMac.csproj
+++ b/src/Eto.Mac/Eto.XamMac.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Forms\NotificationHandler.cs" />
     <Compile Include="AsyncQueue.cs" />
     <Compile Include="Forms\MacFieldEditor.cs" />
+    <Compile Include="Drawing\EtoFontManager.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/src/Eto.Mac/Eto.XamMac2-modern.csproj
+++ b/src/Eto.Mac/Eto.XamMac2-modern.csproj
@@ -238,6 +238,7 @@
     <Compile Include="Forms\TrayIndicatorHandler.cs" />
     <Compile Include="AsyncQueue.cs" />
     <Compile Include="Forms\MacFieldEditor.cs" />
+    <Compile Include="Drawing\EtoFontManager.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/src/Eto.Mac/Eto.XamMac2-net45.csproj
+++ b/src/Eto.Mac/Eto.XamMac2-net45.csproj
@@ -248,6 +248,7 @@
     <Compile Include="Forms\TrayIndicatorHandler.cs" />
     <Compile Include="AsyncQueue.cs" />
     <Compile Include="Forms\MacFieldEditor.cs" />
+    <Compile Include="Drawing\EtoFontManager.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/src/Eto.Mac/Forms/ApplicationHandler.cs
+++ b/src/Eto.Mac/Forms/ApplicationHandler.cs
@@ -4,6 +4,7 @@ using Eto.Mac.Forms.Actions;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.InteropServices;
+using Eto.Mac.Drawing;
 
 #if XAMMAC2
 using AppKit;
@@ -196,6 +197,8 @@ namespace Eto.Mac.Forms
 					CrashReporter.Attach();
 
 				EtoBundle.Init();
+
+				EtoFontManager.Install();
 
 				if (Control.Delegate == null)
 					Control.Delegate = AppDelegate ?? new AppDelegate();

--- a/src/Eto.Mac/Forms/Controls/LinkButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/LinkButtonHandler.cs
@@ -62,12 +62,13 @@ namespace Eto.Mac.Forms.Controls
 
 			public override bool AcceptsFirstResponder()
 			{
-				return Handler.Enabled;
+				return Handler?.Enabled == true;
 			}
 
 			public override void DrawRect(CGRect dirtyRect)
 			{
-				if (Handler.HasFocus)
+				var h = Handler;
+				if (h != null && h.HasFocus)
 				{
 					NSGraphicsContext.CurrentContext.SaveGraphicsState();
 					GraphicsExtensions.SetFocusRingStyle(NSFocusRingPlacement.RingOnly);

--- a/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -264,12 +264,14 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void Resize(NSSplitView splitView, CGSize oldSize)
 			{
-				Handler.ResizeSubviews(oldSize);
+				Handler?.ResizeSubviews(oldSize);
 			}
 
 			public override nfloat ConstrainSplitPosition(NSSplitView splitView, nfloat proposedPosition, nint subviewDividerIndex)
 			{
 				var h = Handler;
+				if (h == null)
+					return proposedPosition;
 				var totalSize = splitView.IsVertical ? splitView.Bounds.Width : splitView.Bounds.Height;
 
 				if (h.Panel1?.Visible != true)
@@ -297,6 +299,8 @@ namespace Eto.Mac.Forms.Controls
 			public override void DidResizeSubviews(NSNotification notification)
 			{
 				var h = Handler;
+				if (h == null)
+					return;
 				var subview = h.Control.Subviews[0];
 				if (subview != null && h.position != null && h.initialPositionSet && h.Widget.Loaded && h.Control.Window != null) // && h.Widget.ParentWindow != null && h.Widget.ParentWindow.Loaded)
 				{

--- a/src/Eto.WinForms/Drawing/FontTypefaceHandler.cs
+++ b/src/Eto.WinForms/Drawing/FontTypefaceHandler.cs
@@ -5,19 +5,19 @@ namespace Eto.WinForms.Drawing
 {
 	public class FontTypefaceHandler : WidgetHandler<sd.FontStyle, FontTypeface>, FontTypeface.IHandler
 	{
-		public FontTypefaceHandler (sd.FontStyle style)
+		string name;
+
+		public FontTypefaceHandler(sd.FontStyle style)
 		{
-			this.Control = style;
-			Name = this.FontStyle.ToString ().Replace (',', ' ');
+			Control = style;
 		}
 
-		public string Name { get; set; }
+		public string Name => name ?? (name = GetName());
 
 		public string LocalizedName => Name;
 
-		public FontStyle FontStyle
-		{
-			get { return Control.ToEtoStyle (); }
-		}
+		public FontStyle FontStyle => Control.ToEtoStyle();
+
+		string GetName() => FontStyle.ToString().Replace(",", string.Empty);
 	}
 }

--- a/src/Eto.WinForms/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/RichTextAreaHandler.cs
@@ -138,8 +138,7 @@ namespace Eto.WinForms.Forms.Controls
 			get => SelectionFont.Typeface;
 			set
 			{
-				var fontStyle = value.ToSD();
-				SetSelectionFontStyle(font => new sd.Font(font.FontFamily, font.Size, fontStyle));
+				SetSelectionFontStyle(font => value.ToSDFont(font.Size));
 			}
 		}
 

--- a/src/Eto.WinForms/WinConversions.cs
+++ b/src/Eto.WinForms/WinConversions.cs
@@ -214,6 +214,11 @@ namespace Eto.WinForms
 			return FontTypefaceHandler.GetControl(typeface);
 		}
 
+		public static sd.Font ToSDFont(this FontTypeface typeface, float size)
+		{
+			return new sd.Font(typeface.Family.ToSD(), size, typeface.ToSD());
+		}
+
 		public static sd.Font ToSD(this SystemFont systemFont)
 		{
 			switch (systemFont)

--- a/src/Eto/CollectionChangedHandler.cs
+++ b/src/Eto/CollectionChangedHandler.cs
@@ -359,7 +359,7 @@ namespace Eto
 		/// <returns>Index of the item, or -1 if not found</returns>
 		protected override int InternalIndexOf(TItem item)
 		{
-			return Collection.IndexOf(item);
+			return Collection?.IndexOf(item) ?? -1;
 		}
 
 		/// <summary>

--- a/test/Eto.Test/Sections/UnitTestPanel.cs
+++ b/test/Eto.Test/Sections/UnitTestPanel.cs
@@ -532,6 +532,8 @@ namespace Eto.Test.Sections
 			}
 		}
 
+		public bool ShowOutput { get; set; }
+
 		public event EventHandler<UnitTestLogEventArgs> Log;
 
 		public event EventHandler<UnitTestProgressEventArgs> Progress;
@@ -685,6 +687,10 @@ namespace Eto.Test.Sections
 				progressArgs.AddResult(result);
 				Progress?.Invoke(this, progressArgs);
 
+				// ITestListener.ShowOutput is not currently called, we need to redirect console and trace output
+				if (ShowOutput && !string.IsNullOrEmpty(result.Output))
+					WriteLog(result.Output);
+
 				if (result.AssertionResults.Count > 0)
 				{
 					foreach (var assertion in result.AssertionResults)
@@ -708,7 +714,8 @@ namespace Eto.Test.Sections
 
 		void ITestListener.TestOutput(TestOutput output)
 		{
-			if (!string.IsNullOrEmpty(output.Text))
+			// not currently called, we need to redirect console and trace output
+			if (ShowOutput && !string.IsNullOrEmpty(output.Text))
 				WriteLog(output.Text);
 		}
 	}
@@ -1095,11 +1102,14 @@ namespace Eto.Test.Sections
 				}
 			};
 
+			var showOuputCheckBox = new CheckBox { Text = "Show Output" };
+			showOuputCheckBox.CheckedBinding.Bind(runner, r => r.ShowOutput);
+
 			var buttons = new TableLayout
 			{
 				Padding = new Padding(10),
 				Spacing = new Size(5, 5),
-				Rows = { new TableRow(startButton, stopButton, null, testCountLabel) }
+				Rows = { new TableRow(startButton, stopButton, showOuputCheckBox, null, testCountLabel) }
 			};
 
 			var statusChecks = new CheckBoxList

--- a/test/Eto.Test/UnitTests/Forms/Controls/DropDownTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/DropDownTests.cs
@@ -105,5 +105,25 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				TestDropDownSelection(dropDown, item1, item2, item3, true);
 			});
 		}
+
+		[Test]
+		public void SettingDataStoreToNullWithSelectedItemShouldNotCrash()
+		{
+			Invoke(() =>
+			{
+				var dropDown = new DropDown();
+
+				var items = new[] { "Item 1", "Item 2", "Item 3" };
+
+				dropDown.DataStore = items;
+				dropDown.SelectedIndex = 1;
+				// sanity check
+				Assert.AreEqual(items[1], dropDown.SelectedValue, "#1");
+
+				dropDown.DataStore = null;
+				Assert.AreEqual(-1, dropDown.SelectedIndex, "#2.1");
+				Assert.IsNull(dropDown.SelectedValue, "#2.2");
+			});
+		}
 	}
 }


### PR DESCRIPTION
This includes fonts with Light/UltraLight/Medium/Strong/Narrow variants.  WPF does not by default save/load these from RTF correctly, so we transform the font names when saving or loading.