### PR TITLE
Clipboard/DataObject updates

### DIFF
--- a/src/Eto.Gtk/Forms/ClipboardHandler.cs
+++ b/src/Eto.Gtk/Forms/ClipboardHandler.cs
@@ -178,6 +178,11 @@ namespace Eto.GtkSharp.Forms
 			Update();
 		}
 
+		public bool Contains(string type)
+		{
+			return Control.WaitIsTargetAvailable(Gdk.Atom.Intern(type, false));
+		}
+
 		public string[] Types
 		{
 			get
@@ -208,11 +213,20 @@ namespace Eto.GtkSharp.Forms
 			}
 		}
 
+
+		public bool ContainsText => Control.WaitIsTextAvailable();
+
+		public bool ContainsHtml => Contains("text/html");
+
+		public bool ContainsImage => Control.WaitIsImageAvailable() || Contains("eto-icon");
+
+		public bool ContainsUris => Contains("text/uri-list");
+
 		public Uri[] Uris
 		{
 			set
 			{
-				var uris = value?.Select(r => r.AbsolutePath).ToArray();
+				var uris = value?.Select(r => r.AbsoluteUri).ToArray();
 				AddEntry("text/uri-list", value, (data, selection) => selection.SetSelectedUris2(uris));
 			}
 			get

--- a/src/Eto.Gtk/GtkConversions.cs
+++ b/src/Eto.Gtk/GtkConversions.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Eto.Drawing;
 using Eto.Forms;
 using Eto.GtkSharp.Drawing;
@@ -806,18 +808,8 @@ namespace Eto.GtkSharp
 		public static bool SetSelectedUris2(this Gtk.SelectionData data, string[] uris)
 		{
 			int length = uris?.Length ?? 0;
-			IntPtr[] array = new IntPtr[length + 1];
-			for (int i = 0; i < length; i++)
-			{
-				array[i] = GLib.Marshaller.StringToPtrGStrdup(uris[i]);
-			}
-			array[length] = IntPtr.Zero;
-			var result = NativeMethods.gtk_selection_data_set_uris(data.Handle, array);
-			for (int i = 0; i < length; i++)
-			{
-				GLib.Marshaller.Free(array[i]);
-			}
-			return result;
+			var ptr = GLib.Marshaller.StringArrayToNullTermPointer(uris);
+			return NativeMethods.gtk_selection_data_set_uris(data.Handle, ptr);
 		}
 
 		public static string[] GetSelectedUris(this Gtk.SelectionData data)

--- a/src/Eto.Mac/Eto.Mac.csproj
+++ b/src/Eto.Mac/Eto.Mac.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Forms\MacFieldEditor.cs" />
     <Compile Include="Drawing\EtoFontManager.cs" />
     <Compile Include="MacVersion.cs" />
+    <Compile Include="Forms\MemoryDataObjectHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Eto.Mac/Eto.Mac64.csproj
+++ b/src/Eto.Mac/Eto.Mac64.csproj
@@ -228,6 +228,7 @@
     <Compile Include="Forms\MacFieldEditor.cs" />
     <Compile Include="Drawing\EtoFontManager.cs" />
     <Compile Include="MacVersion.cs" />
+    <Compile Include="Forms\MemoryDataObjectHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Eto.Mac/Eto.XamMac.csproj
+++ b/src/Eto.Mac/Eto.XamMac.csproj
@@ -246,6 +246,7 @@
     <Compile Include="Forms\MacFieldEditor.cs" />
     <Compile Include="Drawing\EtoFontManager.cs" />
     <Compile Include="MacVersion.cs" />
+    <Compile Include="Forms\MemoryDataObjectHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/src/Eto.Mac/Eto.XamMac2-modern.csproj
+++ b/src/Eto.Mac/Eto.XamMac2-modern.csproj
@@ -240,6 +240,7 @@
     <Compile Include="Forms\MacFieldEditor.cs" />
     <Compile Include="Drawing\EtoFontManager.cs" />
     <Compile Include="MacVersion.cs" />
+    <Compile Include="Forms\MemoryDataObjectHandler.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/src/Eto.Mac/Eto.XamMac2-net45.csproj
+++ b/src/Eto.Mac/Eto.XamMac2-net45.csproj
@@ -250,6 +250,7 @@
     <Compile Include="Forms\MacFieldEditor.cs" />
     <Compile Include="Drawing\EtoFontManager.cs" />
     <Compile Include="MacVersion.cs" />
+    <Compile Include="Forms\MemoryDataObjectHandler.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/src/Eto.Mac/Forms/ClipboardHandler.cs
+++ b/src/Eto.Mac/Forms/ClipboardHandler.cs
@@ -40,6 +40,7 @@ namespace Eto.Mac.Forms
 
 		protected override bool DisposeControl => false;
 
+		/*
 		public DataObject DataObject
 		{
 			get
@@ -53,7 +54,7 @@ namespace Eto.Mac.Forms
 				handler?.Apply(Control);
 			}
 		}
-
+		*/
 
 	}
 }

--- a/src/Eto.Mac/Forms/DataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/DataObjectHandler.cs
@@ -45,67 +45,20 @@ namespace Eto.Mac.Forms
 
 	public class DataObjectHandler : DataObjectHandler<DataObject, DataObject.ICallback>, DataObject.IHandler
 	{
-		public DataObjectHandler()
-		{
-		}
+		internal static Class[] UriTypes = { new Class(typeof(NSUrl)) };
+		internal static IntPtr selIsFileReferenceURLHandle = Selector.GetHandle("isFileReferenceURL");
 
 		public DataObjectHandler(NSPasteboard item)
 		{
 			Control = item;
 		}
-
 	}
 
