### PR TITLE
Adds cascading style support.

### DIFF
--- a/src/Eto.Mac/Forms/Controls/TabPageHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TabPageHandler.cs
@@ -48,9 +48,10 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void DrawLabel(bool shouldTruncateLabel, CGRect labelRect)
 			{
-				if (Handler.image != null)
+				var h = Handler;
+				if (h?.image != null)
 				{
-					var nsimage = (NSImage)Handler.image.ControlObject;
+					var nsimage = (NSImage)h.image.ControlObject;
 
 					if (nsimage.RespondsToSelector(new Selector(selDrawInRectFromRectOperationFractionRespectFlippedHints)))
 						nsimage.Draw(new CGRect(labelRect.X, labelRect.Y, labelRect.Height, labelRect.Height), new CGRect(CGPoint.Empty, nsimage.Size), NSCompositingOperation.SourceOver, 1, true, null);
@@ -72,7 +73,7 @@ namespace Eto.Mac.Forms.Controls
 			public override CGSize SizeOfLabel(bool computeMin)
 			{
 				var size = base.SizeOfLabel(computeMin);
-				if (Handler.image != null)
+				if (Handler?.image != null)
 				{
 					size.Width += size.Height + ICON_PADDING;
 				}

--- a/src/Eto/DefaultStyleProvider.cs
+++ b/src/Eto/DefaultStyleProvider.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+
+namespace Eto
+{
+	/// <summary>
+	/// The default style provider which supports setting styles from delegates.
+	/// </summary>
+    public class DefaultStyleProvider : IStyleProvider
+    {
+        readonly Dictionary<object, IList<Action<object>>> styleMap = new Dictionary<object, IList<Action<object>>>();
+        readonly Dictionary<object, IList<Action<object>>> cascadingStyleMap = new Dictionary<object, IList<Action<object>>>();
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="T:DefaultStyleProvider"/> allows inheriting styles from the parent object.
+		/// </summary>
+		/// <remarks>
+		/// This is used when applying cascading styles, sometimes the user or the provider will not want
+		/// parent styles to be applicable.
+		/// </remarks>
+		/// <value><c>true</c> to inherit parent styles; otherwise, <c>false</c>.</value>
+		[DefaultValue(true)]
+        public bool Inherit { get; set; } = true;
+
+		#region Events
+
+		/// <summary>
+		/// Event to handle when a widget is being styled
+		/// </summary>
+		public event Action<object> StyleWidget;
+
+        #endregion
+
+        /// <summary>
+        /// Adds a style for a widget
+        /// </summary>
+        /// <remarks>
+        /// Styling a widget allows you to access the widget or its native handler class and apply logic.
+        /// 
+        /// Styling a handler allows you to access both the platform-specifics for the widget.  
+        /// It requires you to add a reference to one of the Eto.*.dll's so that you can utilize
+        /// the platform handler directly.  Typically this would be called before your application is run.
+        /// </remarks>
+        /// <example>
+        /// <code><![CDATA[
+        /// // make all labels vertically aligned
+        /// style.Add<Label>(null, label => {
+        /// 	label.VerticalAlignment = VerticalAlignment.Center;
+        /// 	// other stuff
+        /// });
+        /// 
+        /// // access native controls to modify things that Eto doesn't give direct access to
+        /// style.Add<Eto.Mac.Forms.Controls.ButtonHandler>(null, handler => {
+        /// 	handler.Control.SomeProperty = someValue;
+        /// 	// other stuff
+        /// });
+        /// ]]>
+        /// </code>
+        /// </example>
+        /// <typeparam name="T">Type of the widget or handler to style</typeparam>
+        /// <param name="style">Identifier of the style</param>
+        /// <param name="handler">Delegate with your logic to style the widget</param>
+        public void Add<T>(string style, Action<T> handler)
+            where T : class
+        {
+            var list = CreateStyleList((object)style ?? typeof(T));
+            list.Add(widget =>
+            {
+				if (widget is T control)
+					handler(control);
+				else if (widget is IHandlerSource handlerSource && handlerSource.Handler is T handlerControl)
+					handler(handlerControl);
+            });
+            cascadingStyleMap.Clear();
+        }
+
+		/// <summary>
+		/// Clears all styles from this provider
+		/// </summary>
+		public void Clear()
+		{
+			styleMap.Clear();
+			cascadingStyleMap.Clear();
+		}
+
+		IList<Action<object>> CreateStyleList(object style)
+        {
+			if (!styleMap.TryGetValue(style, out var styleHandlers))
+			{
+				styleHandlers = new List<Action<object>>();
+				styleMap[style] = styleHandlers;
+			}
+			return styleHandlers;
+        }
+
+        IList<Action<object>> GetStyleList(object style)
+        {
+            return styleMap.TryGetValue(style, out var styleHandlers) ? styleHandlers : null;
+        }
+
+        IList<Action<object>> GetCascadingStyleList(Type type)
+        {
+            if (type == null)
+                return null;
+            // get a cached list of cascading styles so we don't have to traverse each time
+            if (cascadingStyleMap.TryGetValue(type, out var childHandlers))
+            {
+                return childHandlers;
+            }
+
+            // don't have a cascading style set, so build one
+            // styles are applied in order from superclass styles down to subclass styles.
+            IEnumerable<Action<object>> styleHandlers = Enumerable.Empty<Action<object>>();
+            Type currentType = type;
+            do
+            {
+                if (styleMap.TryGetValue(currentType, out var typeStyles) && typeStyles != null)
+                    styleHandlers = typeStyles.Concat(styleHandlers);
+            }
+            while ((currentType = currentType.GetBaseType()) != null);
+
+            // create a cached list, but if its empty don't store it
+            childHandlers = styleHandlers.ToList();
+            if (childHandlers.Count == 0)
+                childHandlers = null;
+            cascadingStyleMap.Add(type, childHandlers);
+
+            return childHandlers;
+        }
+
+        void ApplyStyles(object widget, string style)
+        {
+            if (widget != null && !string.IsNullOrEmpty(style))
+            {
+                var styles = style.Split(' ');
+                for (int i = 0; i < styles.Length; i++)
+                {
+                    var currentStyle = styles[i];
+                    var styleHandlers = GetStyleList(currentStyle);
+                    if (styleHandlers != null)
+                    {
+                        for (int j = 0; j < styleHandlers.Count; j++)
+                        {
+                            var styleHandler = styleHandlers[j];
+                            styleHandler(widget);
+                        }
+                    }
+                }
+            }
+            StyleWidget?.Invoke(widget);
+        }
+
+        void ApplyDefaults(object widget)
+        {
+			if (widget == null)
+				return;
+
+			var styles = GetCascadingStyleList(widget.GetType());
+			if (styles != null)
+			{
+
+				for (int i = 0; i < styles.Count; i++)
+				{
+					var styleHandler = styles[i];
+					styleHandler(widget);
+				}
+			}
+		}
+
+		bool IStyleProvider.Inherit => Inherit;
+
+		void IStyleProvider.ApplyCascadingStyle(object container, object widget, string style)
+		{
+			ApplyDefaults(widget);
+			ApplyStyles(widget, style);
+		}
+
+        void IStyleProvider.ApplyDefault(object widget) => ApplyDefaults(widget);
+
+		void IStyleProvider.ApplyStyle(object widget, string style) => ApplyStyles(widget, style);
+	}
+}
+

--- a/src/Eto/Forms/Container.cs
+++ b/src/Eto/Forms/Container.cs
@@ -110,6 +110,74 @@ namespace Eto.Forms
 			}
 		}
 
+		static readonly object StyleProvider_Key = new object();
+		static readonly object DefaultStyleProvider_Key = new object();
+
+		/// <summary>
+		/// Gets or sets the style provider for this container.
+		/// </summary>
+		/// <remarks>
+		/// The style provider is used to style this container and its children.
+		/// </remarks>
+		/// <value>The style provider.</value>
+		public IStyleProvider StyleProvider
+		{
+			get => Properties.Get<IStyleProvider>(StyleProvider_Key) ?? Properties.Get<DefaultStyleProvider>(DefaultStyleProvider_Key);
+			set => Properties.Set(StyleProvider_Key, value);
+		}
+
+		/// <summary>
+		/// Gets the default style provider for this container.
+		/// </summary>
+		/// <remarks>
+		/// Use this to apply styles to any child controls of this container.
+		/// By default, styles will apply to all children, including children of children unless
+		/// <see cref="DefaultStyleProvider.Inherit"/> is set to <c>false</c>.
+		/// 
+		/// Typically, you would set Inherit to false when creating composite controls
+		/// that already have all their styles applied and you don't want any other styles
+		/// to be inherited.
+		/// </remarks>
+		/// <value>The default style provider for this container.</value>
+		public DefaultStyleProvider Styles => Properties.Create<DefaultStyleProvider>(DefaultStyleProvider_Key);
+
+		internal void ApplyStyles(object widget, string style)
+		{
+			var styleProvider = StyleProvider;
+
+			if (styleProvider == null)
+			{
+				// no styles for this container, check the parent
+				Parent?.ApplyStyles(widget, style);
+				return;
+			}
+
+			// apply parent styles first, if this provider allows inheriting them
+			if (styleProvider.Inherit)
+				Parent?.ApplyStyles(widget, style);
+
+			// now apply any of this providers' styles, which may override parent styles
+			styleProvider.ApplyCascadingStyle(this, widget, style);
+		}
+
+		/// <summary>
+		/// Handles when the <see cref="Style"/> is changed.
+		/// </summary>
+		/// <remarks>
+		/// This applies the cascading styles to the control and any of its children.
+		/// </remarks>
+		protected override void OnStyleChanged(EventArgs e)
+		{
+			base.OnStyleChanged(e);
+			if (Loaded && Handler.RecurseToChildren)
+			{
+				foreach (Control control in VisualControls)
+				{
+					control.TriggerStyleChanged(EventArgs.Empty);
+				}
+			}
+		}
+
 		/// <summary>
 		/// Raises the <see cref="Control.PreLoad"/> event, and recurses to this container's children
 		/// </summary>

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -491,6 +491,8 @@ namespace Eto.Forms
 		{
 			Properties.TriggerEvent(PreLoadKey, this, e);
 			Handler.OnPreLoad(e);
+
+			ApplyStyles();
 		}
 
 		static readonly object LoadKey = new object();
@@ -1001,6 +1003,12 @@ namespace Eto.Forms
 				OnUnLoad(e);
 		}
 
