### PR TITLE
Wpf: ImageView should expand to container regardless of image size

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
@@ -11,11 +11,14 @@ namespace Eto.Wpf.Forms.Controls
 	public class ImageViewHandler : WpfFrameworkElement<CustomControls.MultiSizeImage, ImageView, ImageView.ICallback>, ImageView.IHandler
 	{
 		Image image;
+		swc.Border border;
+
+		public override FrameworkElement ContainerControl => border;
 
 		public override Color BackgroundColor
 		{
-			get { return Control.Background.ToEtoColor(); }
-			set { Control.Background = value.ToWpfBrush(Control.Background); }
+			get { return border.Background.ToEtoColor(); }
+			set { border.Background = value.ToWpfBrush(border.Background); }
 		}
 
 		public ImageViewHandler()
@@ -28,6 +31,7 @@ namespace Eto.Wpf.Forms.Controls
 				StretchDirection = swc.StretchDirection.Both
 			};
 			Control.SizeChanged += Control_SizeChanged;
+			border = new swc.Border { Child = Control };
 		}
 
 		void Control_SizeChanged(object sender, SizeChangedEventArgs e)

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -79,13 +79,17 @@ namespace Eto.Wpf.Forms
 		public static bool ShouldCaptureMouse;
 	}
 
+	class WpfFrameworkElement
+	{
+		internal static readonly object Cursor_Key = new object();
+	}
+
 	public abstract class WpfFrameworkElement<TControl, TWidget, TCallback> : WidgetHandler<TControl, TWidget, TCallback>, Control.IHandler, IWpfFrameworkElement
 		where TControl : System.Windows.FrameworkElement
 		where TWidget : Control
 		where TCallback : Control.ICallback
 	{
 		Size? newSize;
-		Cursor cursor;
 		sw.Size parentMinimumSize;
 		bool isMouseOver;
 		bool isMouseCaptured;
@@ -254,11 +258,13 @@ namespace Eto.Wpf.Forms
 
 		public virtual Cursor Cursor
 		{
-			get { return cursor; }
+			get => Widget.Properties.Get<Cursor>(WpfFrameworkElement.Cursor_Key);
 			set
 			{
-				cursor = value;
-				Control.Cursor = cursor != null ? ((CursorHandler)cursor.Handler).Control : null;
+				if (Widget.Properties.TrySet(WpfFrameworkElement.Cursor_Key, value))
+				{
+					ContainerControl.Cursor = (value?.Handler as CursorHandler)?.Control;
+				}
 			}
 		}
 

--- a/test/Eto.Test/UnitTests/Forms/Controls/ScrollableTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ScrollableTests.cs
@@ -33,5 +33,24 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				};
 			});
 		}
+
+		[Test, TestCaseSource(nameof(GetControlTypes)), ManualTest]
+		public void AllControlsShouldExpandWidth(IControlTypeInfo<Control> info)
+		{
+			ManualForm("Control and blue background should expand to width of scrollable", form =>
+			{
+				var control = info.CreateControl();
+				info.PopulateControl(control);
+				control.BackgroundColor = Colors.Blue;
+
+				return new Scrollable
+				{
+					Size = new Size(300, 200),
+					Content = control,
+					ExpandContentWidth = true,
+					ExpandContentHeight = false
+				};
+			});
+		}
 	}
 }

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -641,7 +641,8 @@ namespace Eto.Test.UnitTests
 				{
 					var ti = r.Type.GetTypeInfo();
 					return !typeof(Window).GetTypeInfo().IsAssignableFrom(ti)
-						&& !typeof(TabPage).GetTypeInfo().IsAssignableFrom(ti);
+						&& !typeof(TabPage).GetTypeInfo().IsAssignableFrom(ti)
+						&& !typeof(DocumentPage).GetTypeInfo().IsAssignableFrom(ti);
 				});
 		}
 
@@ -651,6 +652,7 @@ namespace Eto.Test.UnitTests
 			Type Type { get; }
 			T CreateControl();
 			Container CreateContainer(Control control);
