### PR TITLE
Gtk updates

### DIFF
--- a/src/Eto.Gtk/CustomControls/BaseComboBox.gtk2.cs
+++ b/src/Eto.Gtk/CustomControls/BaseComboBox.gtk2.cs
@@ -1,14 +1,10 @@
+#if GTK2
 using System;
 using Gtk;
 
 namespace Eto.GtkSharp.CustomControls
 {
-	public class BaseComboBox 
-	#if GTK3
-		: EventBox
-	#else
-		: SizableBin
-	#endif
+	public class BaseComboBox : SizableBin
 	{
 		Entry entry;
 		Button popupButton;
@@ -17,17 +13,9 @@ namespace Eto.GtkSharp.CustomControls
 		{
 			AppPaintable = true;
 			Build();
-#if GTK3
-			SetSizeRequest(150, 30);
-			foreach (var cls in PopupButton.StyleContext.ListClasses())
-				PopupButton.StyleContext.RemoveClass(cls);
-			entry.StyleContext.RemoveClass("entry");
-			StyleContext.AddClass("entry");
-#else
 			BorderWidth = 1;
-#endif
 		}
-		#if GTK2
+
 		int vpadding;
 		static readonly int DefaultEntryHeight = new ComboBoxEntry().SizeRequest().Height;
 
@@ -35,6 +23,12 @@ namespace Eto.GtkSharp.CustomControls
 		{
 			base.OnSizeRequested(ref requisition);
 			requisition.Height += vpadding; // for border
+		}
+
+		public event EventHandler PopupButtonClicked
+		{
+			add => PopupButton.Clicked += value;
+			remove => PopupButton.Clicked -= value;
 		}
 
 		[GLib.ConnectBefore]
@@ -59,50 +53,6 @@ namespace Eto.GtkSharp.CustomControls
 			}
 			return true;
 		}
-		#else
-		protected override bool OnDrawn(Cairo.Context cr)
-		{
-			bool ret = true;
-			var rect = this.Allocation;
-			if (rect.Width > 0 && rect.Height > 0)
-			{
-				var arrowWidth = popupButton.Allocation.Width;
-				var arrowPos = rect.Width - arrowWidth;
-				var arrowSize = 10;
-
-				StyleContext.Save();
-				StyleContext.State = Entry.StyleContext.State;
-				StyleContext.RenderBackground(cr, 0, 0, rect.Width, rect.Height);
-
-				ret = base.OnDrawn(cr);
-
-				StyleContext.RenderArrow(cr, Math.PI, arrowPos, (rect.Height - arrowSize) / 2, arrowSize);
-
-				cr.SetSourceColor(new Cairo.Color(.8, .8, .8));
-				cr.Rectangle(arrowPos - 5, 2, 1, rect.Height - 4);
-				cr.Fill();
-
-				StyleContext.RenderFrame(cr, 0, 0, rect.Width, rect.Height);
-				StyleContext.Restore();
-
-			}
-			return ret;
-		}
-
-		class InvisibleButton : Gtk.Button
-		{
-			public InvisibleButton()
-			{
-				AppPaintable = true;
-			}
-
-			protected override bool OnDrawn(Cairo.Context cr)
-			{
-				return false; //return base.OnDrawn(cr);
-			}
-		}
-
-		#endif
 		public Entry Entry { get { return entry; } }
 
 		public Button PopupButton { get { return popupButton; } }
@@ -132,12 +82,7 @@ namespace Eto.GtkSharp.CustomControls
 
 		Gtk.Widget CreatePopupButton()
 		{
-#if GTK3
-			popupButton = new InvisibleButton();
-#else
-
 			popupButton = new Button();
-#endif
 			popupButton.WidthRequest = ArrowSize + 6;
 			popupButton.CanFocus = false;
 			return popupButton;
@@ -148,20 +93,15 @@ namespace Eto.GtkSharp.CustomControls
 			var vbox = new VBox();
 			var hbox = new HBox();
 
-#if GTK2
 			CreateEntry();
 			vpadding = (DefaultEntryHeight - entry.SizeRequest().Height) / 2;
 			entry.HeightRequest = -1;
 			hbox.PackStart(entry, true, true, 4);
 			hbox.PackEnd(CreatePopupButton(), false, false, 2);
 			vbox.PackStart(hbox, true, true, (uint)vpadding);
-#else
-			hbox.PackStart(CreateEntry(), true, true, 8);
-			hbox.PackEnd(CreatePopupButton(), false, false, 2);
-			vbox.PackStart(hbox, true, true, 0);
-#endif
 			Add(vbox);
 		}
 	}
 }
 
+#endif

--- a/src/Eto.Gtk/CustomControls/BaseComboBox.gtk3.cs
+++ b/src/Eto.Gtk/CustomControls/BaseComboBox.gtk3.cs
@@ -1,0 +1,85 @@
+#if GTK3
+using System;
+using Gtk;
+
+namespace Eto.GtkSharp.CustomControls
+{
+	public class BaseComboBox : Gtk.EventBox
+	{
+		ComboEntry entry;
+		public int ArrowWidth { get; set; } = 28;
+
+		public BaseComboBox()
+		{
+			AddEvents((int)Gdk.EventMask.ButtonPressMask);
+			AddEvents((int)Gdk.EventMask.ButtonReleaseMask);
+			ButtonPressEvent += HandleButtonPressEvent;
+
+			entry = new ComboEntry { Host = this };
+			Add(entry);
+		}
+
+		[GLib.ConnectBefore]
+		private void HandleButtonPressEvent(object o, ButtonPressEventArgs args)
+		{
+			if (args.Event.X > AllocatedWidth - ArrowWidth && Sensitive)
+			{
+				OnPopupButtonClicked(EventArgs.Empty);
+			}
+		}
+
+		public Entry Entry => entry;
+
+		public event EventHandler PopupButtonClicked;
+
+		protected virtual void OnPopupButtonClicked(EventArgs e)
+		{
+			PopupButtonClicked?.Invoke(this, e);
+		}
+
+		class ComboEntry : Gtk.Entry
+		{
+			public BaseComboBox Host { get; set; }
+
+			protected override void OnGetTextAreaSize(out int x, out int y, out int width, out int height)
+			{
+				base.OnGetTextAreaSize(out x, out y, out width, out height);
+				width -= Host.ArrowWidth;
+			}
+
+			protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)
+			{
+				base.OnGetPreferredWidth(out minimum_width, out natural_width);
+				natural_width = Math.Max(natural_width, 180);
+			}
+
+			protected override bool OnDrawn(Cairo.Context cr)
+			{
+				bool ret = true;
+				var rect = Allocation;
+				if (rect.Width > 0 && rect.Height > 0)
+				{
+					var dropDownPos = rect.Width - Host.ArrowWidth;
+					var arrowSize = 10;
+					var arrowPos = dropDownPos + (Host.ArrowWidth - arrowSize - 2) / 2;
+
+					StyleContext.Save();
+
+					ret = base.OnDrawn(cr);
+
+					StyleContext.RenderArrow(cr, Math.PI, arrowPos, (rect.Height - arrowSize) / 2, arrowSize);
+
+					cr.SetSourceColor(new Cairo.Color(.8, .8, .8));
+					cr.Rectangle(dropDownPos, 2, 1, rect.Height - 4);
+					cr.Fill();
+
+					StyleContext.Restore();
+
+				}
+				return ret;
+			}
+		}
+
+	}
+}
+#endif