+		internal void TriggerStyleChanged(EventArgs e)
+		{
+			using (Platform.Context)
+				OnStyleChanged(e);
+		}
+
 		/// <summary>
 		/// Gets or sets the color for the background of the control
 		/// </summary>
@@ -1262,6 +1270,24 @@ namespace Eto.Forms
 		{
 			Handler.DoDragDrop(data, allowedEffects);
 		}
+
+		/// <summary>
+		/// Handles when the <see cref="Style"/> is changed.
+		/// </summary>
+		/// <remarks>
+		/// This applies the cascading styles to the control and any of its children.
+		/// </remarks>
+		protected override void OnStyleChanged(EventArgs e)
+		{
+			base.OnStyleChanged(e);
+
+			// already loaded, re-apply styles as they have changed
+			if (Loaded)
+				ApplyStyles();
+		}
+
+		internal virtual void ApplyStyles() => Parent?.ApplyStyles(this, Style);
+
 
 		/// <summary>
 		/// Handles the disposal of this control

--- a/src/Eto/Platform.cs
+++ b/src/Eto/Platform.cs
@@ -167,9 +167,8 @@ namespace Eto
 		/// <param name="e">Arguments for the event</param>
 		protected virtual void OnWidgetCreated(WidgetCreatedEventArgs e)
 		{
-			Eto.Style.OnStyleWidgetDefaults(e.Instance);
-			if (WidgetCreated != null)
-				WidgetCreated(this, e);
+			Eto.Style.Provider?.ApplyDefault(e.Instance);
+			WidgetCreated?.Invoke(this, e);
 		}
 
 		internal void TriggerWidgetCreated(WidgetCreatedEventArgs args)