-	public abstract class DataObjectHandler<TWidget, TCallback> : WidgetHandler<NSPasteboard, TWidget, TCallback>, IDataObject, IDataObjectHandler
+	public abstract class DataObjectHandler<TWidget, TCallback> : WidgetHandler<NSPasteboard, TWidget, TCallback>, IDataObject
 		where TWidget : Widget
 		where TCallback : Widget.ICallback
 	{
 		nint _changeCount;
-		Dictionary<string, BaseItem> _dataItems;
-
-		Dictionary<string, BaseItem> DataItems => _dataItems ?? (_dataItems = new Dictionary<string, BaseItem>());
-
-		const string UrlKey = "ba330802-0ac2-4ee0-a22f-0e67316ac339";
-
-		abstract class BaseItem
-		{
-			public abstract void Apply(NSPasteboard pasteboard, string type);
-			public abstract void Apply(NSPasteboardItem item, string type);
-			public virtual IEnumerable<NSObject> GetItems() => null;
-		}
-
-		class StringItem : BaseItem
-		{
-			public string Value { get; set; }
-			public override void Apply(NSPasteboard pasteboard, string type)
-			{
-				//pasteboard.DeclareTypes(new[] { type }, null);
-				pasteboard.SetStringForType(Value, type);
-			}
-			public override void Apply(NSPasteboardItem item, string type) => item.SetStringForType(Value, type);
-		}
-
-		class DataItem : BaseItem
-		{
-			public NSData Value { get; set; }
-			public override void Apply(NSPasteboard pasteboard, string type) => pasteboard.SetDataForType(Value, type);
-			public override void Apply(NSPasteboardItem item, string type) => item.SetDataForType(Value, type);
-		}
-
-		class PropertyListItem : BaseItem
-		{
-			public NSObject Value { get; set; }
-			public override void Apply(NSPasteboard pasteboard, string type) => pasteboard.SetPropertyListForType(Value, type);
-			public override void Apply(NSPasteboardItem item, string type) => item.SetPropertyListForType(Value, type);
-		}
-
-		class UrlItem : BaseItem
-		{
-			public NSUrl[] Values { get; set; }
-			public override void Apply(NSPasteboard pasteboard, string type) => pasteboard.WriteObjects(Values);
-			public override void Apply(NSPasteboardItem item, string type) { }
-			public override IEnumerable<NSObject> GetItems() => Values;
-		}
 
 		void ClearIfNeeded()
 		{
@@ -115,11 +68,6 @@ namespace Eto.Mac.Forms
 
 		public void SetData(byte[] value, string type)
 		{
-			if (Control == null)
-			{
-				DataItems[type] = new DataItem { Value = NSData.FromArray(value) };
-				return;
-			}
 			ClearIfNeeded();
 			Control.SetDataForType(NSData.FromArray(value), type);
 		}
@@ -128,29 +76,17 @@ namespace Eto.Mac.Forms
 		{
 			set
 			{
-				if (Control == null)
-				{
-					DataItems[NSPasteboard.NSPasteboardTypeHTML] = new StringItem { Value = value };
-					return;
-				}
 				ClearIfNeeded();
 				Control.SetStringForType(value, NSPasteboard.NSPasteboardTypeHTML);
 			}
 			get
 			{
-				if (Control == null)
-					return GetDataItem<StringItem>(NSPasteboard.NSPasteboardTypeHTML)?.Value;
 				return Control.GetStringForType(NSPasteboard.NSPasteboardTypeHTML);
 			}
 		}
 
 		public void SetString(string value, string type)
 		{
-			if (Control == null)
-			{
-				DataItems[type] = new StringItem { Value = value };
-				return;
-			}
 			ClearIfNeeded();
 			Control.SetStringForType(value, type);
 		}
@@ -159,18 +95,11 @@ namespace Eto.Mac.Forms
 		{
 			set
 			{
-				if (Control == null)
-				{
-					DataItems[NSPasteboard.NSPasteboardTypeString] = new StringItem { Value = value };
-					return;
-				}
 				ClearIfNeeded();
 				Control.SetStringForType(value, NSPasteboard.NSPasteboardTypeString);
 			}
 			get
 			{
-				if (Control == null)
-					return GetDataItem<StringItem>(NSPasteboard.NSPasteboardTypeString)?.Value;
 				return Control.GetStringForType(NSPasteboard.NSPasteboardTypeString);
 			}
 		}
@@ -179,26 +108,16 @@ namespace Eto.Mac.Forms
 		{
 			set
 			{
+				ClearIfNeeded();
 				var handler = value.Handler as IImageHandler;
 				if (handler != null)
 				{
 					var data = handler.GetImage().AsTiff();
-					if (Control == null)
-					{
-						DataItems[NSPasteboard.NSPasteboardTypeTIFF] = new DataItem { Value = data };
-						return;
-					}
-					ClearIfNeeded();
 					Control.SetDataForType(data, NSPasteboard.NSPasteboardTypeTIFF);
 				}
 			}
 			get
 			{
-				if (Control == null)
-				{
-					var data = GetDataItem<DataItem>(NSPasteboard.NSPasteboardTypeTIFF)?.Value?.AsStream();
-					return data != null ? new Bitmap(data) : null;
-				}
 				var oldFail = Class.ThrowOnInitFailure;
 				Class.ThrowOnInitFailure = false;
 				var image = new NSImage(Control);
@@ -213,21 +132,8 @@ namespace Eto.Mac.Forms
 			}
 		}
 
-		T GetDataItem<T>(string type)
-			where T: BaseItem
-		{
-			if (DataItems.TryGetValue(type, out var val))
-			{
-				return val as T;
-			}
-			return null;
-		}
-
 		public byte[] GetData(string type)
 		{
-			if (Control == null)
-				return GetDataItem<DataItem>(type)?.Value?.ToArray();
-
 			var availableType = Control.GetAvailableTypeFromArray(new string[] { type });
 
 			if (availableType != null)
@@ -242,48 +148,36 @@ namespace Eto.Mac.Forms
 			return null;
 		}
 
-		public string GetString(string type)
+		public string GetString(string type) => Control.GetStringForType(type);
+
+
+		public string[] Types => Control.Types;
+
+		static Uri UrlToUri(NSUrl url)
 		{
-			if (Control == null)
-				return GetDataItem<StringItem>(type)?.Value;
-
-			return Control.GetStringForType(type);
+			// why is this not mapped??
+			if (Messaging.bool_objc_msgSend(url.Handle, DataObjectHandler.selIsFileReferenceURLHandle))
+				return url.FilePathUrl;
+			return url;
 		}
-
-
-		public string[] Types
-		{
-			get
-			{
-				if (Control == null)
-					return _dataItems?.Keys.ToArray() ?? new string[0];
-				return Control.Types;
-			}
-		}
-
-		static Class[] UriTypes = new Class[] { new Class(typeof(NSUrl)) };
 
 		public Uri[] Uris
 		{
 			get
 			{
 				// 10.6+ file list:
-				if (Control.CanReadObjectForClasses(UriTypes, null))
+				if (Control.CanReadObjectForClasses(DataObjectHandler.UriTypes, null))
 				{
-					var objs = Control.ReadObjectsForClasses(UriTypes, null);
+					var objs = Control.ReadObjectsForClasses(DataObjectHandler.UriTypes, null);
 					if (objs != null)
-						return objs.OfType<NSUrl>().Select(r => (Uri)r).ToArray();
+						return objs.OfType<NSUrl>().Select(UrlToUri).ToArray();
 				}
 
 				var availableType = Control.GetAvailableTypeFromArray(new string[] { NSPasteboard.NSFilenamesType });
 				if (availableType != null)
 				{
 					// old-school way of passing files
-					NSArray files;
-					if (Control == null)
-						files = GetDataItem<PropertyListItem>(availableType)?.Value as NSArray;
-					else
-						files = Control.GetPropertyListForType(availableType) as NSArray;
+					var files = Control.GetPropertyListForType(availableType) as NSArray;
 
 					if (files != null)
 					{
@@ -300,57 +194,29 @@ namespace Eto.Mac.Forms
 			}
 			set
 			{
+				ClearIfNeeded();
 				var files = value?.Select(r => (NSUrl)r).ToArray();
-				if (Control == null)
-				{
-					DataItems[UrlKey] = new UrlItem { Values = files };
-					return;
-				}
 				Control.WriteObjects(files);
 			}
 		}
 
+		public bool ContainsText => Control.CanReadItemWithDataConformingToTypes(new[] { NSPasteboard.NSPasteboardTypeString });
+
+		public bool ContainsHtml => Control.CanReadItemWithDataConformingToTypes(new[] { NSPasteboard.NSPasteboardTypeHTML });
+
+		public bool ContainsImage => Control.CanReadItemWithDataConformingToTypes(new[] { NSPasteboard.NSPasteboardTypePNG, NSPasteboard.NSPasteboardTypeTIFF, NSPasteboard.NSPasteboardTypePDF });
+
+		public bool ContainsUris => Control.CanReadObjectForClasses(DataObjectHandler.UriTypes, null)
+			|| Control.GetAvailableTypeFromArray(new string[] { NSPasteboard.NSFilenamesType }) != null;
+
 		public void Clear()
 		{
-			if (Control != null)
-				_changeCount = Control.ClearContents();
-			_dataItems?.Clear();
+			_changeCount = Control.ClearContents();
 		}
 
-		public void Apply(NSPasteboard pasteboard)
+		public bool Contains(string type)
 		{
-			if (_dataItems == null)
-				return;
-			foreach (var item in _dataItems)
-			{
-				item.Value.Apply(pasteboard, item.Key);
-			}
-		}
-
-		public IEnumerable<NSObject> GetPasteboardItems()
-		{
-			if (_dataItems == null)
-				yield break;
-			NSPasteboardItem pasteboardItem = null;
-			foreach (var item in _dataItems)
-			{
-				var items = item.Value.GetItems();
-				if (items != null)
-				{
-					foreach (var i in items)
-					{
-						yield return i;
-					}
-				}
-				else
-				{
-					if (pasteboardItem == null)
-						pasteboardItem = new NSPasteboardItem();
-					item.Value.Apply(pasteboardItem, item.Key);
-				}
-			}
-			if (pasteboardItem != null)
-				yield return pasteboardItem;
+			return Control.GetAvailableTypeFromArray(new[] { type }) != null;
 		}
 	}
 }

--- a/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using Eto.Forms;
+using Eto.Drawing;
+using Eto.Mac.Drawing;
+using System.Linq;
+using System.Collections.Generic;
+
+#if XAMMAC2
+using AppKit;
+using Foundation;
+using ObjCRuntime;
+#else
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+using MonoMac.CoreGraphics;
+using MonoMac.ObjCRuntime;
+using MonoMac.CoreAnimation;
+#if Mac64
+using nfloat = System.Double;
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nfloat = System.Single;
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
+#endif
+
+namespace Eto.Mac.Forms
+{
+	public class MemoryDataObjectHandler : WidgetHandler<Dictionary<string, MemoryDataObjectHandler.BaseItem>, DataObject, DataObject.ICallback>, DataObject.IHandler, IDataObject, IDataObjectHandler
+	{
+		const string UrlKey = "ba330802-0ac2-4ee0-a22f-0e67316ac339";
+
+		public abstract class BaseItem
+		{
+			public abstract void Apply(NSPasteboard pasteboard, string type);
+			public abstract void Apply(NSPasteboardItem item, string type);
+			public virtual IEnumerable<NSObject> GetItems() => null;
+		}
+
+		public class StringItem : BaseItem
+		{
+			public string Value { get; set; }
+			public override void Apply(NSPasteboard pasteboard, string type)
+			{
+				//pasteboard.DeclareTypes(new[] { type }, null);
+				pasteboard.SetStringForType(Value, type);
+			}
+			public override void Apply(NSPasteboardItem item, string type) => item.SetStringForType(Value, type);
+		}
+
+		public class DataItem : BaseItem
+		{
+			public NSData Value { get; set; }
+			public override void Apply(NSPasteboard pasteboard, string type) => pasteboard.SetDataForType(Value, type);
+			public override void Apply(NSPasteboardItem item, string type) => item.SetDataForType(Value, type);
+		}
+
+		public class PropertyListItem : BaseItem
+		{
+			public NSObject Value { get; set; }
+			public override void Apply(NSPasteboard pasteboard, string type) => pasteboard.SetPropertyListForType(Value, type);
+			public override void Apply(NSPasteboardItem item, string type) => item.SetPropertyListForType(Value, type);
+		}
+
+		public class UrlItem : BaseItem
+		{
+			Uri[] _values;
+			NSUrl[] _nsvalues;
+			public Uri[] Values
+			{
+				get => _values;
+				set
+				{
+					_values = value;
+					_nsvalues = null;
+				}
+			}
+			NSUrl[] GetNSValues()
+			{
+				if (_nsvalues != null)
+					return _nsvalues;
+				_nsvalues = _values.Where(r => r.IsAbsoluteUri).Select(r => (NSUrl)r).ToArray();
+				return _nsvalues;
+			}
+
+			public override void Apply(NSPasteboard pasteboard, string type) => pasteboard.WriteObjects(GetNSValues());
+			public override void Apply(NSPasteboardItem item, string type) { }
+			public override IEnumerable<NSObject> GetItems() => GetNSValues();
+		}
+
+		public MemoryDataObjectHandler()
+		{
+			Control = new Dictionary<string, BaseItem>();
+		}
+
+		public void SetData(byte[] value, string type)
+		{
+			Control[type] = value == null ? null : new DataItem { Value = NSData.FromArray(value) };
+		}
+
+		public string Html
+		{
+			get => GetDataItem<StringItem>(NSPasteboard.NSPasteboardTypeHTML)?.Value;
+			set => Control[NSPasteboard.NSPasteboardTypeHTML] = string.IsNullOrEmpty(value) ? null : new StringItem { Value = value };
+		}
+
+		public void SetString(string value, string type) => Control[type] = string.IsNullOrEmpty(value) ? null : new StringItem { Value = value };
+
+		public string Text
+		{
+			get => GetDataItem<StringItem>(NSPasteboard.NSPasteboardTypeString)?.Value;
+			set => Control[NSPasteboard.NSPasteboardTypeString] = string.IsNullOrEmpty(value) ? null : new StringItem { Value = value };
+		}
+
+		public Image Image
+		{
+			set
+			{
+				var handler = value.Handler as IImageHandler;
+				if (handler != null)
+				{
+					var data = handler.GetImage().AsTiff();
+					Control[NSPasteboard.NSPasteboardTypeTIFF] = new DataItem { Value = data };
+				}
+				else Control[NSPasteboard.NSPasteboardTypeTIFF] = null;
+			}
+			get
+			{
+				var item = GetDataItem<DataItem>(NSPasteboard.NSPasteboardTypeTIFF);
+				var data = item?.Value?.AsStream();
+				return data != null ? new Bitmap(data) : null;
+			}
+		}
+
+		T GetDataItem<T>(string type)
+			where T : BaseItem
+		{
+			if (Control.TryGetValue(type, out var val))
+			{
+				return val as T;
+			}
+			return null;
+		}
+
+		public byte[] GetData(string type) => GetDataItem<DataItem>(type)?.Value?.ToArray();
+
+		public string GetString(string type) => GetDataItem<StringItem>(type)?.Value;
+
+
+		public string[] Types => Control.Keys.ToArray();
+
+		public Uri[] Uris
+		{
+			get => GetDataItem<UrlItem>(UrlKey)?.Values;
+			set => Control[UrlKey] = value?.Length > 0 ? new UrlItem { Values = value } : null;
+		}
+
+		public bool ContainsText => GetDataItem<StringItem>(NSPasteboard.NSPasteboardTypeString) != null;
+
+		public bool ContainsHtml => GetDataItem<StringItem>(NSPasteboard.NSPasteboardTypeHTML) != null;
+
+		public bool ContainsImage => GetDataItem<DataItem>(NSPasteboard.NSPasteboardTypeTIFF) != null;
+
+		public bool ContainsUris => GetDataItem<UrlItem>(UrlKey) != null;
+
+		public void Clear()
+		{
+			Control.Clear();
+		}
+
+		public void Apply(NSPasteboard pasteboard)
+		{
+			foreach (var item in Control)
+			{
+				item.Value.Apply(pasteboard, item.Key);
+			}
+		}
+
+		public IEnumerable<NSObject> GetPasteboardItems()
+		{
+			NSPasteboardItem pasteboardItem = null;
+			foreach (var item in Control)
+			{
+				var items = item.Value.GetItems();
+				if (items != null)
+				{
+					foreach (var i in items)
+					{
+						yield return i;
+					}
+				}
+				else
+				{
+					if (pasteboardItem == null)
+						pasteboardItem = new NSPasteboardItem();
+					item.Value.Apply(pasteboardItem, item.Key);
+				}
+			}
+			if (pasteboardItem != null)
+				yield return pasteboardItem;
+		}
+
+		public bool ContainsString(string type) => GetDataItem<StringItem>(type) != null;
+
+		public bool Contains(string type) => GetDataItem<DataItem>(type) != null;
+
+	}
+}

--- a/src/Eto.Mac/MacExtensions.cs
+++ b/src/Eto.Mac/MacExtensions.cs
@@ -102,7 +102,22 @@ namespace Eto.Mac
 			return Runtime.GetNSObject<NSColor>(intPtr);
 		}
 
-		#if !XAMMAC
+		static readonly IntPtr selCanReadItemWithDataConformingToTypes_Handle = Selector.GetHandle("canReadItemWithDataConformingToTypes:");
+		public static bool CanReadItemWithDataConformingToTypes(this NSPasteboard pasteboard, NSString[] utiTypes)
+		{
+			NSApplication.EnsureUIThread();
+			if (utiTypes == null)
+			{
+				throw new ArgumentNullException(nameof(utiTypes));
+			}
+			NSArray nSArray = NSArray.FromNSObjects(utiTypes);
+			bool result = Messaging.bool_objc_msgSend_IntPtr(pasteboard.Handle, selCanReadItemWithDataConformingToTypes_Handle, nSArray.Handle);
+			nSArray.Dispose();
+			return result;
+		}
+
+
+#if !XAMMAC
 		public static void DangerousRetain(this NSObject obj)
 		{
 			obj.Retain();
@@ -120,7 +135,7 @@ namespace Eto.Mac
 		{
 			return Messaging.GetNSObject<NSColor>(Messaging.IntPtr_objc_msgSend_IntPtr(NSColorClassPtr, selColorWithCGColor, cgColor.Handle));
 		}
-		#endif
+#endif
 	}
 }
 

