### PR TITLE
Mac: ToolBar fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,6 +14,8 @@ jobs:
     vmImage: 'macOS-10.13'
   
   steps:
+  - script: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 5_16_0
+    displayName: 'Select Xamarin SDK version'
   - task: msbuild@1
     displayName: Build and Package
     inputs: 

--- a/src/Eto.Gtk/Forms/ToolBar/ToolBarHandler.cs
+++ b/src/Eto.Gtk/Forms/ToolBar/ToolBarHandler.cs
@@ -37,7 +37,7 @@ namespace Eto.GtkSharp.Forms.ToolBar
 			((IToolBarItemHandler)item.Handler).CreateControl(this, index);
 		}
 
-		public void RemoveButton(ToolItem item)
+		public void RemoveButton(ToolItem item, int index)
 		{
 			if (item.ControlObject != null) Control.Remove((Gtk.Widget)item.ControlObject);
 		}

--- a/src/Eto.Mac/Forms/ToolBar/RadioToolItemHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/RadioToolItemHandler.cs
@@ -37,10 +37,7 @@ namespace Eto.Mac.Forms.ToolBar
 			}
 		}
 
-		public override bool Selectable
-		{
-			get { return true; }
-		}
+		public override bool Selectable => true;
 
 		public override void ControlAdded (ToolBarHandler toolbar)
 		{

--- a/src/Eto.Mac/Forms/ToolBar/SeparatorToolItemHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/SeparatorToolItemHandler.cs
@@ -34,9 +34,9 @@ namespace Eto.Mac.Forms.ToolBar
 {
 	public class SeparatorToolItemHandler : ToolItemHandler<NSToolbarItem, SeparatorToolItem>, SeparatorToolItem.IHandler, IToolBarBaseItemHandler
 	{
-		public static string DividerIdentifier = "divider";
-		Drawable drawable;
 		SeparatorToolItemType type = SeparatorToolItemType.Divider;
+
+		ToolBarHandler ParentHandler => Widget.Parent?.Handler as ToolBarHandler;
 
 		protected override bool IsButton => false;
 
@@ -47,7 +47,7 @@ namespace Eto.Mac.Forms.ToolBar
 				switch (Type)
 				{
 					case SeparatorToolItemType.Divider:
-						return DividerIdentifier;
+						return ToolBarHandler.DividerIdentifier;
 					case SeparatorToolItemType.Space:
 						return NSToolbar.NSToolbarSpaceItemIdentifier;
 					case SeparatorToolItemType.FlexibleSpace:
@@ -62,36 +62,17 @@ namespace Eto.Mac.Forms.ToolBar
 
 		public SeparatorToolItemType Type
 		{
-			get { return type; }
+			get => type;
 			set
 			{
 				if (type != value)
 				{
 					type = value;
-					drawable = null;
-					Control = null;
+					ParentHandler?.ChangeIdentifier(Widget);
 				}
 			}
 		}
 
-		protected override NSToolbarItem CreateControl()
-		{
-			if (type == SeparatorToolItemType.Divider)
-			{
-				drawable = new Drawable { Size = new Size(1, 20) };
-				drawable.Paint += (sender, e) =>
-				{
-					e.Graphics.DrawLine(new Color(SystemColors.WindowBackground, 0.5f), 0, 0, 0, drawable.Height);
-				};
-				var view = drawable.ToNative(true);
-				view.AutoresizingMask = NSViewResizingMask.HeightSizable;
-				return new NSToolbarItem(DividerIdentifier)
-				{
-					View = view,
-					PaletteLabel = "Divider"
-				};
-			}
-			return null;
-		}
+		protected override NSToolbarItem CreateControl() => null;
 	}
 }

--- a/src/Eto.Mac/Forms/ToolBar/ToolBarHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/ToolBarHandler.cs
@@ -2,6 +2,7 @@ using System;
 using Eto.Forms;
 using System.Linq;
 using System.Collections.Generic;
+using Eto.Drawing;
 
 #if XAMMAC2
 using AppKit;
@@ -35,138 +36,327 @@ namespace Eto.Mac.Forms.ToolBar
 {
 	public class ToolBarHandler : WidgetHandler<NSToolbar, Eto.Forms.ToolBar>, Eto.Forms.ToolBar.IHandler
 	{
-		ToolBarDock dock = ToolBarDock.Top;
+		public static string DividerIdentifier = "Divider";
+
+		int suppressVisibleUpdate;
 		readonly List<IToolBarBaseItemHandler> items = new List<IToolBarBaseItemHandler>();
 
-		class TBDelegate : NSToolbarDelegate
+		public class DividerToolbarItem : NSToolbarItem
+		{
+			Drawable _drawable;
+			Color _color;
+
+			static readonly bool supportsSeparatorColor = ObjCExtensions.RespondsToSelector<NSColor>("separatorColor");
+
+			public DividerToolbarItem(bool willBeInserted) : base(DividerIdentifier)
+			{
+				_drawable = new Drawable
+				{
+					Size = willBeInserted ? new Size(1, 20) : new Size(20, 20)
+				};
+				_drawable.Paint += Drawable_Paint;
+				View = _drawable.ToNative(true);
+				View.AutoresizingMask = NSViewResizingMask.HeightSizable | NSViewResizingMask.WidthSizable;
+				PaletteLabel = Application.Instance.Localize(this, "Divider");
+				MenuFormRepresentation = NSMenuItem.SeparatorItem;
+#if MONOMAC || XAMMAC2
+				if (supportsSeparatorColor)
+					_color = NSColor.SeparatorColor.ToEto();
+				else
+					_color = new Color(SystemColors.WindowBackground, 0.5f);
+#else
+				_color = new Color(SystemColors.WindowBackground, 0.5f);
+#endif
+			}
+
+			public override bool AllowsDuplicatesInToolbar => true;
+
+			void Drawable_Paint(object sender, PaintEventArgs e)
+			{
+				var x = _drawable.Width / 2;
+
+				e.Graphics.DrawLine(_color, x, 0, x, _drawable.Height);
+			}
+		}
+
+		class EtoToolbarDelegate : NSToolbarDelegate
 		{
 			WeakReference handler;
 
-			public ToolBarHandler Handler { get { return (ToolBarHandler)handler.Target; } set { handler = new WeakReference(value); } }
+			public ToolBarHandler Handler { get => (ToolBarHandler)handler?.Target; set => handler = new WeakReference(value); }
 
 			public override string[] SelectableItemIdentifiers(NSToolbar toolbar)
 			{
-				return Handler.items.Where(r => r.Selectable && r.Visible).Select(r => r.Identifier).ToArray();
+				var h = Handler;
+				if (h == null)
+					return new string[0];
+				return h.items.Where(r => r.Selectable && r.Visible).Select(r => r.Identifier).ToArray();
 			}
 
 			public override void WillAddItem(NSNotification notification)
 			{
+				var h = Handler;
+				if (h == null)
+					return;
+				if (notification.UserInfo[itemKey] is NSToolbarItem item)
+					h.SetItemVisibility(item, true);
 			}
 
+			static readonly NSString itemKey = new NSString("item");
 			public override void DidRemoveItem(NSNotification notification)
 			{
+				var h = Handler;
+				if (h == null)
+					return;
+				if (notification.UserInfo[itemKey] is NSToolbarItem item)
+					h.SetItemVisibility(item, false);
 			}
 
 			public override NSToolbarItem WillInsertItem(NSToolbar toolbar, string itemIdentifier, bool willBeInserted)
 			{
-				var item = Handler.items.FirstOrDefault(r => r.Identifier == itemIdentifier);
-				return item == null || !item.Visible ? null : item.Control;
+				var h = Handler;
+				if (h == null)
+					return null;
+
+				if (itemIdentifier == DividerIdentifier)
+					return new DividerToolbarItem(willBeInserted);
+
+				var item = h.items.FirstOrDefault(r => r.Identifier == itemIdentifier);
+				if (willBeInserted)
+				{
+					item?.SetVisible(true);
+				}
+				return item?.Control;
 			}
 
 			public override string[] DefaultItemIdentifiers(NSToolbar toolbar)
 			{
-				return Handler.items.Where(r => r.Visible).Select(r => r.Identifier).ToArray();
+				var h = Handler;
+				if (h == null)
+					return new string[0];
+				return h.items.Where(r => r.Visible).Select(r => r.Identifier).ToArray();
 			}
+
+			static string[] systemIdentifiers = {
+				DividerIdentifier,
+				NSToolbar.NSToolbarSeparatorItemIdentifier,
+				NSToolbar.NSToolbarSpaceItemIdentifier,
+				NSToolbar.NSToolbarFlexibleSpaceItemIdentifier,
+				NSToolbar.NSToolbarCustomizeToolbarItemIdentifier
+			};
 
 			public override string[] AllowedItemIdentifiers(NSToolbar toolbar)
 			{
-				return Handler.items.Select(r => r.Identifier)
-				.Union(
-					new string[]
-					{ 
-						SeparatorToolItemHandler.DividerIdentifier,
-						NSToolbar.NSToolbarSeparatorItemIdentifier, 
-						NSToolbar.NSToolbarSpaceItemIdentifier,
-						NSToolbar.NSToolbarFlexibleSpaceItemIdentifier,
-						NSToolbar.NSToolbarCustomizeToolbarItemIdentifier
-					}).ToArray();
+				var h = Handler;
+				if (h == null)
+					return systemIdentifiers;
+				return systemIdentifiers.Union(h.items.Select(r => r.Identifier)).Distinct().ToArray();
 			}
 		}
 
-		protected override NSToolbar CreateControl()
+		private void SetItemVisibility(NSToolbarItem item, bool visible)
 		{
-			return new NSToolbar("main");
+			if (suppressVisibleUpdate > 0)
+				return;
+			// set visibility of item when added/removed from customization
+			var handler = GetEtoItem(item)?.Handler as IToolBarBaseItemHandler;
+			handler?.SetVisible(visible);
 		}
+
+		protected override NSToolbar CreateControl() => new NSToolbar(Guid.NewGuid().ToString());
 
 		protected override void Initialize()
 		{
 			Control.SizeMode = NSToolbarSizeMode.Default;
 			Control.Visible = true;
 			Control.ShowsBaselineSeparator = true;
-			//Control.AllowsUserCustomization = true;
 			Control.DisplayMode = NSToolbarDisplayMode.IconAndLabel;
-			Control.Delegate = new TBDelegate { Handler = this };
+			Control.Delegate = new EtoToolbarDelegate { Handler = this };
+
+			//Control.AutosavesConfiguration = true;
+			//Control.AllowsUserCustomization = true;
 
 			base.Initialize();
 		}
 
 		public ToolBarDock Dock
 		{
-			get { return dock; }
-			set { dock = value; }
+			get => ToolBarDock.Top;
+#pragma warning disable RECS0029 // Warns about property or indexer setters and event adders or removers that do not use the value parameter
+			set
+			{
+				// can't change dock position, but not detrimental so we don't throw.
+			}
+#pragma warning restore RECS0029 // Warns about property or indexer setters and event adders or removers that do not use the value parameter
 		}
 
 		public void AddButton(ToolItem item, int index)
 		{
 			var handler = (IToolBarBaseItemHandler)item.Handler;
 			items.Insert(index, handler);
-			if (item.Visible)
-				Control.InsertItem(handler.Identifier, index);
-			if (handler != null)
-				handler.ControlAdded(this);
+			var idx = GetIndex(item, true);
+			if (idx >= 0 && idx <= Control.Items.Length)
+			{
+				suppressVisibleUpdate++;
+				Control.InsertItem(handler.Identifier, idx);
+				suppressVisibleUpdate--;
+				OnControlItemsChanged();
+			}
+			handler.ControlAdded(this);
 		}
 
-		public void RemoveButton(ToolItem item)
+		public void RemoveButton(ToolItem item, int index)
 		{
-			var handler = item.Handler as IToolBarBaseItemHandler;
-			var index = items.IndexOf(handler);
-			items.Remove(handler);
-			//var handler = item.Handler as IToolBarItemHandler;
+			var handler = (IToolBarBaseItemHandler)item.Handler;
 			var idx = GetIndex(item);
-			if (idx >= 0)
-				Control.RemoveItem(index);
+			if (idx >= 0 && idx < Control.Items.Length)
+			{
+				suppressVisibleUpdate++;
+				Control.RemoveItem(idx);
+				suppressVisibleUpdate--;
+				OnControlItemsChanged();
+			}
+
+			items.Remove(handler);
+		}
+
+		internal void ChangeIdentifier(ToolItem item)
+		{
+			var idx = GetIndex(item);
+			if (idx >= 0 && idx < Control.Items.Length)
+			{
+				suppressVisibleUpdate++;
+				// re-add it!
+				Control.RemoveItem(idx);
+				Control.InsertItem(GetIdentifier(item), idx);
+				suppressVisibleUpdate--;
+				OnControlItemsChanged();
+			}
+		}
+
+		void OnControlItemsChanged()
+		{
+#if !XAMMAC2
+			// re-retrieve items so they aren't GC'd (only needed in MonoMac)
+			var newitems = Control.Items;
+#endif
 		}
 
 		public ToolBarTextAlign TextAlign
 		{
-			get
-			{
-				/*switch (control.TextAlign)
-				{
-					case SWF.ToolBarTextAlign.Right:
-						return ToolBarTextAlign.Right;
-					default:
-					case SWF.ToolBarTextAlign.Underneath:
-						return ToolBarTextAlign.Underneath;
-				}
-				 */
-				return ToolBarTextAlign.Underneath;
-			}
+			get => ToolBarTextAlign.Underneath;
+#pragma warning disable RECS0029 // Warns about property or indexer setters and event adders or removers that do not use the value parameter
 			set
 			{
-				switch (value)
-				{
-					case ToolBarTextAlign.Right:
-						//control.TextAlign = SWF.ToolBarTextAlign.Right;
-						break;
-				}
+				// can't change on macOS, but that's okay.
 			}
+#pragma warning restore RECS0029 // Warns about property or indexer setters and event adders or removers that do not use the value parameter
 		}
 
 		public void Clear()
 		{
+			suppressVisibleUpdate++;
 			for (int i = Control.Items.Length - 1; i >= 0; i--)
 			{
 				Control.RemoveItem(i);
 			}
+			suppressVisibleUpdate--;
 			items.Clear();
 			// allow menu items to be GC'd
-			var newitems = Control.Items;
+			OnControlItemsChanged();
 		}
 
-		internal int GetIndex(ToolItem item)
+		/// <summary>
+		/// Gets the native index of the specified eto item
+		/// </summary>
+		/// <returns>The index to use.</returns>
+		/// <param name="item">Item to find the index for.</param>
+		/// <param name="forInsert">Set to true to specify that we want to find the index to insert to, and it doesn't exist in the items yet.</param>
+		/// <param name="checkVisible">Set to true to check that the item is visible first, which will return -1 if it is not.</param>
+		internal int GetIndex(ToolItem item, bool forInsert = false, bool checkVisible = true)
 		{
-			return Widget.Items.Where(r => r.Visible).TakeWhile(r => !ReferenceEquals(r, item)).Count();
+			if (checkVisible && !item.Visible)
+				return -1;
+
+			var nativeItems = Control.Items;
+			var idx = 0;
+			for (int i = 0; i < Widget.Items.Count; i++)
+			{
+				var curitem = Widget.Items[i];
+				if (ReferenceEquals(curitem, item))
+				{
+					if (curitem.Visible || forInsert)
+						return idx;
+					return -1;
+				}
+
+				if (idx >= nativeItems.Length)
+				{
+					if (forInsert)
+						return idx;
+				}
+				else if (curitem.Visible)
+				{
+					var nativeItem = nativeItems[idx];
+					if (nativeItem.Identifier == GetIdentifier(curitem))
+						idx++;
+				}
+			}
+			return -1;
+		}
+
+		internal void ChangeVisibility(ToolItem item, bool value)
+		{
+			suppressVisibleUpdate++;
+			var nsitem = GetNSItem(item);
+			var nativeItems = Control.Items;
+			int idx;
+			if (nsitem != null)
+				idx = Array.IndexOf(nativeItems, nsitem);
+			else
+				idx = GetIndex(item, checkVisible: false); // lookup by index of eto item
+
+			// lookup by index of native control
+			if (value)
+			{
+				if (idx == -1)
+				{
+					idx = GetIndex(item, true, false);
+					if (idx >= 0 && idx <= nativeItems.Length)
+						Control.InsertItem(GetIdentifier(item), idx);
+				}
+			}
+			else if (idx != -1 && idx < nativeItems.Length)
+			{
+				Control.RemoveItem(idx);
+			}
+			OnControlItemsChanged();
+			suppressVisibleUpdate--;
+		}
+
+		string GetIdentifier(ToolItem item) => (item.Handler as IToolBarBaseItemHandler)?.Identifier;
+
+		NSToolbarItem GetNSItem(ToolItem item) => item.ControlObject as NSToolbarItem;
+
+		ToolItem GetEtoItem(NSToolbarItem item)
+		{
+			var itemIdentifier = item.Identifier;
+			var etoItem = items.FirstOrDefault(r => r.Identifier == itemIdentifier);
+			if (etoItem != null)
+				return etoItem.Widget;
+			var index = Array.IndexOf(Control.Items, item);
+
+			var idx = 0;
+			for (int i = 0; i < Widget.Items.Count; i++)
+			{
+				var curitem = Widget.Items[i];
+				if (idx == index)
+					return curitem;
+
+				if (curitem.Visible)
+					idx++;
+			}
+			return null;
 		}
 	}
 }

--- a/src/Eto.Mac/ObjCExtensions.cs
+++ b/src/Eto.Mac/ObjCExtensions.cs
@@ -86,7 +86,7 @@ namespace Eto.Mac
 
 		public static bool ClassRespondsToSelector(IntPtr cls, IntPtr selector)
 		{
-			return Messaging.bool_objc_msgSend_IntPtr(cls, selInstancesRespondToSelector, selector);
+			return Messaging.bool_objc_msgSend_IntPtr(cls, selRespondsToSelector, selector);
 		}
 
 		public static bool RespondsToSelector<T>(IntPtr selector)

--- a/src/Eto.WinForms/Forms/ToolBar/ToolBarHandler.cs
+++ b/src/Eto.WinForms/Forms/ToolBar/ToolBarHandler.cs
@@ -27,7 +27,7 @@ namespace Eto.WinForms.Forms.ToolBar
 			((IToolBarItemHandler)item.Handler).CreateControl(this, index);
 		}
 
-		public void RemoveButton(ToolItem item)
+		public void RemoveButton(ToolItem item, int index)
 		{
 			Control.Items.Remove((SWF.ToolStripItem)item.ControlObject);
 		}

--- a/src/Eto.Wpf/Forms/ToolBar/ToolBarHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/ToolBarHandler.cs
@@ -17,7 +17,7 @@ namespace Eto.Wpf.Forms.ToolBar
 			Control.Items.Insert(index, button.ControlObject);
 		}
 