--- a/src/Eto/Widget.cs
+++ b/src/Eto/Widget.cs
@@ -426,7 +426,7 @@ namespace Eto
 		/// </summary>
 		protected virtual void OnStyleChanged(EventArgs e)
 		{
-			Eto.Style.OnStyleWidget(this);
+			Eto.Style.Provider?.ApplyStyle(this, Style);
 			Properties.TriggerEvent(StyleChangedKey, this, e);
 		}
 

--- a/src/Eto/WidgetHandler.cs
+++ b/src/Eto/WidgetHandler.cs
@@ -124,7 +124,7 @@ namespace Eto
 		/// </remarks>
 		protected virtual void Initialize()
 		{
-			Style.OnStyleWidgetDefaults(this);
+			Style.Provider?.ApplyDefault(this);
 		}
 
 		void Widget.IHandler.Initialize()

--- a/test/Eto.Test/Sections/Behaviors/ContextMenuSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ContextMenuSection.cs
@@ -19,6 +19,8 @@ namespace Eto.Test.Sections.Behaviors
 
 		ContextMenuSection(bool inDialog)
 		{
+			Styles.Add<Label>(null, l => l.VerticalAlignment = VerticalAlignment.Center);
+
 			var relativeToLabelCheckBox = new CheckBox { Text = "Relative to label" };
 			relativeToLabelCheckBox.CheckedBinding.Bind(this, c => c.RelativeToLabel);
 
@@ -139,7 +141,6 @@ namespace Eto.Test.Sections.Behaviors
 				BackgroundColor = Colors.Blue,
 				TextColor = Colors.White,
 				TextAlignment = TextAlignment.Center,
-				VerticalAlignment = VerticalAlignment.Center,
 				Text = "Click on me!"
 			};
 			label.MouseDown += (sender, e) =>

