### PR TITLE
Grid and ListControl updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,6 +9,7 @@ indent_style = tab
 indent_size = 4
 tab_size = 4
 charset=utf-8
+csharp_new_line_before_open_brace = all
 
 # packages.config uses spaces
 [**\packages.config]

--- a/src/Eto.Gtk/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DropDownHandler.cs
@@ -29,6 +29,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		where TWidget : DropDown
 		where TCallback : DropDown.ICallback
 	{
+		IIndirectBinding<string> _itemTextBinding;
 		protected Font font;
 		protected CollectionHandler collection;
 		protected Gtk.ListStore listStore;
@@ -227,6 +228,18 @@ namespace Eto.GtkSharp.Forms.Controls
 					Control.QueueDraw();
 			}
 		}
+
+		public IIndirectBinding<string> ItemTextBinding
+		{
+			get => _itemTextBinding;
+			set
+			{
+				_itemTextBinding = value;
+				if (Widget.Loaded)
+					Control.QueueDraw();
+			}
+		}
+		public IIndirectBinding<string> ItemKeyBinding { get; set; }
 
 		public override void AttachEvent(string id)
 		{

--- a/src/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
@@ -10,6 +10,7 @@ namespace Eto.GtkSharp.Forms.Controls
 {
 	public class ListBoxHandler : GtkControl<Gtk.TreeView, ListBox, ListBox.ICallback>, ListBox.IHandler, IGtkEnumerableModelHandler<object>
 	{
+		IIndirectBinding<string> _itemTextBinding;
 		readonly Gtk.ScrolledWindow scroll;
 		GtkEnumerableModel<object> model;
 		ContextMenu contextMenu;
@@ -224,5 +225,17 @@ namespace Eto.GtkSharp.Forms.Controls
 			get { return Control.GetBase(); }
 			set { Control.SetBase(value); }
 		}
+
+		public IIndirectBinding<string> ItemTextBinding
+		{
+			get => _itemTextBinding;
+			set
+			{
+				_itemTextBinding = value;
+				if (Widget.Loaded)
+					Control.QueueDraw();
+			}
+		}
+		public IIndirectBinding<string> ItemKeyBinding { get; set; }
 	}
 }

--- a/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
@@ -60,10 +60,11 @@ namespace Eto.Mac.Forms.Cells
 				widthCell = Callback.OnCreateCell(Widget, args);
 				if (widthCell == null)
 					return Callback.OnGetPreferredWidth(Widget, args);
-				widthCell.ToNative(true);
+				widthCell.AttachNative();
 				widthCells.Add(identifier, widthCell);
 			}
 			Callback.OnConfigureCell(Widget, args, widthCell);
+			widthCell.GetMacControl()?.InvalidateMeasure();
 
 			var result = widthCell.GetPreferredSize(SizeF.PositiveInfinity).Width;
 

--- a/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using System.Linq;
 using System.Collections.Generic;
@@ -233,11 +233,10 @@ namespace Eto.Mac.Forms.Controls
 
 		public IEnumerable<object> DataStore
 		{
-			get { return collection == null ? null : collection.Collection; }
+			get => collection?.Collection;
 			set
 			{
-				if (collection != null)
-					collection.Unregister();
+				collection?.Unregister();
 				collection = new CollectionHandler { Handler = this };
 				collection.Register(value);
 			}
@@ -342,5 +341,25 @@ namespace Eto.Mac.Forms.Controls
 			get { return Control.Bordered; }
 			set { Control.Bordered = value; }
 		}
+
+		IIndirectBinding<string> itemTextBinding;
+		public IIndirectBinding<string> ItemTextBinding
+		{
+			get => itemTextBinding;
+			set
+			{
+				itemTextBinding = value;
+				var dataStore = DataStore;
+				if (dataStore != null)
+				{
+					int selectedIndex = SelectedIndex;
+					// re-add all items
+					DataStore = dataStore;
+					SelectedIndex = selectedIndex;
+				}
+			}
+		}
+
+		public IIndirectBinding<string> ItemKeyBinding { get; set; }
 	}
 }

--- a/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
@@ -225,7 +225,7 @@ namespace Eto.Mac.Forms.Controls
 
 		public IEnumerable<object> DataStore
 		{
-			get { return collection == null ? null : collection.Collection; }
+			get => collection?.Collection;
 			set
 			{
 				var selected = Widget.SelectedValue;
@@ -238,6 +238,7 @@ namespace Eto.Mac.Forms.Controls
 					Control.SelectItem(collection.IndexOf(selected));
 					Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
 				}
+				InvalidateMeasure();
 			}
 		}
 
