### PR TITLE
New SegmentedButton and ToggleButton

### DIFF
--- a/src/Eto.Gtk/Eto.Gtk.csproj
+++ b/src/Eto.Gtk/Eto.Gtk.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
+    <RootNamespace>Eto.GtkSharp</RootNamespace>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>TRACE;PCL;GTK3;DEBUG;NETSTANDARD2_0;GTKCORE</DefineConstants>

--- a/src/Eto.Gtk/Eto.Gtk2.csproj
+++ b/src/Eto.Gtk/Eto.Gtk2.csproj
@@ -287,6 +287,7 @@
     <Compile Include="Forms\TableLayoutHandler.gtk2.cs" />
     <Compile Include="CustomControls\BaseComboBox.gtk2.cs" />
     <Compile Include="CustomControls\BaseComboBox.gtk3.cs" />
+    <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/src/Eto.Gtk/Eto.Gtk3.csproj
+++ b/src/Eto.Gtk/Eto.Gtk3.csproj
@@ -285,6 +285,7 @@
     <Compile Include="Forms\TableLayoutHandler.gtk3.cs" />
     <Compile Include="CustomControls\BaseComboBox.gtk2.cs" />
     <Compile Include="CustomControls\BaseComboBox.gtk3.cs" />
+    <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Eto.Gtk/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ButtonHandler.cs
@@ -4,43 +4,59 @@ using Eto.Drawing;
 
 namespace Eto.GtkSharp.Forms.Controls
 {
+	public class ButtonHandler : ButtonHandler<Gtk.Button, Button, Button.ICallback>
+	{
+		public static int MinimumWidth = 80;
+
+		public class EtoButton : Gtk.Button
+		{
+			WeakReference _reference;
+			public ButtonHandler Handler
+			{
+				get => _reference?.Target as ButtonHandler;
+				set => _reference = new WeakReference(value);
+			}
+#if GTK3
+			protected override void OnAdjustSizeRequest(Gtk.Orientation orientation, out int minimum_size, out int natural_size)
+			{
+				base.OnAdjustSizeRequest(orientation, out minimum_size, out natural_size);
+				var h = Handler;
+				if (h == null)
+					return;
+				h.MinimumSize.AdjustMinimumSizeRequest(orientation, ref minimum_size, ref natural_size);
+			}
+#endif
+		}
+
+		protected override int DefaultMinimumWidth => MinimumWidth;
+
+		internal static readonly object Image_Key = new object();
+		internal static readonly object ImagePosition_Key = new object();
+		internal static readonly object MinimumSize_Key = new object();
+
+		protected override Gtk.Button CreateControl() => new EtoButton { Handler = this };
+	}
+
 	/// <summary>
 	/// Button handler.
 	/// </summary>
-	/// <copyright>(c) 2012-2013 by Curtis Wensley</copyright>
+	/// <copyright>(c) 2012-2019 by Curtis Wensley</copyright>
 	/// <license type="BSD-3">See LICENSE for full terms</license>
-	public class ButtonHandler : GtkControl<Gtk.Button, Button, Button.ICallback>, Button.IHandler
+	public class ButtonHandler<TControl, TWidget, TCallback> : GtkControl<TControl, TWidget, TCallback>, Button.IHandler
+		where TControl : Gtk.Button
+		where TWidget : Button
+		where TCallback : Button.ICallback
 	{
 		readonly Gtk.AccelLabel label;
 		readonly Gtk.Image gtkimage;
 		readonly Gtk.Table table;
 
-		public static int MinimumWidth = 80;
+		protected override Gtk.Widget FontControl => label;
 
-		protected override Gtk.Widget FontControl
-		{
-			get { return label; }
-		}
-
-		public class EtoButton : Gtk.Button
-		{
-			public ButtonHandler Handler { get; set; }
-
-#if GTK3
-			protected override void OnAdjustSizeRequest(Gtk.Orientation orientation, out int minimum_size, out int natural_size)
-			{
-				base.OnAdjustSizeRequest(orientation, out minimum_size, out natural_size);
-				var minSize = Handler.MinimumSize;
-
-				//minimum_size = orientation == Gtk.Orientation.Horizontal ? minSize.Width : minSize.Height;
-				//natural_size = Math.Max(natural_size, minimum_size);
-			}
-#endif
-		}
+		protected virtual int DefaultMinimumWidth => 0;
 
 		public ButtonHandler()
 		{
-			Control = new EtoButton { Handler = this };
 			// need separate widgets as the theme can (and usually) disables images on buttons
 			// gtk3 can override the theme per button, but gtk2 cannot
 			table = new Gtk.Table(3, 3, false);
@@ -51,37 +67,35 @@ namespace Eto.GtkSharp.Forms.Controls
 			table.Attach(label, 1, 2, 1, 2, Gtk.AttachOptions.Expand, Gtk.AttachOptions.Expand, 0, 0);
 			gtkimage = new Gtk.Image();
 			gtkimage.NoShowAll = true;
-			Control.Child = table;
 		}
 
 		protected override void Initialize()
 		{
 			base.Initialize();
+			Control.Child = table;
 			Control.Clicked += Connector.HandleClicked;
 #if GTK2
 			Control.SizeAllocated += Connector.HandleButtonSizeAllocated;
 			Control.SizeRequested += Connector.HandleButtonSizeRequested;
-#else
-			Control.WidthRequest = MinimumWidth;
 #endif
 
 			SetImagePosition(false);
 		}
 
-		protected new ButtonConnector Connector { get { return (ButtonConnector)base.Connector; } }
+		protected new ButtonConnector Connector => (ButtonConnector)base.Connector;
 
-		protected override WeakConnector CreateConnector()
-		{
-			return new ButtonConnector();
-		}
+		protected override WeakConnector CreateConnector() => new ButtonConnector();
 
 		protected class ButtonConnector : GtkControlConnector
 		{
-			public new ButtonHandler Handler { get { return (ButtonHandler)base.Handler; } }
+			new ButtonHandler<TControl, TWidget, TCallback> Handler => (ButtonHandler<TControl, TWidget, TCallback>)base.Handler;
 
-			public void HandleClicked(object sender, EventArgs e)
+			public virtual void HandleClicked(object sender, EventArgs e)
 			{
-				Handler.Callback.OnClick(Handler.Widget, EventArgs.Empty);
+				var h = Handler;
+				if (h == null)
+					return;
+				h.Callback.OnClick(h.Widget, EventArgs.Empty);
 			}
 
 #if GTK2
@@ -134,21 +148,20 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
-		static readonly object Image_Key = new object();
-
 		public Image Image
 		{
-			get { return Widget.Properties.Get<Image>(Image_Key); }
+			get { return Widget.Properties.Get<Image>(ButtonHandler.Image_Key); }
 			set
 			{
-				Widget.Properties.Set(Image_Key, value, () =>
+				if (Widget.Properties.TrySet(ButtonHandler.Image_Key, value))
 				{
 					Image.SetGtkImage(gtkimage);
 					if (value == null)
 						gtkimage.Hide();
 					else
 						gtkimage.Show();
-				});
+					Control.QueueResize();
+				};
 			}
 		}
 
@@ -216,15 +229,17 @@ namespace Eto.GtkSharp.Forms.Controls
 			if (removeImage)
 				table.Remove(gtkimage);
 			table.Attach(gtkimage, left, right, top, bottom, options, options, 0, 0);
-
+			Control.QueueResize();
 		}
-
-		static readonly object ImagePosition_Key = new object();
 
 		public ButtonImagePosition ImagePosition
 		{
-			get { return Widget.Properties.Get<ButtonImagePosition>(ImagePosition_Key); }
-			set { Widget.Properties.Set(ImagePosition_Key, value, () => SetImagePosition()); }
+			get { return Widget.Properties.Get<ButtonImagePosition>(ButtonHandler.ImagePosition_Key); }
+			set
+			{
+				if (Widget.Properties.TrySet(ButtonHandler.ImagePosition_Key, value))
+					SetImagePosition();
+			}
 		}
 
 		public Color TextColor
@@ -233,21 +248,15 @@ namespace Eto.GtkSharp.Forms.Controls
 			set { label.SetForeground(value); }
 		}
 
-		static readonly object MinimumSize_Key = new object();
-
 		public Size MinimumSize
 		{
-			get { return Widget.Properties.Get(MinimumSize_Key, () => new Size(MinimumWidth, 0)); }
+			get { return Widget.Properties.Get<Size?>(ButtonHandler.MinimumSize_Key) ?? new Size(DefaultMinimumWidth, 0); }
 			set
 			{
 				if (MinimumSize != value)
 				{
-					Widget.Properties[MinimumSize_Key] = value;
-#if GTK3
-					SetSize();
-#else
-					ContainerControl.QueueResize();
-#endif
+					Widget.Properties[ButtonHandler.MinimumSize_Key] = value;
+					Control.QueueResize(); 
 				}
 			}
 		}

--- a/src/Eto.Gtk/Forms/Controls/ToggleButtonHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ToggleButtonHandler.cs
@@ -1,0 +1,76 @@
+using System;
+using Eto.Forms;
+
+namespace Eto.GtkSharp.Forms.Controls
+{
+	public class ToggleButtonHandler : ButtonHandler<Gtk.ToggleButton, ToggleButton, ToggleButton.ICallback>, ToggleButton.IHandler
+	{
+		int suppressClick;
+
+		public class EtoToggleButton : Gtk.ToggleButton
+		{
+			WeakReference _reference;
+			public ToggleButtonHandler Handler
+			{
+				get => _reference?.Target as ToggleButtonHandler;
+				set => _reference = new WeakReference(value);
+			}
+#if GTK3
+			protected override void OnAdjustSizeRequest(Gtk.Orientation orientation, out int minimum_size, out int natural_size)
+			{
+				base.OnAdjustSizeRequest(orientation, out minimum_size, out natural_size);
+				var h = Handler;
+				if (h == null)
+					return;
+				h.MinimumSize.AdjustMinimumSizeRequest(orientation, ref minimum_size, ref natural_size);
+			}
+#endif
+		}
+
+		protected override Gtk.ToggleButton CreateControl() => new EtoToggleButton { Handler = this };
+
+		public bool Checked
+		{
+			get => Control.Active;
+			set
+			{
+				suppressClick++;
+				Control.Active = value;
+				suppressClick--;
+			}
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case ToggleButton.CheckedChangedEvent:
+					// handled by button click
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		protected new ToggleButtonConnector Connector => (ToggleButtonConnector)base.Connector;
+
+		protected override WeakConnector CreateConnector() => new ToggleButtonConnector();
+
+		protected class ToggleButtonConnector : ButtonConnector
+		{
+			new ToggleButtonHandler Handler => (ToggleButtonHandler)base.Handler;
+
+			public override void HandleClicked(object sender, EventArgs e)
+			{
+				var h = Handler;
+				if (h == null)
+					return;
+				h.Callback.OnCheckedChanged(h.Widget, EventArgs.Empty);
+
+				if (h.suppressClick == 0)
+					base.HandleClicked(sender, e);
+			}
+		}
+	}
+}

--- a/src/Eto.Gtk/Forms/GtkContainer.cs
+++ b/src/Eto.Gtk/Forms/GtkContainer.cs
@@ -34,6 +34,8 @@ namespace Eto.GtkSharp.Forms
 		IEnumerable<Gtk.Widget> GetOrderedWidgets()
 		{
 			var parent = Widget.IsVisualControl ? Widget.LogicalParent : Widget;
+			if (parent == null)
+				yield break;
 			foreach (var ctl in parent.Controls.OrderBy(r => r.TabIndex))
 			{
 				var widget = ctl.GetContainerWidget();

--- a/src/Eto.Gtk/Gtk3Compatibility.cs
+++ b/src/Eto.Gtk/Gtk3Compatibility.cs
@@ -44,6 +44,16 @@ namespace Eto.GtkSharp
 
 		public static Gdk.Window GetWindow(this Gtk.Widget widget)
 		{
+			if (widget is Gtk.Button b)
+			{
+				var eventWindowPtr = NativeMethods.gtk_button_get_event_window(b.Handle);
+				if (eventWindowPtr != IntPtr.Zero)
+				{
+					var window = GLib.Object.GetObject(eventWindowPtr) as Gdk.Window;
+					if (window != null)
+						return window;
+				}
+			}
 			return widget.GdkWindow;
 		}
 
@@ -134,7 +144,8 @@ namespace Eto.GtkSharp
 
 		public static Gdk.Window GetWindow(this Gtk.Widget widget)
 		{
-			return widget.Window;
+			var window = (widget as Gtk.Button)?.EventWindow;
+			return window ?? widget.Window;
 		}
 
 		public static Gtk.Requisition GetPreferredSize(this Gtk.Widget widget)

--- a/src/Eto.Gtk/GtkConversions.cs
+++ b/src/Eto.Gtk/GtkConversions.cs
@@ -817,5 +817,14 @@ namespace Eto.GtkSharp
 			IntPtr ptr = NativeMethods.gtk_selection_data_get_uris(data.Handle);
 			return GLib.Marshaller.NullTermPtrToStringArray(ptr, true);
 		}
+
+#if GTK3
+		public static void AdjustMinimumSizeRequest(this Size minimumSize, Gtk.Orientation orientation, ref int minimum_size, ref int natural_size)
+		{
+			var min = orientation == Gtk.Orientation.Horizontal ? minimumSize.Width : minimumSize.Height;
+			minimum_size = Math.Max(minimum_size, min);
+			natural_size = Math.Max(natural_size, min);
+		}
+#endif
 	}
 }

--- a/src/Eto.Gtk/GtkExtensions.cs
+++ b/src/Eto.Gtk/GtkExtensions.cs
@@ -1,0 +1,32 @@
+using System;
+using Eto.Drawing;
+
+namespace Eto.GtkSharp
+{
+	static class GtkExtensions
+	{
+		public static void RemoveAllChildren(this Gtk.Container widget)
+		{
+			foreach (Gtk.Widget w in widget.Children)
+			{
+				widget.Remove(w);
+			}
+		}
+
+		public static Point GetScreenPosition(this Gtk.Widget widget)
+		{
+			var parent = widget.ParentWindow;
+			widget.GetWindow().GetOrigin(out var x, out var y);
+
+			if (parent != null)
+			{
+				parent.GetOrigin(out var wx, out var wy);
+				var extents = parent.FrameExtents;
+				//x += (wx + extents.X) / parent.ScaleFactor;
+				//y += (wy + extents.Y) / parent.ScaleFactor;
+			}
+
+			return new Point(x, y);
+		}
+	}
+}

--- a/src/Eto.Gtk/NativeMethods.cs
+++ b/src/Eto.Gtk/NativeMethods.cs
@@ -166,6 +166,9 @@ namespace Eto.GtkSharp
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
 
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gtk_button_get_event_window(IntPtr button);
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
 		}
@@ -321,6 +324,9 @@ namespace Eto.GtkSharp
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
 
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gtk_button_get_event_window(IntPtr button);
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
 		}
@@ -475,6 +481,9 @@ namespace Eto.GtkSharp
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
+
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gtk_button_get_event_window(IntPtr button);
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
@@ -742,6 +751,16 @@ namespace Eto.GtkSharp
 				return NMMac.gtk_grid_get_child_at(raw, left, top);
 			else
 				return NMWindows.gtk_grid_get_child_at(raw, left, top);
+		}
+
+		public static IntPtr gtk_button_get_event_window(IntPtr button)
+		{
+			if (EtoEnvironment.Platform.IsLinux)
+				return NMLinux.gtk_button_get_event_window(button);
+			else if (EtoEnvironment.Platform.IsMac)
+				return NMMac.gtk_button_get_event_window(button);
+			else
+				return NMWindows.gtk_button_get_event_window(button);
 		}
 
 		public static IntPtr webkit_web_view_new()