-		public void RemoveButton(ToolItem button)
+		public void RemoveButton(ToolItem button, int index)
 		{
 			Control.Items.Remove(button.ControlObject);
 		}

--- a/src/Eto/Forms/ToolBar/ToolBar.cs
+++ b/src/Eto/Forms/ToolBar/ToolBar.cs
@@ -171,7 +171,8 @@ namespace Eto.Forms
 			/// Removes the specified button.
 			/// </summary>
 			/// <param name="button">Button to remove.</param>
-			void RemoveButton(ToolItem button);
+			/// <param name="index">Index of the button to remove.</param>
+			void RemoveButton(ToolItem button, int index);
 
 			/// <summary>
 			/// Clears all buttons from the toolbar

--- a/src/Eto/Forms/ToolBar/ToolItemCollection.cs
+++ b/src/Eto/Forms/ToolBar/ToolItemCollection.cs
@@ -39,8 +39,8 @@ namespace Eto.Forms
 		protected override void RemoveItem(int index)
 		{
 			var item = this[index];
+			parent.Handler.RemoveButton(item, index);
 			base.RemoveItem(index);
-			parent.Handler.RemoveButton(item);
 			item.Parent = null;
 		}
 

--- a/test/Eto.Test/MainForm.cs
+++ b/test/Eto.Test/MainForm.cs
@@ -304,9 +304,17 @@ namespace Eto.Test
 					ToolBar.Items.Add(new RadioToolItem { Text = "Radio2", Image = TestIcons.TestImage });
 					ToolBar.Items.Add(new RadioToolItem { Text = "Radio3 (Disabled)", Image = TestIcons.TestImage, Enabled = false });
 				}
