### PR TITLE
Mac: Fix PixelLayout when sizing children

### DIFF
--- a/src/Eto.Mac/Forms/MacPanel.cs
+++ b/src/Eto.Mac/Forms/MacPanel.cs
@@ -115,18 +115,30 @@ namespace Eto.Mac.Forms
 				var control = value.GetContainerView();
 				if (control != null)
 				{
-#if OSX
-					control.AutoresizingMask = ContentResizingMask();
-					ContentControl.AddSubview(control); // default
-#elif IOS
-					control.AutoresizingMask = UIViewAutoresizing.FlexibleDimensions;
-					control.Frame = new CGRect(0, 0, ContentControl.Bounds.Width, ContentControl.Bounds.Height);
-					this.AddChild(value);
-#endif
+					SetContent(control);
 				}
 
 				InvalidateMeasure();
 			}
+		}
+
+		void SetContent(NSView control)
+		{
+#if OSX
+			if (ContentControl is NSBox box)
+			{
+				box.ContentView = control;
+			}
+			else
+			{
+				control.AutoresizingMask = ContentResizingMask();
+				ContentControl.AddSubview(control); // default
+			}
+#elif IOS
+			control.AutoresizingMask = UIViewAutoresizing.FlexibleDimensions;
+			control.Frame = new CGRect(0, 0, ContentControl.Bounds.Width, ContentControl.Bounds.Height);
+			this.AddChild(value);
+#endif
 		}
 
 #if OSX

--- a/test/Eto.Test/UnitTests/Forms/Layout/PixelLayoutTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Layout/PixelLayoutTests.cs
@@ -1,0 +1,37 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Layout
+{
+	[TestFixture]
+	public class PixelLayoutTests : TestBase
+	{
+		[Test, ManualTest]
+		public void SettingChildSizeShouldNotChangePosition()
+		{
+			ManualForm("Panels should be at all four corners,\ngreen on top, blue on bottom.\nThe boxes should not move when the form is resized", form =>
+			{
+
+				var layout = new PixelLayout { Size = new Size(300, 300) };
+
+				var tl = new Panel { BackgroundColor = Colors.Green, Size = new Size(200, 200) };
+				layout.Add(tl, 0, 0);
+
+				var tr = new Panel { BackgroundColor = Colors.Green, Size = new Size(200, 200) };
+				layout.Add(tr, 200, 0);
+
+				var bl = new Panel { BackgroundColor = Colors.Blue, Size = new Size(200, 200) };
+				layout.Add(bl, 0, 200);
+
+				var br = new Panel { BackgroundColor = Colors.Blue, Size = new Size(200, 200) };
+				layout.Add(br, 200, 200);
+
+				tl.Size = tr.Size = bl.Size = br.Size = new Size(100, 100);
+
+				return layout;
+			});
+		}
+	}
+}


### PR DESCRIPTION
- PixelLayout now uses a child NSView for the positioned controls, as adding to NSBox directly causes many weird problems.
- Set NSBox.ContentView instead of adding the subview directly so that NSBox can take care of positioning the content instead of relying on the resizing mask.

Fixes #1317
Fixes #1316