--- a/test/Eto.Test/Sections/UnitTestPanel.cs
+++ b/test/Eto.Test/Sections/UnitTestPanel.cs
@@ -1376,7 +1376,13 @@ namespace Eto.Test.Sections
 				case TestStatus.Warning:
 					return CreateImage(Colors.Yellow, Colors.Black, "!");
 				case TestStatus.Failed:
-					return CreateImage(Colors.Red, Colors.White, "✖");
+					return CreateImage(Colors.Red, (g, b) =>
+					{
+						var offset = 10;
+						var pen = new Pen(Colors.White, 4);
+						g.DrawLine(pen, offset, offset, b.Width - offset, b.Height - offset);
+						g.DrawLine(pen, b.Width - offset, offset, offset, b.Height - offset);
+					});
 				case TestStatus.Inconclusive:
 					return CreateImage(Colors.Yellow, Colors.Black, "?");
 				case TestStatus.Skipped:
@@ -1388,24 +1394,31 @@ namespace Eto.Test.Sections
 			}
 		}
 
+		static Image CreateImage(Color color, Action<Graphics, Bitmap> draw)
+		{
+			var bmp = new Bitmap(32, 32, PixelFormat.Format32bppRgba);
+			using (var g = new Graphics(bmp))
+			{
+				var r = new RectangleF(Point.Empty, bmp.Size);
+				r.Inflate(-1, -1);
+				g.FillEllipse(color, r);
+				draw?.Invoke(g, bmp);
+			}
+			return bmp.WithSize(16, 16);
+		}
+
 		static Image CreateImage(Color color, Color textcolor, string text)
 		{
-			return Application.Instance.Invoke(() =>
+			return CreateImage(color, (g, b) =>
 			{
-				var bmp = new Bitmap(32, 32, PixelFormat.Format32bppRgba);
-				using (var g = new Graphics(bmp))
+				var r = new RectangleF(Point.Empty, b.Size);
+				r.Inflate(-1, -1);
+				if (text != null)
 				{
-					var r = new RectangleF(Point.Empty, bmp.Size);
-					r.Inflate(-1, -1);
-					g.FillEllipse(color, r);
-					if (text != null)
-					{
-						var font = SystemFonts.Default(SystemFonts.Default().Size * 2);
-						var size = g.MeasureString(font, text);
-						g.DrawText(font, textcolor, r.Location + (PointF)(r.Size - size) / 2, text);
-					}
+					var font = SystemFonts.Default(SystemFonts.Default().Size * 2);
+					var size = g.MeasureString(font, text);
+					g.DrawText(font, textcolor, r.Location + (PointF)(r.Size - size) / 2, text);
 				}
-				return bmp.WithSize(16, 16);
 			});
 		}
 

--- a/test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
+++ b/test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
@@ -267,7 +267,8 @@ namespace Eto.Test.UnitTests.Drawing
 				Assert.AreEqual(Colors.Green, bd.GetPixel(10, 0), "#5");
 				Assert.AreEqual(Colors.Red, bd.GetPixel(20, 0), "#6");
 			}