+
+				// add an invisible button and separator and allow them to be toggled.
 				var invisibleButton = new ButtonToolItem { Text = "Invisible", Visible = false };
+				var sep = new SeparatorToolItem { Type = SeparatorToolItemType.Divider, Visible = false };
+				ToolBar.Items.Add(sep);
 				ToolBar.Items.Add(invisibleButton);
-				clickButton.Click += (sender, e) => invisibleButton.Visible = !invisibleButton.Visible;
+				clickButton.Click += (sender, e) =>
+				{
+					invisibleButton.Visible = !invisibleButton.Visible;
+					sep.Visible = invisibleButton.Visible;
+				};
 			}
 		}
 

--- a/test/Eto.Test/Sections/Behaviors/ToolBarSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ToolBarSection.cs
@@ -1,0 +1,124 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+
+namespace Eto.Test.Sections.Behaviors
+{
+	[Section("Behaviors", typeof(ToolBar))]
+	public class ToolBarSection : DynamicLayout
+	{
+		public ToolBarSection()
+		{
+			var showDialogButton = new Button { Text = "Show Test Dialog" };
+			showDialogButton.Click += (sender, e) => ShowTestDialog();
+			AddCentered(showDialogButton, verticalCenter: true);
+		}
+
+		private void ShowTestDialog()
+		{
+			int count = 0;
+			var toolBar = new ToolBar();
+			var dlg = new Dialog
+			{
+				ClientSize = new Size(400, 300),
+				Resizable = true,
+				ToolBar = toolBar
+			};
+
+			dlg.Styles.Add<Label>(null, l => l.VerticalAlignment = VerticalAlignment.Center);
+
+			var indexStepper = new NumericStepper { MinValue = -1, MaxValue = -1, Value = -1 };
+			var typeDropDown = new DropDown
+			{
+				Items = { "Button", "Radio", "Check", "Separator:Divider", "Separator:Space", "Separator:FlexableSpace" },
+				SelectedIndex = 0
+			};
+
+			var withImageCheck = new CheckBox { Text = "With Image", Checked = true };
+
+			Image GetImage()
+			{
+				if (withImageCheck.Checked == true)
+					return TestIcons.TestIcon;
+				return null;
+			}
+
+
+			void SetStepperLimit()
+			{
+				if (toolBar.Items.Count == 0)
+					indexStepper.MinValue = indexStepper.MaxValue = -1;
+				else
+				{
+					indexStepper.MinValue = 0;
+					indexStepper.MaxValue = toolBar.Items.Count - 1;
+				}
+			}
+
+			ToolItem CreateItem()
+			{
+				switch (typeDropDown.SelectedKey?.ToLowerInvariant())
+				{
+					default:
+					case "button":
+						return new ButtonToolItem { Text = $"Button{++count}", Image = GetImage() };
+					case "radio":
+						return new RadioToolItem { Text = $"Radio{++count}", Image = GetImage() };
+					case "check":
+						return new CheckToolItem { Text = $"Check{++count}", Image = GetImage() };
+					case "separator:divider":
+						return new SeparatorToolItem { Type = SeparatorToolItemType.Divider };
+					case "separator:space":
+						return new SeparatorToolItem { Type = SeparatorToolItemType.Space };
+					case "separator:flexablespace":
+						return new SeparatorToolItem { Type = SeparatorToolItemType.FlexibleSpace };
+				}
+			}
+
+			var addButton = new Button { Text = "Add" };
+			addButton.Click += (sender, e) =>
+			{
+				toolBar.Items.Add(CreateItem());
+				SetStepperLimit();
+			};
+
+			var removeButton = new Button { Text = "Remove" };
+			removeButton.Click += (sender, e) =>
+			{
+				var index = (int)indexStepper.Value;
+				if (index >= 0)
+					toolBar.Items.RemoveAt(index);
+				SetStepperLimit();
+			};
+
+			var insertButton = new Button { Text = "Insert" };
+			insertButton.Click += (sender, e) =>
+			{
+				var index = (int)indexStepper.Value;
+				if (index >= 0)
+					toolBar.Items.Insert(index, CreateItem());
+				SetStepperLimit();
+			};
+
+			var clearButton = new Button { Text = "Clear" };
+			clearButton.Click += (sender, e) =>
+			{
+				toolBar.Items.Clear();
+				SetStepperLimit();
+			};
+
+			var layout = new DynamicLayout();
+
+			layout.BeginCentered(yscale: true);
+			layout.AddSeparateRow(null, "Type:", typeDropDown, withImageCheck, null);
+			layout.AddSeparateRow(null, addButton, insertButton, removeButton, "Index:", indexStepper, null);
+			layout.AddSeparateRow(null, clearButton, null);
+			layout.EndCentered();
+
+			dlg.Content = layout;
+
+
+			dlg.ShowModal();
+		}
+	}
+}