--- a/src/Eto.Mac/Messaging.cs
+++ b/src/Eto.Mac/Messaging.cs
@@ -47,7 +47,7 @@ namespace Eto.Mac
 		public static readonly IntPtr CoreTextHandle = Dlfcn.dlopen("/System/Library/Frameworks/ApplicationServices.framework/Frameworks/CoreText.framework/CoreText", 0);
 
 		public static T GetNSObject<T>(IntPtr ptr)
-			where T: NSObject
+			where T : NSObject
 		{
 			return Runtime.GetNSObject<T>(ptr);
 		}
@@ -75,6 +75,9 @@ namespace Eto.Mac
 
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
 		public static extern void void_objc_msgSendSuper_CGRect(IntPtr receiver, IntPtr selector, CGRect arg1);
+
+		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		public static extern bool bool_objc_msgSend(IntPtr receiver, IntPtr selector);
 
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
 		public static extern bool bool_objc_msgSend_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -205,7 +205,7 @@ namespace Eto.Mac
 			p.Add<Screen.IScreensHandler>(() => new ScreensHandler());
 			p.Add<Keyboard.IHandler>(() => new KeyboardHandler());
 			p.Add<FixedMaskedTextProvider.IHandler>(() => new FixedMaskedTextProviderHandler());
-			p.Add<DataObject.IHandler>(() => new DataObjectHandler());
+			p.Add<DataObject.IHandler>(() => new MemoryDataObjectHandler());
 			p.Add<OpenWithDialog.IHandler>(() => new OpenWithDialogHandler());
 			p.Add<Notification.IHandler>(() => new NotificationHandler());
 			p.Add<TrayIndicator.IHandler>(() => new TrayIndicatorHandler());

--- a/src/Eto.WinForms/Forms/ClipboardHandler.cs
+++ b/src/Eto.WinForms/Forms/ClipboardHandler.cs
@@ -14,226 +14,37 @@ using System.Linq;
 
 namespace Eto.WinForms.Forms
 {
-	public class ClipboardHandler : WidgetHandler<swf.DataObject, Clipboard>, Clipboard.IHandler
+	public class ClipboardHandler : DataObjectHandler<Clipboard, Clipboard.ICallback>, Clipboard.IHandler
 	{
 		public ClipboardHandler()
 		{
 			Control = new swf.DataObject();
 		}
 
-		void Update()
+		protected override bool InnerContainsFileDropList => swf.Clipboard.ContainsFileDropList();
+
+		protected override StringCollection InnerGetFileDropList() => swf.Clipboard.GetFileDropList();
+
+		protected override swf.IDataObject InnerDataObject => swf.Clipboard.GetDataObject();
+
+		public override bool ContainsText => swf.Clipboard.ContainsText();
+
+		public override bool ContainsHtml => swf.Clipboard.ContainsText(swf.TextDataFormat.Html);
+
+		protected override bool InnerContainsImage => swf.Clipboard.ContainsImage();
+
+		public override string[] Types => swf.Clipboard.GetDataObject()?.GetFormats();
+
+		public override string Html
 		{
-			swf.Clipboard.SetDataObject(Control);
+			set => base.Html = value;
+			get => swf.Clipboard.ContainsText(swf.TextDataFormat.Html) ? swf.Clipboard.GetText(swf.TextDataFormat.Html)?.TrimEnd('\0') : null;
 		}
 
-		public void SetData(byte[] value, string type)
+		public override string Text
 		{
-			Control.SetData(type, value);
-			Update();
-		}
-
-		public void SetString(string value, string type)
-		{
-			Control.SetData(type, value);
-			Update();
-		}
-
-		public string Html
-		{
-			set
-			{
-				Control.SetText(value ?? string.Empty, swf.TextDataFormat.Html);
-				Update();
-			}
-			get
-			{
-				return swf.Clipboard.ContainsText(swf.TextDataFormat.Html) ? swf.Clipboard.GetText(swf.TextDataFormat.Html)?.TrimEnd('\0') : null;
-			}
-		}
-
-		public string Text
-		{
-			set
-			{
-				Control.SetText(value ?? string.Empty);
-				Update();
-			}
-			get
-			{
-				return swf.Clipboard.ContainsText() ? swf.Clipboard.GetText() : null;
-			}
-		}
-
-		public Image Image
-		{
-			set
-			{
-				var dib = (value as Bitmap)?.ToDIB();
-				if (dib != null)
-					Control.SetData(swf.DataFormats.Dib, dib);
-				else
-					Control.SetImage(value.ToSD());
-				Update();
-			}
-			get
-			{
-				Image result = null;
-
-				try
-				{
-					var sdimage = GetImageFromClipboard() as sd.Bitmap;
-
-					if (sdimage != null)
-					{
-						var handler = new BitmapHandler(sdimage);
-
-						result = new Bitmap(handler);
-					}
-				}
-				catch
-				{
-				}
-
-				return result;
-			}
-		}
-
-		/// <summary>
-		/// see http://stackoverflow.com/questions/11273669/how-to-paste-a-transparent-image-from-the-clipboard-in-a-c-sharp-winforms-app
-		/// </summary>
-		static sd.Image GetImageFromClipboard()
-		{
-			if (swf.Clipboard.GetDataObject() == null)
-				return null;
-
-			if (swf.Clipboard.GetDataObject().GetDataPresent(swf.DataFormats.Dib))
-			{
-				var dib = ((System.IO.MemoryStream)swf.Clipboard.GetData(swf.DataFormats.Dib)).ToArray();
-
-				var width = BitConverter.ToInt32(dib, 4);
-				var height = BitConverter.ToInt32(dib, 8);
-				var bpp = BitConverter.ToInt16(dib, 14);
-
-				if (bpp == 32)
-				{
-					var gch = GCHandle.Alloc(dib, GCHandleType.Pinned);
-
-					sd.Bitmap bmp = null;
-
-					try
-					{
-						var ptr = new IntPtr((long)gch.AddrOfPinnedObject() + 40);
-
-						bmp = new sd.Bitmap(width, height, width * 4, sdi.PixelFormat.Format32bppArgb, ptr);
-
-						var result = new sd.Bitmap(bmp);
-
-						// Images are rotated and flipped for some reason.
-						// This rotates them back.
-						result.RotateFlip(sd.RotateFlipType.Rotate180FlipX);
-
-						return result;
-					}
-					finally
-					{
-						gch.Free();
-
-						if (bmp != null)
-							bmp.Dispose();
-					}
-				}
-			}
-			if (swf.Clipboard.ContainsFileDropList())
-			{
-				var list = swf.Clipboard.GetFileDropList();
-				if (list != null && list.Count > 0)
-				{
-					var path = list[0];
-					sd.Image bmp = null;
-					try
-					{
-						bmp = sd.Image.FromFile(path);
-						var result = new sd.Bitmap(bmp);
-						return result;
-					}
-					catch
-					{
-					}
-					finally
-					{
-						if (bmp != null)
-							bmp.Dispose();
-					}
-				}
-			}
-
-			return swf.Clipboard.ContainsImage() ? swf.Clipboard.GetImage() : null;
-		}
-
-		public byte[] GetData(string type)
-		{
-			if (swf.Clipboard.ContainsData(type))
-			{
-				var data = swf.Clipboard.GetData(type);
-				var bytes = data as byte[];
-				if (bytes != null)
-					return bytes;
-				if (data != null)
-				{
-					var converter = sc.TypeDescriptor.GetConverter(data.GetType());
-					if (converter != null && converter.CanConvertTo(typeof(byte[])))
-					{
-						return converter.ConvertTo(data, typeof(byte[])) as byte[];
-					}
-
-#pragma warning disable 618
-					var etoConverter = TypeDescriptor.GetConverter(data.GetType());
-					if (etoConverter != null && etoConverter.CanConvertTo(typeof(byte[])))
-					{
-						return etoConverter.ConvertTo(data, typeof(byte[])) as byte[];
-					}
-#pragma warning restore 618
-				}
-				if (data is string)
-				{
-					return Encoding.UTF8.GetBytes(data as string);
-				}
-				if (data is IConvertible)
-				{
-					return Convert.ChangeType(data, typeof(byte[])) as byte[];
-				}
-			}
-			return null;
-		}
-
-		public string GetString(string type)
-		{
-			if (swf.Clipboard.ContainsData(type))
-				return swf.Clipboard.GetData(type) as string;
-			return null;
-		}
-
-		public string[] Types => swf.Clipboard.GetDataObject()?.GetFormats();
-
-		public Uri[] Uris
-		{
-			get
-			{
-				return Control.ContainsFileDropList() ? Control.GetFileDropList().OfType<string>().Select(s => new Uri(s)).ToArray() : null;
-			}
-			set
-			{
-				if (value != null)
-				{
-					var files = new StringCollection();
-					files.AddRange(value.Select(r => r.AbsolutePath).ToArray());
-					Control.SetFileDropList(files);
-				}
-				else
-				{
-					Control.SetFileDropList(null);
-				}
-			}
+			set => base.Text = value;
+			get => swf.Clipboard.ContainsText() ? swf.Clipboard.GetText() : null;
 		}
 
 		public DataObject DataObject
@@ -246,11 +57,20 @@ namespace Eto.WinForms.Forms
 			}
 		}
 