--- a/src/Eto.Gtk/CustomControls/DateComboBox.cs
+++ b/src/Eto.Gtk/CustomControls/DateComboBox.cs
@@ -83,7 +83,7 @@ namespace Eto.GtkSharp.CustomControls
 			NormalColor = Entry.GetTextColor();
 
 			Entry.Changed += HandleChanged;
-			PopupButton.Clicked += delegate
+			PopupButtonClicked += delegate
 			{
 				var dlg = new DateComboBoxDialog(selectedDate ?? DateTime.Now, this.Mode);
 				dlg.DateChanged += delegate

--- a/src/Eto.Gtk/CustomControls/DateComboBoxDialog.cs
+++ b/src/Eto.Gtk/CustomControls/DateComboBoxDialog.cs
@@ -64,7 +64,7 @@ namespace Eto.GtkSharp.CustomControls
 			this.ButtonPressEvent += delegate(object o, Gtk.ButtonPressEventArgs args) {
 				if (args.Event.Type == Gdk.EventType.ButtonPress) {
 					// single click only!
-					Close ();
+					CloseDialog ();
 				}
 			};
 			
@@ -100,7 +100,7 @@ namespace Eto.GtkSharp.CustomControls
 		}
 #endif
 
-		void Close ()
+		void CloseDialog ()
 		{
 			this.RemoveGrab ();
 			Destroy();
@@ -130,7 +130,7 @@ namespace Eto.GtkSharp.CustomControls
 			
 			calendar.DaySelectedDoubleClick += delegate {
 				OnDateChanged (EventArgs.Empty);
-				Close ();
+				CloseDialog ();
 			};
 
 			vbox.PackStart(calendar, false, false, 0);
@@ -152,7 +152,7 @@ namespace Eto.GtkSharp.CustomControls
 					UpdateClock ();
 				}
 				OnDateChanged (EventArgs.Empty);
-				Close ();
+				CloseDialog ();
 			};
 			
 			hbox.PackStart (todayButton, false, false, 0);

--- a/src/Eto.Gtk/Drawing/FontFamilyHandler.cs
+++ b/src/Eto.Gtk/Drawing/FontFamilyHandler.cs
@@ -14,7 +14,7 @@ namespace Eto.GtkSharp.Drawing
 
 		public IEnumerable<FontTypeface> Typefaces
 		{
-			get { return Control.Faces.Select(r => new FontTypeface(Widget, new FontTypefaceHandler(r))); }
+			get { return Control.Faces.Where(r => r != null).Select(r => new FontTypeface(Widget, new FontTypefaceHandler(r))); }
 		}
 
 		public FontFamilyHandler()
