### PR TITLE
ControlConverter should not specify that it can convert Control

### DIFF
--- a/src/Eto/Drawing/ColorConverter.cs
+++ b/src/Eto/Drawing/ColorConverter.cs
@@ -25,9 +25,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter supports the <paramref name="destinationType"/>, false otherwise</returns>
 		public override bool CanConvertTo(sc.ITypeDescriptorContext context, Type destinationType)
 		{
-			if (destinationType == typeof(string))
-				return true;
-			return base.CanConvertTo(context, destinationType);
+			return destinationType == typeof(string);
 		}
 
 		/// <summary>
@@ -38,9 +36,7 @@ namespace Eto.Drawing
 		/// <returns>True if this can convert to the <paramref name="sourceType"/>, false otherwise</returns>
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			if (sourceType == typeof(string))
-				return true;
-			return base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>
@@ -102,9 +98,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter supports the <paramref name="destinationType"/>, false otherwise</returns>
 		public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
 		{
-			if (destinationType == typeof(string))
-				return true;
-			return base.CanConvertTo(context, destinationType);
+			return destinationType == typeof(string);
 		}
 
 		/// <summary>
@@ -115,9 +109,7 @@ namespace Eto.Drawing
 		/// <returns>True if this can convert to the <paramref name="sourceType"/>, false otherwise</returns>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			if (sourceType == typeof(string))
-				return true;
-			return base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>

--- a/src/Eto/Drawing/FontConverter.cs
+++ b/src/Eto/Drawing/FontConverter.cs
@@ -22,7 +22,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can handle converting from the specified <paramref name="sourceType"/> to an font</returns>
 		public override bool CanConvertFrom (sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof (string) || base.CanConvertFrom (context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>

--- a/src/Eto/Drawing/ImageConverter.cs
+++ b/src/Eto/Drawing/ImageConverter.cs
@@ -55,7 +55,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can handle converting from the specified <paramref name="sourceType"/> to an image</returns>
 		public override bool CanConvertFrom (sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || typeof(NamespaceInfo).IsAssignableFrom(sourceType) || typeof(Stream).IsAssignableFrom(sourceType) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string) || typeof(NamespaceInfo).IsAssignableFrom(sourceType) || typeof(Stream).IsAssignableFrom(sourceType);
 		}
 
 		/// <summary>
@@ -160,7 +160,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can handle converting from the specified <paramref name="sourceType"/> to an image</returns>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || typeof(NamespaceInfo).IsAssignableFrom(sourceType) || typeof(Stream).IsAssignableFrom(sourceType) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string) || typeof(NamespaceInfo).IsAssignableFrom(sourceType) || typeof(Stream).IsAssignableFrom(sourceType);
 		}
 
 		/// <summary>

--- a/src/Eto/Drawing/PaddingConverter.cs
+++ b/src/Eto/Drawing/PaddingConverter.cs
@@ -24,7 +24,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>
@@ -95,7 +95,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>

--- a/src/Eto/Drawing/PointConverter.cs
+++ b/src/Eto/Drawing/PointConverter.cs
@@ -27,7 +27,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>
@@ -86,7 +86,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>

--- a/src/Eto/Drawing/PointFConverter.cs
+++ b/src/Eto/Drawing/PointFConverter.cs
@@ -27,7 +27,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>
@@ -86,7 +86,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>

--- a/src/Eto/Drawing/RectangleConverter.cs
+++ b/src/Eto/Drawing/RectangleConverter.cs
@@ -27,7 +27,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>
@@ -87,7 +87,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>

--- a/src/Eto/Drawing/RectangleFConverter.cs
+++ b/src/Eto/Drawing/RectangleFConverter.cs
@@ -27,7 +27,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>
@@ -87,7 +87,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>

--- a/src/Eto/Drawing/SizeConverter.cs
+++ b/src/Eto/Drawing/SizeConverter.cs
@@ -27,7 +27,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>
@@ -85,7 +85,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>

--- a/src/Eto/Drawing/SizeFConverter.cs
+++ b/src/Eto/Drawing/SizeFConverter.cs
@@ -27,7 +27,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>
@@ -85,7 +85,7 @@ namespace Eto.Drawing
 		/// <returns>True if this converter can convert from the specified type, false otherwise</returns>
 		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/ControlConverter.cs
+++ b/src/Eto/Forms/ControlConverter.cs
@@ -7,7 +7,7 @@ namespace Eto.Forms
 	{
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || typeof(Control).IsAssignableFrom(sourceType) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		public override bool CanConvertTo(sc.ITypeDescriptorContext context, Type destinationType)
@@ -17,15 +17,9 @@ namespace Eto.Forms
 
 		public override object ConvertFrom(sc.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)
 		{
-			var text = value as string;
-			if (!string.IsNullOrEmpty(text))
+			if (value is string text)
 				return new Label { Text = text };
-			var control = value as Control;
-			if (control != null)
-				return control;
-			if (value == null)
-				return null;
-			return base.ConvertFrom(context, culture, value);
+			return null;
 		}
 	}
 }

--- a/src/Eto/Forms/KeysConverter.cs
+++ b/src/Eto/Forms/KeysConverter.cs
@@ -15,12 +15,12 @@ namespace Eto.Forms
 
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+			return sourceType == typeof(string);
 		}
 
 		public override bool CanConvertTo(sc.ITypeDescriptorContext context, Type destinationType)
 		{
-			return destinationType == typeof(string) || base.CanConvertTo(context, destinationType);
+			return destinationType == typeof(string);
 		}
 
 		public override object ConvertFrom(sc.ITypeDescriptorContext context, System.Globalization.CultureInfo culture, object value)

--- a/src/Eto/Forms/Menu/MenuItemConverter.cs
+++ b/src/Eto/Forms/Menu/MenuItemConverter.cs
@@ -7,7 +7,7 @@ namespace Eto.Forms
 	{
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return typeof(Command).IsAssignableFrom(sourceType) || base.CanConvertFrom(context, sourceType);
+			return typeof(Command).IsAssignableFrom(sourceType);
 		}
 
 		public override bool CanConvertTo(sc.ITypeDescriptorContext context, Type destinationType)

--- a/src/Eto/Forms/ToolBar/ToolItemConverter.cs
+++ b/src/Eto/Forms/ToolBar/ToolItemConverter.cs
@@ -7,7 +7,7 @@ namespace Eto.Forms
 	{
 		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
 		{
-			return typeof(Command).IsAssignableFrom(sourceType) || base.CanConvertFrom(context, sourceType);
+			return typeof(Command).IsAssignableFrom(sourceType);
 		}
 
 		public override bool CanConvertTo(sc.ITypeDescriptorContext context, Type destinationType)


### PR DESCRIPTION
- Control and Control subclasses don’t need conversion, and it messes up IronPython when trying to find method overloads.
- Don’t use base.CanConvertFrom/To, only use the converter for what we specify.