-		public void Clear()
+		protected override sd.Image InnerGetImage() => swf.Clipboard.GetImage();
+
+		protected override object InnerGetData(string type) => swf.Clipboard.GetData(type);
+
+
+		protected override void Update() => swf.Clipboard.SetDataObject(Control);
+
+		public override void Clear()
 		{
 			swf.Clipboard.Clear();
 			Control = new swf.DataObject();
 		}
+
+		public override bool Contains(string type) => swf.Clipboard.ContainsData(type);
 	}
 }
 

--- a/src/Eto.Wpf/Forms/ClipboardHandler.cs
+++ b/src/Eto.Wpf/Forms/ClipboardHandler.cs
@@ -15,16 +15,11 @@ using System.Collections.Specialized;
 
 namespace Eto.Wpf.Forms
 {
-	public class ClipboardHandler : WidgetHandler<sw.DataObject, Clipboard>, Clipboard.IHandler
+	public class ClipboardHandler : DataObjectHandler<Clipboard, Clipboard.ICallback>, Clipboard.IHandler
 	{
-		public ClipboardHandler()
-		{
-			Control = new sw.DataObject();
-		}
+		public override string[] Types => sw.Clipboard.GetDataObject()?.GetFormats();
 
-		public string[] Types => sw.Clipboard.GetDataObject()?.GetFormats();
-
-		void Update()
+		protected override void Update()
 		{
 			// internally WPF retries here so no need to retry
 			sw.Clipboard.SetDataObject(Control);
@@ -51,124 +46,23 @@ namespace Eto.Wpf.Forms
 			throw new InvalidOperationException(); // should not get here
 		}
 
-		public void SetString(string value, string type)
-		{
-			if (string.IsNullOrEmpty(type))
-				Control.SetText(value);
-			else
-				Control.SetData(type, value);
-			Update();
-		}
 
-		public void SetData(byte[] value, string type)
-		{
-			Control.SetData(type, value);
-			Update();
-		}
+		public override bool Contains(string type) => Retry(() => sw.Clipboard.ContainsData(type));
 
-		public string GetString(string type)
-		{
-			if (string.IsNullOrEmpty(type))
-				return Text;
-			return Retry(() => sw.Clipboard.ContainsData(type) ? Convert.ToString(sw.Clipboard.GetData(type)) : null);
-		}
+		public override bool ContainsText => Retry(() => sw.Clipboard.ContainsText());
 
-		public byte[] GetData(string type)
-		{
-			return Retry(() =>
-			{
-				if (sw.Clipboard.ContainsData(type))
-				{
-					var data = sw.Clipboard.GetData(type);
-					var bytes = data as byte[];
-					if (bytes != null)
-						return bytes;
-					if (data != null)
-					{
-						var converter = sc.TypeDescriptor.GetConverter(data.GetType());
-						if (converter != null && converter.CanConvertTo(typeof(byte[])))
-						{
-							return converter.ConvertTo(data, typeof(byte[])) as byte[];
-						}
-#pragma warning disable 618
-						var etoConverter = TypeDescriptor.GetConverter(data.GetType());
-						if (etoConverter != null && etoConverter.CanConvertTo(typeof(byte[])))
-						{
-							return etoConverter.ConvertTo(data, typeof(byte[])) as byte[];
-						}
-#pragma warning restore 618
-					}
-					if (data is string)
-					{
-						return Encoding.UTF8.GetBytes(data as string);
-					}
-					if (data is IConvertible)
-					{
-						return Convert.ChangeType(data, typeof(byte[])) as byte[];
-					}
-				}
-				return null;
-			});
-		}
-
-		public string Text
+		public override string Text
 		{
 			get { return Retry(() => sw.Clipboard.ContainsText() ? sw.Clipboard.GetText() : null); }
-			set
-			{
-				Control.SetText(value);
-				Update();
-			}
+			set => base.Text = value;
 		}
 
-		public string Html
+		public override bool ContainsHtml => Retry(() => sw.Clipboard.ContainsText(sw.TextDataFormat.Html));
+
+		public override string Html
 		{
 			get { return Retry(() => sw.Clipboard.ContainsText(sw.TextDataFormat.Html) ? sw.Clipboard.GetText(sw.TextDataFormat.Html) : null); }
-			set
-			{
-				Control.SetText(value, sw.TextDataFormat.Html);
-				Update();
-			}
-		}
-
-		public Image Image
-		{
-			get { return Retry(() => sw.Clipboard.ContainsImage() ? new Bitmap(new BitmapHandler(sw.Clipboard.GetImage())) : null); }
-			set
-			{
-				var dib = (value as Bitmap)?.ToDIB();
-				if (dib != null)
-				{
-					// write a DIB here, so we can preserve transparency of the image
-					Control.SetData(sw.DataFormats.Dib, dib);
-					Update();
-					return;
-				}
-
-				Control.SetImage(value.ToWpf());
-				Update();
-			}
-		}
-
-		public Uri[] Uris
-		{
-			get
-			{
-				return sw.Clipboard.ContainsFileDropList() ? sw.Clipboard.GetFileDropList().OfType<string>().Select(s => new Uri(s)).ToArray() : null;
-			}
-			set
-			{
-				if (value != null)
-				{
-					var files = new StringCollection();
-					files.AddRange(value.Select(r => r.AbsolutePath).ToArray());
-					sw.Clipboard.SetFileDropList(files);
-				}
-				else
-				{
-					sw.Clipboard.SetFileDropList(null);
-				}
-			}
+			set => base.Html = value;
 		}
 
 		public DataObject DataObject
@@ -177,10 +71,20 @@ namespace Eto.Wpf.Forms
 			set { sw.Clipboard.SetDataObject(value.ToWpf()); }
 		}
 
-		public void Clear()
+		protected override bool InnerContainsImage => Retry(() => sw.Clipboard.ContainsImage());
+
+		protected override bool InnerContainsFileDropList => Retry(() => sw.Clipboard.ContainsFileDropList());
+
+		public override void Clear()
 		{
 			sw.Clipboard.Clear();
 			Control = new sw.DataObject();
 		}
+
+		protected override swmi.BitmapSource InnerGetImage() => Retry(() => sw.Clipboard.GetImage());
+
+		protected override StringCollection InnerGetFileDropList() => Retry(() => sw.Clipboard.GetFileDropList());
+
+		protected override object InnerGetData(string type) => Retry(() => sw.Clipboard.GetData(type));
 	}
 }