@@ -64,13 +64,13 @@ namespace Eto.GtkSharp.Drawing
 			switch (familyName.ToUpperInvariant())
 			{
 				case FontFamilies.MonospaceFamilyName:
-					Control = GetFontFamily("monospace", "FreeMono", "Courier");
+					Control = GetFontFamily("monospace", "FreeMono", "Courier New", "Courier");
 					break;
 				case FontFamilies.SansFamilyName:
-					Control = GetFontFamily("sans", "FreeSans");
+					Control = GetFontFamily("sans", "FreeSans", "Arial", "Helvetica");
 					break;
 				case FontFamilies.SerifFamilyName:
-					Control = GetFontFamily("serif", "FreeSerif");
+					Control = GetFontFamily("serif", "FreeSerif", "Times New Roman", "Times");
 					break;
 				case FontFamilies.CursiveFamilyName:
 				// from http://www.codestyle.org/css/font-family/sampler-Cursive.shtml#cursive-linux

--- a/src/Eto.Gtk/Drawing/FontHandler.cs
+++ b/src/Eto.Gtk/Drawing/FontHandler.cs
@@ -192,7 +192,9 @@ namespace Eto.GtkSharp.Drawing
 
 			foreach (var face in family.Faces)
 			{
-				var faceDesc = face.Describe();
+				var faceDesc = face?.Describe();
+				if (faceDesc == null)
+					continue;
 				if (faceDesc.Weight == weight && faceDesc.Style == style && faceDesc.Stretch == stretch)
 				{
 					return face;

--- a/src/Eto.Gtk/Drawing/FontTypefaceHandler.cs
+++ b/src/Eto.Gtk/Drawing/FontTypefaceHandler.cs
@@ -9,7 +9,7 @@ namespace Eto.GtkSharp.Drawing
 			this.Control = pangoFace;
 		}
 
-		public string Name => Control.FaceName;
+		public string Name => Control?.FaceName;
 
 		public string LocalizedName => Name;
 
@@ -17,6 +17,8 @@ namespace Eto.GtkSharp.Drawing
 		{
 			get {
 				var style = FontStyle.None;
+				if (Control == null)
+					return style;
 				var description = Control.Describe ();
 				if (description.Style == Pango.Style.Italic || description.Style == Pango.Style.Oblique)
 					style |= FontStyle.Italic;

--- a/src/Eto.Gtk/Eto.Gtk.csproj
+++ b/src/Eto.Gtk/Eto.Gtk.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.22.24.36" />
+    <PackageReference Include="GtkSharp" Version="3.22.24.37" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eto\Eto.csproj" />

--- a/src/Eto.Gtk/Eto.Gtk2.csproj
+++ b/src/Eto.Gtk/Eto.Gtk2.csproj
@@ -192,7 +192,6 @@
     <Compile Include="Forms\ColorDialogHandlerOld.cs" />
     <Compile Include="Drawing\GraphicsPathHandler.cs" />
     <Compile Include="Forms\Controls\DateTimePickerHandler.cs" />
-    <Compile Include="CustomControls\BaseComboBox.cs" />
     <Compile Include="CustomControls\DateComboBox.cs" />
     <Compile Include="CustomControls\DateComboBoxDialog.cs" />
     <Compile Include="CustomControls\AnalogClock.cs" />
@@ -288,6 +287,8 @@
     </Compile>
     <Compile Include="Forms\LinuxTrayIndicatorHandler.cs" />
     <Compile Include="Forms\DataObjectHandler.cs" />
+    <Compile Include="CustomControls\BaseComboBox.gtk2.cs" />
+    <Compile Include="CustomControls\BaseComboBox.gtk3.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/src/Eto.Gtk/Eto.Gtk2.csproj
+++ b/src/Eto.Gtk/Eto.Gtk2.csproj
@@ -127,9 +127,6 @@
     <Compile Include="Forms\SaveFileDialog.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Forms\TableLayoutHandler.cs">
-      <SubType>Code</SubType>
-    </Compile>
     <Compile Include="IO\SystemIcons.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -287,6 +284,7 @@
     </Compile>
     <Compile Include="Forms\LinuxTrayIndicatorHandler.cs" />
     <Compile Include="Forms\DataObjectHandler.cs" />
+    <Compile Include="Forms\TableLayoutHandler.gtk2.cs" />
     <Compile Include="CustomControls\BaseComboBox.gtk2.cs" />
     <Compile Include="CustomControls\BaseComboBox.gtk3.cs" />
   </ItemGroup>

--- a/src/Eto.Gtk/Eto.Gtk3.csproj
+++ b/src/Eto.Gtk/Eto.Gtk3.csproj
@@ -190,7 +190,6 @@
     <Compile Include="Forms\ColorDialogHandlerOld.cs" />
     <Compile Include="Drawing\GraphicsPathHandler.cs" />
     <Compile Include="Forms\Controls\DateTimePickerHandler.cs" />
-    <Compile Include="CustomControls\BaseComboBox.cs" />
     <Compile Include="CustomControls\DateComboBox.cs" />
     <Compile Include="CustomControls\DateComboBoxDialog.cs" />
     <Compile Include="CustomControls\AnalogClock.cs" />
@@ -283,6 +282,8 @@
     <Compile Include="Forms\LinuxNotificationHandler.cs" />
     <Compile Include="Forms\Controls\WebKit2WebViewHandler.cs" />
     <Compile Include="Forms\DataObjectHandler.cs" />
+    <Compile Include="CustomControls\BaseComboBox.gtk2.cs" />
+    <Compile Include="CustomControls\BaseComboBox.gtk3.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Eto.Gtk/Eto.Gtk3.csproj
+++ b/src/Eto.Gtk/Eto.Gtk3.csproj
@@ -137,7 +137,7 @@
     <Compile Include="Forms\SaveFileDialog.cs">
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="Forms\TableLayoutHandler.cs">
+    <Compile Include="Forms\TableLayoutHandler.gtk2.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="GtkConversions.cs" />
@@ -282,6 +282,7 @@
     <Compile Include="Forms\LinuxNotificationHandler.cs" />
     <Compile Include="Forms\Controls\WebKit2WebViewHandler.cs" />
     <Compile Include="Forms\DataObjectHandler.cs" />
+    <Compile Include="Forms\TableLayoutHandler.gtk3.cs" />
     <Compile Include="CustomControls\BaseComboBox.gtk2.cs" />
     <Compile Include="CustomControls\BaseComboBox.gtk3.cs" />
   </ItemGroup>

--- a/src/Eto.Gtk/Forms/AboutDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/AboutDialogHandler.cs
@@ -101,6 +101,7 @@ namespace Eto.GtkSharp.Forms
 			Control.ShowAll();
 			var response = (Gtk.ResponseType)Control.Run();
 			Control.Hide();
+			Control.Unrealize();
 
 			if (response == Gtk.ResponseType.Ok)
 				return DialogResult.Ok;

--- a/src/Eto.Gtk/Forms/ColorDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/ColorDialogHandler.cs
@@ -37,6 +37,7 @@ namespace Eto.GtkSharp.Forms
 			Control.ShowAll();
 			var response = (Gtk.ResponseType)Control.Run();
 			Control.Hide();
+			Control.Unrealize();
 
 			if (response == Gtk.ResponseType.Ok)
 				Callback.OnColorChanged(Widget, EventArgs.Empty);

--- a/src/Eto.Gtk/Forms/Controls/ColorPickerHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ColorPickerHandler.cs
@@ -40,7 +40,13 @@ namespace Eto.GtkSharp.Forms.Controls
 				Handler.Callback.OnColorChanged(Handler.Widget, EventArgs.Empty);
 			}
 		}
-
+#if GTK3
+		public Eto.Drawing.Color Color
+		{
+			get { return Control.Rgba.ToEto(); }
+			set { Control.Rgba = value.ToRGBA(); }
+		}
+#else
 		public Eto.Drawing.Color Color
 		{
 			get { return Control.Color.ToEto(Control.Alpha); }
@@ -49,7 +55,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				Control.Alpha = (ushort)(value.A * ushort.MaxValue);
 			}
 		}
-
+#endif
 		public bool AllowAlpha
 		{
 			get { return Control.UseAlpha; }

--- a/src/Eto.Gtk/Forms/Controls/DocumentPageHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DocumentPageHandler.cs
@@ -48,7 +48,8 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			tab.PackEnd(closeButton, false, true, 0);
 			label = new Gtk.Label();
-			label.SetAlignment(0.5f, 0.5f);
+			label.Xalign = 0.5f;
+			label.Yalign = 0.5f;
 			tab.PackEnd(label, true, true, 0);
 
 			tab.ShowAll();
@@ -69,10 +70,11 @@ namespace Eto.GtkSharp.Forms.Controls
 			var closewidth = (closeButton.Visible) ? closeButton.Allocation.Width : 0;
 			var width = (float)label.Allocation.Width / (label.Allocation.Width - Math.Abs(closewidth - imagewidth));
 
+			label.Yalign = 0.5f;
 			if (imagewidth >= closewidth)
-				label.SetAlignment(1 - width / 2, 0.5f);
+				label.Xalign = 1 - width / 2;
 			else
-				label.SetAlignment(width / 2, 0.5f);
+				label.Xalign = width / 2;
 		}
 
 		public Gtk.Widget LabelControl

--- a/src/Eto.Gtk/Forms/Controls/FilePickerHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/FilePickerHandler.cs
@@ -72,6 +72,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			var result = savedialog.Run();
 			savedialog.Hide();
+			savedialog.Unrealize();
 
 			if (result == (int)Gtk.ResponseType.Ok)
 				saveentry.Text = savedialog.Filename;

--- a/src/Eto.Gtk/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/LabelHandler.cs
@@ -17,6 +17,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public class EtoLabel : Gtk.Label
 		{
+#if GTK2
 			int? wrapWidth;
 
 			public void ResetWidth()
@@ -24,7 +25,6 @@ namespace Eto.GtkSharp.Forms.Controls
 				wrapWidth = null;
 			}
 
-			#if GTK2
 			protected override void OnSizeRequested(ref Gtk.Requisition requisition)
 			{
 				int width, height;
@@ -41,17 +41,6 @@ namespace Eto.GtkSharp.Forms.Controls
 					requisition.Height = height;
 				}
 			}