--- a/src/Eto.Gtk/NativeMethods.tt
+++ b/src/Eto.Gtk/NativeMethods.tt
@@ -65,7 +65,8 @@ var gtkmethods = new[]
     "bool gtk_selection_data_set_uris(IntPtr raw, IntPtr[] uris)",
     "bool gtk_print_unix_dialog_get_embed_page_setup(IntPtr raw)",
     "void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed)",
-    "IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top)"
+    "IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top)",
+    "IntPtr gtk_button_get_event_window(IntPtr button)"
 };
 
 var gdkmethods = new[]

--- a/src/Eto.Gtk/Platform.cs
+++ b/src/Eto.Gtk/Platform.cs
@@ -12,6 +12,7 @@ using Eto.Forms.ThemedControls;
 using Eto.GtkSharp.Forms.Menu;
 using Eto.GtkSharp.Forms.ToolBar;
 using Eto.Shared.Forms;
+using System.Linq;
 
 namespace Eto.GtkSharp
 {
@@ -81,6 +82,16 @@ namespace Eto.GtkSharp
 				{
 					table.Control.StyleContext.AddClass("linked");
 				}
+			});
+
+			Style.Add<ThemedSegmentedButtonHandler>(null, h =>
+			{
+				// show segmented buttons linked together
+				h.Control.Styles.Add<TableLayout>("buttons", table =>
+				{
+					var tableHandler = table.Handler as TableLayoutHandler;
+					tableHandler?.Control.StyleContext.AddClass("linked");
+				});
 			});
 		}
 #endif
@@ -157,6 +168,10 @@ namespace Eto.GtkSharp
 			p.Add<RichTextArea.IHandler>(() => new RichTextAreaHandler());
 			p.Add<Stepper.IHandler>(() => new ThemedStepperHandler());
 			p.Add<TextStepper.IHandler>(() => new TextStepperHandler());
+			p.Add<ButtonSegmentedItem.IHandler>(() => new ThemedButtonSegmentedItemHandler());
+			p.Add<MenuSegmentedItem.IHandler>(() => new ThemedMenuSegmentedItemHandler());
+			p.Add<SegmentedButton.IHandler>(() => new ThemedSegmentedButtonHandler());
+			p.Add<ToggleButton.IHandler>(() => new ToggleButtonHandler());
 
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/src/Eto.Mac/Eto.Mac.csproj
+++ b/src/Eto.Mac/Eto.Mac.csproj
@@ -229,6 +229,8 @@
     <Compile Include="Drawing\EtoFontManager.cs" />
     <Compile Include="MacVersion.cs" />
     <Compile Include="Forms\MemoryDataObjectHandler.cs" />
+    <Compile Include="Forms\Controls\SegmentedButtonHandler.cs" />
+    <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Eto.Mac/Eto.Mac64.csproj
+++ b/src/Eto.Mac/Eto.Mac64.csproj
@@ -229,6 +229,8 @@
     <Compile Include="Drawing\EtoFontManager.cs" />
     <Compile Include="MacVersion.cs" />
     <Compile Include="Forms\MemoryDataObjectHandler.cs" />
+    <Compile Include="Forms\Controls\SegmentedButtonHandler.cs" />
+    <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Eto.Mac/Eto.XamMac.csproj
+++ b/src/Eto.Mac/Eto.XamMac.csproj
@@ -247,6 +247,8 @@
     <Compile Include="Drawing\EtoFontManager.cs" />
     <Compile Include="MacVersion.cs" />
     <Compile Include="Forms\MemoryDataObjectHandler.cs" />
+    <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
+    <Compile Include="Forms\Controls\SegmentedButtonHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/src/Eto.Mac/Eto.XamMac2-modern.csproj
+++ b/src/Eto.Mac/Eto.XamMac2-modern.csproj
@@ -241,6 +241,8 @@
     <Compile Include="Drawing\EtoFontManager.cs" />
     <Compile Include="MacVersion.cs" />
     <Compile Include="Forms\MemoryDataObjectHandler.cs" />
+    <Compile Include="Forms\Controls\SegmentedButtonHandler.cs" />
+    <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/src/Eto.Mac/Eto.XamMac2-net45.csproj
+++ b/src/Eto.Mac/Eto.XamMac2-net45.csproj
@@ -251,6 +251,8 @@
     <Compile Include="Drawing\EtoFontManager.cs" />
     <Compile Include="MacVersion.cs" />
     <Compile Include="Forms\MemoryDataObjectHandler.cs" />