-			Shown(f => new ImageView { Image = bmp }, 
+
+			await Task.Run(() => Shown(f => new ImageView { Image = bmp }, 
 				iv => {
 
 				// also test in UI thread
@@ -281,7 +282,7 @@ namespace Eto.Test.UnitTests.Drawing
 					Assert.AreEqual(Colors.Green, bd.GetPixel(10, 0), "#11");
 					Assert.AreEqual(Colors.Red, bd.GetPixel(20, 0), "#12");
 				}
-			});
+			}));
 		}
 
 		[Test]

--- a/test/Eto.Test/UnitTests/Forms/CascadingStyleTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/CascadingStyleTests.cs
@@ -1,0 +1,109 @@
+﻿using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms
+{
+    [TestFixture]
+    public class CascadingStyleTests : TestBase
+    {
+        [Test, InvokeOnUI]
+        public void DefaultStyleShouldApplyFromContainer()
+        {
+            var container = new Panel();
+
+            container.Styles.Add<Label>(null, l => l.Visible = false);
+
+            var child = new Label();
+            container.Content = child;
+            Assert.IsTrue(child.Visible);
+
+            container.AttachNative(); // trigger load to apply styles
+
+            Assert.IsFalse(child.Visible);
+        }
+
+        [Test, InvokeOnUI]
+        public void StyleShouldApplyFromContainer()
+        {
+            var container = new Panel();
+
+            container.Styles.Add<Label>("style", l => l.Visible = false);
+
+            var child = new Label();
+            container.Content = child;
+            Assert.IsTrue(child.Visible);
+
+            container.AttachNative(); // trigger load to apply styles
+            Assert.IsTrue(child.Visible);
+
+            child.Style = "style";
+
+            Assert.IsFalse(child.Visible);
+        }
+
+        [Test, InvokeOnUI]
+        public void StyleShouldApplyFromParentToChildOrder()
+        {
+            var container1 = new Panel();
+            container1.Styles.Add<Label>(null, l => l.VerticalAlignment = VerticalAlignment.Bottom);
+
+            var container2 = new Panel();
+            container2.Styles.Add<Label>("style", l => l.VerticalAlignment = VerticalAlignment.Center);
+            container1.Content = container2;
+
+            var child = new Label();
+            container2.Content = child;
+            Assert.AreEqual(VerticalAlignment.Top, child.VerticalAlignment);
+
+            container1.AttachNative(); // trigger load to apply styles
+
+            // container1 style applies
+            Assert.AreEqual(VerticalAlignment.Bottom, child.VerticalAlignment);
+
+            child.Style = "style";
+
+            // container2 style now applies
+            Assert.AreEqual(VerticalAlignment.Center, child.VerticalAlignment);
+
+            child.Style = null;
+
+            // container1 style now applies again
+            Assert.AreEqual(VerticalAlignment.Bottom, child.VerticalAlignment);
+        }
+
+		[Test, InvokeOnUI]
+		public void StyleShouldApplyWhenControlDynamicallyAdded()
+		{
+			var container = new Panel();
+
+			container.Styles.Add<Label>("style", l => l.Visible = false);
+
+			container.AttachNative(); // trigger load to apply styles
+
+			var child = new Label();
+			child.Style = "style";
+			Assert.IsTrue(child.Visible);
+
+			container.Content = child; // styles apply now that it is a child of the container
+
+			Assert.IsFalse(child.Visible);
+		}
+
+		[Test, InvokeOnUI]
+		public void DefaultStyleShouldApplyWhenControlDynamicallyAdded()
+		{
+			var container = new Panel();
+
+			container.Styles.Add<Label>(null, l => l.Visible = false);
+
+			container.AttachNative();
+
+			var child = new Label();
+			Assert.IsTrue(child.Visible);
+
+			container.Content = child; // styles apply now that it is a child of the container
+
+			Assert.IsFalse(child.Visible);
+		}
+	}
+}