--- a/test/Eto.Test/Sections/UnitTestPanel.cs
+++ b/test/Eto.Test/Sections/UnitTestPanel.cs
@@ -726,12 +726,17 @@ namespace Eto.Test.Sections
 					{
 						if (assertion.Status == AssertionStatus.Passed)
 							continue;
-						WriteLog($"{assertion.Status}: {result.Message}\n{result.StackTrace}");
+						if (!string.IsNullOrEmpty(result.StackTrace))
+							WriteLog($"{assertion.Status}: {assertion.Message}\n{assertion.StackTrace}");
+						else
+							WriteLog($"{assertion.Status}: {assertion.Message}");
 					}
 				}
-				else
+				else if (result.ResultState.Status != TestStatus.Passed && result.ResultState.Status != TestStatus.Skipped)
 				{
-					if (result.ResultState.Status != TestStatus.Passed && result.ResultState.Status != TestStatus.Skipped)
+					if (!string.IsNullOrEmpty(result.StackTrace))
+						WriteLog($"{result.ResultState.Status}: {result.Message}\n{result.StackTrace}");
+					else
 						WriteLog($"{result.ResultState.Status}: {result.Message}");
 				}
 			}

--- a/test/Eto.Test/UnitTests/Forms/ToolBarTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ToolBarTests.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Threading;
+using Eto.Forms;
+using NUnit.Framework;
+using Eto.Drawing;
+namespace Eto.Test.UnitTests.Forms
+{
+	[TestFixture]
+	public class ToolBarTests : TestBase
+	{
+		[Test, InvokeOnUI]
+		public void AddingDividerSeparatorShouldNotCrash()
+		{
+			var form = new Dialog { Size = new Size(800, 300) };
+
+			var tb = new ToolBar();
+			form.ToolBar = tb;
+			for (int i = 0; i < 20; i++)
+			{
+				GC.Collect();
+				GC.WaitForPendingFinalizers();
+				Thread.Sleep(10);
+				var item = new ButtonToolItem { Text = i.ToString() };
+				tb.Items.Add(item);
+
+				tb.Items.AddSeparator(type: SeparatorToolItemType.Divider);
+			}
+
+			form.Shown += (sender, e) => Application.Instance.AsyncInvoke(form.Close);
+			form.ShowModal();
+		}
+	}
+}


### PR DESCRIPTION
- Properly support multiple Divider items
- Fix crashes due to toolbars having the same identifier
- Fix removing tool items
- Use NSColor.SeparatorColor when available (10.14+)
- Fix crash with Divider due to GC’d Drawable instance
- Allow changing separator type