-			#else
-
-			protected override void OnAdjustSizeRequest (Gtk.Orientation orientation, out int minimum_size, out int natural_size)
-			{
-				base.OnAdjustSizeRequest (orientation, out minimum_size, out natural_size);
-				if (orientation == Gtk.Orientation.Horizontal)
-				{
-					minimum_size = natural_size;// wrapWidth ?? natural_size;
-				}
-			}
-			#endif
 
 			protected override void OnSizeAllocated(Gdk.Rectangle allocation)
 			{
@@ -91,10 +80,22 @@ namespace Eto.GtkSharp.Forms.Controls
 				Layout.GetPixelSize(out pixWidth, out pixHeight);
 				HeightRequest = pixHeight;
 				wrapWidth = width;
-#if GTK3
-				Gtk.Application.Invoke((sender, e) => QueueResize());
-#endif
 			}
+#else
+			public void ResetWidth()
+			{
+			}
+
+			protected override Gtk.SizeRequestMode OnGetRequestMode() => Gtk.SizeRequestMode.HeightForWidth;
+
+			protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)
+			{
+				base.OnGetPreferredWidth(out minimum_width, out natural_width);
+
+				// label should allow shrinking, natural width is used instead
+				minimum_width = 0;
+			}
+#endif
 
 		}
 
@@ -104,7 +105,6 @@ namespace Eto.GtkSharp.Forms.Controls
 #if GTK2
 			eventBox.ResizeMode = Gtk.ResizeMode.Immediate;
 #endif
-			//eventBox.VisibleWindow = false;
 			Control = new EtoLabel();
 			Control.Xalign = 0;
 			Control.Yalign = 0;
@@ -155,7 +155,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				default:
 					throw new NotSupportedException();
 			}
-			eventBox.QueueResize();
+			Control.QueueResize();
 		}
 
 		public override void AttachEvent(string id)

--- a/src/Eto.Gtk/Forms/Controls/LinkButtonHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/LinkButtonHandler.cs
@@ -18,7 +18,8 @@ namespace Eto.GtkSharp.Forms.Controls
 		public LinkButtonHandler()
 		{
 			Control = new Gtk.LinkButton(string.Empty);
-			Control.SetAlignment(0f, .5f);
+			Control.Xalign = 0f;
+			Control.Yalign = .5f;
 			Control.TooltipText = null;
 			box = new Gtk.EventBox();
 			box.Child = Control;

--- a/src/Eto.Gtk/Forms/Controls/PanelHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/PanelHandler.cs
@@ -4,12 +4,22 @@ namespace Eto.GtkSharp.Forms.Controls
 {
 	public class PanelHandler : GtkPanel<Gtk.EventBox, Panel, Panel.ICallback>, Panel.IHandler
 	{
+#if GTK3
+		public PanelHandler()
+		{
+			Control = new Gtk.EventBox();
+		}
+
+		protected override void SetContainerContent(Gtk.Widget content)
+		{
+			Control.Add(content);
+		}
+#else
 		readonly Gtk.VBox box;
 
 		public PanelHandler()
 		{
 			Control = new Gtk.EventBox();
-			//Control.VisibleWindow = false; // can't use this as it causes overlapping widgets
 			box = new Gtk.VBox();
 			Control.Add(box);
 		}
@@ -18,5 +28,6 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			box.Add(content);
 		}
+#endif
 	}
 }

--- a/src/Eto.Gtk/Forms/DialogHandler.cs
+++ b/src/Eto.Gtk/Forms/DialogHandler.cs
@@ -99,6 +99,7 @@ namespace Eto.GtkSharp.Forms
 
 			WasClosed = false;
 			Control.Hide();
+			Control.Unrealize();
 
 			CleanupButtons();
 		}