--- a/test/Eto.Test/UnitTests/Forms/DefaultStyleProviderTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/DefaultStyleProviderTests.cs
@@ -1,0 +1,115 @@
+using System;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms
+{
+	[Handler(typeof(IHandler))]
+	public class StyledWidget : Widget
+	{
+		new IHandler Handler => (IHandler)base.Handler;
+
+		public bool SomeProperty
+		{
+			get => Handler.SomeProperty;
+			set => Handler.SomeProperty = value;
+		}
+
+		public new interface IHandler : Widget.IHandler
+		{
+			bool SomeProperty { get; set; }
+		}
+	}
+
+	public class StyledWidgetHandler : WidgetHandler<StyledWidget>, StyledWidget.IHandler
+	{
+		public bool SomeProperty { get; set; }
+	}
+
+	[TestFixture]
+	public class DefaultStyleProviderTests : TestBase
+	{
+		static DefaultStyleProviderTests()
+		{
+			Platform.Instance.Add<StyledWidget.IHandler>(() => new StyledWidgetHandler());
+		}
+
+		[Test, InvokeOnUI]
+		public void BaseClassShouldApplyDefault()
+		{
+			var style = new DefaultStyleProvider();
+			var provider = (IStyleProvider)style;
+			style.Add<Control>(null, c => c.Visible = false);
+
+			var label = new Label();
+			Assert.IsTrue(label.Visible);
+			provider.ApplyDefault(label);
+			Assert.IsFalse(label.Visible);
+		}
+
+		[Test, InvokeOnUI]
+		public void BaseClassWithStyleShouldApply()
+		{
+			var style = new DefaultStyleProvider();
+			var provider = (IStyleProvider)style;
+			style.Add<Control>("style", c => c.Visible = false);
+
+			var label = new Label();
+			Assert.IsTrue(label.Visible);
+			provider.ApplyStyle(label, "style");
+			Assert.IsFalse(label.Visible);
+		}
+
+		[Test, InvokeOnUI]
+		public void OtherClassShouldNotApplyDefault()
+		{
+			var style = new DefaultStyleProvider();
+			var provider = (IStyleProvider)style;
+			style.Add<Button>(null, c => c.Visible = false);
+
+			var label = new Label();
+			Assert.IsTrue(label.Visible);
+			provider.ApplyDefault(label);
+			Assert.IsTrue(label.Visible);
+		}
+
+		[Test, InvokeOnUI]
+		public void OtherClassWithStyleShouldNotApply()
+		{
+			var style = new DefaultStyleProvider();
+			var provider = (IStyleProvider)style;
+			style.Add<Button>("style", c => c.Visible = false);
+
+			var label = new Label();
+			Assert.IsTrue(label.Visible);
+			provider.ApplyStyle(label, "style");
+			Assert.IsTrue(label.Visible);
+		}
+
+		[Test, InvokeOnUI]
+		public void HandlerShouldApplyDefault()
+		{
+			var style = new DefaultStyleProvider();
+			var provider = (IStyleProvider)style;
+			style.Add<StyledWidgetHandler>(null, h => h.SomeProperty = true);
+
+			var styledWidget = new StyledWidget();
+			Assert.IsFalse(styledWidget.SomeProperty);
+			provider.ApplyDefault(styledWidget.Handler);
+			Assert.IsTrue(styledWidget.SomeProperty);
+		}
+
+		[Test, InvokeOnUI]
+		public void HandlerWithStyleShouldApply()
+		{
+			var style = new DefaultStyleProvider();
+			var provider = (IStyleProvider)style;
+			style.Add<StyledWidgetHandler>("style", h => h.SomeProperty = true);
+
+			var styledWidget = new StyledWidget();
+			Assert.IsFalse(styledWidget.SomeProperty);
+			provider.ApplyStyle(styledWidget.Handler, "style");
+			Assert.IsTrue(styledWidget.SomeProperty);
+		}
+	}
+}