@@ -283,8 +284,30 @@ namespace Eto.Mac.Forms.Controls
 		public bool ShowBorder
 		{
 			get { return Control.Bordered; }
-			set { Control.Bordered = value; }
+			set
+			{
+				Control.Bordered = value;
+				InvalidateMeasure();
+			}
 		}
+
+		IIndirectBinding<string> itemTextBinding;
+		public IIndirectBinding<string> ItemTextBinding
+		{
+			get => itemTextBinding;
+			set
+			{
+				itemTextBinding = value;
+				var dataStore = DataStore;
+				if (dataStore != null)
+				{
+					// re-add all items
+					DataStore = dataStore;
+				}
+			}
+		}
+
+		public IIndirectBinding<string> ItemKeyBinding { get; set; }
 
 		void EnsureDelegate()
 		{

--- a/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
@@ -121,17 +121,17 @@ namespace Eto.Mac.Forms.Controls
 			{
 				var width = GetPreferredWidth(rowRange);
 				if (force || width > Control.Width)
-					Control.Width = width;
+					Control.Width = (nfloat)Math.Ceiling(width);
 			}
 		}
 
 		public nfloat GetPreferredWidth(NSRange? range = null)
 		{
 			var handler = DataViewHandler;
-			nfloat width = (nfloat)0; //Control.DataCell.CellSize.Width;
+			nfloat width = 0;
 			var outlineView = handler.Table as NSOutlineView;
 			if (handler.ShowHeader)
-				width = (nfloat)Math.Max(Control.HeaderCell.CellSize.Width, width);
+				width = (nfloat)Math.Max(Control.HeaderCell.CellSizeForBounds(new CGRect(0, 0, int.MaxValue, int.MaxValue)).Width, width);
 
 			if (dataCell != null)
 			{
@@ -210,8 +210,8 @@ namespace Eto.Mac.Forms.Controls
 
 		public int Width
 		{
-			get { return (int)Control.Width; }
-			set { Control.Width = value; }
+			get { return (int)Math.Ceiling(Control.Width) + 3; }
+			set { Control.Width = Math.Max(0, value - 3); }
 		}
 
 		public bool Visible

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -138,6 +138,12 @@ namespace Eto.Mac.Forms.Controls
 			{
 				return AllowedOperation ?? NSDragOperation.None;
 			}
+
+			public override void Layout()
+			{
+				base.Layout();
+				Handler?.PerformLayout();
+			}
 		}
 
 		public class EtoTableViewDataSource : NSTableViewDataSource
@@ -520,8 +526,8 @@ namespace Eto.Mac.Forms.Controls
 					collection.Unregister();
 				collection = new CollectionHandler { Handler = this };
 				collection.Register(value);
-				if (Widget.Loaded)
-					AutoSizeColumns(true);
+				ResetAutoSizedColumns();
+				InvalidateMeasure();
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
@@ -109,7 +109,7 @@ namespace Eto.Mac.Forms.Controls
 
 		public override SizeF GetPreferredSize(SizeF availableSize)
 		{
-			var boundsSize = new SizeF(14, (float)TitleCell.CellSize.Height + 8);
+			var boundsSize = new SizeF(16, (float)TitleCell.CellSize.Height + 8);
 			availableSize -= boundsSize;
 
 			return base.GetPreferredSize(availableSize) + boundsSize;

--- a/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
@@ -324,5 +324,17 @@ namespace Eto.Mac.Forms.Controls
 				Control.SetNeedsDisplay();
 			}
 		}
+
+		IIndirectBinding<string> itemTextBinding;
+		public IIndirectBinding<string> ItemTextBinding
+		{
+			get => itemTextBinding;
+			set
+			{
+				itemTextBinding = value;
+				Control.ReloadData();
+			}
+		}
+		public IIndirectBinding<string> ItemKeyBinding { get; set; }
 	}
 }

--- a/src/Eto.Mac/Forms/Controls/MacLabel.cs
+++ b/src/Eto.Mac/Forms/Controls/MacLabel.cs
@@ -161,12 +161,12 @@ namespace Eto.Mac.Forms.Controls
 				return naturalSizeInfinity.Value;
 			}
 
