### PR TITLE
Make Eto buildable with .NET Core SDK

### DIFF
--- a/build/Common.Build.targets
+++ b/build/Common.Build.targets
@@ -1,76 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <UsingTask TaskName="_GetCommonFiles" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
-    <ParameterGroup>
-      <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
-      <Names ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
-      <Result ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Code Type="Fragment" Language="cs">
-        <![CDATA[  
-        var result = new List<ITaskItem>();
-        foreach (var fileItem in Files)
-        {  
-          string name = fileItem.GetMetadata("Filename");
-          foreach (var nameItem in Names)
-          {
-            if (string.Equals(name, nameItem.ItemSpec, StringComparison.OrdinalIgnoreCase))
-            {
-              result.Add(new TaskItem(fileItem.ItemSpec));
-              break;
-            }
-          }
-        }  
-        Result = result.ToArray();
-]]>
-      </Code>
-    </Task>
-  </UsingTask>
-	 
-  <UsingTask TaskName="GenerateVersion" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
-    <ParameterGroup>
-      <Version ParameterType="System.String" Required="true" Output="true" />
-    </ParameterGroup>
-    <Task>
-      <Code Type="Class" Language="cs">
-<![CDATA[
-    using System;
-    using System.IO;
-    using System.Text;
-    using System.Text.RegularExpressions;
-    using System.Reflection;
-    using System.Diagnostics;
-    using System.Linq;
-    using Microsoft.Build.Framework;
-    using Microsoft.Build.Utilities;
-
-    public class GenerateVersion : Task
-    {
-      [Output]
-      public string Version { get; set; }
-
-      public override bool Execute()
-      {
-        var currentDate = DateTime.Now;
-        var timeSpanDays = currentDate - new DateTime(2000, 01, 01);
-        var timeSpanSeconds = currentDate - DateTime.Today;
-
-        var numberOfDays = (int)timeSpanDays.TotalDays;
-        var numberOfSeconds = (int)(timeSpanSeconds.TotalSeconds / 2);
-        var versionString = Version.Replace(".*", "");
-            
-        var version = System.Version.Parse(versionString);
-            
-        Version = string.Format("{0}.{1}.{2}.{3}", version.Major, version.Minor, numberOfDays, numberOfSeconds);
-        
-        return true;
-      }
-    }
-]]></Code>
-    </Task>
-  </UsingTask>
-
   <Target Name="_EmbedReferencedAssemblies" Condition="$(EmbedReferences) != ''" AfterTargets="ResolveAssemblyReferences">
     <PropertyGroup>
       <EmbedDebugSymbols Condition="$(EmbedDebugSymbols) == ''">false</EmbedDebugSymbols>
@@ -168,9 +97,12 @@
     b) VS on Mac won't break intellisense when strong naming the assemblies
        see: https://github.com/mono/monodevelop/issues/4763
     -->
-    <GenerateVersion Version="$(AssemblyVersion)">
-    	<Output TaskParameter="Version" PropertyName="AssemblyFileVersion" />
-    </GenerateVersion>
+    <PropertyGroup>
+      <AssemblyVersionMajorMinor>$([System.Version]::Parse($([System.String]::Copy('$(AssemblyVersion)').Replace('.*', ''))).ToString(2))</AssemblyVersionMajorMinor>
+      <DaysSince2000>$([System.DateTime]::Now.Subtract($([System.DateTime]::Parse('2000-01-01T00:00:00Z'))).TotalDays.ToString('0'))</DaysSince2000>
+      <SecondsOfTodayHalved>$([MSBuild]::Divide($([System.DateTime]::Now.Subtract($([System.DateTime]::Today)).TotalSeconds), 2).ToString('0'))</SecondsOfTodayHalved>
+      <AssemblyFileVersion>$(AssemblyVersionMajorMinor).$(DaysSince2000).$(SecondsOfTodayHalved)</AssemblyFileVersion>
+    </PropertyGroup>
 
     <ItemGroup>
       <VersionInfo Include="[assembly: System.Reflection.AssemblyVersion(&quot;$(AssemblyVersion)&quot;)]" />

--- a/build/Common.Build.targets
+++ b/build/Common.Build.targets
@@ -59,11 +59,11 @@
 
   <Target Name="FixGtkReferences" Condition="$(FixGtkReferences)=='true'" BeforeTargets="BeforeBuild">
     <!-- 
-  	Set the path of gtk references explicitly for linux msbuild support.
-  	msbuild on linux crashes with gtk references and uses the wrong references when 
-  	both Gtk#2 and Gtk#3 are installed.
-  	It's most likely because the Reference.Filename incorrectly includes the ", Version=" portion of the reference.
-  	-->
+    Set the path of gtk references explicitly for linux msbuild support.
+    msbuild on linux crashes with gtk references and uses the wrong references when 
+    both Gtk#2 and Gtk#3 are installed.
+    It's most likely because the Reference.Filename incorrectly includes the ", Version=" portion of the reference.
+    -->
     <PropertyGroup>
       <CliReferencePath Condition="$(CliReferencePath)==''">/usr/lib/cli/</CliReferencePath>
     </PropertyGroup>