--- a/src/Eto.Gtk/Forms/FontDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/FontDialogHandler.cs
@@ -47,6 +47,7 @@ namespace Eto.GtkSharp.Forms
 			Control.ShowAll();
 			var response = (Gtk.ResponseType)Control.Run();
 			Control.Hide();
+			Control.Unrealize();
 
 			if (response == Gtk.ResponseType.Ok)
 			{

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -101,6 +101,8 @@ namespace Eto.GtkSharp.Forms
 
 		public virtual Point CurrentLocation { get; set; }
 
+		public Size DesiredSize => size;
+
 		public virtual Size Size
 		{
 			get
@@ -120,10 +122,18 @@ namespace Eto.GtkSharp.Forms
 						if (size.Height == -1)
 							size.Height = defSize.Height;
 					}
-					ContainerControl.SetSizeRequest(size.Width, size.Height);
+					SetSize(size);
 				}
 			}
 		}
+
+		protected void SetSize() => SetSize(DefaultSize);
+
+		protected virtual void SetSize(Size size)
+		{
+			ContainerControl.SetSizeRequest(size.Width, size.Height);
+		}
+
 		public virtual bool Enabled
 		{
 			get

--- a/src/Eto.Gtk/Forms/GtkFileDialog.cs
+++ b/src/Eto.Gtk/Forms/GtkFileDialog.cs
@@ -87,6 +87,7 @@ namespace Eto.GtkSharp.Forms
 			int result = Control.Run();
 
 			Control.Hide ();
+			Control.Unrealize();
 
 			DialogResult response = ((Gtk.ResponseType)result).ToEto ();
 			if (response == DialogResult.Ok && !string.IsNullOrEmpty(Control.CurrentFolder))

--- a/src/Eto.Gtk/Forms/GtkPanel.cs
+++ b/src/Eto.Gtk/Forms/GtkPanel.cs
@@ -84,17 +84,15 @@ namespace Eto.GtkSharp.Forms
 			}
 		}
 