--- a/src/Eto.Wpf/Forms/DataObjectHandler.cs
+++ b/src/Eto.Wpf/Forms/DataObjectHandler.cs
@@ -8,11 +8,52 @@ using System.Threading.Tasks;
 using sw = System.Windows;
 using Eto.Drawing;
 using System.Collections.Specialized;
+using System.IO;
+using System.Windows.Media.Imaging;
 
 namespace Eto.Wpf.Forms
 {
-	public class DataObjectHandler : WidgetHandler<sw.DataObject, DataObject, DataObject.ICallback>, DataObject.IHandler
+	public class DataObjectHandler : DataObjectHandler<DataObject, DataObject.ICallback>
 	{
+		public override string[] Types => Control.GetFormats();
+
+		public override bool ContainsText => Control.ContainsText();
+
+		public override bool ContainsHtml => Control.ContainsText(sw.TextDataFormat.Html);
+
+		protected override bool InnerContainsImage => Control.ContainsImage();
+
+		protected override bool InnerContainsFileDropList => Control.ContainsFileDropList();
+
+		public DataObjectHandler()
+		{
+		}
+		public DataObjectHandler(sw.IDataObject data)
+			: base(data)
+		{
+		}
+
+		protected override object InnerGetData(string type) => Control.GetData(type);
+
+		public override void Clear()
+		{
+			Control = new sw.DataObject();
+			Update();
+		}
+
+		protected override BitmapSource InnerGetImage() => Control.GetImage();
+
+		protected override StringCollection InnerGetFileDropList() => Control.GetFileDropList();
+
+		public override bool Contains(string type) => Control.GetDataPresent(type);
+	}
+
+	public abstract class DataObjectHandler<TWidget, TCallback> : WidgetHandler<sw.DataObject, TWidget, TCallback>, DataObject.IHandler
+		where TWidget: Widget
+	{
+		public const string UniformResourceLocatorW_Format = "UniformResourceLocatorW";
+		public const string UniformResourceLocator_Format = "UniformResourceLocator";
+
 		public DataObjectHandler()
 		{
 			Control = new sw.DataObject();
@@ -23,23 +64,51 @@ namespace Eto.Wpf.Forms
 			Control = new sw.DataObject(data);
 		}
 
-		public string[] Types => Control.GetFormats();
-
-		public string Text
+		protected virtual void Update()
 		{
-			get { return Control.ContainsText() ? Control.GetText() : null; }
-			set { Control.SetText(value); }
 		}
 
-		public string Html
+		public abstract string[] Types { get; }
+
+		public abstract bool ContainsText { get; }
+
+		public virtual string Text
+		{
+			get { return ContainsText ? Control.GetText() : null; }
+			set
+			{
+				Control.SetText(value);
+				Update();
+			}
+		}
+
+		public abstract bool ContainsHtml { get; }
+
+		public virtual string Html
 		{
 			get { return Control.ContainsText(sw.TextDataFormat.Html) ? Control.GetText(sw.TextDataFormat.Html) : null; }
-			set { Control.SetText(value, sw.TextDataFormat.Html); }
+			set
+			{
+				Control.SetText(value, sw.TextDataFormat.Html);
+				Update();
+			}
 		}
+
+		protected abstract bool InnerContainsImage { get; }
+		protected abstract BitmapSource InnerGetImage();
+
+		public bool ContainsImage => InnerContainsImage || Contains(sw.DataFormats.Dib);
 
 		public Image Image
 		{
-			get { return Control.ContainsImage() ? Control.GetImage().ToEto() : null; }
+			get
+			{
+				if (InnerContainsImage)
+					return InnerGetImage().ToEto();
+				if (Contains(sw.DataFormats.Dib) && InnerGetData(sw.DataFormats.Dib) is Stream stream)
+					return Win32.FromDIB(stream);
+				return null;
+			}
 			set
 			{
 				var dib = (value as Bitmap).ToDIB();
@@ -47,84 +116,164 @@ namespace Eto.Wpf.Forms
 				{
 					// write a DIB here, so we can preserve transparency of the image
 					Control.SetData(sw.DataFormats.Dib, dib);
-					return;
 				}
+				else
+					Control.SetImage(value.ToWpf());
 
-				Control.SetImage(value.ToWpf());
+				Update();
 			}
 		}
+
+		protected abstract bool InnerContainsFileDropList { get; }
+
+		protected abstract StringCollection InnerGetFileDropList();
+
+		public bool ContainsUris => InnerContainsFileDropList
+			|| Contains(UniformResourceLocatorW_Format)
+			|| Contains(UniformResourceLocator_Format);
 
 		public Uri[] Uris
 		{
 			get
 			{
-				return Control.ContainsFileDropList() ? Control.GetFileDropList().OfType<string>().Select(s => new Uri(s)).ToArray() : null;
+				var list = InnerContainsFileDropList
+					? InnerGetFileDropList().OfType<string>().Select(s => new Uri(s)) 
+					: null;
+
+				string urlString = null;
+				if (Contains(UniformResourceLocatorW_Format))
+					urlString = GetString(UniformResourceLocatorW_Format, Encoding.Unicode);
+				else if (Contains(UniformResourceLocator_Format))
+					urlString = GetString(UniformResourceLocator_Format);
+
+				if (!string.IsNullOrEmpty(urlString) && Uri.TryCreate(urlString, UriKind.RelativeOrAbsolute, out var uri))
+				{
+					var uris = new[] { uri };
+					list = list?.Concat(uris) ?? uris;
+				}
+				return list?.ToArray();
 			}
 			set
 			{
 				if (value != null)
 				{
+					var coll = value as IList<Uri> ?? value.ToList();
+
+					// file uris
 					var files = new StringCollection();
-					files.AddRange(value.Select(r => r.AbsolutePath).ToArray());
-					Control.SetFileDropList(files);
+					files.AddRange(coll.Where(r => r.IsFile).Select(r => r.AbsolutePath).ToArray());
+					if (files.Count > 0)
+						Control.SetFileDropList(files);
+
+					// web uris (windows only supports one)
+					var url = coll.Where(r => !r.IsFile).FirstOrDefault();
+					if (url != null)
+					{
+						SetString(url.ToString(), UniformResourceLocator_Format);
+						SetString(url.ToString(), UniformResourceLocatorW_Format);
+					}
 				}
 				else
 				{
-					Control.SetFileDropList(null);
+					Control.SetData(sw.DataFormats.FileDrop, null);
+					Control.SetData(UniformResourceLocatorW_Format, null);
+					Control.SetData(UniformResourceLocator_Format, null);
 				}
+				Update();
 			}
 		}
 
-		public void Clear()
-		{
-			Control = new sw.DataObject();
-		}
+		public abstract void Clear();
+
+		public abstract bool Contains(string type);
+
+		protected abstract object InnerGetData(string type);
 
 		public byte[] GetData(string type)
 		{
-			if (Control.GetDataPresent(type))
+			if (Contains(type))
 			{
-				var data = Control.GetData(type);
-				var bytes = data as byte[];
-				if (bytes != null)
-					return bytes;
-				if (data != null)
-				{
-					var converter = sc.TypeDescriptor.GetConverter(data.GetType());
-					if (converter != null && converter.CanConvertTo(typeof(byte[])))
-					{
-						return converter.ConvertTo(data, typeof(byte[])) as byte[];
-					}
-#pragma warning disable 618
-					var etoConverter = TypeDescriptor.GetConverter(data.GetType());
-					if (etoConverter != null && etoConverter.CanConvertTo(typeof(byte[])))
-					{
-						return etoConverter.ConvertTo(data, typeof(byte[])) as byte[];
-					}
-#pragma warning restore 618
-				}
-				if (data is string)
-				{
-					return Encoding.UTF8.GetBytes(data as string);
-				}
-				if (data is IConvertible)
-				{
-					return Convert.ChangeType(data, typeof(byte[])) as byte[];
-				}
+				return GetAsData(InnerGetData(type));
 			}
 			return null;
 		}
 
-		public string GetString(string type)
+		protected byte[] GetAsData(object data)
+		{
+			if (data is byte[] bytes)
+				return bytes;
+			if (data is string str)
+				return Encoding.UTF8.GetBytes(str);
+			if (data is MemoryStream ms)
+				return ms.ToArray();
+			if (data is Stream stream)
+			{
+				ms = new MemoryStream();
+				stream.CopyTo(ms);
+				ms.Position = 0;
+				return ms.ToArray();
+			}
+			if (data != null)
+			{
+				var converter = sc.TypeDescriptor.GetConverter(data.GetType());
+				if (converter != null && converter.CanConvertTo(typeof(byte[])))
+				{
+					return converter.ConvertTo(data, typeof(byte[])) as byte[];
+				}
+#pragma warning disable 618
+				var etoConverter = TypeDescriptor.GetConverter(data.GetType());
+				if (etoConverter != null && etoConverter.CanConvertTo(typeof(byte[])))
+				{
+					return etoConverter.ConvertTo(data, typeof(byte[])) as byte[];
+				}
+#pragma warning restore 618
+			}
+			if (data is IConvertible)
+				return Convert.ChangeType(data, typeof(byte[])) as byte[];
+			return null;
+		}
+
+		public string GetString(string type) => GetString(type, Encoding.UTF8);
+
+		protected string GetString(string type, Encoding encoding)
 		{
 			if (string.IsNullOrEmpty(type))
 				return Text;
-			return Control.GetDataPresent(type) ? Convert.ToString(Control.GetData(type)) : null;
+			if (!Contains(type))
+				return null;
+			return GetAsString(InnerGetData(type), encoding);
+		}
+
+		protected string GetAsString(object data, Encoding encoding)
+		{
+			if (data is string str)
+				return str;
+			if (data is MemoryStream ms)
+				return encoding.GetString(ms.ToArray()).TrimEnd('\0'); // can contain a zero at the end, thanks windows.
+			if (data != null)
+			{
+				var converter = sc.TypeDescriptor.GetConverter(data.GetType());
+				if (converter != null && converter.CanConvertTo(typeof(string)))
+				{
+					return converter.ConvertTo(data, typeof(string)) as string;
+				}
+#pragma warning disable 618
+				var etoConverter = TypeDescriptor.GetConverter(data.GetType());
+				if (etoConverter != null && etoConverter.CanConvertTo(typeof(string)))
+				{
+					return etoConverter.ConvertTo(data, typeof(string)) as string;
+				}
+#pragma warning restore 618
+			}
+			if (data is IConvertible)
+				return Convert.ChangeType(data, typeof(string)) as string;
+			return null;
 		}
 
 		public void SetData(byte[] value, string type)
 		{
 			Control.SetData(type, value);
+			Update();
 		}
 
 		public void SetString(string value, string type)
@@ -133,6 +282,7 @@ namespace Eto.Wpf.Forms
 				Control.SetText(value);
 			else
 				Control.SetData(type, value);
+			Update();
 		}
 	}
 }