+    <Compile Include="Forms\Controls\SegmentedButtonHandler.cs" />
+    <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/src/Eto.Mac/Forms/Controls/SegmentedButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SegmentedButtonHandler.cs
@@ -1,0 +1,474 @@
+using System;
+using Eto.Forms;
+using System.Collections.Generic;
+using Eto.Drawing;
+using System.Linq;
+
+#if XAMMAC2
+using AppKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using CoreAnimation;
+using CoreImage;
+#else
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+using MonoMac.CoreGraphics;
+using MonoMac.ObjCRuntime;
+using MonoMac.CoreAnimation;
+using MonoMac.CoreImage;
+#if Mac64
+using nfloat = System.Double;
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nfloat = System.Single;
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
+#endif
+
+namespace Eto.Mac.Forms.Controls
+{
+	interface ISegmentedItemHandler
+	{
+		void TriggerClick();
+	}
+
+	static class SegmentedItemHandler
+	{
+		internal static readonly object Text_Key = new object();
+		internal static readonly object Image_Key = new object();
+		internal static readonly object Width_Key = new object();
+		internal static readonly object Selected_Key = new object();
+		internal static readonly object Enabled_Key = new object();
+		internal static readonly object Visible_Key = new object();
+		internal static readonly object ToolTip_Key = new object();
+	}
+
+	public abstract class SegmentedItemHandler<TControl, TWidget, TCallback> : WidgetHandler<TControl, TWidget, TCallback>, SegmentedItem.IHandler, ISegmentedItemHandler
+		where TWidget: SegmentedItem
+		where TCallback: SegmentedItem.ICallback
+	{
+		SegmentedButtonHandler ParentHandler => Widget.Parent?.Handler as SegmentedButtonHandler;
+		NSSegmentedControl SegmentedControl => ParentHandler?.Control;
+		int CurrentSegment => Widget.Parent?.Items.IndexOf(Widget) ?? -1;
+
+		public string Text
+		{
+			get => Widget.Properties.Get<string>(SegmentedItemHandler.Text_Key);
+			set
+			{
+				if (Widget.Properties.TrySet(SegmentedItemHandler.Text_Key, value))
+				{
+					SegmentedControl?.SetLabel(value, CurrentSegment);
+				}
+			}
+		}
+		public Image Image
+		{
+			get => Widget.Properties.Get<Image>(SegmentedItemHandler.Image_Key);
+			set
+			{
+				if (Widget.Properties.TrySet(SegmentedItemHandler.Image_Key, value))
+				{
+					SegmentedControl?.SetImage(value.ToNS(), CurrentSegment);
+				}
+			}
+		}
+
+		public int Width
+		{
+			get => Widget.Properties.Get<int>(SegmentedItemHandler.Width_Key) ;
+			set
+			{
+				if (Widget.Properties.TrySet(SegmentedItemHandler.Width_Key, value))
+				{
+					SegmentedControl?.SetWidth(value, CurrentSegment);
+				}
+			}
+		}
+
+		public bool Selected
+		{
+			get => SegmentedControl?.IsSelectedForSegment(CurrentSegment) ?? Widget.Properties.Get<bool>(SegmentedItemHandler.Selected_Key);
+			set
+			{
+				if (value != Selected)
+				{
+					Widget.Properties.Set(SegmentedItemHandler.Selected_Key, value);
+					if (!value && ParentHandler?.SelectionMode == SegmentedSelectionMode.Single)
+						SegmentedControl.SelectedSegment = -1;
+					else
+						SegmentedControl?.SetSelected(value, CurrentSegment);
+					ParentHandler?.TriggerSelectionChanged(false);
+				}
+			}
+		}
+		public bool Enabled
+		{
+			get => Widget.Properties.Get<bool>(SegmentedItemHandler.Enabled_Key, true);
+			set
+			{
+				if (Widget.Properties.TrySet(SegmentedItemHandler.Enabled_Key, value, true))
+				{
+					SegmentedControl?.SetEnabled(value, CurrentSegment);
+				}
+			}
+		}
+		public bool Visible { get; set; } = true;
+		public string ToolTip
+		{
+			get => Widget.Properties.Get<string>(SegmentedItemHandler.ToolTip_Key);
+			set
+			{
+				if (Widget.Properties.TrySet(SegmentedItemHandler.ToolTip_Key, value))
+				{
+					SegmentedControl?.SetToolTip(value, CurrentSegment);
+				}
+			}
+		}
+
+		public void TriggerClick() => Callback.OnClick(Widget, EventArgs.Empty);
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case SegmentedItem.ClickEvent:
+					// handled intrinsically
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+	}
+
+	public class ButtonSegmentedItemHandler : SegmentedItemHandler<object, ButtonSegmentedItem, ButtonSegmentedItem.ICallback>, ButtonSegmentedItem.IHandler
+	{
+
+	}
+
+	public class MenuSegmentedItemHandler : SegmentedItemHandler<object, MenuSegmentedItem, MenuSegmentedItem.ICallback>, MenuSegmentedItem.IHandler
+	{
+		public ContextMenu Menu { get; set; }
+		public bool CanSelect { get; set; }
+	}
+
+
+	public class SegmentedButtonHandler : MacView<NSSegmentedControl, SegmentedButton, SegmentedButton.ICallback>, SegmentedButton.IHandler
+	{
+		int? lastSelected;
+
+		public class EtoSegmentedCell : NSSegmentedCell
+		{
+			public SegmentedButtonHandler Handler => (ControlView as EtoSegmentedControl)?.Handler;
+
+			static IntPtr selMenuDelayTimeForSegment = Selector.GetHandle("_menuDelayTimeForSegment:");
+
+			// private API, but only way to do this..
+			[Export("_menuDelayTimeForSegment:")]
+			nfloat MenuDelayTimeForSegment(nint segment)
+			{
+				if (ShowMenu(segment))
+					return 0;
+
+				return Messaging.nfloat_objc_msgSendSuper_nint(SuperHandle, selMenuDelayTimeForSegment, segment);
+			}
+
+			bool ShowMenu(nint segment)
+			{
+				if (segment < 0 || GetMenu(segment) == null)
+					return false;
+				var item = Handler?.Widget.Items[(int)segment] as MenuSegmentedItem;
+				return item?.CanSelect == false;
+			}
+
+		}
+
+		public class EtoSegmentedControl : NSSegmentedControl, IMacControl
+		{
+			public WeakReference WeakHandler { get; set; }
+
+			public SegmentedButtonHandler Handler => WeakHandler?.Target as SegmentedButtonHandler;
+
+			public EtoSegmentedControl()
+			{
+				Cell = new EtoSegmentedCell();
+				TrackingMode = NSSegmentSwitchTracking.Momentary;
+				Target = this;
+				Action = selClicked;
+			}
+
+			static readonly Selector selClicked = new Selector("clicked:");
+
+			[Export("clicked:")]
+			public void Clicked(NSObject sender) => Handler?.TriggerSegmentClicked();
+
+		}
+
+		private void TriggerSegmentClicked()
+		{
+			// using SelectedSegment as this is the segment that was clicked last.
+			var selected = (int)Control.SelectedSegment;
+			if (selected >= 0)
+			{
+				var item = Widget.Items[selected];
+				Callback.OnItemClicked(Widget, new SegmentedItemClickEventArgs(item, selected));
+				(item.Handler as ISegmentedItemHandler)?.TriggerClick();
+			}
+
+			TriggerSelectionChanged(false);
+		}
+
+		protected override NSSegmentedControl CreateControl() => new EtoSegmentedControl();
+
+		static readonly object SelectionMode_Key = new object();
+
+		public SegmentedSelectionMode SelectionMode
+		{
+			get => Widget.Properties.Get<SegmentedSelectionMode>(SelectionMode_Key);
+			set
+			{
+				if (Widget.Properties.TrySet(SelectionMode_Key, value))
+				{
+					bool selectionChanged = false;
+					switch (value)
+					{
+						case SegmentedSelectionMode.None:
+							selectionChanged = HasSelection;
+							Control.UnselectAllSegments();
+							Control.TrackingMode = NSSegmentSwitchTracking.Momentary;
+							break;
+						case SegmentedSelectionMode.Single:
+							var count = Control.SegmentCount;
+							bool wasSelected = false;
+							for (nint i = 0; i < count; i++)
+							{
+								if (wasSelected)
+								{
+									selectionChanged |= Control.IsSelectedForSegment(i);
+									Control.SetSelected(false, i);
+								}
+								else if (Control.IsSelectedForSegment(i))
+									wasSelected = true;
+							}
+							Control.TrackingMode = NSSegmentSwitchTracking.SelectOne;
+							break;
+						case SegmentedSelectionMode.Multiple:
+							Control.TrackingMode = NSSegmentSwitchTracking.SelectAny;
+							break;
+						default:
+							throw new NotSupportedException();
+					}
+					if (selectionChanged)
+						TriggerSelectionChanged(true);
+				}
+			}
+		}
+
+		public override NSView ContainerControl => Control;
+
+		public int SelectedIndex
+		{
+			get
+			{
+				// NSSegmentedControl.SelectedSegment returns the item that was last changed, but we want the currently selected segment.
+				for (int i = 0; i < Control.SegmentCount; i++)
+				{
+					if (Control.IsSelectedForSegment(i))
+						return i;
+				}
+				return -1;
+			}
+			set
+			{
+				if (value != SelectedIndex)
+				{
+					Control.SelectedSegment = value;
+					TriggerSelectionChanged(true);
+				}
+			}
+		}
+
+		public IEnumerable<int> SelectedIndexes
+		{
+			get
+			{
+				if (SelectionMode == SegmentedSelectionMode.None)
+					yield break;
+
+				for (int i = 0; i < Widget.Items.Count; i++)
+				{
+					if (Control.IsSelectedForSegment(i))
+						yield return i;
+				}
+			}
+			set
+			{
+				Control.UnselectAllSegments();
+				if (SelectionMode == SegmentedSelectionMode.None)
+					return;
+				if (value != null)
+				{
+					foreach (var index in value)
+					{
+						Control.SetSelected(true, index);
+					}
+				}
+				TriggerSelectionChanged(true);
+			}
+		}
+
+		nint IndexOf(SegmentedItem item)
+		{
+			if (item == null)
+				return -1;
+			return Widget.Items.IndexOf(item);
+		}
+
+		public void ClearItems()
+		{
+			var wasSelected = Widget.Items.Any(r => r.Selected);
+			Control.SegmentCount = 0;
+			if (wasSelected)
+				TriggerSelectionChanged(true);
+		}
+
+		public void InsertItem(int index, SegmentedItem item)
+		{
+			var count = ++Control.SegmentCount;
+
+			// need to copy items as we can't insert items
+			if (index < count - 1)
+			{
+				for (nint i = index; i < count; i++)
+				{
+					var next = i - 1;
+					CopyItem(i, next);
+				}
+			}
+			SetItem(index, item);
+			if (item.Selected)
+				TriggerSelectionChanged(true);
+		}
+
+		static readonly IntPtr selSetToolTipForSegment = Selector.GetHandle("setToolTip:forSegment:");
+		static readonly IntPtr selSetShowsMenuIndicator = Selector.GetHandle("setShowsMenuIndicator:forSegment:");
+
+		// 10.13+
+		static readonly bool supportsTooltip = ObjCExtensions.InstancesRespondToSelector<NSSegmentedCell>(selSetToolTipForSegment);
+		static readonly bool supportsMenuIndicator = ObjCExtensions.InstancesRespondToSelector<NSSegmentedControl>(selSetShowsMenuIndicator);
+
+		public void SetItem(int index, SegmentedItem item)
+		{
+			Control.SetLabel(item.Text ?? string.Empty, index);
+			Control.SetImage(item.Image.ToNS(), index);
+			Control.SetEnabled(item.Enabled, index);
+			Control.SetSelected(item.Selected, index);
+			Control.SetWidth(item.Width < 0 ? 0 : item.Width, index);
+			var menu = (item as MenuSegmentedItem)?.Menu.ToNS();
+			Control.SetMenu(menu, index);
+			if (supportsMenuIndicator)
+			{
+				Control.SetShowsMenuIndicator(menu != null, index);
+			}
+			if (supportsTooltip)
+			{
+				Control.SetToolTip(item.ToolTip ?? string.Empty, index);
+			}
+		}
+
+		public void RemoveItem(int index, SegmentedItem item)
+		{
+			var wasSelected = item.Selected;
+			// no way to remove an item, need to copy all item data then set count.
+			for (nint i = Control.SegmentCount - 1; i > index; i--)
+			{
+				var prev = i - 1;
+				CopyItem(i, prev);
+			}
+			if (wasSelected)
+			{
+				// when removing the selected item, it selects the previous item by default. ugh.
+				if (SelectionMode == SegmentedSelectionMode.Single)
+					Control.SelectedSegment = -1;
+				TriggerSelectionChanged(true);
+			}
+		}
+
+		private void CopyItem(nint i, nint prev)
+		{
+			Control.SetLabel(Control.GetLabel(i), prev);
+			Control.SetImage(Control.GetImage(i), prev);
+			Control.SetEnabled(Control.IsEnabled(i), prev);
+			Control.SetSelected(Control.IsSelectedForSegment(i), prev);
+			Control.SetMenu(Control.GetMenu(i), prev);
+			Control.SetWidth(Control.GetWidth(i), prev);
+			if (supportsMenuIndicator)
+			{
+				Control.SetShowsMenuIndicator(Control.ShowsMenuIndicator(i), prev);
+			}
+			if (supportsTooltip)
+			{
+				Control.SetToolTip(Control.GetToolTip(i), prev);
+			}
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case SegmentedButton.ItemClickEvent:
+				case SegmentedButton.SelectedIndexesChangedEvent:
+					// handled automatically
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		bool HasSelection => SelectedIndex != -1;
+
+		public void SelectAll()
+		{
+			if (SelectionMode == SegmentedSelectionMode.None)
+				return;
+			var didSelect = false;
+			var count = Control.SegmentCount;
+			for (int i = 0; i < count; i++)
+			{
+				didSelect |= !Control.IsSelectedForSegment(i);
+				Control.SetSelected(true, i);
+			}
+			if (didSelect)
+				TriggerSelectionChanged(true);
+		}
+
+		public void ClearSelection()
+		{
+			var wasSelected = HasSelection;
+			Control.UnselectAllSegments();
+			if (wasSelected)
+				TriggerSelectionChanged(true);
+		}
+
+		internal void TriggerSelectionChanged(bool force)
+		{
+			var selectedIndex = SelectedIndex;
+			if (force || SelectionMode == SegmentedSelectionMode.Multiple || lastSelected != selectedIndex)
+			{
+				Callback.OnSelectedIndexesChanged(Widget, EventArgs.Empty);
+				lastSelected = selectedIndex;
+			}
+		}
+	}
+}

--- a/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
@@ -1,0 +1,99 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+
+#if XAMMAC2
+using AppKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using CoreAnimation;
+using CoreImage;
+#else
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+using MonoMac.CoreGraphics;
+using MonoMac.ObjCRuntime;
+using MonoMac.CoreAnimation;
+using MonoMac.CoreImage;
+#if Mac64
+using nfloat = System.Double;
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nfloat = System.Single;
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
+#endif
+
+namespace Eto.Mac.Forms.Controls
+{
+	public class ToggleButtonHandler : ButtonHandler<ToggleButton, ToggleButton.ICallback>, ToggleButton.IHandler
+	{
+		static Size s_defaultMinimumSize;
+
+		protected override Size DefaultMinimumSize => s_defaultMinimumSize;
+
+		protected override NSButtonType DefaultButtonType => NSButtonType.PushOnPushOff;
+
+		static ToggleButtonHandler()
+		{
+			// store the normal size for a rounded button, so we can determine what style to give it based on actual size
+			var b = new EtoButton(NSButtonType.PushOnPushOff);
+			s_defaultMinimumSize = b.FittingSize.ToEtoSize();
+		}
+
+		protected override void SetImagePosition()
+		{
+			if ((PreferredSize?.Width ?? -1) == -1)
+			{
+				var position = ImagePosition.ToNS();
+				if (string.IsNullOrEmpty(Text))
+					position = NSCellImagePosition.ImageOnly;
+				Control.ImagePosition = position;
+				SetBezel();
+			}
+			else
+				base.SetImagePosition();
+		}
+
+		public bool Checked
+		{
+			get => Control.State == NSCellStateValue.On;
+			set
+			{
+				if (value != Checked)
+				{
+					Control.State = value ? NSCellStateValue.On : NSCellStateValue.Off;
+					Callback.OnCheckedChanged(Widget, EventArgs.Empty);
+				}
+			}
+		}
+
+		protected override void OnActivated()
+		{
+			TriggerMouseCallback();
+			Callback.OnCheckedChanged(Widget, EventArgs.Empty);
+			Callback.OnClick(Widget, EventArgs.Empty);
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case ToggleButton.CheckedChangedEvent:
+					// handled intrinsically
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+	}
+}

--- a/src/Eto.Mac/Messaging.cs
+++ b/src/Eto.Mac/Messaging.cs
@@ -62,6 +62,9 @@ namespace Eto.Mac
 		public static extern void void_objc_msgSendSuper_SizeF(IntPtr receiver, IntPtr selector, CGSize arg1);
 
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		public static extern nfloat nfloat_objc_msgSendSuper_nint(IntPtr receiver, IntPtr selector, nint segment);
+
+		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
 		public static extern bool bool_objc_msgSendSuper(IntPtr receiver, IntPtr selector);
 
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -164,6 +164,10 @@ namespace Eto.Mac
 			p.Add<FilePicker.IHandler>(() => new ThemedFilePickerHandler());
 			p.Add<DocumentControl.IHandler>(() => new ThemedDocumentControlHandler());
 			p.Add<DocumentPage.IHandler>(() => new ThemedDocumentPageHandler());
+			p.Add<SegmentedButton.IHandler>(() => new SegmentedButtonHandler());
+			p.Add<ButtonSegmentedItem.IHandler>(() => new ButtonSegmentedItemHandler());
+			p.Add<MenuSegmentedItem.IHandler>(() => new MenuSegmentedItemHandler());
+			p.Add<ToggleButton.IHandler>(() => new ToggleButtonHandler());
 
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/src/Eto.WinForms/Eto.WinForms.csproj
+++ b/src/Eto.WinForms/Eto.WinForms.csproj
@@ -76,6 +76,7 @@
     <Compile Include="Drawing\RadialGradientBrushHandler.cs" />
     <Compile Include="Drawing\SystemColorsHandler.cs" />
     <Compile Include="Forms\Cells\CustomCellHandler.cs" />
+    <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
     <Compile Include="Forms\Controls\TextStepperHandler.cs" />
     <Compile Include="Forms\Controls\StepperHandler.cs" />
     <Compile Include="Forms\DataObjectHandler.cs" />

--- a/src/Eto.WinForms/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/ButtonHandler.cs
@@ -7,18 +7,23 @@ using Eto.Forms;
 
 namespace Eto.WinForms.Forms.Controls
 {
-	/// <summary>
-	/// Button handler.
-	/// </summary>
-	/// <copyright>(c) 2012-2013 by Curtis Wensley</copyright>
-	/// <license type="BSD-3">See LICENSE for full terms</license>
-	public class ButtonHandler : WindowsControl<ButtonHandler.EtoButton, Button, Button.ICallback>, Button.IHandler
+	public class ButtonHandler : ButtonHandler<ButtonHandler.EtoButton, Button, Button.ICallback>, Button.IHandler
 	{
+
 		// windows guidelines specify default height of 23
 		public static Size DefaultMinimumSize = new Size(80, 23);
 
+		protected override Size GetDefaultMinimumSize() => DefaultMinimumSize;
+
 		public class EtoButton : swf.Button
 		{
+			public EtoButton()
+			{
+				AutoSizeMode = swf.AutoSizeMode.GrowAndShrink;
+				TextImageRelation = swf.TextImageRelation.ImageBeforeText;
+				AutoSize = true;
+			}
+
 			public override sd.Size GetPreferredSize(sd.Size proposedSize)
 			{
 				var size = base.GetPreferredSize(sd.Size.Empty);
@@ -43,23 +48,28 @@ namespace Eto.WinForms.Forms.Controls
 			}
 		}
 
-		public override Size? GetDefaultSize(Size availableSize)
+		protected override EtoButton CreateControl() => new EtoButton();
+
+	}
+
+	public abstract class ButtonHandler<TControl, TWidget, TCallback> : WindowsControl<TControl, TWidget, TCallback>, Button.IHandler
+		where TControl: swf.ButtonBase
+		where TWidget: Button
+		where TCallback: Button.ICallback
+	{
+		protected abstract Size GetDefaultMinimumSize();
+
+		public override Size? GetDefaultSize(Size availableSize) => MinimumSize;
+
+		protected override void Initialize()
 		{
-			return MinimumSize;
+			base.Initialize();
+			Control.Click += Control_Click;
 		}
 
-		public ButtonHandler()
+		void Control_Click(object sender, EventArgs e)
 		{
-			Control = new EtoButton
-			{
-				AutoSizeMode = swf.AutoSizeMode.GrowAndShrink,
-				TextImageRelation = swf.TextImageRelation.ImageBeforeText,
-				AutoSize = true
-			};
-			Control.Click += delegate
-			{
-				Callback.OnClick(Widget, EventArgs.Empty);
-			};
+			Callback.OnClick(Widget, EventArgs.Empty);
 		}
 
 		public override string Text
@@ -109,7 +119,7 @@ namespace Eto.WinForms.Forms.Controls
 
 		public Size MinimumSize
 		{
-			get { return Widget.Properties.Get(MinimumSize_Key, DefaultMinimumSize); }
+			get { return Widget.Properties.Get(MinimumSize_Key, GetDefaultMinimumSize); }
 			set
 			{
 				if (MinimumSize != value)

--- a/src/Eto.WinForms/Forms/Controls/ToggleButtonHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/ToggleButtonHandler.cs
@@ -1,0 +1,73 @@
+using System;
+using System.Linq;
+using sd = System.Drawing;
+using swf = System.Windows.Forms;
+using Eto.Drawing;
+using Eto.Forms;
+
+namespace Eto.WinForms.Forms.Controls
+{
+	public class ToggleButtonHandler : ButtonHandler<ToggleButtonHandler.EtoButton, ToggleButton, ToggleButton.ICallback>, ToggleButton.IHandler
+	{
+		protected override Size GetDefaultMinimumSize() => new Size(23, 23);
+
+		public class EtoButton : swf.CheckBox
+		{
+			public EtoButton()
+			{
+				Appearance = swf.Appearance.Button;
+				TextImageRelation = swf.TextImageRelation.ImageBeforeText;
+				AutoSize = true;
+			}
+
+			public override sd.Size GetPreferredSize(sd.Size proposedSize)
+			{
+				var size = base.GetPreferredSize(sd.Size.Empty);
+
+				if (AutoSize && Image != null)
+				{
+					if (!string.IsNullOrEmpty(Text))
+						// fix bug where text will wrap if it has both an image and text
+						size.Width += 3;
+					else
+						// fix bug with image and no text
+						size.Height += 1;
+				}
+				if (Image != null)
+				{
+					var imgSize = Image.Size.ToEto() + 8;
+					size.Width = Math.Max(size.Width, imgSize.Width);
+					size.Height = Math.Max(size.Height, imgSize.Height);
+				}
+
+				return size;
+			}
+		}
+
+		protected override EtoButton CreateControl() => new EtoButton();
+
+		public bool Checked
+		{
+			get => Control.Checked;
+			set => Control.Checked = value;
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case ToggleButton.CheckedChangedEvent:
+					Control.CheckedChanged += Control_CheckedChanged;
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		void Control_CheckedChanged(object sender, EventArgs e)
+		{
+			Callback.OnCheckedChanged(Widget, EventArgs.Empty);
+		}
+	}
+}

--- a/src/Eto.WinForms/Platform.cs
+++ b/src/Eto.WinForms/Platform.cs
@@ -110,6 +110,10 @@ namespace Eto.WinForms
 			p.Add<FilePicker.IHandler>(() => new ThemedFilePickerHandler());
 			p.Add<DocumentControl.IHandler>(() => new ThemedDocumentControlHandler());
 			p.Add<DocumentPage.IHandler>(() => new ThemedDocumentPageHandler());
+			p.Add<SegmentedButton.IHandler>(() => new ThemedSegmentedButtonHandler());
+			p.Add<ButtonSegmentedItem.IHandler>(() => new ThemedButtonSegmentedItemHandler());
+			p.Add<MenuSegmentedItem.IHandler>(() => new ThemedMenuSegmentedItemHandler());
+			p.Add<ToggleButton.IHandler>(() => new ToggleButtonHandler());
 
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/src/Eto.Wpf/CustomControls/TreeGridView/TreeToggleButton.cs
+++ b/src/Eto.Wpf/CustomControls/TreeGridView/TreeToggleButton.cs
@@ -5,10 +5,11 @@ using Eto.Forms;
 using System.Windows.Controls;
 using Eto.CustomControls;
 using swc = System.Windows.Controls;
+using swcp = System.Windows.Controls.Primitives;
 
 namespace Eto.Wpf.CustomControls.TreeGridView
 {
-	public class TreeToggleButton : ToggleButton
+	public class TreeToggleButton : swcp.ToggleButton
 	{
 		public const int LevelWidth = 16;
 

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -93,6 +93,7 @@
     <Compile Include="Drawing\SystemColorsHandler.cs" />
     <Compile Include="Forms\Controls\ExpanderHandler.cs" />
     <Compile Include="Forms\Cells\CustomCellHandler.cs" />
+    <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
     <Compile Include="Forms\NativeFormHandler.cs" />
     <Compile Include="LogicalScreenHelper.cs" />
     <Compile Include="PropertyChangeNotifier.cs" />

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -563,7 +563,7 @@ namespace Eto.Wpf.Forms.Controls
 		public BorderType Border
 		{
 			get { return Widget.Properties.Get(GridHandler.Border_Key, BorderType.Bezel); }
-			set { Widget.Properties.Set(GridHandler.Border_Key, value, () => Control.SetEtoBorderType(value)); }
+			set { if (Widget.Properties.TrySet(GridHandler.Border_Key, value)) Control.SetEtoBorderType(value); }
 		}
 
 		public void ReloadData(IEnumerable<int> rows)

--- a/src/Eto.Wpf/Forms/Controls/ToggleButtonHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ToggleButtonHandler.cs
@@ -1,0 +1,54 @@
+using Eto.Drawing;
+using Eto.Forms;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using wf = System.Windows;
+using swc = System.Windows.Controls;
+using swcp = System.Windows.Controls.Primitives;
+
+namespace Eto.Wpf.Forms.Controls
+{
+	public class EtoToggleButton : swcp.ToggleButton, IEtoWpfControl
+	{
+		public IWpfFrameworkElement Handler { get; set; }
+
+		protected override wf.Size MeasureOverride(wf.Size constraint)
+		{
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+		}
+	}
+
+	public class ToggleButtonHandler : ButtonHandler<EtoToggleButton, ToggleButton, ToggleButton.ICallback>, ToggleButton.IHandler
+	{
+		protected override EtoToggleButton CreateControl() => new EtoToggleButton { Handler = this };
+
+		protected override Size GetDefaultMinimumSize() => new Size(23, 23);
+
+		public bool Checked
+		{
+			get => Control.IsChecked ?? false;
+			set => Control.IsChecked = value;
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case ToggleButton.CheckedChangedEvent:
+					AttachPropertyChanged(EtoToggleButton.IsCheckedProperty, OnCheckedChanged);
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		private void OnCheckedChanged(object sender, EventArgs e)
+		{
+			Callback.OnCheckedChanged(Widget, EventArgs.Empty);
+		}
+	}
+}

--- a/src/Eto.Wpf/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/ContextMenuHandler.cs
@@ -76,18 +76,43 @@ namespace Eto.Wpf.Forms.Menu
 
 		public void Show(Control relativeTo, PointF? location)
 		{
-			Control.Placement = swc.Primitives.PlacementMode.MousePoint;
 			if (relativeTo != null)
 			{
 				Control.PlacementTarget = relativeTo.ControlObject as sw.UIElement;
 				if (location != null)
 				{
-					Control.Placement = PlacementMode.RelativePoint;
-					Control.HorizontalOffset = location.Value.X;
-					Control.VerticalOffset = location.Value.Y;
+					Control.HorizontalOffset = 0;
+					Control.VerticalOffset = 0;
+
+					var pt = location.Value;
+
+					if (pt.X == 0 && pt.Y == relativeTo.Height)
+					{
+						// try to stay at the bottom and scroll if needed, e.g. useful for drop down menus
+						// will show above control if necessary
+						Control.Placement = PlacementMode.Bottom;
+					}
+					else if (pt.Y == 0 && pt.X == relativeTo.Width)
+					{
+						Control.Placement = PlacementMode.Right;
+					}
+					else
+					{
+						// Location should be the upper left corner, but PlacementMode.RelativePoint 
+						// can show the menu from its upper right corner.
+						Control.Placement = PlacementMode.Custom;
+						var logicalPixelSize = relativeTo.ParentWindow?.LogicalPixelSize;
+						if (logicalPixelSize != null)
+							pt *= logicalPixelSize.Value;
+						Control.CustomPopupPlacementCallback = (popupSize, targetSize, offset) =>
+						{
+							return new[] { new CustomPopupPlacement(pt.ToWpf(), PopupPrimaryAxis.Horizontal) };
+						};
+					}
 				}
 				else
 				{
+					Control.Placement = swc.Primitives.PlacementMode.MousePoint;
 					Control.HorizontalOffset = 0;
 					Control.VerticalOffset = 0;
 				}
@@ -100,6 +125,7 @@ namespace Eto.Wpf.Forms.Menu
 			}
 			else
 			{
+				Control.Placement = swc.Primitives.PlacementMode.MousePoint;
 				Control.HorizontalOffset = 0;
 				Control.VerticalOffset = 0;
 			}

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -625,7 +625,7 @@ namespace Eto.Wpf.Forms
 			var args = e.ToEto(Control, swi.MouseButtonState.Released);
 			Callback.OnMouseUp(Widget, args);
 			e.Handled = args.Handled;
-			if (isMouseCaptured && Control.IsMouseCaptured)
+			if ((isMouseCaptured || args.Handled) && Control.IsMouseCaptured)
 			{
 				Control.ReleaseMouseCapture();
 				isMouseCaptured = false;
@@ -836,6 +836,12 @@ namespace Eto.Wpf.Forms
 			// otherwise, we're hosted it something native like win32 or mfc.
 			// TODO: check if handle is a window?
 			return WinFormsHelpers.ToEtoWindow(handle);
+		}
+
+		protected void AttachPropertyChanged(sw.DependencyProperty property, EventHandler handler, sw.DependencyObject control = null)
+		{
+			control = control ?? Control;
+			Widget.Properties.Set(property, PropertyChangeNotifier.Register(property, handler, control));
 		}
 	}
 }

--- a/src/Eto.Wpf/Platform.cs
+++ b/src/Eto.Wpf/Platform.cs
@@ -14,6 +14,7 @@ using Eto.IO;
 using Eto.Wpf.IO;
 using Eto.Forms.ThemedControls;
 using Eto.Shared.Forms;
+using System.Linq;
 
 namespace Eto.Wpf
 {
@@ -33,6 +34,20 @@ namespace Eto.Wpf
 		static Platform()
 		{
 			EmbeddedAssemblyLoader.Register("Eto.Wpf.CustomControls.Assemblies");
+
+			Style.Add<ThemedSegmentedButtonHandler>(null, h =>
+			{
+				h.Control.Styles.Add<ToggleButtonHandler>(null, tb =>
+				{
+					if (tb.Widget.Parent is TableLayout tl && tl.Rows.Count > 0 && tl.Spacing.Width == 0)
+					{
+						var isFirst = ReferenceEquals(tl.Rows[0].Cells[0].Control, tb.Widget);
+						var thickness = tb.Control.BorderThickness;
+						thickness.Left = isFirst ? thickness.Right : 0;
+						tb.Control.BorderThickness = thickness;
+					}
+				});
+			});
 		}
 
 		public Platform()
@@ -116,6 +131,10 @@ namespace Eto.Wpf
 			p.Add<FilePicker.IHandler>(() => new ThemedFilePickerHandler());
 			p.Add<DocumentControl.IHandler>(() => new ThemedDocumentControlHandler());
 			p.Add<DocumentPage.IHandler>(() => new ThemedDocumentPageHandler());
+			p.Add<SegmentedButton.IHandler>(() => new ThemedSegmentedButtonHandler());
+			p.Add<ButtonSegmentedItem.IHandler>(() => new ThemedButtonSegmentedItemHandler());
+			p.Add<MenuSegmentedItem.IHandler>(() => new ThemedMenuSegmentedItemHandler());
+			p.Add<ToggleButton.IHandler>(() => new ToggleButtonHandler());
 			
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/src/Eto/DefaultStyleProvider.cs
+++ b/src/Eto/DefaultStyleProvider.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
@@ -174,6 +174,8 @@ namespace Eto
 		void IStyleProvider.ApplyCascadingStyle(object container, object widget, string style)
 		{
 			ApplyDefaults(widget);
+			if (widget is IHandlerSource handlerSource)
+				ApplyDefaults(handlerSource.Handler);
 			ApplyStyles(widget, style);
 		}
 

--- a/src/Eto/Forms/Binding/BindableExtensions.cs
+++ b/src/Eto/Forms/Binding/BindableExtensions.cs
@@ -211,6 +211,80 @@ namespace Eto.Forms
 				defaultContextValue
 			);
 		}
+
+		/// <summary>
+		/// Gets a bindable binding with the inverse of the specified boolean value binding.
+		/// </summary>
+		/// <returns>A new binding to the inverse value.</returns>
+		/// <param name="binding">Binding to invert.</param>
+		/// <typeparam name="T">The type of the bindable object.</typeparam>
+		public static BindableBinding<T, bool?> Inverse<T>(this BindableBinding<T, bool?> binding)
+			where T: IBindable
+		{
+			return binding.Convert(c => !c, c => !c);
+		}
+
+		/// <summary>
+		/// Gets a bindable binding with the inverse of the specified boolean value binding.
+		/// </summary>
+		/// <returns>A new binding to the inverse value.</returns>
+		/// <param name="binding">Binding to invert.</param>
+		/// <typeparam name="T">The type of the bindable object.</typeparam>
+		public static BindableBinding<T, bool> Inverse<T>(this BindableBinding<T, bool> binding)
+			where T: IBindable
+		{
+			return binding.Convert(c => !c, c => !c);
+		}
+
+		/// <summary>
+		/// Gets a binding with the inverse of the specified nullable boolean value binding.
+		/// </summary>
+		/// <returns>A new binding to the inverse value.</returns>
+		/// <param name="binding">Binding to invert.</param>
+		public static DirectBinding<bool?> Inverse(this DirectBinding<bool?> binding)
+		{
+			return binding.Convert(c => !c, c => !c);
+		}
+
+		/// <summary>
+		/// Gets a binding with the inverse of the specified nullable boolean value binding.
+		/// </summary>
+		/// <returns>A new binding to the inverse value.</returns>
+		/// <param name="binding">Binding to invert.</param>
+		public static DirectBinding<bool> Inverse(this DirectBinding<bool> binding)
+		{
+			return binding.Convert(c => !c, c => !c);
+		}
+
+		/// <summary>
+		/// Gets a binding that returns a <paramref name="defaultValue"/> if the specified <paramref name="binding"/> returns a null value.
+		/// </summary>
+		/// <returns>A new binding that returns a non-nullable value.</returns>
+		/// <param name="binding">Source of the binding to get the value.</param>
+		/// <param name="defaultValue">Default value, or null to use <c>default(TValue)</c>.</param>
+		/// <typeparam name="T">The type of the bindable object.</typeparam>
+		/// <typeparam name="TValue">The value type to convert from nullable to non-nullable.</typeparam>
+		public static BindableBinding<T, TValue> DefaultIfNull<T, TValue>(this BindableBinding<T, TValue?> binding, TValue? defaultValue = null)
+			where T: IBindable
+			where TValue: struct
+		{
+			return binding.Convert(c => c ?? defaultValue ?? default(TValue), c => c);
+		}
+
+		/// <summary>
+		/// Gets a binding that returns a <paramref name="defaultValue"/> if the specified <paramref name="binding"/> returns a null value.
+		/// </summary>
+		/// <returns>A new binding that returns a non-null value.</returns>
+		/// <param name="binding">Source of the binding to get the value.</param>
+		/// <param name="defaultValue">Default value to return instead of null.</param>
+		/// <typeparam name="T">The type of the bindable object.</typeparam>
+		/// <typeparam name="TValue">The value type.</typeparam>
+		public static BindableBinding<T, TValue> DefaultIfNull<T, TValue>(this BindableBinding<T, TValue> binding, TValue defaultValue)
+			where T : IBindable
+			where TValue : class
+		{
+			return binding.Convert(c => c ?? defaultValue, c => c);
+		}
 	}
 }
 

--- a/src/Eto/Forms/Container.cs
+++ b/src/Eto/Forms/Container.cs
@@ -141,7 +141,8 @@ namespace Eto.Forms
 		/// <value>The default style provider for this container.</value>
 		public DefaultStyleProvider Styles => Properties.Create<DefaultStyleProvider>(DefaultStyleProvider_Key);
 
-		internal void ApplyStyles(object widget, string style)
+		/// <inheritdoc />
+		protected override void ApplyStyles(object widget, string style)
 		{
 			var styleProvider = StyleProvider;
 

--- a/src/Eto/Forms/Controls/Button.cs
+++ b/src/Eto/Forms/Controls/Button.cs
@@ -141,7 +141,16 @@ namespace Eto.Forms
 			{
 				base.Size = value;
 				// Ensure minimum size is at least as small as the desired explicit size
-				MinimumSize = Size.Min(value, MinimumSize);
+				if (value.Width != -1 || value.Height != -1)
+				{
+					var min = MinimumSize;
+					var size = Size.Min(value, min);
+					if (size.Width == -1)
+						size.Width = min.Width;
+					if (size.Height == -1)
+						size.Height = min.Height;
+					MinimumSize = size;
+				}
 			}
 		}
 
@@ -165,9 +174,9 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Triggers the <see cref="Click"/> event for the button, if the button is visable and enabled.
+		/// Triggers the <see cref="Click"/> event for the button, if the button is visible and enabled.
 		/// </summary>
-		public void PerformClick()
+		public virtual void PerformClick()
 		{
 			if (Enabled && Visible)
 				OnClick(EventArgs.Empty);

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -492,7 +492,7 @@ namespace Eto.Forms
 			Properties.TriggerEvent(PreLoadKey, this, e);
 			Handler.OnPreLoad(e);
 
-			ApplyStyles();
+			OnApplyCascadingStyles();
 		}
 
 		static readonly object LoadKey = new object();
@@ -1283,10 +1283,31 @@ namespace Eto.Forms
 
 			// already loaded, re-apply styles as they have changed
 			if (Loaded)
-				ApplyStyles();
+				OnApplyCascadingStyles();
 		}
 
-		internal virtual void ApplyStyles() => Parent?.ApplyStyles(this, Style);
+		/// <summary>
+		/// Called when cascading styles should be applied to this control.
+		/// </summary>
+		/// <remarks>
+		/// You don't typically have to call this directly, but override it to apply styles to any child item(s)
+		/// that may need styling at the same time.
+		/// 
+		/// This is automatically done for any Container based control and its child controls.
+		/// </remarks>
+		protected virtual void OnApplyCascadingStyles() => ApplyStyles(this, Style);
+
+		/// <summary>
+		/// Applies the styles to the specified <paramref name="widget"/> up the parent chain.
+		/// </summary>
+		/// <remarks>
+		/// This traverses up the parent chain to apply any cascading styles defined in parent container objects.
+		/// 
+		/// Call this method on any child widget of a control.
+		/// </remarks>
+		/// <param name="widget">Widget to style.</param>
+		/// <param name="style">Style of the widget to apply.</param>
+		protected virtual void ApplyStyles(object widget, string style) => Parent?.ApplyStyles(this, Style);
 
 
 		/// <summary>

--- a/src/Eto/Forms/Controls/ToggleButton.cs
+++ b/src/Eto/Forms/Controls/ToggleButton.cs
@@ -1,0 +1,103 @@
+using System;
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Specialized Button that can be toggled on or off.
+	/// </summary>
+	/// <remarks>
+	/// This is similar to the <see cref="CheckBox"/> but appears depressed or highlighted when "checked".
+	/// </remarks>
+	[Handler(typeof(IHandler))]
+	public class ToggleButton : Button
+	{
+		new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.ToggleButton"/> is checked.
+		/// </summary>
+		/// <value><c>true</c> if checked; otherwise, <c>false</c>.</value>
+		public bool Checked
+		{
+			get => Handler.Checked;
+			set => Handler.Checked = value;
+		}
+
+		/// <summary>
+		/// Identifier for handlers when attaching the <see cref="CheckedChanged"/> event.
+		/// </summary>
+		public const string CheckedChangedEvent = "ToggleButton.CheckedChanged";
+
+		/// <summary>
+		/// Occurs when the <see cref="Checked"/> value changes.
+		/// </summary>
+		public event EventHandler<EventArgs> CheckedChanged
+		{
+			add => Properties.AddHandlerEvent(CheckedChangedEvent, value);
+			remove => Properties.RemoveEvent(CheckedChangedEvent, value);
+		}
+
+		/// <summary>
+		/// Raises the <see cref="Checked"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnCheckedChanged(EventArgs e) => Properties.TriggerEvent(CheckedChangedEvent, this, e);
+
+		/// <summary>
+		/// Clicks the toggle button programatically, raising the same events and toggling the Checked state if Enabled and Visible.
+		/// </summary>
+		public override void PerformClick()
+		{
+			if (Enabled && Visible)
+			{
+				Checked = !Checked;
+				OnClick(EventArgs.Empty);
+			}
+		}
+
+		/// <summary>
+		/// Callback interface for handlers of the <see cref="ToggleButton"/>.
+		/// </summary>
+		public new interface ICallback : Button.ICallback
+		{
+			/// <summary>
+			/// Raises the CheckedChanged event.
+			/// </summary>
+			void OnCheckedChanged(ToggleButton widget, EventArgs e);
+		}
+
+		static ICallback callback => new Callback();
+
+		/// <summary>
+		/// Gets the callback instance for the <see cref="ToggleButton"/>.
+		/// </summary>
+		/// <returns>The callback object.</returns>
+		protected override object GetCallback() => callback;
+
+		/// <summary>
+		/// Callback implementation for the <see cref="ToggleButton"/>.
+		/// </summary>
+		protected new class Callback : Button.Callback, ICallback
+		{
+			/// <summary>
+			/// Raises the CheckedChanged event.
+			/// </summary>
+			public void OnCheckedChanged(ToggleButton widget, EventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnCheckedChanged(e);
+			}
+		}
+
+		/// <summary>
+		/// Handler interface for the <see cref="ToggleButton"/>
+		/// </summary>
+		public new interface IHandler : Button.IHandler
+		{
+			/// <summary>
+			/// Gets or sets a value indicating whether the ToggleButton is checked.
+			/// </summary>
+			/// <value><c>true</c> if checked; otherwise, <c>false</c>.</value>
+			bool Checked { get; set; }
+		}
+	}
+}

--- a/src/Eto/Forms/SegmentedButton/ButtonSegmentedItem.cs
+++ b/src/Eto/Forms/SegmentedButton/ButtonSegmentedItem.cs
@@ -1,0 +1,18 @@
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Segmented item that can be clicked.
+	/// </summary>
+    [Handler(typeof(IHandler))]
+    public class ButtonSegmentedItem : SegmentedItem
+    {
+        new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Handler interface for the <see cref="ButtonSegmentedItem"/>.
+		/// </summary>
+		public new interface IHandler : SegmentedItem.IHandler
+        {
+        }
+    }
+}

--- a/src/Eto/Forms/SegmentedButton/MenuSegmentedItem.cs
+++ b/src/Eto/Forms/SegmentedButton/MenuSegmentedItem.cs
@@ -1,0 +1,59 @@
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Segmented item that can have a drop down menu, and optionally be selected.
+	/// </summary>
+    [Handler(typeof(IHandler))]
+    public class MenuSegmentedItem : SegmentedItem
+    {
+        new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.MenuSegmentedItem"/> can be selected.
+		/// </summary>
+		/// <remarks>
+		/// When this is <c>true</c>, the user will typically have to hold the button down to bring up the menu, otherwise
+		/// a single click will bring up the menu and the item will never be selected/clicked.
+		/// </remarks>
+		/// <value><c>true</c> if this item can be selected; otherwise, <c>false</c>.</value>
+        public bool CanSelect
+        {
+            get => Handler.CanSelect;
+            set => Handler.CanSelect = value;
+        }
+
+		/// <summary>
+		/// Gets or sets the menu to display when the user clicks the item.
+		/// </summary>
+		/// <seealso cref="CanSelect"/>.
+		/// <value>The menu to display.</value>
+        public ContextMenu Menu
+        {
+            get => Handler.Menu;
+            set => Handler.Menu = value;
+        }
+
+		/// <summary>
+		/// Handler interface for the <see cref="MenuSegmentedItem"/>.
+		/// </summary>
+        public new interface IHandler : SegmentedItem.IHandler
+        {
+			/// <summary>
+			/// Gets or sets the menu to display when the user clicks the item.
+			/// </summary>
+			/// <seealso cref="CanSelect"/>.
+			/// <value>The menu to display.</value>
+			ContextMenu Menu { get; set; }
+
+			/// <summary>
+			/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.MenuSegmentedItem"/> can be selected.
+			/// </summary>
+			/// <remarks>
+			/// When this is <c>true</c>, the user will typically have to hold the button down to bring up the menu, otherwise
+			/// a single click will bring up the menu and the item will never be selected/clicked.
+			/// </remarks>
+			/// <value><c>true</c> if this item can be selected; otherwise, <c>false</c>.</value>
+			bool CanSelect { get; set; }
+        }
+    }
+}

--- a/src/Eto/Forms/SegmentedButton/SegmentedButton.cs
+++ b/src/Eto/Forms/SegmentedButton/SegmentedButton.cs
@@ -1,0 +1,351 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Enumeration of the selection modes for the <see cref="SegmentedButton"/>.
+	/// </summary>
+	public enum SegmentedSelectionMode
+	{
+		/// <summary>
+		/// No selection is possible, but you can click on each segment to trigger its click event.
+		/// </summary>
+		None,
+		/// <summary>
+		/// Only a single segment can be selected at a time
+		/// </summary>
+		/// <remarks>
+		/// When clicking on a selected segment in this mode it will remain selected.
+		/// </remarks>
+		Single,
+		/// <summary>
+		/// Multiple segments can be selected
+		/// </summary>
+		/// <remarks>
+		/// Clicking a segment will toggle its selection on or off.
+		/// </remarks>
+		Multiple
+	}
+
+	/// <summary>
+	/// Button with multiple segments that can be clicked.
+	/// </summary>
+	/// <remarks>
+	/// The SegmentedButton allows you to group multiple buttons together visually.
+	/// </remarks>
+	[Handler(typeof(IHandler))]
+	public class SegmentedButton : Control
+	{
+		new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Gets the collection of segmented items
+		/// </summary>
+		/// <value>The segmented items.</value>
+		public SegmentedItemCollection Items { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.Forms.SegmentedButton"/> class.
+		/// </summary>
+		public SegmentedButton()
+		{
+			Items = new SegmentedItemCollection(this);
+		}
+
+		/// <inheritdoc />
+		protected override void OnApplyCascadingStyles()
+		{
+			base.OnApplyCascadingStyles();
+			foreach (var item in Items)
+				ApplyStyles(item, item.Style);
+		}
+
+		/// <summary>
+		/// Gets or sets the selection mode.
+		/// </summary>
+		/// <value>The selection mode.</value>
+		public SegmentedSelectionMode SelectionMode
+		{
+			get => Handler.SelectionMode;
+			set => Handler.SelectionMode = value;
+		}
+
+		#region Events
+
+
+		/// <summary>
+		/// Identifier for handlers when attaching the <see cref="SelectedItemsChanged"/> event.
+		/// </summary>
+		public const string SelectedItemsChangedEvent = "SegmentedButton.SelectedItemsChanged";
+
+		/// <summary>
+		/// Occurs when the <see cref="SelectedItems"/> have changed.
+		/// </summary>
+		public event EventHandler<EventArgs> SelectedItemsChanged
+		{
+			add => Properties.AddEvent(SelectedItemsChangedEvent, value);
+			remove => Properties.RemoveEvent(SelectedItemsChangedEvent, value);
+		}
+
+		/// <summary>
+		/// Raises the <see cref="SelectedItemsChanged"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnSelectedItemsChanged(EventArgs e)
+		{
+			Properties.TriggerEvent(SelectedItemsChangedEvent, this, e);
+		}
+
+		/// <summary>
+		/// Identifier for handlers when attaching the <see cref="SelectedIndexesChanged"/> event.
+		/// </summary>
+		public const string SelectedIndexesChangedEvent = "SegmentedButton.SelectedIndexesChanged";
+
+		/// <summary>
+		/// Occurs when the <see cref="SelectedIndexes"/> have changed.
+		/// </summary>
+		public event EventHandler<EventArgs> SelectedIndexesChanged
+		{
+			add => Properties.AddHandlerEvent(SelectedIndexesChangedEvent, value);
+			remove => Properties.RemoveEvent(SelectedIndexesChangedEvent, value);
+		}
+
+		/// <summary>
+		/// Raises the <see cref="SelectedIndexesChanged"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnSelectedIndexesChanged(EventArgs e)
+		{
+			Properties.TriggerEvent(SelectedIndexesChangedEvent, this, e);
+			OnSelectedItemsChanged(e);
+		}
+
+		/// <summary>
+		/// Identifier for handlers when attaching the <see cref="ItemClick"/> event.
+		/// </summary>
+		public const string ItemClickEvent = "SegmentedButton.ItemClick";
+
+		/// <summary>
+		/// Occurs when an item has been clicked.
+		/// </summary>
+		/// <seealso cref="SegmentedItem.Click"/>
+		public event EventHandler<SegmentedItemClickEventArgs> ItemClick
+		{
+			add => Properties.AddHandlerEvent(ItemClickEvent, value);
+			remove => Properties.RemoveEvent(ItemClickEvent, value);
+		}
+
+		/// <summary>
+		/// Raises the <see cref="ItemClick"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnItemClicked(SegmentedItemClickEventArgs e)
+		{
+			Properties.TriggerEvent(ItemClickEvent, this, e);
+		}
+
+		#endregion
+
+		/// <summary>
+		/// Gets or sets the selected items.
+		/// </summary>
+		/// <remarks>
+		/// You can only set selected item based on the current value of <see cref="SelectionMode"/>.
+		/// 
+		/// For <see cref="SegmentedSelectionMode.Multiple"/>, any combination of items can be selected.
+		/// For <see cref="SegmentedSelectionMode.Single"/>, only a single item will be selected. Setting multiple items in this mode
+		/// will only result in a single item being selected.
+		/// For <see cref="SegmentedSelectionMode.None"/>, no items can be selected.
+		/// </remarks>
+		/// <value>The selected items.</value>
+		public IEnumerable<SegmentedItem> SelectedItems
+		{
+			get => SelectedIndexes?.Select(r => Items[r]) ?? Enumerable.Empty<SegmentedItem>();
+			set => SelectedIndexes = value?.Select(r => Items.IndexOf(r));
+		}
+
+		/// <summary>
+		/// Gets or sets the selected item, or null for no selection.
+		/// </summary>
+		/// <remarks>
+		/// This works when <see cref="SelectionMode"/> is either single or multiple.
+		/// 
+		/// When setting this value in multiple selection mode, all other selected items will be cleared.
+		/// </remarks>
+		/// <value>The selected item, <c>null</c> when nothing is selected.</value>
+		public SegmentedItem SelectedItem
+		{
+			get
+			{
+				var index = SelectedIndex;
+				if (index == -1)
+					return null;
+				return Items[index];
+			}
+			set => SelectedIndex = Items.IndexOf(value);
+		}
+
+		/// <summary>
+		/// Gets or sets the selected indexes.
+		/// </summary>
+		/// <remarks>
+		/// You can only set selected indexes based on the current value of <see cref="SelectionMode"/>.
+		/// 
+		/// For <see cref="SegmentedSelectionMode.Multiple"/>, any combination of indexes can be selected.
+		/// For <see cref="SegmentedSelectionMode.Single"/>, only a single index will be selected. Setting multiple indexes in this mode
+		/// will only result in a single index being selected.
+		/// For <see cref="SegmentedSelectionMode.None"/>, no indexes can be selected.
+		/// </remarks>
+		/// <value>The selected indexes.</value>
+		public IEnumerable<int> SelectedIndexes
+		{
+			get => Handler.SelectedIndexes;
+			set => Handler.SelectedIndexes = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the index of the selected item, or -1 for no selection.
+		/// </summary>
+		/// <remarks>
+		/// This works when <see cref="SelectionMode"/> is either single or multiple.
+		/// 
+		/// When setting this value in multiple selection mode, all other selected items will be cleared.
+		/// </remarks>
+		/// <value>The index of the selected item, or -1 when nothing is selected.</value>
+		public int SelectedIndex
+		{
+			get => Handler.SelectedIndex;
+			set => Handler.SelectedIndex = value;
+		}
+
+		/// <summary>
+		/// Selects all items when <see cref="SelectionMode"/> is set to Multiple.
+		/// </summary>
+		public void SelectAll() => Handler.SelectAll();
+
+		/// <summary>
+		/// Clears all selected items.
+		/// </summary>
+		public void ClearSelection() => Handler.ClearSelection();
+
+		static readonly Callback s_callback = new Callback();
+
+		/// <inheritdoc />
+		protected override object GetCallback() => s_callback;
+
+		/// <summary>
+		/// Callback methods for handlers of <see cref="SegmentedButton"/>.
+		/// </summary>
+		protected new class Callback : Control.Callback, ICallback
+		{
+			/// <summary>
+			/// Raises the ItemClicked event.
+			/// </summary>
+			public void OnItemClicked(SegmentedButton widget, SegmentedItemClickEventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnItemClicked(e);
+			}
+
+			/// <summary>
+			/// Raises the SelectedIndexesChanged event
+			/// </summary>
+			public void OnSelectedIndexesChanged(SegmentedButton widget, EventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnSelectedIndexesChanged(e);
+			}
+		}
+
+		/// <summary>
+		/// Callback interface for handlers of <see cref="SegmentedButton"/>
+		/// </summary>
+		public new interface ICallback : Control.ICallback
+		{
+			/// <summary>
+			/// Raises the ItemClicked event.
+			/// </summary>
+			void OnItemClicked(SegmentedButton widget, SegmentedItemClickEventArgs e);
+
+			/// <summary>
+			/// Raises the SelectedIndexesChanged event
+			/// </summary>
+			void OnSelectedIndexesChanged(SegmentedButton widget, EventArgs e);
+		}
+
+		/// <summary>
+		/// Handler interface for <see cref="SegmentedButton"/>.
+		/// </summary>
+		public new interface IHandler : Control.IHandler
+		{
+			/// <summary>
+			/// Gets or sets the index of the selected item, or -1 for no selection.
+			/// </summary>
+			/// <remarks>
+			/// This works when <see cref="SelectionMode"/> is either single or multiple.
+			/// 
+			/// When setting this value in multiple selection mode, all other selected items will be cleared.
+			/// </remarks>
+			/// <value>The index of the selected item, or -1 when nothing is selected.</value>
+			int SelectedIndex { get; set; }
+
+			/// <summary>
+			/// Gets or sets the selected indexes.
+			/// </summary>
+			/// <remarks>
+			/// You can only set selected indexes based on the current value of <see cref="SelectionMode"/>.
+			/// 
+			/// For <see cref="SegmentedSelectionMode.Multiple"/>, any combination of indexes can be selected.
+			/// For <see cref="SegmentedSelectionMode.Single"/>, only a single index will be selected. Setting multiple indexes in this mode
+			/// will only result in a single index being selected.
+			/// For <see cref="SegmentedSelectionMode.None"/>, no indexes can be selected.
+			/// </remarks>
+			/// <value>The selected indexes.</value>
+			IEnumerable<int> SelectedIndexes { get; set; }
+
+			/// <summary>
+			/// Gets or sets the selection mode.
+			/// </summary>
+			/// <value>The selection mode.</value>
+			SegmentedSelectionMode SelectionMode { get; set; }
+
+			/// <summary>
+			/// Selects all items when <see cref="SelectionMode"/> is set to Multiple.
+			/// </summary>
+			void SelectAll();
+
+			/// <summary>
+			/// Clears all selected items.
+			/// </summary>
+			void ClearSelection();
+
+			/// <summary>
+			/// Clears all items from the segmented button.
+			/// </summary>
+			void ClearItems();
+
+			/// <summary>
+			/// Inserts the item at the specified index.
+			/// </summary>
+			/// <param name="index">Index to insert at.</param>
+			/// <param name="item">Item to insert.</param>
+			void InsertItem(int index, SegmentedItem item);
+
+			/// <summary>
+			/// Removes the item at the specified index.
+			/// </summary>
+			/// <param name="index">Index to remove.</param>
+			/// <param name="item">Item that is being removed.</param>
+			void RemoveItem(int index, SegmentedItem item);
+
+			/// <summary>
+			/// Sets the item at the specified index, replacing its existing item.
+			/// </summary>
+			/// <param name="index">Index to replace at.</param>
+			/// <param name="item">Item to replace with.</param>
+			void SetItem(int index, SegmentedItem item);
+		}
+	}
+}

--- a/src/Eto/Forms/SegmentedButton/SegmentedItem.cs
+++ b/src/Eto/Forms/SegmentedButton/SegmentedItem.cs
@@ -1,0 +1,230 @@
+using System;
+using System.ComponentModel;
+using Eto.Drawing;
+using sc = System.ComponentModel;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Base class for items of the <see cref="SegmentedButton"/> control.
+	/// </summary>
+    [sc.TypeConverter(typeof(SegmentedItemConverter))]
+    public abstract class SegmentedItem : Widget
+    {
+        new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Gets the parent button this item belongs to.
+		/// </summary>
+		/// <remarks>
+		/// Note this is only set after adding your item to the <see cref="SegmentedButton.Items"/> collection.
+		/// </remarks>
+		/// <value>The parent control.</value>
+		public SegmentedButton Parent { get; internal set; }
+
+		/// <summary>
+		/// Gets or sets the text to display for this segment.
+		/// </summary>
+		/// <value>The segment text.</value>
+		public string Text
+        {
+            get => Handler.Text;
+            set => Handler.Text = value;
+        }
+
+		/// <summary>
+		/// Gets or sets the ToolTip to display for this segment
+		/// </summary>
+		/// <value>The segment tooltip.</value>
+        public string ToolTip
+        {
+            get => Handler.ToolTip;
+            set => Handler.ToolTip = value;
+        }
+
+		/// <summary>
+		/// Gets or sets the image to display in this segment.
+		/// </summary>
+		/// <value>The segment image.</value>
+        public Image Image
+        {
+            get => Handler.Image;
+            set => Handler.Image = value;
+        }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.SegmentedItem"/> is enabled.
+		/// </summary>
+		/// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
+        [DefaultValue(true)]
+        public bool Enabled
+        {
+            get => Handler.Enabled;
+            set => Handler.Enabled = value;
+        }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.SegmentedItem"/> is visible.
+		/// </summary>
+		/// <value><c>true</c> if visible; otherwise, <c>false</c>.</value>
+        [DefaultValue(true)]
+        public bool Visible
+        {
+            get => Handler.Visible;
+            set => Handler.Visible = value;
+        }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.SegmentedItem"/> is selected.
+		/// </summary>
+		/// <value><c>true</c> if selected; otherwise, <c>false</c>.</value>
+        public bool Selected
+        {
+            get => Handler.Selected;
+            set => Handler.Selected = value;
+        }
+
+		/// <summary>
+		/// Gets or sets the width of this segment, or -1 to auto size.
+		/// </summary>
+		/// <value>The width of this segment.</value>
+		[DefaultValue(-1)]
+        public int Width
+        {
+            get => Handler.Width;
+            set => Handler.Width = value;
+        }
+
+		#region Events
+
+		/// <summary>
+		/// Identifier for handlers to attach the <see cref="Click"/> event.
+		/// </summary>
+		public const string ClickEvent = "SegmentedItem.Click";
+
+		/// <summary>
+		/// Occurs when this segment is clicked.
+		/// </summary>
+        public event EventHandler<EventArgs> Click
+        {
+            add => Properties.AddHandlerEvent(ClickEvent, value);
+            remove => Properties.RemoveEvent(ClickEvent, value);
+        }
+
+		/// <summary>
+		/// Raises the <see cref="Click"/> event.
+		/// </summary>
+		/// <param name="e">Event argments</param>
+        protected virtual void OnClick(EventArgs e)
+        {
+            Properties.TriggerEvent(ClickEvent, this, e);
+        }
+
+		#endregion
+
+		static readonly ICallback s_callback = new Callback();
+
+		/// <inheritdoc />
+        protected override object GetCallback() => s_callback;
+
+		/// <summary>
+		/// Callback interface for handlers of the <see cref="SegmentedItem"/>.
+		/// </summary>
+        public new interface ICallback : Widget.ICallback
+        {
+			/// <summary>
+			/// Raises the Click event.
+			/// </summary>
+            void OnClick(SegmentedItem widget, EventArgs e);
+        }
+
+		/// <summary>
+		/// Callback implementation for the <see cref="SegmentedItem"/>.
+		/// </summary>
+        protected class Callback : ICallback
+        {
+			/// <summary>
+			/// Raises the Click event.
+			/// </summary>
+            public void OnClick(SegmentedItem widget, EventArgs e)
+            {
+                using (widget.Platform.Context)
+                    widget.OnClick(e);
+            }
+        }
+
+		/// <summary>
+		/// Handler interface for the <see cref="SegmentedItem"/>.
+		/// </summary>
+        public new interface IHandler : Widget.IHandler
+        {
+			/// <summary>
+			/// Gets or sets the text to display for this segment.
+			/// </summary>
+			/// <value>The segment text.</value>
+			string Text { get; set; }
+			/// <summary>
+			/// Gets or sets the ToolTip to display for this segment
+			/// </summary>
+			/// <value>The segment tooltip.</value>
+			string ToolTip { get; set; }
+			/// <summary>
+			/// Gets or sets the image to display in this segment.
+			/// </summary>
+			/// <value>The segment image.</value>
+			Image Image { get; set; }
+			/// <summary>
+			/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.SegmentedItem"/> is enabled.
+			/// </summary>
+			/// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>
+			bool Enabled { get; set; }
+			/// <summary>
+			/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.SegmentedItem"/> is visible.
+			/// </summary>
+			/// <value><c>true</c> if visible; otherwise, <c>false</c>.</value>
+			bool Visible { get; set; }
+			/// <summary>
+			/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.SegmentedItem"/> is selected.
+			/// </summary>
+			/// <value><c>true</c> if selected; otherwise, <c>false</c>.</value>
+			bool Selected { get; set; }
+			/// <summary>
+			/// Gets or sets the width of this segment, or -1 to auto size.
+			/// </summary>
+			/// <value>The width of this segment.</value>
+			int Width { get; set; }
+        }
+
+		/// <summary>
+		/// Implicitly converts a string to a segmented item.
+		/// </summary>
+		/// <remarks>
+		/// This allows you to do things like the following:
+		/// <code><![CDATA[
+		/// new SegmentedButton { Items = { "First", "Second", "Third" } };
+		/// ]]></code>
+		/// </remarks>
+		/// <returns>A segmented item with the specified text.</returns>
+		/// <param name="text">Text for the segmented item.</param>
+        public static implicit operator SegmentedItem(string text)
+        {
+            return new ButtonSegmentedItem { Text = text };
+        }
+
+		/// <summary>
+		/// Implicitly converts an image to a segmented item.
+		/// </summary>
+		/// <remarks>
+		/// This allows you to do things like the following:
+		/// <code><![CDATA[
+		/// new SegmentedButton { Items = { myImage1, myImage2, myImage3 } };
+		/// ]]></code>
+		/// </remarks>
+		/// <returns>A segmented item with the specified image.</returns>
+		/// <param name="image">Image for the segmented item.</param>
+		public static implicit operator SegmentedItem(Image image)
+        {
+            return new ButtonSegmentedItem { Image = image };
+		}
+	}
+}

--- a/src/Eto/Forms/SegmentedButton/SegmentedItemClickEventArgs.cs
+++ b/src/Eto/Forms/SegmentedButton/SegmentedItemClickEventArgs.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Event arguments when clicking a segment in the <see cref="SegmentedButton"/>.
+	/// </summary>
+    public class SegmentedItemClickEventArgs : EventArgs
+    {
+		/// <summary>
+		/// Gets the item that was clicked
+		/// </summary>
+		/// <value>The item that was clicked.</value>
+        public SegmentedItem Item { get; }
+
+		/// <summary>
+		/// Gets the index of the item that was clicked.
+		/// </summary>
+		/// <value>The index of the item that was clicked.</value>
+        public int Index { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.Forms.SegmentedItemClickEventArgs"/> class.
+		/// </summary>
+		/// <param name="item">Item that was clicked.</param>
+		/// <param name="index">Index of the item that was clicked.</param>
+        public SegmentedItemClickEventArgs(SegmentedItem item, int index)
+        {
+            Item = item;
+            Index = index;
+        }
+    }
+}

--- a/src/Eto/Forms/SegmentedButton/SegmentedItemCollection.cs
+++ b/src/Eto/Forms/SegmentedButton/SegmentedItemCollection.cs
@@ -1,0 +1,72 @@
+﻿using System.Collections.ObjectModel;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Collection of <see cref="SegmentedItem"/> objects for the <see cref="SegmentedButton"/>.
+	/// </summary>
+    public class SegmentedItemCollection : Collection<SegmentedItem>
+    {
+        SegmentedButton Parent { get; }
+		SegmentedButton.IHandler Handler => Parent.Handler as SegmentedButton.IHandler;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.Forms.SegmentedItemCollection"/> class.
+		/// </summary>
+		/// <param name="parent">Parent.</param>
+		internal SegmentedItemCollection(SegmentedButton parent)
+        {
+            Parent = parent;
+        }
+
+		/// <summary>
+		/// Clears the items.
+		/// </summary>
+        protected override void ClearItems()
+        {
+			foreach (var item in this)
+			{
+				item.Parent = null;
+			}
+			base.ClearItems();
+            Handler.ClearItems();
+        }
+
+		/// <summary>
+		/// Inserts the item at the specified index.
+		/// </summary>
+		/// <param name="index">Index to insert at.</param>
+		/// <param name="item">Item to insert.</param>
+		protected override void InsertItem(int index, SegmentedItem item)
+        {
+            base.InsertItem(index, item);
+            Handler.InsertItem(index, item);
+			item.Parent = Parent;
+		}
+
+		/// <summary>
+		/// Removes the item at the specified index.
+		/// </summary>
+		/// <param name="index">Index to remove.</param>
+		protected override void RemoveItem(int index)
+        {
+            var item = this[index];
+			Handler.RemoveItem(index, item);
+            base.RemoveItem(index);
+			item.Parent = null;
+        }
+
+		/// <summary>
+		/// Sets the item at the specified index, replacing its existing item.
+		/// </summary>
+		/// <param name="index">Index to replace at.</param>
+		/// <param name="item">Item to replace with.</param>
+		protected override void SetItem(int index, SegmentedItem item)
+        {
+			this[index].Parent = null;
+            base.SetItem(index, item);
+            Handler.SetItem(index, item);
+			item.Parent = Parent;
+        }
+    }
+}

--- a/src/Eto/Forms/SegmentedButton/SegmentedItemConverter.cs
+++ b/src/Eto/Forms/SegmentedButton/SegmentedItemConverter.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Globalization;
+using Eto.Drawing;
+using sc = System.ComponentModel;
+
+namespace Eto.Forms
+{
+	internal class SegmentedItemConverter : sc.TypeConverter
+	{
+		public override bool CanConvertFrom(sc.ITypeDescriptorContext context, Type sourceType)
+		{
+			return sourceType == typeof(string) || sourceType == typeof(Image);
+		}
+
+		public override object ConvertFrom(sc.ITypeDescriptorContext context, CultureInfo culture, object value)
+		{
+			if (value is string str)
+				return new ButtonSegmentedItem { Text = str };
+			if (value is Image img)
+				return new ButtonSegmentedItem { Image = img };
+
+			return base.ConvertFrom(context, culture, value);
+		}
+	}
+}

--- a/src/Eto/Forms/ThemedControls/ThemedSegmentedButtonHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedSegmentedButtonHandler.cs
@@ -1,0 +1,486 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Eto.Drawing;
+using System.Linq;
+
+namespace Eto.Forms.ThemedControls
+{
+	/// <summary>
+	/// Themed <see cref="MenuSegmentedItem"/> handler
+	/// </summary>
+	public class ThemedMenuSegmentedItemHandler : ThemedSegmentedItemHandler<MenuSegmentedItem, MenuSegmentedItem.ICallback>, MenuSegmentedItem.IHandler
+	{
+		UITimer timer;
+		bool menuWasShown;
+		string text;
+		string menuIndicator = "▼";
+
+		/// <summary>
+		/// Delay for the menu to show when the mouse is down and <see cref="CanSelect"/> is <c>true</c>.
+		/// </summary>
+		public TimeSpan MenuDelay { get; set; } = TimeSpan.FromSeconds(0.5);
+
+		/// <summary>
+		/// Gets or sets the indicator to show to the right of the text.
+		/// </summary>
+		/// <value>The menu indicator.</value>
+		public string MenuIndicator
+		{
+			get => menuIndicator;
+			set
+			{
+				menuIndicator = value;
+				SetText();
+			}
+		}
+
+		/// <inheritdoc/>
+		public ContextMenu Menu { get; set; }
+
+		/// <inheritdoc/>
+		public bool CanSelect { get; set; }
+
+		/// <inheritdoc/>
+		public override string Text
+		{
+			get => text;
+			set
+			{
+				text = value;
+				SetText();
+			}
+		}
+
+		void SetText()
+		{
+			if (!string.IsNullOrEmpty(text))
+				base.Text = text + " " + MenuIndicator;
+			else
+				base.Text = MenuIndicator;
+		}
+
+		/// <inheritdoc/>
+		protected override void Initialize()
+		{
+			base.Initialize();
+			Control.MouseDown += Control_MouseDown;
+			Control.MouseUp += Control_MouseUp;
+		}
+
+		private void Control_MouseUp(object sender, MouseEventArgs e)
+		{
+			e.Handled |= menuWasShown;
+			menuWasShown = false;
+			timer?.Stop();
+		}
+
+		private void Timer_Elapsed(object sender, EventArgs e)
+		{
+			menuWasShown = true;
+			Menu?.Show(Control, new PointF(0, Control.Height));
+			timer.Stop();
+		}
+
+		private void Control_MouseDown(object sender, MouseEventArgs e)
+		{
+			if (CanSelect)
+			{
+				menuWasShown = false;
+				if (timer == null)
+				{
+					timer = new UITimer { Interval = MenuDelay.TotalSeconds };
+					timer.Elapsed += Timer_Elapsed;
+				}
+				timer.Start();
+			}
+			else
+			{
+				Menu?.Show(Control, new PointF(0, Control.Height));
+				menuWasShown = true;
+				e.Handled = true;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Themed <see cref="ButtonSegmentedItem"/> handler.
+	/// </summary>
+	public class ThemedButtonSegmentedItemHandler : ThemedSegmentedItemHandler<ButtonSegmentedItem, ButtonSegmentedItem.ICallback>, ButtonSegmentedItem.IHandler
+	{
+
+	}
+
+	/// <summary>
+	/// Themed <see cref="SegmentedItem"/> handler which uses a <see cref="ToggleButton"/> for its display.
+	/// </summary>
+	public abstract class ThemedSegmentedItemHandler<TWidget, TCallback> : WidgetHandler<ToggleButton, TWidget, TCallback>, SegmentedItem.IHandler
+		where TWidget : SegmentedItem
+		where TCallback : SegmentedItem.ICallback
+	{
+		/// <summary>
+		/// Gets the parent handler.
+		/// </summary>
+		/// <value>The parent handler.</value>
+		protected ThemedSegmentedButtonHandler ParentHandler => Widget.Parent?.Handler as ThemedSegmentedButtonHandler;
+
+		/// <inheritdoc/>
+		public bool Enabled { get => Control.Enabled; set => Control.Enabled = value; }
+		/// <inheritdoc/>
+		public bool Visible { get => Control.Visible; set => Control.Visible = value; }
+		/// <inheritdoc/>
+		public string ToolTip { get => Control.ToolTip; set => Control.ToolTip = value; }
+		/// <inheritdoc/>
+		public int Width { get => Control.Width; set => Control.Width = value; }
+		/// <inheritdoc/>
+		public virtual string Text
+		{
+			get => Control.Text;
+			set
+			{
+				Control.Text = value;
+				Control.ImagePosition = string.IsNullOrEmpty(value) ? ButtonImagePosition.Overlay : ButtonImagePosition.Left;
+			}
+		}
+		/// <inheritdoc/>
+		public Image Image { get => Control.Image; set => Control.Image = value; }
+		/// <inheritdoc/>
+		public bool Selected
+		{
+			get => Control.Checked;
+			set
+			{
+				if (!value || ParentHandler?.SelectionMode != SegmentedSelectionMode.None)
+				{
+					Control.Checked = value;
+				}
+			}
+		}
+
+		/// <inheritdoc/>
+		protected override ToggleButton CreateControl() => new ToggleButton { ImagePosition = ButtonImagePosition.Overlay };
+
+		/// <inheritdoc/>
+		protected override void Initialize()
+		{
+			base.Initialize();
+
+			Control.CheckedChanged += Control_CheckedChanged;
+			Control.MouseUp += Control_MouseUp;
+		}
+
+		private void Control_MouseUp(object sender, MouseEventArgs e)
+		{
+			var mode = ParentHandler?.SelectionMode ?? SegmentedSelectionMode.None;
+			if (mode == SegmentedSelectionMode.None // no selection
+				|| (mode == SegmentedSelectionMode.Single && Control.Checked) // can't "unselect"
+				)
+			{
+				e.Handled = true;
+				TriggerClick();
+			}
+		}
+
+		private void Control_CheckedChanged(object sender, EventArgs e)
+		{
+			ParentHandler?.TriggerSelectionChanged(Widget);
+			if (Control.Checked)
+				ParentHandler?.EnsureSingleSelected(Widget, false);
+		}
+
+		/// <inheritdoc/>
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case SegmentedItem.ClickEvent:
+					Control.Click += Control_Click;
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		private void Control_Click(object sender, EventArgs e) => TriggerClick();
+
+		void TriggerClick()
+		{
+			Callback.OnClick(Widget, EventArgs.Empty);
+			ParentHandler?.TriggerItemClick(Widget);
+		}
+	}
+
+	/// <summary>
+	/// Themed <see cref="SegmentedButton"/> handler which uses a series of <see cref="ToggleButton"/> controls in a table.
+	/// </summary>
+	public class ThemedSegmentedButtonHandler : ThemedControlHandler<Panel, SegmentedButton, SegmentedButton.ICallback>, SegmentedButton.IHandler
+	{
+		int suppressSelectionChanged;
+		SegmentedSelectionMode selectionMode;
+
+		/// <inheritdoc/>
+		protected override Panel CreateControl() => new Panel();
+
+		/// <inheritdoc/>
+		public SegmentedSelectionMode SelectionMode
+		{
+			get => selectionMode;
+			set
+			{
+				selectionMode = value;
+
+				switch (value)
+				{
+					case SegmentedSelectionMode.None:
+						ClearSelection();
+						break;
+					case SegmentedSelectionMode.Single:
+						EnsureSingleSelected();
+						break;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the spacing between the buttons
+		/// </summary>
+		/// <value>The spacing between the buttons.</value>
+		public int Spacing { get; set; }
+
+		/// <inheritdoc/>
+		public int SelectedIndex
+		{
+			get
+			{
+				for (int i = 0; i < Widget.Items.Count; i++)
+				{
+					if (Widget.Items[i].Selected)
+						return i;
+				}
+				return -1;
+			}
+			set
+			{
+				if (selectionMode == SegmentedSelectionMode.None)
+					return;
+				if (value > 0)
+					Widget.Items[value].Selected = true;
+				else
+					ClearSelection();
+			}
+		}
+
+		/// <inheritdoc/>
+		public IEnumerable<int> SelectedIndexes
+		{
+			get
+			{
+				for (int i = 0; i < Widget.Items.Count; i++)
+				{
+					if (Widget.Items[i].Selected)
+						yield return i;
+				}
+			}
+			set
+			{
+				if (selectionMode == SegmentedSelectionMode.None)
+					return;
+				var indexes = new HashSet<int>(value);
+				suppressSelectionChanged++;
+				var newSelection = false;
+				for (int i = 0; i < Widget.Items.Count; i++)
+				{
+					var item = Widget.Items[i];
+					var newSelected = indexes.Contains(i);
+					if (item.Selected != newSelected)
+					{
+						newSelected = true;
+						item.Selected = newSelected;
+						if (newSelected && selectionMode != SegmentedSelectionMode.Multiple)
+							break;
+					}
+				}
+				suppressSelectionChanged--;
+				if (newSelection)
+					TriggerSelectionChanged();
+			}
+		}
+
+		/// <inheritdoc/>
+		public void ClearItems()
+		{
+			var hasSelected = SelectedIndex != -1;
+			CreateTable(false);
+			if (hasSelected)
+				TriggerSelectionChanged();
+		}
+
+		Control GetControl(SegmentedItem item) => item.ControlObject as Control;
+
+		TableCell GetCell(SegmentedItem item) => new TableCell(GetControl(item));
+
+		/// <inheritdoc/>
+		public void ClearSelection()
+		{
+			suppressSelectionChanged++;
+			var wasSelected = false;
+			for (int i = 0; i < Widget.Items.Count; i++)
+			{
+				var item = Widget.Items[i];
+				wasSelected |= item.Selected;
+				item.Selected = false;
+			}
+			suppressSelectionChanged--;
+			if (wasSelected)
+				TriggerSelectionChanged();
+		}
+
+		/// <inheritdoc/>
+		public void InsertItem(int index, SegmentedItem item)
+		{
+			var isSelected = item.Selected;
+			CreateTable(false);
+			if (isSelected)
+			{
+				suppressSelectionChanged++;
+				if (SelectionMode == SegmentedSelectionMode.Single)
+					EnsureSingleSelected(item, false);
+				suppressSelectionChanged--;
+
+				TriggerSelectionChanged();
+			}
+		}
+
+		/// <inheritdoc/>
+		public void RemoveItem(int index, SegmentedItem item)
+		{
+			var wasSelected = item.Selected;
+			CreateTable(false);
+			if (wasSelected)
+				TriggerSelectionChanged();
+		}
+
+		/// <inheritdoc/>
+		public void SelectAll()
+		{
+			suppressSelectionChanged++;
+			bool wasChanged = false;
+			foreach (var item in Widget.Items)
+			{
+				wasChanged |= !item.Selected;
+				item.Selected = true;
+			}
+			suppressSelectionChanged--;
+			if (wasChanged)
+				TriggerSelectionChanged();
+		}
+
+		/// <inheritdoc/>
+		public void SetItem(int index, SegmentedItem item)
+		{
+			var wasSelected = Widget.Items[index].Selected;
+			var isSelected = item.Selected;
+			CreateTable(false);
+			if (wasSelected || isSelected)
+				TriggerSelectionChanged();
+		}
+
+		internal void TriggerItemClick(SegmentedItem item)
+		{
+			var index = Widget.Items.IndexOf(item);
+			Callback.OnItemClicked(Widget, new SegmentedItemClickEventArgs(item, index));
+		}
+
+		internal void TriggerSelectionChanged(SegmentedItem item)
+		{
+			if (suppressSelectionChanged > 0)
+				return;
+			if (selectionMode != SegmentedSelectionMode.Multiple && item.Selected)
+			{
+				suppressSelectionChanged++;
+				for (int i = 0; i < Widget.Items.Count; i++)
+				{
+					var current = Widget.Items[i];
+					if (!ReferenceEquals(item, current))
+						current.Selected = false;
+				}
+				suppressSelectionChanged--;
+			}
+			TriggerSelectionChanged();
+		}
+
+		internal void TriggerSelectionChanged()
+		{
+			if (suppressSelectionChanged > 0)
+				return;
+			Callback.OnSelectedIndexesChanged(Widget, EventArgs.Empty);
+		}
+
+		internal void EnsureSingleSelected()
+		{
+			var selectedIndex = SelectedIndex;
+			if (selectedIndex >= 0)
+				EnsureSingleSelected(Widget.Items[selectedIndex], true);
+		}
+
+		internal void EnsureSingleSelected(SegmentedItem item, bool force)
+		{
+			if ((!force && selectionMode == SegmentedSelectionMode.Multiple) || item == null)
+				return;
+
+			var items = Widget.Items;
+			suppressSelectionChanged++;
+			var wasSelected = false;
+			for (int i = 0; i < items.Count; i++)
+			{
+				var currentItem = items[i];
+				if (ReferenceEquals(currentItem, item))
+					continue;
+				wasSelected |= currentItem.Selected;
+				currentItem.Selected = false;
+				
+			}
+			suppressSelectionChanged--;
+			if (wasSelected)
+				TriggerSelectionChanged();
+		}
+
+		/// <inheritdoc/>
+		public override void OnPreLoad(EventArgs e)
+		{
+			if (Control.Content == null)
+				CreateTable(true);
+
+			base.OnPreLoad(e);
+		}
+
+		/// <inheritdoc/>
+		public override void OnLoad(EventArgs e)
+		{
+			if (Control.Content == null)
+				CreateTable(true);
+
+			base.OnLoad(e);
+		}
+
+		void CreateTable(bool force)
+		{
+			if (force || Widget.Loaded)
+			{
+				if (Widget.Items.Count > 0)
+				{
+					var buttonTable = new TableLayout
+					{
+						Style = "buttons",
+						Spacing = new Size(Spacing, 0),
+						Rows = { new TableRow(Widget.Items.Select(GetCell)) }
+					};
+					Control.Content = TableLayout.AutoSized(buttonTable, centered: true);
+				}
+				else
+					Control.Content = null;
+			}
+		}
+	}
+}

--- a/test/Eto.Test/Sections/Controls/SegmentedButtonSection.cs
+++ b/test/Eto.Test/Sections/Controls/SegmentedButtonSection.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Linq;
+using System.Windows.Input;
+using Eto.Forms;
+
+namespace Eto.Test.Sections.Controls
+{
+	[Section("Controls", typeof(SegmentedButton))]
+	public class SegmentedButtonSection : DynamicLayout
+	{
+		public SegmentedButtonSection()
+		{
+			var segbutton = new SegmentedButton();
+
+			segbutton.Items.Add(new ButtonSegmentedItem { Image = TestIcons.TestIcon.WithSize(16, 16) });
+			segbutton.Items.Add(new ButtonSegmentedItem { Text = "Some Text", Image = TestIcons.TestImage.WithSize(16, 16) });
+			segbutton.Items.Add(new ButtonSegmentedItem { Text = "Text Only" });
+			segbutton.Items.Add(new ButtonSegmentedItem { Text = "Width=150", Width = 150 });
+			segbutton.Items.Add(new MenuSegmentedItem
+			{
+				Text = "Selectable Menu",
+				CanSelect = true,
+				Menu = new ContextMenu
+				{
+					Items =
+					{
+						CreateMenuItem("Menu Item 1"),
+						CreateMenuItem("Menu Item 2")
+					}
+				}
+			});
+			segbutton.Items.Add(new MenuSegmentedItem
+			{
+				Text = "Menu Only",
+				Image = TestIcons.TestImage.WithSize(16, 16),
+				CanSelect = false,
+				Menu = new ContextMenu
+				{
+					Items =
+					{
+						CreateMenuItem("Menu Item 1"),
+						CreateMenuItem("Menu Item 2")
+					}
+				}
+			});
+
+			LogEvents(segbutton);
+
+
+			var selectionModeDropDown = new EnumDropDown<SegmentedSelectionMode>();
+			selectionModeDropDown.SelectedValueBinding.Bind(segbutton, b => b.SelectionMode);
+
+			var selectAllButton = new Button { Text = "SelectAll" };
+			selectAllButton.Click += (sender, e) => segbutton.SelectAll();
+			//selectAllButton.Bind(c => c.Enabled, selectionModeDropDown.SelectedValueBinding.Convert(r => r == SegmentedSelectionMode.Multiple));
+
+			var clearSelectionButton = new Button { Text = "ClearSelection" };
+			clearSelectionButton.Click += (sender, e) => segbutton.ClearSelection();
+			clearSelectionButton.Bind(c => c.Enabled, selectionModeDropDown.SelectedValueBinding.Convert(r => r != SegmentedSelectionMode.None));
+
+
+			// layout
+			BeginCentered();
+			AddSeparateRow("SelectionMode:", selectionModeDropDown);
+			AddSeparateRow(selectAllButton, clearSelectionButton);
+			EndCentered();
+
+			AddSeparateRow(segbutton);
+
+		}
+
+		void LogEvents(SegmentedButton button)
+		{
+			button.SelectedIndexesChanged += (sender, e) => Log.Write(sender, $"SelectedIndexesChanged: {string.Join(", ", button.SelectedIndexes.Select(r => r.ToString()))}");
+			button.SelectedItemsChanged += (sender, e) => Log.Write(sender, $"SelectedItemsChanged: {string.Join(", ", button.SelectedItems.Select(ItemDesc))}");
+			button.ItemClick += (sender, e) => Log.Write(sender, $"ItemClick: {ItemDesc(e.Item)}, Index: {e.Index}");
+
+			foreach (var item in button.Items)
+			{
+				LogEvents(item);
+			}
+		}
+
+		void LogEvents(SegmentedItem item)
+		{
+			item.Click += (sender, e) => Log.Write(sender, $"Click: {ItemDesc(item)}");
+		}
+
+		MenuItem CreateMenuItem(string text)
+		{
+			var item = new ButtonMenuItem { Text = text };
+			item.Click += (sender, e) => Log.Write(sender, $"Click, {text}");
+			return item;
+		}
+
+		string ItemDesc(SegmentedItem item) => $"{item.GetType().Name}, {item.Text}";
+	}
+}

--- a/test/Eto.Test/Sections/Controls/ToggleButtonSection.cs
+++ b/test/Eto.Test/Sections/Controls/ToggleButtonSection.cs
@@ -1,0 +1,131 @@
+using Eto.Forms;
+using Eto.Drawing;
+using System.Collections.Generic;
+using System.Text;
+using System.ComponentModel;
+
+namespace Eto.Test.Sections.Controls
+{
+	[Section("Controls", typeof(ToggleButton))]
+	public class ToggleButtonSection : BaseButtonSection<ToggleButton>
+	{
+		protected override string DefaultText => "Toggle Me";
+
+		protected override void LogEvents(ToggleButton button)
+		{
+			base.LogEvents(button);
+			button.CheckedChanged += (sender, e) => Log.Write(sender, $"CheckedChanged, Checked:{button.Checked}");
+		}
+
+		protected override void AddAdditionalOptions()
+		{
+			base.AddAdditionalOptions();
+
+			var checkedCheck = new CheckBox { Text = "Checked" };
+			checkedCheck.CheckedBinding.Bind(Control, b => b.Checked);
+
+			AddSeparateRow(null, checkedCheck, null);
+		}
+	}
+	[Section("Controls", typeof(ToggleButton), "Button (new)")]
+	public class NewButtonSection : BaseButtonSection<Button>
+	{
+		protected override string DefaultText => "Click Me";
+	}
+
+	public abstract class BaseButtonSection<T> : DynamicLayout
+		where T : Button, new()
+	{
+		protected T Control { get; private set; }
+
+		protected abstract string DefaultText { get; }
+
+		public BaseButtonSection()
+		{
+			Styles.Add<Label>(null, l => l.VerticalAlignment = VerticalAlignment.Center);
+
+			Image image = TestIcons.TestIcon.WithSize(16, 16);
+			Image largeImage = TestIcons.TestIcon.WithSize(100, 100);
+
+			DefaultSpacing = new Size(2, 2);
+
+			var button = new T();
+			button.Text = DefaultText;
+			button.Image = image;
+			Control = button;
+
+			var originalMinimumSize = button.MinimumSize;
+
+			LogEvents(button);
+
+			var textBox = new TextBox();
+			textBox.TextBinding.Bind(button, b => b.Text);
+
+			var enabledCheck = new CheckBox { Text = "Enabled" };
+			enabledCheck.CheckedBinding.Bind(button, b => b.Enabled);
+
+			var visibleCheck = new CheckBox { Text = "Visible" };
+			visibleCheck.CheckedBinding.Bind(button, b => b.Visible);
+
+			var withTextCheck = new CheckBox { Text = "With Text" };
+			withTextCheck.CheckedBinding
+				.Convert(r => r == true ? textBox.Text : null, s => !string.IsNullOrEmpty(s))
+				.Bind(button, c => c.Text);
+			withTextCheck.CheckedBinding.Bind(textBox, b => b.Enabled);
+
+			var withImageSelection = new RadioButtonList { Items = { "Image", "Large Image", "No Image" } };
+			withImageSelection.SelectedIndexBinding
+				.Convert(
+					i => i == 0 ? image : i == 1 ? largeImage : null,
+					img => img == image ? 0 : img == largeImage ? 1 : 2
+					)
+				.Bind(button, c => c.Image);
+
+			var performClick = new Button { Text = "PerformClick" };
+			performClick.Click += (sender, e) => button.PerformClick();
+
+			var minimumSizeEntry = new SizeEntry();
+			minimumSizeEntry.ValueBinding.Bind(button, b => b.MinimumSize);
+
+			var clearMinimumSize = new CheckBox { Text = "Clear MinimumSize" };
+			clearMinimumSize.CheckedBinding
+				.Convert(ischecked => ischecked == true ? Size.Empty : originalMinimumSize, size => size.IsEmpty)
+				.Bind(button, c => c.MinimumSize);
+			clearMinimumSize.CheckedBinding.Inverse().Bind(minimumSizeEntry, m => m.Enabled);
+
+			var sizeEntry = new SizeEntry();
+			sizeEntry.ValueBinding.Bind(button, b => b.Size, DualBindingMode.OneWayToSource);
+
+			var imagePositionDropDown = new EnumDropDown<ButtonImagePosition>();
+			imagePositionDropDown.SelectedValueBinding.Bind(button, c => c.ImagePosition);
+
+			var backgroundColorPicker = new ColorPicker { AllowAlpha = true };
+			backgroundColorPicker.ValueBinding.Bind(button, b => b.BackgroundColor);
+
+			var textColorPicker = new ColorPicker { AllowAlpha = true };
+			textColorPicker.ValueBinding.Bind(button, b => b.TextColor);
+
+			BeginVertical(padding: 10);
+			AddSeparateRow(null, enabledCheck, visibleCheck, null);
+			AddSeparateRow(null, "With:", withImageSelection, imagePositionDropDown, null);
+			AddSeparateRow(null, withTextCheck, textBox, null);
+			AddSeparateRow(null, clearMinimumSize, minimumSizeEntry, null);
+			AddSeparateRow(null, "Size:", sizeEntry, null);
+			AddSeparateRow(null, "BackgroundColor", backgroundColorPicker, "TextColor", textColorPicker, null);
+			AddSeparateRow(null, performClick, null);
+			AddAdditionalOptions();
+			EndVertical();
+
+			AddAutoSized(button, centered: true);
+		}
+
+		protected virtual void LogEvents(T button)
+		{
+			button.Click += (sender, e) => Log.Write(sender, $"Click");
+		}
+
+		protected virtual void AddAdditionalOptions()
+		{
+		}
+	}
+}

--- a/test/Eto.Test/SizeEntry.cs
+++ b/test/Eto.Test/SizeEntry.cs
@@ -1,0 +1,58 @@
+using Eto.Forms;
+using Eto.Drawing;
+using System;
+
+namespace Eto.Test
+{
+	/// <summary>
+	/// Easily bindable entry for a Size struct
+	/// </summary>
+    public class SizeEntry : TableLayout
+    {
+        NumericStepper widthText;
+        NumericStepper heightText;
+        public event EventHandler<EventArgs> ValueChanged;
+
+        protected virtual void OnValueChanged(EventArgs e)
+        {
+            ValueChanged?.Invoke(this, e);
+        }
+
+        public Size Value
+        {
+            get => new Size((int)widthText.Value, (int)heightText.Value);
+            set
+            {
+                widthText.Value = value.Width;
+                heightText.Value = value.Height;
+            }
+        }
+
+        public SizeEntry()
+        {
+            widthText = new NumericStepper { MinValue = -1, Value = -1 };
+            widthText.ValueChanged += StepperValueChanged;
+            heightText = new NumericStepper { MinValue = -1, Value = -1 };
+            heightText.ValueChanged += StepperValueChanged;
+
+            Styles.Inherit = false;
+            Styles.Add<Label>(null, l => l.VerticalAlignment = VerticalAlignment.Center);
+
+            Rows.Add(new TableRow("Width:", widthText, "Height:", heightText, null));
+        }
+
+        void StepperValueChanged(object sender, EventArgs e)
+        {
+            OnValueChanged(e);
+        }
+
+        public BindableBinding<SizeEntry, Size> ValueBinding =>
+            new BindableBinding<SizeEntry, Size>(
+                this,
+                c => c.Value,
+                (c, v) => c.Value = v,
+                (s, eh) => s.ValueChanged += eh,
+                (s, eh) => s.ValueChanged -= eh
+            );
+    }
+}

--- a/test/Eto.Test/UnitTests/Forms/Controls/SegmentedButtonTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/SegmentedButtonTests.cs
@@ -1,0 +1,206 @@
+using System;
+using NUnit.Framework;
+using Eto.Forms;
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	[TestFixture]
+	public class SegmentedButtonTests : TestBase
+	{
+		[Test, ManualTest]
+		public void ClickingSelectedSegmentShouldNotTriggerSelectionChanged()
+		{
+			var selectedIndexesChangedCount = 0;
+			var itemClickCount = 0;
+			var clickCount = 0;
+			SegmentedItem itemClicked = null;
+			SegmentedItem itemItemClicked = null;
+			SegmentedItem itemExpected = null;
+
+			Form(form =>
+			{
+				itemExpected = new ButtonSegmentedItem { Text = "Click Me!", Selected = true };
+				var segmentedButton = new SegmentedButton
+				{
+					SelectionMode = SegmentedSelectionMode.Single,
+					Items = { "First", itemExpected, "Last" }
+				};
+
+
+				segmentedButton.SelectedIndexesChanged += (sender, e) => selectedIndexesChangedCount++;
+				segmentedButton.ItemClick += (sender, e) =>
+				{
+					itemItemClicked = e.Item;
+					itemClickCount++;
+				};
+				itemExpected.Click += (sender, e) =>
+				{
+					itemClicked = sender as SegmentedItem;
+					clickCount++;
+					Application.Instance.AsyncInvoke(form.Close);
+				};
+
+				Assert.IsTrue(itemExpected.Selected, "#1.1");
+
+				form.Content = new StackLayout
+				{
+					Spacing = 10,
+					Padding = 10,
+					Items =
+					{ 
+						"Click the selected segment",
+						segmentedButton
+					}
+				};
+			}, -1);
+
+			Assert.AreEqual(0, selectedIndexesChangedCount, "#2.1");
+			Assert.AreEqual(1, itemClickCount, "#2.2");
+			Assert.AreEqual(1, clickCount, "#2.3");
+
+			Assert.IsNotNull(itemExpected, "#3.1");
+			Assert.AreSame(itemExpected, itemClicked, "#3.2");
+			Assert.AreSame(itemExpected, itemItemClicked, "#3.3");
+		}
+
+		[Test, InvokeOnUI]
+		public void SettingSelectedOnItemShouldChangeSelection()
+		{
+			var segmentedButton = new SegmentedButton
+			{
+				Items = { "Item1", "Item2", "Item3" }
+			};
+
+			var selectedIndexesChangedCount = 0;
+			segmentedButton.SelectedIndexesChanged += (sender, e) => selectedIndexesChangedCount++;
+
+			segmentedButton.Items[0].Selected = true;
+		}
+
+		[Test, InvokeOnUI]
+		public void SettingMultipleSelectedInSingleModeShouldOnlyHaveOneSelectedItem()
+		{
+			var item1 = new ButtonSegmentedItem { Text = "Item1", Selected = true };
+			var item2 = new ButtonSegmentedItem { Text = "Item2", Selected = true };
+			var item3 = new ButtonSegmentedItem { Text = "Item3", Selected = true };
+
+			var segmentedButton = new SegmentedButton
+			{
+				SelectionMode = SegmentedSelectionMode.Single
+			};
+
+			var selectedIndexesChangedCount = 0;
+			segmentedButton.SelectedIndexesChanged += (sender, e) => selectedIndexesChangedCount++;
+
+			segmentedButton.Items.Add(item1);
+			Assert.AreEqual(1, selectedIndexesChangedCount, "#1.1");
+			segmentedButton.Items.Add(item2);
+			Assert.AreEqual(2, selectedIndexesChangedCount, "#1.2");
+			segmentedButton.Items.Add(item3);
+			Assert.AreEqual(3, selectedIndexesChangedCount, "#1.3");
+
+			Assert.AreEqual(2, segmentedButton.SelectedIndex, "#2.1");
+			Assert.AreSame(item3, segmentedButton.SelectedItem, "#2.2");
+			CollectionAssert.AreEqual(new[] { item3 }, segmentedButton.SelectedItems, "#2.3");
+			CollectionAssert.AreEqual(new[] { 2 }, segmentedButton.SelectedIndexes, "#2.4");
+			Assert.AreEqual(3, selectedIndexesChangedCount, "#2.5");
+
+			item1.Selected = true;
+
+			Assert.AreEqual(0, segmentedButton.SelectedIndex, "#3.1");
+			Assert.AreSame(item1, segmentedButton.SelectedItem, "#3.2");
+			CollectionAssert.AreEqual(new[] { item1 }, segmentedButton.SelectedItems, "#3.3");
+			CollectionAssert.AreEqual(new[] { 0 }, segmentedButton.SelectedIndexes, "#3.4");
+			Assert.AreEqual(4, selectedIndexesChangedCount, "#3.5");
+
+			item1.Selected = false;
+
+			Assert.AreEqual(-1, segmentedButton.SelectedIndex, "#4.1");
+			Assert.IsNull(segmentedButton.SelectedItem, "#4.2");
+			CollectionAssert.AreEqual(new SegmentedItem[0], segmentedButton.SelectedItems, "#4.3");
+			CollectionAssert.AreEqual(new int[0], segmentedButton.SelectedIndexes, "#4.4");
+			Assert.AreEqual(5, selectedIndexesChangedCount, "#4.5");
+		}
+
+		[Test, InvokeOnUI]
+		public void AddingAndRemovingSelectedItemShouldChangeSelection()
+		{
+			var item1 = new ButtonSegmentedItem { Text = "Item1" };
+			var item2 = new ButtonSegmentedItem { Text = "Item2", Selected = true };
+			var item3 = new ButtonSegmentedItem { Text = "Item3" };
+
+			var segmentedButton = new SegmentedButton
+			{
+				SelectionMode = SegmentedSelectionMode.Single,
+			};
+			var selectedIndexesChangedCount = 0;
+			segmentedButton.SelectedIndexesChanged += (sender, e) => selectedIndexesChangedCount++;
+
+			// add non-selected item
+			segmentedButton.Items.Add(item1);
+			Assert.AreEqual(0, selectedIndexesChangedCount, "#1.1");
+			Assert.AreEqual(-1, segmentedButton.SelectedIndex, "#1.2");
+
+			// add item that was selected (selection now changed to that item!)
+			segmentedButton.Items.Add(item2);
+			Assert.AreEqual(1, selectedIndexesChangedCount, "#2.1");
+			Assert.AreEqual(1, segmentedButton.SelectedIndex, "#2.2");
+
+			// add another item (no change)
+			segmentedButton.Items.Add(item3);
+			Assert.AreEqual(1, selectedIndexesChangedCount, "#3.1");
+			Assert.AreEqual(1, segmentedButton.SelectedIndex, "#3.2");
+
+			// remove a non-selected item (no change)
+			segmentedButton.Items.Remove(item3);
+			Assert.AreEqual(1, selectedIndexesChangedCount, "#4.1");
+			Assert.AreEqual(1, segmentedButton.SelectedIndex, "#4.2");
+
+			// remove the selected item (change!)
+			segmentedButton.Items.Remove(item2);
+			Assert.AreEqual(2, selectedIndexesChangedCount, "#5.1");
+			Assert.AreEqual(-1, segmentedButton.SelectedIndex, "#5.2");
+		}
+
+		[Test, InvokeOnUI]
+		public void ChangingModesShouldUpdateSelection()
+		{
+			var item1 = new ButtonSegmentedItem { Text = "Item1", Selected = true };
+			var item2 = new ButtonSegmentedItem { Text = "Item2", Selected = true };
+			var item3 = new ButtonSegmentedItem { Text = "Item3", Selected = true };
+
+			var segmentedButton = new SegmentedButton
+			{
+				SelectionMode = SegmentedSelectionMode.Multiple,
+				Items = { item1, item2, item3 }
+			};
+
+			var selectedIndexesChangedCount = 0;
+			segmentedButton.SelectedIndexesChanged += (sender, e) => selectedIndexesChangedCount++;
+
+			// sanity check, in multiple selection last selected is returned
+			Assert.AreEqual(0, segmentedButton.SelectedIndex, "#1.1");
+			Assert.AreEqual(item1, segmentedButton.SelectedItem, "#1.2");
+			CollectionAssert.AreEquivalent(new[] { 0, 1, 2 }, segmentedButton.SelectedIndexes, "#1.3");
+			CollectionAssert.AreEquivalent(new[] { item1, item2, item3 }, segmentedButton.SelectedItems, "#1.4");
+
+			// change mode to single
+			segmentedButton.SelectionMode = SegmentedSelectionMode.Single;
+			Assert.AreEqual(1, selectedIndexesChangedCount, "#2.1");
+			Assert.AreEqual(0, segmentedButton.SelectedIndex, "#2.2");
+			Assert.AreEqual(item1, segmentedButton.SelectedItem, "#2.3");
+			CollectionAssert.AreEquivalent(new[] { 0 }, segmentedButton.SelectedIndexes, "#2.4");
+			CollectionAssert.AreEquivalent(new[] { item1 }, segmentedButton.SelectedItems, "#2.5");
+
+			// accessing selected items shouldn't trigger anything
+			Assert.AreEqual(1, selectedIndexesChangedCount, "#3.1");
+
+			// change mode to none
+			segmentedButton.SelectionMode = SegmentedSelectionMode.None;
+			Assert.AreEqual(2, selectedIndexesChangedCount, "#4.1");
+			Assert.AreEqual(-1, segmentedButton.SelectedIndex, "#4.2");
+			Assert.AreEqual(null, segmentedButton.SelectedItem, "#4.3");
+			CollectionAssert.IsEmpty(segmentedButton.SelectedIndexes, "#4.4");
+			CollectionAssert.IsEmpty(segmentedButton.SelectedItems, "#4.5");
+		}
+	}
+}


### PR DESCRIPTION
- Added ToggleButton, which is a Button, but can be toggled on an off.
- Added SegmentedButton which allows you to have a button with different segments, and items with a menu.
- Added BindableExtensions.Inverse() for bool and bool? bindings to more easily invert its value.
- Added BindableExtensions.DefaultIfNull() for value and class types so you can easily convert a nullable binding to non-nullable.
- Button.Size should at least be the MinimumSize, but not if it is -1.
- Add Control.OnApplyCascadingStyles and ApplyStyles for controls that want to style its children when they are not a Container.
- Fix issue applying cascading styles with the Handler class.
- Added PropertyStore.TrySet to more efficiently execute logic when the value is changed.
- Fixed PropertyStore.Set with the property changed delegate parameter when the default value is different.
- Wpf: Setting relative position of menu now places from upper left corner unless showing exactly below or to right of control.
- Wpf: Release capture of the mouse when handling Control.MouseUp but not MouseDown.
- Gtk: Fix converting relative point to screen for Button

Fixes #889