-		public Padding Padding
+		public virtual Padding Padding
 		{
-			get
-			{
-				uint top, left, right, bottom;
-				alignment.GetPadding(out top, out bottom, out left, out right);
-				return new Padding((int)left, (int)top, (int)right, (int)bottom);
-			}
+			get => new Padding((int)alignment.LeftPadding, (int)alignment.TopPadding, (int)alignment.RightPadding, (int)alignment.BottomPadding);
 			set
 			{
-				alignment.SetPadding((uint)value.Top, (uint)value.Bottom, (uint)value.Left, (uint)value.Right);
+				alignment.LeftPadding = (uint)value.Left;
+				alignment.RightPadding = (uint)value.Right;
+				alignment.TopPadding = (uint)value.Top;
+				alignment.BottomPadding = (uint)value.Bottom;
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/GtkWindow.cs
+++ b/src/Eto.Gtk/Forms/GtkWindow.cs
@@ -468,7 +468,7 @@ namespace Eto.GtkSharp.Forms
 					closing(args);
 				else
 				{
-					var windows = Gdk.Screen.Default.ToplevelWindows.Where(r => r.WindowType != Gdk.WindowType.Temp).ToList();
+					var windows = Gdk.Screen.Default.ToplevelWindows.Where(r => r.State != Gdk.WindowState.Withdrawn && r.WindowType != Gdk.WindowType.Temp).ToList();
 					if (windows.Count == 1 && ReferenceEquals(windows[0], Control.GetWindow()))
 					{
 						var app = ((ApplicationHandler)Application.Instance.Handler);
@@ -492,6 +492,7 @@ namespace Eto.GtkSharp.Forms
 			if (CloseWindow())
 			{
 				Control.Hide();
+				Control.Unrealize();
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/OtherTrayIndicatorHandler.cs
+++ b/src/Eto.Gtk/Forms/OtherTrayIndicatorHandler.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿// status icon is obsolete, but we still want to use it.
+#pragma warning disable 612, 618
+using System;
 using Eto.Drawing;
 using Eto.Forms;
 using Eto.GtkSharp.Drawing;
@@ -63,3 +65,4 @@ namespace Eto.GtkSharp.Forms
         }
     }
 }
+#pragma warning restore 612, 618

--- a/src/Eto.Gtk/Forms/PixelLayoutHandler.cs
+++ b/src/Eto.Gtk/Forms/PixelLayoutHandler.cs
@@ -1,6 +1,7 @@
 using Eto.Forms;
 using Eto.Drawing;
 using Eto.GtkSharp.Forms.Controls;
+using Gtk;
 
 namespace Eto.GtkSharp.Forms
 {
@@ -11,16 +12,36 @@ namespace Eto.GtkSharp.Forms
 			Control = new Gtk.Fixed();
 		}
 
+#if GTK3
+		class EtoVBox : Gtk.VBox
+		{
+			protected override void OnAdjustSizeRequest(Gtk.Orientation orientation, out int minimum_size, out int natural_size)
+			{
+				base.OnAdjustSizeRequest(orientation, out minimum_size, out natural_size);
+				// Gtk.Fixed only uses minimum size, not natural size. ugh.
+				minimum_size = natural_size;
+			}
+		}
+#endif
+
 		public void Add(Control child, int x, int y)
 		{
 			var ctl = child.GetGtkControlHandler();
 
+#if GTK3
 			var widget = ctl.ContainerControl;
 			if (widget.Parent != null)
 				((Gtk.Container)widget.Parent).Remove(widget);
+			widget.ShowAll();
+			widget = new EtoVBox { Child = widget };
+#else
+			var widget = ctl.ContainerControl;
+			if (widget.Parent != null)
+				((Gtk.Container)widget.Parent).Remove(widget);
+			widget.ShowAll();
+#endif
 			Control.Put(widget, x, y);
 			ctl.CurrentLocation = new Point(x, y);
-			widget.ShowAll();
 		}
 
 		public void Move(Control child, int x, int y)
@@ -28,7 +49,12 @@ namespace Eto.GtkSharp.Forms
 			var ctl = child.GetGtkControlHandler();
 			if (ctl.CurrentLocation.X != x || ctl.CurrentLocation.Y != y)
 			{
-				Control.Move(ctl.ContainerControl, x, y);
+#if GTK3
+				var widget = ctl.ContainerControl.Parent;
+#else
+				var widget = ctl.ContainerControl;
+#endif
+				Control.Move(widget, x, y);
 
 				ctl.CurrentLocation = new Point(x, y);
 			}
@@ -36,12 +62,20 @@ namespace Eto.GtkSharp.Forms
 
 		public void Remove(Control child)
 		{
+#if GTK3
+			Control.Remove(child.GetContainerWidget().Parent);
+#else
 			Control.Remove(child.GetContainerWidget());
+#endif
 		}
 
 		public void Update()
 		{
+#if GTK3
+			Control.QueueResize();
+#else
 			Control.ResizeChildren();
+#endif
 		}
 
 		public override void OnLoadComplete(System.EventArgs e)

--- a/src/Eto.Gtk/Forms/Printing/PrintDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/Printing/PrintDialogHandler.cs
@@ -62,6 +62,7 @@ namespace Eto.GtkSharp.Forms.Printing
 			Control.ShowAll ();
 			var response = (Gtk.ResponseType)Control.Run ();
 			Control.Hide ();
+			Control.Unrealize();
 
 			printSettingsHandler.Set(Control.PrintSettings, Control.PageSetup, customOptions.SelectionOnly.Active);
 			if (response == Gtk.ResponseType.Apply) {

--- a/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
@@ -4,28 +4,29 @@ namespace Eto.GtkSharp.Forms
 {
 	public class SelectFolderDialogHandler : WidgetHandler<Gtk.FileChooserDialog, SelectFolderDialog>, SelectFolderDialog.IHandler
 	{
-		public SelectFolderDialogHandler ()
+		public SelectFolderDialogHandler()
 		{
 			Control = new Gtk.FileChooserDialog(string.Empty, null, Gtk.FileChooserAction.SelectFolder);
 			Control.SetCurrentFolder(System.IO.Directory.GetCurrentDirectory());
-			
+
 			Control.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
 			Control.AddButton(Gtk.Stock.Open, Gtk.ResponseType.Ok);
 			Control.DefaultResponse = Gtk.ResponseType.Ok;
 		}
-	
 
-		public DialogResult ShowDialog (Window parent)
+
+		public DialogResult ShowDialog(Window parent)
 		{
 			if (parent != null) Control.TransientFor = (Gtk.Window)parent.ControlObject;
 
 			int result = Control.Run();
-			
-			Control.Hide ();
 
-			DialogResult response = ((Gtk.ResponseType)result).ToEto ();
+			Control.Hide();
+			Control.Unrealize();
+
+			DialogResult response = ((Gtk.ResponseType)result).ToEto();
 			if (response == DialogResult.Ok) System.IO.Directory.SetCurrentDirectory(Control.CurrentFolder);
-			
+
 			return response;
 		}
 

--- a/src/Eto.Gtk/Forms/TableLayoutHandler.gtk2.cs
+++ b/src/Eto.Gtk/Forms/TableLayoutHandler.gtk2.cs
@@ -1,3 +1,4 @@
+#if GTK2
 using System;
 using Eto.Forms;
 using Eto.Drawing;
@@ -40,15 +41,13 @@ namespace Eto.GtkSharp.Forms
 
 		public Padding Padding
 		{
-			get
-			{
-				uint top, bottom, left, right;
-				align.GetPadding(out top, out bottom, out left, out right);
-				return new Padding((int)left, (int)top, (int)right, (int)bottom);
-			}
+			get => new Padding((int)align.LeftPadding, (int)align.TopPadding, (int)align.RightPadding, (int)align.BottomPadding);
 			set
 			{
-				align.SetPadding((uint)value.Top, (uint)value.Bottom, (uint)value.Left, (uint)value.Right);
+				align.LeftPadding = (uint)value.Left;
+				align.RightPadding = (uint)value.Right;
+				align.TopPadding = (uint)value.Top;
+				align.BottomPadding = (uint)value.Bottom;
 			}
 		}
 
@@ -92,7 +91,8 @@ namespace Eto.GtkSharp.Forms
 			lastColumnScale = cols - 1;
 			rowScale = new bool[rows];
 			lastRowScale = rows - 1;
-			Control.Resize((uint)Math.Max(1, rows), (uint)Math.Max(1, cols));
+			Control.NRows = (uint)Math.Max(1, rows);
+			Control.NColumns = (uint)Math.Max(1, cols);
 			controls = new Control[rows, cols];
 			blank = new Gtk.Widget[rows, cols];
 			align.Add(Control);
@@ -161,13 +161,6 @@ namespace Eto.GtkSharp.Forms
 				var widget = child.GetContainerWidget();
 				if (widget.Parent != null)
 					((Gtk.Container)widget.Parent).Remove(widget);
-#if GTK3
-				// fix an odd problem in GTK 3.20 where a drop down would set vertical scaling of a row
-				// even though it is not set to do so (Tested on Ubuntu 16.10)
-				// TODO: we should probably create a new TableLayoutHandler using Gtk.Grid instead
-				widget.Vexpand = false;
-				widget.Hexpand = false;
-#endif
 				Control.Attach(widget, (uint)x, (uint)x + 1, (uint)y, (uint)y + 1, GetColumnOptions(x), GetRowOptions(y), 0, 0);
 				widget.ShowAll();
 				return true;
@@ -247,3 +240,4 @@ namespace Eto.GtkSharp.Forms
 		}
 	}
 }
+#endif

--- a/src/Eto.Gtk/Forms/TableLayoutHandler.gtk3.cs
+++ b/src/Eto.Gtk/Forms/TableLayoutHandler.gtk3.cs
@@ -1,0 +1,232 @@
+#if GTK3
+using System;
+using Eto.Forms;
+using Eto.Drawing;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Eto.GtkSharp.Forms
+{
+	public class TableLayoutHandler : GtkContainer<Gtk.Grid, TableLayout, TableLayout.ICallback>, TableLayout.IHandler
+	{
+		Gtk.Alignment align;
+		Gtk.EventBox box;
+		bool[] columnScale;
+		int lastColumnScale;
+		bool[] rowScale;
+		int lastRowScale;
+		Control[,] controls;
+		Gtk.Widget[,] blank;
+
+		public override Gtk.Widget ContainerControl => box;
+
+		public override Gtk.Widget EventControl => ContainerControl;
+
+		public Size Spacing
+		{
+			get { return new Size((int)Control.ColumnSpacing, (int)Control.RowSpacing); }
+			set
+			{
+				Control.ColumnSpacing = (uint)value.Width;
+				Control.RowSpacing = (uint)value.Height;
+			}
+		}
+
+		public Padding Padding
+		{
+			get => new Padding((int)align.LeftPadding, (int)align.TopPadding, (int)align.RightPadding, (int)align.BottomPadding);
+			set
+			{
+				align.LeftPadding = (uint)value.Left;
+				align.RightPadding = (uint)value.Right;
+				align.TopPadding = (uint)value.Top;
+				align.BottomPadding = (uint)value.Bottom;
+			}
+		}
+
+		public void Add(Control child, int x, int y)
+		{
+			Attach(child, x, y);
+			if (child != null)
+			{
+				var widget = child.GetContainerWidget();
+				widget.ShowAll();
+			}
+		}
+
+		public void Move(Control child, int x, int y)
+		{
+			Attach(child, x, y);
+		}
+
+		public TableLayoutHandler()
+		{
+			align = new Gtk.Alignment(0, 0, 1.0F, 1.0F);
+			align.Hexpand = false;
+			align.Vexpand = false;
+			box = new Gtk.EventBox { Child = align };
+			Control = new Gtk.Grid();
+			align.Add(Control);
+		}
+
+		public void CreateControl(int cols, int rows)
+		{
+			columnScale = new bool[cols];
+			lastColumnScale = cols - 1;
+			rowScale = new bool[rows];
+			lastRowScale = rows - 1;
+			controls = new Control[rows, cols];
+			blank = new Gtk.Widget[rows, cols];
+		}
+
+		public void SetColumnScale(int column, bool scale)
+		{
+			columnScale[column] = scale;
+			var lastScale = lastColumnScale;
+			lastColumnScale = columnScale.Any(r => r) ? -1 : columnScale.Length - 1;
+			SetExpandColumn(column);
+			if (lastScale != lastColumnScale && column != columnScale.Length - 1)
+			{
+				SetExpandColumn(columnScale.Length - 1);
+			}
+		}
+
+		public bool GetColumnScale(int column) => columnScale[column];
+
+		void SetExpandColumn(int column)
+		{
+			for (int y = 0; y < controls.GetLength(0); y++)
+			{
+				SetExpand(Control.GetChildAt(column, y), column, y);
+			}
+		}
+
+		void SetExpandRow(int row)
+		{
+			for (int x = 0; x < controls.GetLength(1); x++)
+			{
+				SetExpand(Control.GetChildAt(x, row), x, row);
+			}
+		}
+
+		bool Attach(Control child, int x, int y)
+		{
+			var old = controls[y, x];
+			if (old != null && !object.ReferenceEquals(old, child))
+			{
+				var widget = old.GetContainerWidget();
+				if (widget.Parent != null)
+					Control.Remove(widget);
+			}
+
+			if (child != null)
+			{
+				var blankWidget = blank[y, x];
+				if (blankWidget != null)
+				{
+					if (blankWidget.Parent != null)
+						Control.Remove(blankWidget);
+					blank[y, x] = null;
+				}
+
+				controls[y, x] = child;
+				var widget = child.GetContainerWidget();
+				if (widget.Parent != null)
+					((Gtk.Container)widget.Parent).Remove(widget);
+
+				SetExpand(widget, x, y);
+				Control.Attach(widget, x, y, 1, 1);
+				widget.ShowAll();
+				return true;
+			}
+			else
+			{
+				controls[y, x] = null;
+				var blankWidget = blank[y, x];
+				if (blankWidget == null)
+					blankWidget = blank[y, x] = new Gtk.VBox();
+				else if (blankWidget.Parent != null)
+					Control.Remove(blankWidget);
+				SetExpand(blankWidget, x, y);
+				Control.Attach(blankWidget, x, y, 1, 1);
+			}
+			return false;
+		}
+
+		public void Remove(Control child)
+		{
+			for (int y = 0; y < controls.GetLength(0); y++)
+			{
+				for (int x = 0; x < controls.GetLength(1); x++)
+				{
+					if (ReferenceEquals(controls[y, x], child))
+					{
+						controls[y, x] = null;
+						var widget = child.GetContainerWidget();
+						Control.Remove(widget);
+
+						var blankWidget = blank[y, x] = new Gtk.VBox();
+						SetExpand(blankWidget, x, y);
+						Control.Attach(blankWidget, x, y, 1, 1);
+						return;
+					}
+				}
+			}
+		}
+
+		void SetExpand(Gtk.Widget widget, int x, int y)
+		{
+			if (widget == null)
+			{
+				var blankWidget = blank[y, x];
+				if (blankWidget == null)
+				{
+					blankWidget = blank[y, x] = new Gtk.VBox();
+					Control.Attach(blankWidget, x, y, 1, 1);
+				}
+				else if (blankWidget.Parent != null)
+					Control.Remove(blankWidget);
+				widget = blankWidget;
+			}
+			widget.Hexpand = columnScale[x] || x == lastColumnScale;
+			widget.Vexpand = rowScale[y] || y == lastRowScale;
+		}
+
+		public void SetRowScale(int row, bool scale)
+		{
+			rowScale[row] = scale;
+			var lastScale = lastRowScale;
+			lastRowScale = rowScale.Any(r => r) ? -1 : rowScale.Length - 1;
+			SetExpandRow(row);
+			if (lastScale != lastRowScale && row != rowScale.Length - 1)
+			{
+				SetExpandRow(rowScale.Length - 1);
+			}
+		}
+
+		public bool GetRowScale(int row) => rowScale[row];
+
+		public void Update() => Control.QueueResize();
+
+		public override void OnLoadComplete(System.EventArgs e)
+		{
+			base.OnLoadComplete(e);
+			SetFocusChain();
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Eto.Forms.Control.ShownEvent:
+					Control.Mapped += Connector.MappedEvent;
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+	}
+}
+
+#endif

--- a/src/Eto.Gtk/Gtk3Compatibility.cs
+++ b/src/Eto.Gtk/Gtk3Compatibility.cs
@@ -216,6 +216,14 @@ namespace Eto.GtkSharp
 		}
 
 		public static Gdk.Atom GetDataType(this Gtk.SelectionData data) => data.DataType;
+
+#if !GTKCORE
+		public static Gtk.Widget GetChildAt(this Gtk.Grid grid, int left, int top)
+		{
+			var ptr = NativeMethods.gtk_grid_get_child_at(grid.Handle, left, top);
+			return GLib.Object.GetObject(ptr) as Gtk.Widget;
+		}
+#endif
 #endif
 
 	}

--- a/src/Eto.Gtk/NativeMethods.cs
+++ b/src/Eto.Gtk/NativeMethods.cs
@@ -163,6 +163,9 @@ namespace Eto.GtkSharp
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed);
 
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
 		}