--- a/build/Common.Build.targets
+++ b/build/Common.Build.targets
@@ -1,5 +1,32 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <UsingTask TaskName="_GetCommonFiles" TaskFactory="CodeTaskFactory" AssemblyFile="$(MSBuildToolsPath)\Microsoft.Build.Tasks.v4.0.dll">
+    <ParameterGroup>
+      <Files ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <Names ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+      <Result ParameterType="Microsoft.Build.Framework.ITaskItem[]" Output="true" />
+    </ParameterGroup>
+    <Task>
+      <Code Type="Fragment" Language="cs">
+        <![CDATA[  
+        var result = new List<ITaskItem>();
+        foreach (var fileItem in Files)
+        {  
+          string name = fileItem.GetMetadata("Filename");
+          foreach (var nameItem in Names)
+          {
+            if (string.Equals(name, nameItem.ItemSpec, StringComparison.OrdinalIgnoreCase))
+            {
+              result.Add(new TaskItem(fileItem.ItemSpec));
+              break;
+            }
+          }
+        }  
+        Result = result.ToArray();
+        ]]>
+      </Code>
+    </Task>
+  </UsingTask>
   <Target Name="_EmbedReferencedAssemblies" Condition="$(EmbedReferences) != ''" AfterTargets="ResolveAssemblyReferences">
     <PropertyGroup>
       <EmbedDebugSymbols Condition="$(EmbedDebugSymbols) == ''">false</EmbedDebugSymbols>
@@ -29,17 +56,17 @@
   </Target>
   <Import Project="$(BasePath)build\MacTemplate\MacTemplate.targets" Condition="$(UseMacTemplate) == 'True'" />
   <Import Condition="Exists('$(BasePath)..\Eto.Common.targets')" Project="$(BasePath)..\Eto.Common.targets" />
-  
+
   <Target Name="FixGtkReferences" Condition="$(FixGtkReferences)=='true'" BeforeTargets="BeforeBuild">
-  	<!-- 
+    <!-- 
   	Set the path of gtk references explicitly for linux msbuild support.
   	msbuild on linux crashes with gtk references and uses the wrong references when 
   	both Gtk#2 and Gtk#3 are installed.
   	It's most likely because the Reference.Filename incorrectly includes the ", Version=" portion of the reference.
   	-->
-  	<PropertyGroup>
-  		<CliReferencePath Condition="$(CliReferencePath)==''">/usr/lib/cli/</CliReferencePath>
-  	</PropertyGroup>
+    <PropertyGroup>
+      <CliReferencePath Condition="$(CliReferencePath)==''">/usr/lib/cli/</CliReferencePath>
+    </PropertyGroup>
     <ItemGroup>
       <!-- collect the references we need to update -->
       <GtkReference Include="%(Reference.Identity)" Condition="%(Reference.Name) != '' and %(Reference.Name)!=%(Reference.Filename) and Exists('$(CliReferencePath)%(Reference.Name)-%(Reference.PackageVersion)/%(Reference.Name).dll')">
@@ -61,7 +88,7 @@
     <Message Text="%(Reference.Filename) - %(Reference.HintPath)" Importance="high" />
     -->
   </Target>
-  
+
   <ItemGroup Condition="$(GenerateAssemblyVersion) == 'True'">
     <Compile Include="$(IntermediateOutputPath)VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
@@ -72,7 +99,7 @@
       <Visible>false</Visible>
     </Compile>
   </ItemGroup>
-  
+
   <Target Name="_WriteVersion"
           BeforeTargets="CoreCompile"
           Condition="$(GenerateAssemblyVersion) == 'True'"


### PR DESCRIPTION
In the past, Eto defines the `_GetCommonFiles` and `GenerateVersion` tasks in `build\Common.Build.targets` by using the MSBuild `CodeTaskFactory` inline-tasks.

However, while I was working on #1295 I noticed the following:

* The `_GetCommonFiles` task is not used anywhere the .NET Core SDK is involved, so it can be ignored.
* The `GenerateVersion` task calculates the the Revision and Build numbers from an existing version. You can do it using static properties and MSBuild Property Functions. The expression is a bit hacky, but it works really well, and thus removes the need to rely on `CodeTaskFactory`.

By using Property Functions instead of Custom Code-Task-Factory-inline-Tasks, Eto can with these changes be built by the .NET Core SDK without any further changes.

Although the MSBuild expression is hacky, this incurs far less overhead than the solution proposed in #1295 and I suggest using this solution instead of #1295.