+			void PopulateControl(Control control);
 		}
 
 		public interface IContainerTypeInfo<out T> : IControlTypeInfo<T>
@@ -686,6 +688,89 @@ namespace Eto.Test.UnitTests
 					return (Container)control;
 
 				return new Panel { Content = control };
+			}
+
+			public void PopulateControl(Control control)
+			{
+				if (control is TextControl textControl)
+					textControl.Text = "Some Text";
+				else if (control is ImageView imageView)
+					imageView.Image = TestIcons.Logo;
+				else if (control is ListControl listControl)
+				{
+					listControl.Items.Add("Item 1");
+					listControl.Items.Add("Item 2");
+					listControl.Items.Add("Item 3");
+				}
+				else if (control is NumericStepper numericStepper)
+					numericStepper.Value = 100;
+				else if (control is TabControl tabControl)
+				{
+					tabControl.Pages.Add(new TabPage { Text = "Tab 1", Content = new Panel { Size = new Size(100, 100), Content = "Hello" }  });
+					tabControl.Pages.Add(new TabPage { Text = "Tab 2" });
+					tabControl.Pages.Add(new TabPage { Text = "Tab 3" });
+				}
+				else if (control is DocumentControl documentControl)
+				{
+					documentControl.Pages.Add(new DocumentPage { Text = "Tab 1", Content = new Panel { Size = new Size(100, 100), Content = "Hello" } });
+					documentControl.Pages.Add(new DocumentPage { Text = "Tab 2" });
+					documentControl.Pages.Add(new DocumentPage { Text = "Tab 3" });
+				}
+				else if (control is Drawable drawable)
+				{
+					drawable.Size = new Size(100, 40);
+					drawable.Paint += (sender, e) =>
+					{
+						var c = drawable.BackgroundColor;
+						if (c.A == 0)
+							c = SystemColors.ControlText;
+						else
+							c.Invert();
+						e.Graphics.DrawText(SystemFonts.Default(), c, 0, 0, "Hello!");
+					};
+				}
+				else if (control is SegmentedButton segmented)
+				{
+					segmented.Items.Add("Segment 1");
+					segmented.Items.Add(TestIcons.Logo.WithSize(20, 20));
+					segmented.Items.Add("Segment 3");
+				}
+				else if (control is CheckBoxList checkBoxList)
+				{
+					checkBoxList.Items.Add("Item 1");
+					checkBoxList.Items.Add("Item 2");
+					checkBoxList.Items.Add("Item 3");
+				}
+				else if (control is RadioButtonList radioButtonList)
+				{
+					radioButtonList.Items.Add("Item 1");
+					radioButtonList.Items.Add("Item 2");
+					radioButtonList.Items.Add("Item 3");
+				}
+				else if (control is PixelLayout pixelLayout)
+				{
+					pixelLayout.Add("Hello", 0, 0);
+					pixelLayout.Add("World!", 24, 24);
+				}
+				else if (control is DynamicLayout dynamicLayout)
+				{
+					dynamicLayout.Add("Hello");
+					dynamicLayout.Add("World!");
+				}
+				else if (control is StackLayout stackLayout)
+				{
+					stackLayout.Items.Add("Hello");
+					stackLayout.Items.Add("World!");
+				}
+				else if (control is TableLayout tableLayout)
+				{
+					tableLayout.Rows.Add(new TableRow(new TableCell("Hello", true), new TableCell("World!", true)));
+					tableLayout.Rows.Add(new TableRow("Row", "2"));
+				}
+				else if (control is Panel panel && panel.Content == null)
+				{
+					panel.Content = "Hello, World!";
+				}
 			}
 
 			public override string ToString() => Type.Name;


### PR DESCRIPTION
This makes sure the ImageView can expand to the width (or height) regardless of the size of image.  In Eto, controls must fill their container fully but the ImageView isn't allowing that.

- Added tests to test all controls within a scrollable to ensure they expand to the width when ExpandContentWidth is true.