@@ -315,6 +318,9 @@ namespace Eto.GtkSharp
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed);
 
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
 		}
@@ -466,6 +472,9 @@ namespace Eto.GtkSharp
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed);
+
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
@@ -723,6 +732,16 @@ namespace Eto.GtkSharp
 				NMMac.gtk_print_unix_dialog_set_embed_page_setup(raw, embed);
 			else
 				NMWindows.gtk_print_unix_dialog_set_embed_page_setup(raw, embed);
+		}
+
+		public static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top)
+		{
+			if (EtoEnvironment.Platform.IsLinux)
+				return NMLinux.gtk_grid_get_child_at(raw, left, top);
+			else if (EtoEnvironment.Platform.IsMac)
+				return NMMac.gtk_grid_get_child_at(raw, left, top);
+			else
+				return NMWindows.gtk_grid_get_child_at(raw, left, top);
 		}
 
 		public static IntPtr webkit_web_view_new()

--- a/src/Eto.Gtk/NativeMethods.tt
+++ b/src/Eto.Gtk/NativeMethods.tt
@@ -64,7 +64,8 @@ var gtkmethods = new[]
     "IntPtr gtk_selection_data_get_uris(IntPtr raw)",
     "bool gtk_selection_data_set_uris(IntPtr raw, IntPtr[] uris)",
     "bool gtk_print_unix_dialog_get_embed_page_setup(IntPtr raw)",