--- a/test/Eto.Test/UnitTests/Forms/GlobalStyleProviderTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/GlobalStyleProviderTests.cs
@@ -1,0 +1,88 @@
+﻿using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms
+{
+    [TestFixture]
+    public class GlobalStyleProviderTests : TestBase
+    {
+        [Test, InvokeOnUI]
+        public void WidgetShouldApplyDefault()
+        {
+            var style = new DefaultStyleProvider();
+            style.Add<StyledWidget>(null, h => h.SomeProperty = true);
+
+            var oldProvider = Style.Provider;
+            Style.Provider = style;
+            try
+            {
+                var styledWidget = new StyledWidget();
+                Assert.IsTrue(styledWidget.SomeProperty);
+            }
+            finally
+            {
+                Style.Provider = oldProvider;
+            }
+        }
+
+        [Test, InvokeOnUI]
+        public void WidgetWithStyleShouldApply()
+        {
+            var style = new DefaultStyleProvider();
+            style.Add<StyledWidget>("style", h => h.SomeProperty = true);
+
+            var oldProvider = Style.Provider;
+            Style.Provider = style;
+            try
+            {
+                var styledWidget = new StyledWidget();
+                Assert.IsFalse(styledWidget.SomeProperty);
+                styledWidget.Style = "style";
+                Assert.IsTrue(styledWidget.SomeProperty);
+            }
+            finally
+            {
+                Style.Provider = oldProvider;
+            }
+        }
+
+        [Test, InvokeOnUI]
+        public void HandlerShouldApplyDefault()
+        {
+            var style = new DefaultStyleProvider();
+            style.Add<StyledWidgetHandler>(null, h => h.SomeProperty = true);
+
+            var oldProvider = Style.Provider;
+            Style.Provider = style;
+            try
+            {
+                var styledWidget = new StyledWidget();
+                Assert.IsTrue(styledWidget.SomeProperty);
+            }
+            finally
+            {
+                Style.Provider = oldProvider;
+            }
+        }
+
+        [Test, InvokeOnUI]
+        public void HandlerWithStyleShouldApply()
+        {
+            var style = new DefaultStyleProvider();
+            style.Add<StyledWidgetHandler>("style", h => h.SomeProperty = true);
+
+            var oldProvider = Style.Provider;
+            Style.Provider = style;
+            try
+            {
+                var styledWidget = new StyledWidget();
+                Assert.IsFalse(styledWidget.SomeProperty);
+                styledWidget.Style = "style";
+                Assert.IsTrue(styledWidget.SomeProperty);
+            }
+            finally
+            {
+                Style.Provider = oldProvider;
+            }
+        }
+    }
+}


### PR DESCRIPTION
This adds the ability for containers to specify styles for children, and also specify if the styles should be inherited from their container when building composite controls that have styles applied already.

You can also create your own style provider and override the default style provider either globally or on a per-control basis.

A simple example:

```c#
var container = new Panel();
container.Styles.Add<Label>(null, label => label.VerticalAlignment = VerticalAlignment.Center);

var label = new Label { Text = "This will be vertically centered!" };
container.Content = label;
```

Fixes #262