### PR TITLE
Mac: Fix changing cursor while control is shown

### DIFF
--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -864,8 +864,12 @@ namespace Eto.Mac.Forms
 			{
 				if (Cursor != value)
 				{
+					bool needsMethod = !Widget.Properties.ContainsKey(MacView.Cursor_Key);
 					Widget.Properties[MacView.Cursor_Key] = value;
+					if (needsMethod)
 					AddMethod(MacView.selResetCursorRects, new Action<IntPtr, IntPtr>(TriggerResetCursorRects), "v@:");
+
+					EventControl.Window?.InvalidateCursorRectsForView(EventControl);
 				}
 			}
 		}


### PR DESCRIPTION
If you changed the cursor while the control is shown it would not reflect the change until you clicked the control.