-    "void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed)"
+    "void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed)",
+    "IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top)"
 };
 
 var gdkmethods = new[]

--- a/src/Eto.Gtk/Platform.cs
+++ b/src/Eto.Gtk/Platform.cs
@@ -70,6 +70,21 @@ namespace Eto.GtkSharp
 			AddTo(this);
 		}
 
+#if GTK3
+		static Platform()
+		{
+			Style.Add<ThemedStepperHandler>(null, h =>
+			{
+				h.Orientation = Orientation.Horizontal;
+				h.Widget.Size = new Size(50, 30);
+				if (h.Control.Content.Handler is TableLayoutHandler table)
+				{
+					table.Control.StyleContext.AddClass("linked");
+				}
+			});
+		}
+#endif
+
 		public static void AddTo(Eto.Platform p)
 		{
 			// Drawing

--- a/test/Eto.Test/SectionList.cs
+++ b/test/Eto.Test/SectionList.cs
@@ -173,7 +173,7 @@ namespace Eto.Test
 			get
 			{
 				var sectionTreeItem = treeView.SelectedItem as SectionTreeItem;
-				return sectionTreeItem.Section as ISection;
+				return sectionTreeItem?.Section as ISection;
 			}
 		}
 

--- a/test/Eto.Test/Sections/Dialogs/FontDialogSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/FontDialogSection.cs
@@ -181,7 +181,13 @@ namespace Eto.Test.Sections.Dialogs
 				if (updating || fontList.SelectedKey == null)
 					return;
 				var family = lookup[fontList.SelectedKey];
-				UpdatePreview(new Font(family.Typefaces.First(), selectedFont.Size, selectedFont.FontDecoration));
+				var typeface = family.Typefaces.FirstOrDefault();
+				Font font;
+				if (typeface == null)
+					font = new Font(family, selectedFont.Size, FontStyle.None, selectedFont.FontDecoration);
+				else
+					font = new Font(family.Typefaces.FirstOrDefault(), selectedFont.Size, selectedFont.FontDecoration);
+				UpdatePreview(font);
 			};
 
 			return fontList;

--- a/test/Eto.Test/Sections/Printing/PrintDialogSection.cs
+++ b/test/Eto.Test/Sections/Printing/PrintDialogSection.cs
@@ -5,7 +5,7 @@ using Eto.Drawing;
 namespace Eto.Test.Sections.Printing
 {
 	[Section("Printing", "Print Dialog")]
-	public class PrintDialogSection : Panel
+	public class PrintDialogSection : Scrollable
 	{
 		PrintSettings settings = new PrintSettings();
 		NumericStepper selectedEnd;


### PR DESCRIPTION
This fixes a few problems with Gtk3/Gtk platforms:
- TableLayout is now based on Gtk.Grid instead of obsolete Gtk.Table.
- Stepper looks better and is horizontal like the NumericStepper.
- Fix rendering of DateTimePicker to make it look much better on Gtk+3.
- On macOS, the default system font is not available so be more resilient in that case
- Label now uses much fewer hacks to use proper sizing in gtk+3 thanks to using Gtk.Grid, and now shows with the correct size immediately instead of after the next run loop.
- Application will now close after a secondary window or dialog is shown and then closed, a bug introduced by #1233