### PR TITLE
Fix KeyEventType in Gtk and macOS

### DIFF
--- a/src/Eto.Gtk/GtkConversions.cs
+++ b/src/Eto.Gtk/GtkConversions.cs
@@ -510,14 +510,16 @@ namespace Eto.GtkSharp
 		{
 			Keys key = args.Key.ToEto() | args.State.ToEtoKey();
 
+			KeyEventType keyEventType = args.Type == Gdk.EventType.KeyRelease ? KeyEventType.KeyUp : KeyEventType.KeyDown;
+
 			if (key != Keys.None)
 			{
 				Keys modifiers = (key & Keys.ModifierMask);
 				if (args.KeyValue <= 128 && ((modifiers & ~Keys.Shift) == 0))
-					return new KeyEventArgs(key, KeyEventType.KeyDown, (char)args.KeyValue);
-				return new KeyEventArgs(key, KeyEventType.KeyDown);
+					return new KeyEventArgs(key, keyEventType, (char)args.KeyValue);
+				return new KeyEventArgs(key, keyEventType);
 			}
-			return args.KeyValue <= 128 ? new KeyEventArgs(key, KeyEventType.KeyDown, (char)args.KeyValue) : null;
+			return args.KeyValue <= 128 ? new KeyEventArgs(key, keyEventType, (char)args.KeyValue) : null;
 		}
 
 		public static MouseButtons ToEtoMouseButtons(this Gdk.ModifierType modifiers)

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -336,16 +336,19 @@ namespace Eto.Mac
 			KeyEventArgs kpea;
 			Keys modifiers = theEvent.ModifierFlags.ToEto();
 			key |= modifiers;
+
+			KeyEventType keyEventType = theEvent.Type == NSEventType.KeyUp ? KeyEventType.KeyUp : KeyEventType.KeyDown;
+
 			if (key != Keys.None)
 			{
 				if (((modifiers & ~(Keys.Shift | Keys.Alt)) == 0))
-					kpea = new KeyEventArgs(key, KeyEventType.KeyDown, keyChar);
+					kpea = new KeyEventArgs(key, keyEventType, keyChar);
 				else
-					kpea = new KeyEventArgs(key, KeyEventType.KeyDown);
+					kpea = new KeyEventArgs(key, keyEventType);
 			}
 			else
 			{
-				kpea = new KeyEventArgs(key, KeyEventType.KeyDown, keyChar);
+				kpea = new KeyEventArgs(key, keyEventType, keyChar);
 			}
 			return kpea;
 		}

--- a/test/Eto.Test/Sections/Behaviors/KeyEventsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/KeyEventsSection.cs
@@ -46,12 +46,12 @@ namespace Eto.Test.Sections.Behaviors
 
 		void control_KeyUp(object sender, KeyEventArgs e)
 		{
-			LogKeyEvent(sender, "KeyUp", e);
+			LogKeyEvent(sender, e.KeyEventType.ToString(), e);
 		}
 
 		void control_KeyDown(object sender, KeyEventArgs e)
 		{
-			LogKeyEvent(sender, "KeyDown", e);
+			LogKeyEvent(sender, e.KeyEventType.ToString(), e);
 		}
 
 		Control ShowParentEvents()


### PR DESCRIPTION
KeyEvents in Gtk and macOS platforms were previously coming through with a KeyEventType of KeyDown, regardless of whether the key had been pressed or released.

Poking around showed the issue lying within the extension methods that convert from native platform key events to Eto key events. The code always created a new KeyEventArgs with a type of KeyDown, whereas this pull request instead takes the platform's event type into consideration, and modifies a unit test to ensure the displayed event type is that of the event, independent of which handler calls LogKeyEvent.

I don't have this issue in WinForms or Wpf, so I haven't changed anything there. What changes I have made I've tested in Gtk2 in Windows 1809, Gtk2 and Gtk3 in Linux Mint 19, and Gtk2, Mac64, XamMac2-modern, and XamMac2-net461 in macOS 10.13.6.