### PR TITLE
Mac: Fix closing modal dialogs out of order

### DIFF
--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -1,7 +1,8 @@
 using System;
-using Eto.Forms;
-using System.Threading.Tasks;
+using System.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
+using Eto.Forms;
 using Eto.Drawing;
 
 #if XAMMAC2
@@ -216,7 +217,15 @@ namespace Eto.Mac.Forms
 		public override void Close()
 		{
 			if (session != null && session.IsSheet)
-				session.Stop();
+			{
+				var args = new CancelEventArgs();
+				Callback.OnClosing(Widget, args);
+				if (!args.Cancel)
+				{
+					session.Stop();
+					Callback.OnClosed(Widget, args);
+				}
+			}
 			else
 				base.Close();
 		}

--- a/test/Eto.Test/UnitTests/Forms/DialogTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/DialogTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Eto.Drawing;
 using Eto.Forms;
 using NUnit.Framework;
@@ -104,5 +105,76 @@ namespace Eto.Test.UnitTests.Forms
 				Assert.IsTrue(result);
 			}, timeout: -1);
 		}
+
+		[InvokeOnUI, ManualTest]
+		[TestCase(true, true, true)]
+		[TestCase(true, true, false)]
+		[TestCase(true, false, false)]
+		[TestCase(false, true, true)]
+		[TestCase(false, true, false)]
+		[TestCase(false, false, false)]
+		public void MultipleDialogsShouldAllowClosingInDifferentOrders(bool inOrder, bool passParent, bool attached)
+		{
+			var parentForm = passParent ? Application.Instance.MainForm : null;
+			int firstClosedCount = 0;
+			int secondClosedCount = 0;
+			bool firstWasClosedFirst = false;
+			var modal1 = new Dialog { Content = "Modal 1", Size = new Size(200, 200) };
+			var closeButton = new Button { Text = "Close" };
+			var modal2 = new Dialog
+			{
+				Content = new StackLayout
+				{
+					Items = {
+						"Modal 2\nWait until Modal 1 closes, then try to close this window.\nThis window should also resize and adjust the label correctly",
+						closeButton
+					}
+				},
+				Size = new Size(200, 200),
+				Resizable = true
+			};
+
+			closeButton.Click += (sender, e) => modal2.Close();
+
+			if (attached)
+			{
+				modal1.DisplayMode = DialogDisplayMode.Attached;
+				modal2.DisplayMode = DialogDisplayMode.Attached;
+			}
+
+			modal2.Closed += (sender, e) =>
+			{
+				firstWasClosedFirst = firstClosedCount > 0;
+				secondClosedCount++;
+			};
+
+			modal1.Closed += (sender, e) => firstClosedCount++;
+
+			Task.Run(() =>
+			{
+				System.Threading.Thread.Sleep(TimeSpan.FromSeconds(2));
+				Application.Instance.AsyncInvoke(modal1.Close);
+			});
+
+			Application.Instance.AsyncInvoke(() =>
+			{
+				if (inOrder)
+					modal1.ShowModal(attached ? (Window)modal2 : parentForm);
+				else
+					modal2.ShowModal(attached ? (Window)modal1 : parentForm);
+			});
+
+			if (inOrder)
+				modal2.ShowModal(parentForm);
+			else
+				modal1.ShowModal(parentForm);
+
+			Assert.AreNotEqual(0, firstClosedCount, "Modal 1 was not closed");
+			Assert.AreNotEqual(0, secondClosedCount, "Modal 2 was not closed");
+			Assert.AreEqual(1, firstClosedCount, "Modal 1 must trigger Closed only once");
+			Assert.AreEqual(1, secondClosedCount, "Modal 2 must trigger Closed only once");
+			Assert.IsTrue(firstWasClosedFirst, "Modal 1 did not close before Modal 2");
+		}
+
 	}
 }


### PR DESCRIPTION
Ensures NSApplication.StopModal() is called during the correct modal loop else it will hang.