-			if (Widget.Loaded && Wrap != WrapMode.None && Size.Width > 0)
+			if (Widget.Loaded && Wrap != WrapMode.None && PreferredSize?.Width > 0)
 			{
 				/*if (!float.IsPositiveInfinity(availableSize.Width))
 					availableSize.Width = Math.Max(Size.Width, availableSize.Width);
 				else*/
-					availableSize.Width = Size.Width;
+				availableSize.Width = PreferredSize.Value.Width;
 				availableSize.Height = float.PositiveInfinity;
 			}
 

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -517,6 +517,12 @@ namespace Eto.Mac.Forms.Controls
 				SetDraggingSourceOperationMask(NSDragOperation.All, true);
 				SetDraggingSourceOperationMask(NSDragOperation.All, false);
 			}
+
+			public override void Layout()
+			{
+				base.Layout();
+				Handler?.PerformLayout();
+			}
 		}
 
 		public override object EventObject
@@ -774,7 +780,10 @@ namespace Eto.Mac.Forms.Controls
 			bool isSelectionChanged = false;
 			foreach (var sel in selection)
 			{
-				var row = Control.RowForItem(GetCachedItem(sel as ITreeGridItem));
+				var cachedItem = GetCachedItem(sel as ITreeGridItem);
+				if (cachedItem == null)
+					continue;
+				var row = Control.RowForItem(cachedItem);
 				if (row >= 0)
 					Control.SelectRow((nnint)row, true);
 				else

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -260,7 +260,7 @@ namespace Eto.Mac.Forms
 		static void HandleWillClose(object sender, EventArgs e)
 		{
 			var handler = GetHandler(sender) as MacWindow<TControl,TWidget,TCallback>;
-			if (handler == null)
+			if (handler == null || !handler.Widget.Loaded) // could already be closed
 				return;
 			if (ApplicationHandler.Instance.ShouldCloseForm(handler.Widget, true))
 				handler.Callback.OnClosed(handler.Widget, EventArgs.Empty);
@@ -610,6 +610,9 @@ namespace Eto.Mac.Forms
 
 		public bool CloseWindow(Action<CancelEventArgs> closing = null)
 		{
+			if (!Widget.Loaded)
+				return true;
+
 			var args = new CancelEventArgs();
 			Callback.OnClosing(Widget, args);
 			if (!args.Cancel && closing != null)

--- a/src/Eto.WinForms/Forms/Controls/ComboBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/ComboBoxHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using swf = System.Windows.Forms;
@@ -11,6 +11,7 @@ namespace Eto.WinForms.Forms.Controls
 	public class ComboBoxHandler : DropDownHandler<EtoComboBox, ComboBox, ComboBox.ICallback>, ComboBox.IHandler
 	{
 		bool readOnly;
+		int suppressTextChanged;
 
 		public ComboBoxHandler()
 		{
@@ -21,18 +22,22 @@ namespace Eto.WinForms.Forms.Controls
 
 		void ControlOnTextChanged(object sender, EventArgs e)
 		{
+			if (suppressTextChanged > 0)
+				return;
 			var selected = SelectedIndex;
 			var text = Text;
 			var item = Control.Items.Cast<object>().FirstOrDefault(r => Widget.ItemTextBinding.GetValue(r) == text);
 			var newIndex = item != null ? Control.Items.IndexOf(item) : -1;
 			if (selected != newIndex)
 			{
+				suppressTextChanged++;
 				var selectionStart = Control.SelectionStart;
 				var selectionLength = Control.SelectionLength;
 				SelectedIndex = newIndex;
 				Text = text;
 				Control.SelectionStart = selectionStart;
 				Control.SelectionLength = selectionLength;
+				suppressTextChanged--;
 			}
 			Callback.OnTextChanged(Widget, EventArgs.Empty);
 		}

--- a/src/Eto.WinForms/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/DropDownHandler.cs
@@ -171,7 +171,8 @@ namespace Eto.WinForms.Forms.Controls
 		where TWidget: DropDown
 		where TCallback: DropDown.ICallback
 	{
-		CollectionHandler collection;
+		IIndirectBinding<string> _itemTextBinding;
+		CollectionHandler _collection;
 
 		public bool ShowBorder
 		{
@@ -252,29 +253,45 @@ namespace Eto.WinForms.Forms.Controls
 
 		protected virtual void UpdateSizes()
 		{
-			if (Widget.Loaded)
-				SetMinimumSize();
 			Control.ResetSize();
+			if (Widget.Loaded)
+				SetMinimumSize(true);
 		}
 
 		public IEnumerable<object> DataStore
 		{
-			get { return collection != null ? collection.Collection : null; }
+			get { return _collection != null ? _collection.Collection : null; }
 			set
 			{
 				var selected = Widget.SelectedValue;
-				collection?.Unregister();
-				collection = new CollectionHandler { Handler = this };
-				collection.Register(value);
+				_collection?.Unregister();
+				_collection = new CollectionHandler { Handler = this };
+				_collection.Register(value);
 				if (!ReferenceEquals(selected, null))
 				{
-					var newSelectedIndex = collection.IndexOf(selected);
+					var newSelectedIndex = _collection.IndexOf(selected);
 					SelectedIndex = newSelectedIndex;
 					if (newSelectedIndex == -1)
 						Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
 				}
 			}
 		}
+
+		public IIndirectBinding<string> ItemTextBinding
+		{
+			get => _itemTextBinding;
+			set
+			{
+				_itemTextBinding = value;
+				if (Widget.Loaded)
+				{
+					Control.Refresh();
+					UpdateSizes();
+				}
+			}
+
+		}
+		public IIndirectBinding<string> ItemKeyBinding { get; set; }
 
 		static readonly Win32.WM[] intrinsicEvents = { Win32.WM.LBUTTONDOWN, Win32.WM.LBUTTONUP, Win32.WM.LBUTTONDBLCLK };
 		public override bool ShouldBubbleEvent(swf.Message msg)

--- a/src/Eto.WinForms/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/ListBoxHandler.cs
@@ -11,7 +11,8 @@ namespace Eto.WinForms.Forms.Controls
 {
 	public class ListBoxHandler : WindowsControl<swf.ListBox, ListBox, ListBox.ICallback>, ListBox.IHandler
 	{
-		CollectionHandler collection;
+		IIndirectBinding<string> _itemTextBinding;
+		CollectionHandler _collection;
 
 		public static int ItemPadding = 2;
 
@@ -171,15 +172,27 @@ namespace Eto.WinForms.Forms.Controls
 
 		public IEnumerable<object> DataStore
 		{
-			get { return collection != null ? collection.Collection : null; }
+			get { return _collection != null ? _collection.Collection : null; }
 			set
 			{
-				if (collection != null)
-					collection.Unregister();
-				collection = new CollectionHandler { Handler = this };
-				collection.Register(value);
+				if (_collection != null)
+					_collection.Unregister();
+				_collection = new CollectionHandler { Handler = this };
+				_collection.Register(value);
 			}
 		}
+
+		public IIndirectBinding<string> ItemTextBinding
+		{
+			get => _itemTextBinding;
+			set
+			{
+				_itemTextBinding = value;
+				Control.Invalidate();
+			}
+		}
+
+		public IIndirectBinding<string> ItemKeyBinding { get; set; }
 
 		static readonly Win32.WM[] intrinsicEvents = {
 														 Win32.WM.LBUTTONDOWN, Win32.WM.LBUTTONUP, Win32.WM.LBUTTONDBLCLK,

--- a/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
@@ -8,6 +8,7 @@ using Eto.Forms;
 using System.Collections;
 using System.Collections.Generic;
 using Eto.Drawing;
+using System.Globalization;
 
 namespace Eto.Wpf.Forms.Controls
 {
@@ -183,6 +184,20 @@ namespace Eto.Wpf.Forms.Controls
 					base.TextColor = value;
 			}
 		}
+
+		IIndirectBinding<string> _itemTextBinding;
+		public IIndirectBinding<string> ItemTextBinding
+		{
+			get => _itemTextBinding;
+			set
+			{
+				_itemTextBinding = value;
+				if (Widget.Loaded)
+					CreateTemplate();
+			}
+		}
+
+		public IIndirectBinding<string> ItemKeyBinding { get; set; }
 
 		void CreateTemplate()
 		{

--- a/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
@@ -7,6 +7,7 @@ namespace Eto.Wpf.Forms.Controls
 {
 	public interface IGridHandler
 	{
+		bool Loaded { get; }
 		sw.FrameworkElement SetupCell (IGridColumnHandler column, sw.FrameworkElement defaultContent);
 		void FormatCell (IGridColumnHandler column, ICellHandler cell, sw.FrameworkElement element, swc.DataGridCell gridcell, object dataItem);
 		void CellEdited(int row, swc.DataGridColumn dataGridColumn, object dataItem);
@@ -60,6 +61,8 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			get
 			{
+				if (GridHandler?.Loaded == true)
+					return (int)Control.ActualWidth;
 				return (int)Control.Width.Value;
 			}
 			set

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -592,5 +592,7 @@ namespace Eto.Wpf.Forms.Controls
 			get { return Widget.Properties.Get<GridDragRowState>(GridHandler.LastDragRow_Key); }
 			set { Widget.Properties.Set(GridHandler.LastDragRow_Key, value); }
 		}
+
+		bool IGridHandler.Loaded => Widget.Loaded;
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ListBoxHandler.cs
@@ -124,5 +124,17 @@ namespace Eto.Wpf.Forms.Controls
 				Control.ContextMenu = contextMenu != null ? contextMenu.ControlObject as sw.Controls.ContextMenu : null;
 			}
 		}
+
+		IIndirectBinding<string> _itemTextBinding;
+		public IIndirectBinding<string> ItemTextBinding
+		{
+			get => _itemTextBinding;
+			set
+			{
+				_itemTextBinding = value;
+				Control.InvalidateVisual();
+			}
+		}
+		public IIndirectBinding<string> ItemKeyBinding { get; set; }
 	}
 }

--- a/src/Eto/Forms/Controls/ListControl.cs
+++ b/src/Eto/Forms/Controls/ListControl.cs
@@ -4,6 +4,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Eto.Drawing;
+using System.ComponentModel;
 
 namespace Eto.Forms
 {
@@ -120,19 +121,27 @@ namespace Eto.Forms
 	[ContentProperty("Items")]
 	public abstract class ListControl : CommonControl
 	{
-		new IHandler Handler { get { return (IHandler)base.Handler; } }
+		new IHandler Handler => (IHandler)base.Handler;
 
 		/// <summary>
 		/// Gets or sets the binding for the text value of each item.
 		/// </summary>
 		/// <value>The text binding.</value>
-		public IIndirectBinding<string> ItemTextBinding { get; set; }
+		public IIndirectBinding<string> ItemTextBinding
+		{
+			get => Handler.ItemTextBinding;
+			set => Handler.ItemTextBinding = value;
+		}
 
 		/// <summary>
 		/// Gets or sets the binding for the key value of each item.
 		/// </summary>
 		/// <value>The key binding.</value>
-		public IIndirectBinding<string> ItemKeyBinding { get; set; }
+		public IIndirectBinding<string> ItemKeyBinding
+		{
+			get => Handler.ItemKeyBinding;
+			set => Handler.ItemKeyBinding = value;
+		}
 
 		/// <summary>
 		/// Gets or sets the binding for the text value of each item.
@@ -473,6 +482,18 @@ namespace Eto.Forms
 			/// </remarks>
 			/// <value>The color of the text.</value>
 			Color TextColor { get; set; }
+
+			/// <summary>
+			/// Gets or sets the binding for the text value of each item.
+			/// </summary>
+			/// <value>The text binding.</value>
+			IIndirectBinding<string> ItemTextBinding { get; set; }
+
+			/// <summary>
+			/// Gets or sets the binding for the key value of each item.
+			/// </summary>
+			/// <value>The key binding.</value>
+			IIndirectBinding<string> ItemKeyBinding { get; set; }
 		}
 	}
 }

--- a/src/Eto/Forms/Layout/TableLayout.cs
+++ b/src/Eto/Forms/Layout/TableLayout.cs
@@ -265,7 +265,6 @@ namespace Eto.Forms
 						SetRowScale(y);
 				}
 			}
-			created = true;
 		}
 
 		void SetCellSize(Size value, bool createRows)
@@ -280,9 +279,9 @@ namespace Eto.Forms
 				{
 					var rows = Enumerable.Range(0, value.Height).Select(r => new TableRow(Enumerable.Range(0, value.Width).Select(c => new TableCell())));
 					Rows = new TableRowCollection(this, rows);
-					created = true;
 				}
 			}
+			created = true;
 		}
 
 		/// <summary>

--- a/test/Eto.Test/UnitTests/Forms/Bindings/ObjectBindingChangedTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Bindings/ObjectBindingChangedTests.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 using System.ComponentModel;
 using Eto.Forms;
 
-namespace Eto.Test.UnitTests.Forms.Binding
+namespace Eto.Test.UnitTests.Forms.Bindings
 {
 	class BindObject : INotifyPropertyChanged
 	{

--- a/test/Eto.Test/UnitTests/Forms/Bindings/ObjectBindingObjectChangedTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Bindings/ObjectBindingObjectChangedTests.cs
@@ -2,7 +2,7 @@
 using NUnit.Framework;
 using Eto.Forms;
 
-namespace Eto.Test.UnitTests.Forms.Binding
+namespace Eto.Test.UnitTests.Forms.Bindings
 {
 	[TestFixture]
 	public class ObjectBindingObjectChangedTests

--- a/test/Eto.Test/UnitTests/Forms/Bindings/PropertyBindingTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Bindings/PropertyBindingTests.cs
@@ -2,7 +2,7 @@
 using NUnit.Framework;
 using Eto.Forms;
 
-namespace Eto.Test.UnitTests.Forms.Binding
+namespace Eto.Test.UnitTests.Forms.Bindings
 {
 	[TestFixture]
 	public class PropertyBindingTests : TestBase

--- a/test/Eto.Test/UnitTests/Forms/Controls/ComboBoxTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ComboBoxTests.cs
@@ -1,15 +1,15 @@
-﻿using Eto.Forms;
+using Eto.Forms;
 using NUnit.Framework;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {
 	[TestFixture]
-	public class ComboBoxTests
+	public class ComboBoxTests : ListControlTests<ComboBox>
 	{
 		[Test]
 		public void InitialValuesShouldBeCorrect()
 		{
-			TestBase.Invoke(() =>
+			Invoke(() =>
 			{
 				var comboBox = new ComboBox();
 				Assert.IsFalse(comboBox.AutoComplete, "AutoComplete should be false");
@@ -21,7 +21,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		[Test]
 		public void TextNotMatchingItemsShouldNotHaveSelectedItem()
 		{
-			TestBase.Invoke(() =>
+			Invoke(() =>
 			{
 				int selectedIndexChanged = 0;
 				var comboBox = new ComboBox { Items = { "Item 1", "Item 2", "Item 3" } };

--- a/test/Eto.Test/UnitTests/Forms/Controls/DropDownTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/DropDownTests.cs
@@ -4,7 +4,7 @@ using Eto.Forms;
 namespace Eto.Test.UnitTests.Forms.Controls
 {
 	[TestFixture]
-	public class DropDownTests : TestBase
+	public class DropDownTests : ListControlTests<DropDown>
 	{
 		static void TestDropDownSelection(DropDown dropDown, object item1, object item2, object item3, bool useIndex = false)
 		{

--- a/test/Eto.Test/UnitTests/Forms/Controls/ListBoxTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ListBoxTests.cs
@@ -1,0 +1,10 @@
+using System;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	public class ListBoxTests : ListControlTests<ListBox>
+	{
+	}
+}

--- a/test/Eto.Test/UnitTests/Forms/Controls/ListControlTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ListControlTests.cs
@@ -1,0 +1,54 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	public enum SetBindingMode
+	{
+		Before,
+		After,
+		Async
+	}
+
+	public class ListControlTests<T> : TestBase
+		where T: ListControl, new()
+	{
+		[ManualTest]
+		[TestCase(SetBindingMode.Before)]
+		[TestCase(SetBindingMode.After)]
+		[TestCase(SetBindingMode.Async)]
+		public void ItemTextBindingShouldWorkRegardlessOfOrder(SetBindingMode mode)
+		{
+			ManualForm("Should show 'Item x' for each item", form =>
+			{
+				var dropDown = new T();
+				if (dropDown is ListBox)
+					dropDown.Size = new Size(150, 200);
+
+				var binding = Binding.Delegate((string d) => "Item " + d);
+				if (mode == SetBindingMode.Before)
+					dropDown.ItemTextBinding = binding;
+				dropDown.DataStore = new[] { "1", "2", "3" };
+				dropDown.SelectedIndex = 0;
+				if (mode == SetBindingMode.After)
+					dropDown.ItemTextBinding = binding;
+
+				if (mode == SetBindingMode.Async)
+				{
+					var updateBindingButton = new Button { Text = "Update ItemTextBinding" };
+					updateBindingButton.Click += (sender, e) => dropDown.ItemTextBinding = binding;
+
+					return new StackLayout
+					{
+						Spacing = 4,
+						Items = { new StackLayoutItem(dropDown, true), updateBindingButton }
+					};
+				}
+				else
+					return dropDown;
+			});
+		}
+	}
+}


### PR DESCRIPTION
Mac: Fixes GridView auto sizing of columns when added dynamically
Wpf: Fix getting current width of columns after GridView is loaded
Mac: GroupBox auto size is too small (possibly a Mojave update?)
ListControl based controls (DropDown, ComboBox, ListBox) should allow you to set the ItemTextBinding at any point, not just before setting the DataStore.
Mac: If you handled Window.Closing event, OnClosed may be called twice which in turn tries to unload all controls more than once.