### PR TITLE
Mac: Add ability to restart modal session for a dialog

### DIFF
--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -127,7 +127,7 @@ namespace Eto.Mac.Forms
 			set
 			{
 				defaultButton = value;
-				
+
 				if (defaultButton != null)
 				{
 					var b = defaultButton.ControlObject as NSButton;
@@ -287,6 +287,16 @@ namespace Eto.Mac.Forms
 				ctl.Frame = new CGRect(point.ToNS(), size.ToNS());
 				ctl.AutoresizingMask = NSViewResizingMask.MinXMargin;
 			}
+		}
+
+		public bool IsDisplayedAsSheet => session?.IsSheet == true;
+
+		public bool RestartModal(Action action)
+		{
+			if (session == null)
+				return false;
+			session.Restart(action);
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
For advanced native scenarios. Useful if you want to hide the dialog to perform some other action, then return to it.