--- a/src/Eto.Wpf/Win32.dib.cs
+++ b/src/Eto.Wpf/Win32.dib.cs
@@ -6,7 +6,7 @@ namespace Eto
 {
 	partial class Win32
 	{
-		public static Bitmap FromDIB(MemoryStream ms)
+		public static Bitmap FromDIB(Stream ms)
 		{
 			var header = new byte[40];
 			ms.Read(header, 0, header.Length);

--- a/src/Eto/Forms/Clipboard.cs
+++ b/src/Eto/Forms/Clipboard.cs
@@ -13,7 +13,7 @@ namespace Eto.Forms
 	[Handler(typeof(Clipboard.IHandler))]
 	public class Clipboard : Widget, IDataObject
 	{
-		new IHandler Handler { get { return (IHandler)base.Handler; } }
+		new IHandler Handler => (IHandler)base.Handler;
 
 		static readonly object Clipboard_Key = new object();
 
@@ -28,6 +28,34 @@ namespace Eto.Forms
 		/// </summary>
 		/// <value>The content types in the clipboard.</value>
 		public string[] Types => Handler.Types;
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.Clipboard"/> contains a value for <see cref="Text"/>.
+		/// </summary>
+		/// <value><c>true</c> if the data object contains text; otherwise, <c>false</c>.</value>
+		public bool ContainsText => Handler.ContainsText;
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.Clipboard"/> contains a value for <see cref="Html"/>.
+		/// </summary>
+		/// <value><c>true</c> if the data object contains html; otherwise, <c>false</c>.</value>
+		public bool ContainsHtml => Handler.ContainsHtml;
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.Clipboard"/> contains a value for <see cref="Image"/>.
+		/// </summary>
+		/// <value><c>true</c> if the data object contains an image; otherwise, <c>false</c>.</value>
+		public bool ContainsImage => Handler.ContainsImage;
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.Clipboard"/> contains a value for <see cref="Uris"/>.
+		/// </summary>
+		/// <remarks>
+		/// This can be a mix of both URL and File objects.  You can use <see cref="Uri.IsFile"/> to test for that.
+		/// On some platforms, (e.g. windows), only a single URL can be retrieved or set.
+		/// </remarks>
+		/// <value><c>true</c> if the data object contains uris; otherwise, <c>false</c>.</value>
+		public bool ContainsUris => Handler.ContainsUris;
 
 		/// <summary>
 		/// Sets a data stream into the clipboard with the specified type identifier.
@@ -58,6 +86,13 @@ namespace Eto.Forms
 		/// <param name="value">Data to store in the clipboard.</param>
 		/// <param name="type">Type identifier to store the data.</param>
 		public void SetData(byte[] value, string type) => Handler.SetData(value, type);
+
+		/// <summary>
+		/// Gets a value indicating that data with the specified type is contained in the clipboard.
+		/// </summary>
+		/// <returns><c>true</c> if the clipboard contains the specified type, <c>false</c> otherwise.</returns>
+		/// <param name="type">Type to test.</param>
+		public bool Contains(string type) => Handler.Contains(type);
 
 		/// <summary>
 		/// Gets a data array from the clipboard with the specified type identifier.
@@ -128,7 +163,6 @@ namespace Eto.Forms
 			get { return Handler.Image; }
 			set { Handler.Image = value; }
 		}
-
 
 		/// <summary>
 		/// Gets or sets the Uri's of the files in the clipboard.

--- a/src/Eto/Forms/DataObject.cs
+++ b/src/Eto/Forms/DataObject.cs
@@ -19,6 +19,34 @@ namespace Eto.Forms
 		string[] Types { get; }
 
 		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.IDataObject"/> contains a value for <see cref="Text"/>.
+		/// </summary>
+		/// <value><c>true</c> if the data object contains text; otherwise, <c>false</c>.</value>
+		bool ContainsText { get; }
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.IDataObject"/> contains a value for <see cref="Html"/>.
+		/// </summary>
+		/// <value><c>true</c> if the data object contains html; otherwise, <c>false</c>.</value>
+		bool ContainsHtml { get; }
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.IDataObject"/> contains a value for <see cref="Image"/>.
+		/// </summary>
+		/// <value><c>true</c> if the data object contains an image; otherwise, <c>false</c>.</value>
+		bool ContainsImage { get; }
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.IDataObject"/> contains a value for <see cref="Uris"/>.
+		/// </summary>
+		/// <remarks>
+		/// This can be a mix of both URL and File objects.  You can use <see cref="Uri.IsFile"/> to test for that.
+		/// On some platforms, (e.g. windows), only a single URL can be retrieved or set.
+		/// </remarks>
+		/// <value><c>true</c> if the data object contains uris; otherwise, <c>false</c>.</value>
+		bool ContainsUris { get; }
+
+		/// <summary>
 		/// Sets a string into the data object with the specified type identifier.
 		/// </summary>
 		/// <remarks>
@@ -46,12 +74,20 @@ namespace Eto.Forms
 		string GetString(string type);
 
 		/// <summary>
+		/// Gets a value indicating that data with the specified type is contained in the data object.
+		/// </summary>
+		/// <returns><c>true</c> if the data object contains the specified type, <c>false</c> otherwise.</returns>
+		/// <param name="type">Type to test.</param>
+		bool Contains(string type);
+
+		/// <summary>
 		/// Gets a data array from the data object with the specified type identifier.
 		/// </summary>
 		/// <returns>The data array, or null if not found in the data object.</returns>
 		/// <seealso cref="SetData"/>
 		/// <param name="type">Type identifier that was used to store the data.</param>
 		byte[] GetData(string type);
+
 
 		/// <summary>
 		/// Gets or sets the plain text in the data object.
@@ -74,6 +110,10 @@ namespace Eto.Forms
 		/// <summary>
 		/// Gets or sets the Uri's of the files in the data object.
 		/// </summary>
+		/// <remarks>
+		/// This can be a mix of both URL and File objects.  You can use <see cref="Uri.IsFile"/> to test for that.
+		/// On some platforms, (e.g. windows), only a single URL can be retrieved or set.
+		/// </remarks>
 		/// <value>The uris of the files, or null if no files are in the data object.</value>
 		Uri[] Uris { get; set; }
 
@@ -113,6 +153,35 @@ namespace Eto.Forms
 		/// <value>The types.</value>
 		public string[] Types => Handler.Types;
 
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.DataObject"/> contains a value for <see cref="Text"/>.
+		/// </summary>
+		/// <value><c>true</c> if the data object contains text; otherwise, <c>false</c>.</value>
+		public bool ContainsText => Handler.ContainsText;
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.DataObject"/> contains a value for <see cref="Html"/>.
+		/// </summary>
+		/// <value><c>true</c> if the data object contains html; otherwise, <c>false</c>.</value>
+		public bool ContainsHtml => Handler.ContainsHtml;
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.DataObject"/> contains a value for <see cref="Image"/>.
+		/// </summary>
+		/// <value><c>true</c> if the data object contains an image; otherwise, <c>false</c>.</value>
+		public bool ContainsImage => Handler.ContainsImage;
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="T:Eto.Forms.DataObject"/> contains a value for <see cref="Uris"/>.
+		/// </summary>
+		/// <remarks>
+		/// This can be a mix of both URL and File objects.  You can use <see cref="Uri.IsFile"/> to test for that.
+		/// On some platforms, (e.g. windows), only a single URL can be retrieved or set.
+		/// </remarks>
+		/// <value><c>true</c> if the data object contains uris; otherwise, <c>false</c>.</value>
+		public bool ContainsUris => Handler.ContainsUris;
+
 		/// <summary>
 		/// Sets a string into the data object with the specified custom type.
 		/// </summary>
@@ -151,6 +220,13 @@ namespace Eto.Forms
 		public void SetData(byte[] value, string type) => Handler.SetData(value, type);
 
 		/// <summary>
+		/// Gets a value indicating that data with the specified type is contained in the data object.
+		/// </summary>
+		/// <returns><c>true</c> if the data object contains the specified type, <c>false</c> otherwise.</returns>
+		/// <param name="type">Type to test.</param>
+		public bool Contains(string type) => Handler.Contains(type);
+
+		/// <summary>
 		/// Gets a string from the data object with the specified type identifier.
 		/// </summary>
 		/// <returns>The string value, or null if it does not exist in the data object.</returns>
@@ -175,7 +251,6 @@ namespace Eto.Forms
 		/// <returns>The byte data.</returns>
 		/// <param name="type">Type identifier to get the data for.</param>
 		public byte[] GetData(string type) => Handler.GetData(type);
-
 
 		/// <summary>
 		/// Gets or sets the plain text in the data object.

--- a/test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using System.Text;
 using Eto.Drawing;
+using System.Linq;
 
 namespace Eto.Test.Sections.Behaviors
 {
@@ -65,12 +66,12 @@ namespace Eto.Test.Sections.Behaviors
 			var panel = new StackLayout { Padding = new Padding(10) };
 			if (clipboard.Text != null)
 			{
-				panel.Items.Add("\nText:");
+				panel.Items.Add(new Label { Text = "\nText:", Font = SystemFonts.Bold() });
 				panel.Items.Add(clipboard.Text);
 			}
 			if (clipboard.Image != null)
 			{
-				panel.Items.Add("\nImage:");
+				panel.Items.Add(new Label { Text = "\nImage:", Font = SystemFonts.Bold() });
 				panel.Items.Add(new ImageView
 					{
 						Image = clipboard.Image
@@ -78,15 +79,22 @@ namespace Eto.Test.Sections.Behaviors
 			}
 			if (clipboard.Html != null)
 			{
-				panel.Items.Add("\nHtml:");
+				panel.Items.Add(new Label { Text = "\nHtml:", Font = SystemFonts.Bold() });
 				panel.Items.Add(clipboard.Html);
 			}
+			var uris = clipboard.Uris;
+			if (uris != null)
+			{
+				panel.Items.Add(new Label { Text = "\nUris:", Font = SystemFonts.Bold() });
+				panel.Items.Add(string.Join(", ", uris.Select(r => r.AbsoluteUri)));
+			}
+
 			var types = clipboard.Types;
 			if (types != null)
 			{
 				foreach (var type in types)
 				{
-					panel.Items.Add(string.Format("\n{0}:", type));
+					panel.Items.Add(new Label { Text = $"\n{type}:", Font = SystemFonts.Bold() });
 					var data = clipboard.GetData(type);
 					if (data != null)
 					{

--- a/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
@@ -26,24 +26,31 @@ namespace Eto.Test.Sections.Behaviors
 
 			var htmlTextArea = new TextArea();
 			var selectFilesButton = new Button { Text = "Select Files" };
-			Uri[] uris = null;
+			Uri[] fileUris = null;
 			selectFilesButton.Click += (sender, e) =>
 			{
 				var ofd = new OpenFileDialog();
 				ofd.MultiSelect = true;
 				ofd.ShowDialog(this);
-				uris = ofd.Filenames.Select(r => new Uri(r)).ToArray();
-				if (uris.Length == 0)
-					uris = null;
+				fileUris = ofd.Filenames.Select(r => new Uri(r)).ToArray();
+				if (fileUris.Length == 0)
+					fileUris = null;
 			};
+
+			var urlTextBox = new TextBox();
 
 			Func<DataObject> createDataObject = () =>
 			{
 				var data = new DataObject();
 				if (!string.IsNullOrEmpty(textBox.Text))
 					data.Text = textBox.Text;
-				if (uris != null)
-					data.Uris = uris;
+				var uris = new List<Uri>();
+				if (fileUris != null)
+					uris.AddRange(fileUris);
+				if (Uri.TryCreate(urlTextBox.Text, UriKind.Absolute, out var uri))
+					uris.Add(uri);
+				if (uris.Count > 0)
+					data.Uris = uris.ToArray();
 				if (!string.IsNullOrEmpty(htmlTextArea.Text))
 					data.Html = htmlTextArea.Text;
 				if (includeImageCheck.Checked == true)
@@ -215,6 +222,7 @@ namespace Eto.Test.Sections.Behaviors
 			layout.BeginGroup("DataObject", 10);
 			layout.AddRow("Text", textBox);
 			layout.AddRow("Html", htmlTextArea);
+			layout.AddRow("Url", urlTextBox);
 			layout.BeginHorizontal();
 			layout.AddSpace();
 			layout.BeginVertical();

--- a/test/Eto.Test/Sections/UnitTestPanel.cs
+++ b/test/Eto.Test/Sections/UnitTestPanel.cs
@@ -1253,7 +1253,7 @@ namespace Eto.Test.Sections
 			{
 				startButton.Enabled = !running;
 				stopButton.Enabled = running;
-				search.Enabled = !running;
+				search.ReadOnly = running;
 				filterControls.Enabled = !running;
 
 				if (!running && StatusFilters.Any())

--- a/test/Eto.Test/UnitTests/Forms/ClipboardTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ClipboardTests.cs
@@ -6,12 +6,27 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Eto.Drawing;
+using System.IO;
 
 namespace Eto.Test.UnitTests.Forms
 {
 	[TestFixture]
-	public class ClipboardTests : TestBase
+	public class ClipboardTests : BaseDataObjectTests<Clipboard>
 	{
+		protected override bool IsClipboard => true;
+	}
+
+	[TestFixture]
+	public class DataObjectTests : BaseDataObjectTests<DataObject>
+	{
+		protected override bool IsClipboard => false;
+	}
+
+	public abstract class BaseDataObjectTests<T> : TestBase
+		where T : IDataObject, IDisposable, new()
+	{
+		protected abstract bool IsClipboard { get; }
+
 		[Test]
 		public void GettingAndSettingTextShouldNotCrash()
 		{
@@ -20,7 +35,7 @@ namespace Eto.Test.UnitTests.Forms
 				for (int i = 0; i < 100; i++)
 				{
 					// this crashes on WPF on some machines.. don't know why as I can't repro the issue.
-					var clipboard = new Clipboard();
+					var clipboard = new T();
 					var val = "Hello" + i;
 					clipboard.Text = val;
 					Assert.AreEqual(val, clipboard.Text);
@@ -28,185 +43,240 @@ namespace Eto.Test.UnitTests.Forms
 			});
 		}
 
-		[Test]
-		public void SettingMultipleFormatsShouldWork()
+		public enum DataType
 		{
+			Text,
+			Html,
+			//Icon, // TODO: not yet implemented fully, if even possible on all platforms
+			Bitmap,
+			String,
+			Data,
+			Uris,
+		}
+
+		const string SampleText = "Hello";
+		const string SampleStringType = "eto-string";
+		const string SampleDataType = "eto-data";
+		const string SampleHtml = "<strong>Some Html</strong>";
+
+		static byte[] SampleByteData => new byte[] { 10, 20, 30 };
+
+		// note: windows only supports a single web uri, but multiple file uris
+		static Uri[] SampleUrlUris => new[] { new Uri("http://google.com") };
+		static Uri[] SampleFileUris
+		{
+			get {
+				var path = EtoEnvironment.GetFolderPath(EtoSpecialFolder.Documents);
+				return new[] { new Uri(path) };
+			}
+		}
+
+		static Uri[] SampleBothUris => SampleUrlUris.Concat(SampleFileUris).ToArray();
+
+		public static DataType[] GetDataTypes() => Enum.GetValues(typeof(DataType)).Cast<DataType>().ToArray();
+
+		void TestIsNullExcept(T dataObject, params DataType[] except)
+		{
+			foreach (var testingType in GetDataTypes())
+			{
+				if (except?.Contains(testingType) == true)
+					continue;
+				TestIsNull(dataObject, testingType);
+			}
+		}
+
+		void TestIsNull(T dataObject, DataType type)
+		{
+			switch (type)
+			{
+				case DataType.Text:
+					Assert.IsFalse(dataObject.ContainsText);
+					Assert.IsNull(dataObject.Text);
+					break;
+				case DataType.Html:
+					Assert.IsFalse(dataObject.ContainsHtml);
+					Assert.IsNull(dataObject.Html);
+					break;
+				//case DataType.Icon:
+				case DataType.Bitmap:
+					Assert.IsFalse(dataObject.ContainsImage);
+					Assert.IsNull(dataObject.Image);
+					break;
+				case DataType.String:
+					CollectionAssert.DoesNotContain(SampleStringType, dataObject.Types);
+					Assert.IsNull(dataObject.GetString(SampleStringType));
+					break;
+				case DataType.Data:
+					CollectionAssert.DoesNotContain(SampleDataType, dataObject.Types);
+					Assert.IsNull(dataObject.GetData(SampleDataType));
+					break;
+				case DataType.Uris:
+					Assert.IsFalse(dataObject.ContainsUris);
+					Assert.IsNull(dataObject.Uris);
+					break;
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
+		void TestValues(T dataObject, params DataType[] types)
+		{
+			foreach (var type in types)
+				TestValue(dataObject, type);
+		}
+
+		void TestValue(T dataObject, DataType type)
+		{
+			switch (type)
+			{
+				case DataType.Text:
+					Assert.IsTrue(dataObject.ContainsText);
+					Assert.IsNotNull(dataObject.Text);
+					Assert.AreEqual(SampleText, dataObject.Text);
+					break;
+				case DataType.Html:
+					Assert.IsTrue(dataObject.ContainsHtml);
+					Assert.IsNotNull(dataObject.Html);
+					Assert.AreEqual(SampleHtml, dataObject.Html);
+					break;
+				//case DataType.Icon:
+					//Assert.IsNotNull(dataObject.Image);
+					//break;
+				case DataType.Bitmap:
+					Assert.IsTrue(dataObject.ContainsImage);
+					Assert.IsNotNull(dataObject.Image);
+					break;
+				case DataType.String:
+					Assert.Contains(SampleStringType, dataObject.Types);
+					Assert.IsNotNull(dataObject.GetString(SampleStringType));
+					Assert.AreEqual(SampleText, dataObject.GetString(SampleStringType));
+					break;
+				case DataType.Data:
+					Assert.Contains(SampleDataType, dataObject.Types);
+					Assert.IsNotNull(dataObject.GetData(SampleDataType));
+					Assert.AreEqual(SampleByteData, dataObject.GetData(SampleDataType));
+					break;
+				case DataType.Uris:
+					Assert.IsTrue(dataObject.ContainsUris);
+					Assert.IsNotNull(dataObject.Uris);
+					if (Platform.Instance.IsGtk && EtoEnvironment.Platform.IsMac && dataObject.Uris.Length != SampleBothUris.Length)
+						Assert.Warn("Gtk on macOS only returns a single URI for some reason.");
+					else
+						CollectionAssert.AreEquivalent(SampleBothUris, dataObject.Uris);
+					break;
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
+		void SetValues(T dataObject, params DataType[] types)
+		{
+			foreach (var type in types)
+				SetValue(dataObject, type);
+		}
+
+		void SetValue(T dataObject, DataType type)
+		{
+			switch (type)
+			{
+				case DataType.Text:
+					dataObject.Text = SampleText;
+					break;
+				case DataType.Html:
+					dataObject.Html = SampleHtml;
+					break;
+				//case DataType.Icon:
+					//dataObject.Image = TestIcons.Logo;
+					//break;
+				case DataType.Bitmap:
+					dataObject.Image = TestIcons.TestImage;
+					break;
+				case DataType.String:
+					dataObject.SetString(SampleText, SampleStringType);
+					break;
+				case DataType.Data:
+					dataObject.SetData(SampleByteData, SampleDataType);
+					break;
+				case DataType.Uris:
+					dataObject.Uris = SampleBothUris;
+					break;
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
+		[TestCaseSource(nameof(GetDataTypes))]
+		public void IndividualValuesShouldBeIndependent(DataType property)
+		{
+			var byteData = new byte[] { 10, 20, 30 };
+
 			Invoke(() =>
 			{
-				var byteData = new byte[] { 10, 20, 30 };
-				using (var clipboard = new Clipboard())
+				using (var clipboard = new T())
 				{
-					clipboard.Text = "Text";
-					clipboard.Html = "<strong>Some Html</strong>";
-					clipboard.SetString("woot", "eto-woot");
-					clipboard.SetData(byteData, "eto-byte-data");
-
-					Assert.AreEqual("Text", clipboard.Text);
-					Assert.AreEqual("<strong>Some Html</strong>", clipboard.Html);
-					Assert.AreEqual("woot", clipboard.GetString("eto-woot"));
-					Assert.AreEqual(byteData, clipboard.GetData("eto-byte-data"));
-
-					Assert.Contains("eto-woot", clipboard.Types);
-					Assert.Contains("eto-byte-data", clipboard.Types);
+					SetValue(clipboard, property);
+					TestValue(clipboard, property);
+					// test all other entries are blank!
+					TestIsNullExcept(clipboard, property);
 				}
-
-				using (var clipboard = new Clipboard())
+			});
+			// if it's a clipboard, test a new instance of the clipboard has the same values that we set.
+			if (IsClipboard)
+			Invoke(() =>
+			{
+				using (var clipboard = new T())
 				{
-					Assert.AreEqual("Text", clipboard.Text);
-					Assert.AreEqual("<strong>Some Html</strong>", clipboard.Html);
-					Assert.AreEqual("woot", clipboard.GetString("eto-woot"));
-					Assert.AreEqual(byteData, clipboard.GetData("eto-byte-data"));
-
-					Assert.Contains("eto-woot", clipboard.Types);
-					Assert.Contains("eto-byte-data", clipboard.Types);
-
-					clipboard.Clear();
-					CollectionAssert.DoesNotContain("eto-woot", clipboard.Types);
-					CollectionAssert.DoesNotContain("eto-byte-data", clipboard.Types);
-					Assert.AreEqual(null, clipboard.Text);
-					Assert.AreEqual(null, clipboard.Html);
-					Assert.AreEqual(null, clipboard.Image);
-					Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-					Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
-				}
-
-				using (var clipboard = new Clipboard())
-				{
-					CollectionAssert.DoesNotContain("eto-woot", clipboard.Types);
-					CollectionAssert.DoesNotContain("eto-byte-data", clipboard.Types);
-					Assert.AreEqual(null, clipboard.Text);
-					Assert.AreEqual(null, clipboard.Html);
-					Assert.AreEqual(null, clipboard.Image);
-					Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-					Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
+					TestValue(clipboard, property);
+					TestIsNullExcept(clipboard, property);
 				}
 			});
 		}
 
-		[TestCase("Text")]
-		[TestCase("Html")]
-		//[TestCase("Image-Icon")] // TODO: not yet implemented fully, if even possible on all platforms
-		[TestCase("Image-Bitmap")]
-		[TestCase("String")]
-		[TestCase("Data")]
-		public void SettingIndividualValueShouldWork(string property)
+		[Test]
+		public void SettingMultipleFormatsShouldWork()
 		{
+			var typesToTest = new[]
+			{
+				DataType.Text,
+				DataType.Html,
+				DataType.String,
+				DataType.Data
+			};
+
 			Invoke(() =>
 			{
-				var byteData = new byte[] { 10, 20, 30 };
-				using (var clipboard = new Clipboard())
+				using (var clipboard = new T())
 				{
-					switch (property)
-					{
-						case "Text":
-							clipboard.Text = "Some Text";
-							Assert.AreEqual("Some Text", clipboard.Text);
-							Assert.AreEqual(null, clipboard.Html);
-							Assert.AreEqual(null, clipboard.Image);
-							Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-							Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
-							break;
-						case "Html":
-							clipboard.Html = "<strong>Some Html</strong>";
-							Assert.AreEqual(null, clipboard.Text);
-							Assert.AreEqual("<strong>Some Html</strong>", clipboard.Html);
-							Assert.AreEqual(null, clipboard.Image);
-							Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-							Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
-							break;
-						case "Image-Icon":
-							clipboard.Image = TestIcons.Logo;
-							Assert.AreEqual(null, clipboard.Text);
-							Assert.AreEqual(null, clipboard.Html);
-							Assert.IsNotNull(clipboard.Image);
-							Assert.IsInstanceOf<Icon>(clipboard.Image);
-							Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-							Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
-							break;
-						case "Image-Bitmap":
-							clipboard.Image = TestIcons.TestImage;
-							Assert.AreEqual(null, clipboard.Text);
-							Assert.AreEqual(null, clipboard.Html);
-							Assert.IsNotNull(clipboard.Image);
-							Assert.IsInstanceOf<Bitmap>(clipboard.Image);
-							Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-							Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
-							break;
-						case "String":
-							clipboard.SetString("Some string value", "eto-woot");
-							Assert.AreEqual(null, clipboard.Text);
-							Assert.AreEqual(null, clipboard.Html);
-							Assert.AreEqual(null, clipboard.Image);
-							Assert.AreEqual("Some string value", clipboard.GetString("eto-woot"));
-							Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
-							Assert.Contains("eto-woot", clipboard.Types);
-							break;
-						case "Data":
-							clipboard.SetData(byteData, "eto-byte-data");
-							Assert.Contains("eto-byte-data", clipboard.Types);
-							Assert.AreEqual(null, clipboard.Text);
-							Assert.AreEqual(null, clipboard.Html);
-							Assert.AreEqual(null, clipboard.Image);
-							Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-							Assert.AreEqual(byteData, clipboard.GetData("eto-byte-data"));
-							break;
-					}
-				}
+					SetValues(clipboard, typesToTest);
+					TestValues(clipboard, typesToTest);
 
-				using (var clipboard = new Clipboard())
-				{
-					switch (property)
-					{
-						case "Text":
-							Assert.AreEqual("Some Text", clipboard.Text);
-							Assert.AreEqual(null, clipboard.Html);
-							Assert.AreEqual(null, clipboard.Image);
-							Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-							Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
-							break;
-						case "Html":
-							Assert.AreEqual(null, clipboard.Text);
-							Assert.AreEqual("<strong>Some Html</strong>", clipboard.Html);
-							Assert.AreEqual(null, clipboard.Image);
-							Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-							Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
-							break;
-						case "Image-Icon":
-							Assert.AreEqual(null, clipboard.Text);
-							Assert.AreEqual(null, clipboard.Html);
-							Assert.IsNotNull(clipboard.Image);
-							Assert.IsInstanceOf<Icon>(clipboard.Image);
-							Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-							Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
-							break;
-						case "Image-Bitmap":
-							Assert.AreEqual(null, clipboard.Text);
-							Assert.AreEqual(null, clipboard.Html);
-							Assert.IsNotNull(clipboard.Image);
-							Assert.IsInstanceOf<Bitmap>(clipboard.Image);
-							Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-							Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
-							break;
-						case "String":
-							Assert.AreEqual(null, clipboard.Text);
-							Assert.AreEqual(null, clipboard.Html);
-							Assert.AreEqual(null, clipboard.Image);
-							Assert.AreEqual("Some string value", clipboard.GetString("eto-woot"));
-							Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
-							Assert.Contains("eto-woot", clipboard.Types);
-							break;
-						case "Data":
-							Assert.Contains("eto-byte-data", clipboard.Types);
-							Assert.AreEqual(null, clipboard.Text);
-							Assert.AreEqual(null, clipboard.Html);
-							Assert.AreEqual(null, clipboard.Image);
-							Assert.AreEqual(null, clipboard.GetString("eto-woot"));
-							Assert.AreEqual(byteData, clipboard.GetData("eto-byte-data"));
-							break;
-					}
-
+					TestIsNullExcept(clipboard, typesToTest);
 				}
 			});
+			if (IsClipboard)
+				Invoke(() =>
+				{
+					using (var clipboard = new T())
+					{
+						TestValues(clipboard, typesToTest);
+						TestIsNullExcept(clipboard, typesToTest);
+
+						clipboard.Clear();
+						TestIsNullExcept(clipboard); // test all!
+					}
+
+					using (var clipboard = new T())
+					{
+						TestIsNullExcept(clipboard);
+						CollectionAssert.DoesNotContain("eto-woot", clipboard.Types);
+						CollectionAssert.DoesNotContain("eto-byte-data", clipboard.Types);
+						Assert.AreEqual(null, clipboard.Text);
+						Assert.AreEqual(null, clipboard.Html);
+						Assert.AreEqual(null, clipboard.Image);
+						Assert.AreEqual(null, clipboard.GetString("eto-woot"));
+						Assert.AreEqual(null, clipboard.GetData("eto-byte-data"));
+					}
+				});
 		}
 	}
 }


### PR DESCRIPTION
- Add DataObject/Clipboard Contains* APIs
- Mac: Get the full file path in Uris instead of a relocatable URI. Fixes #1149
- WinForms/Wpf: GetData() will work properly with a stream.