### PR TITLE
Add binding and command support to SegmentedItem

### DIFF
--- a/src/Eto/Forms/Menu/ButtonMenuItem.cs
+++ b/src/Eto/Forms/Menu/ButtonMenuItem.cs
@@ -12,7 +12,7 @@ namespace Eto.Forms
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	[ContentProperty("Items")]
 	[Handler(typeof(ButtonMenuItem.IHandler))]
-	public class ButtonMenuItem : MenuItem, ISubmenu
+	public class ButtonMenuItem : MenuItem, ISubmenu, IBindableWidgetContainer
 	{
 		MenuItemCollection items;
 
@@ -74,6 +74,8 @@ namespace Eto.Forms
 			set { Handler.Image = value; }
 		}
 
+		IEnumerable<BindableWidget> IBindableWidgetContainer.Children => Items;
+
 		/// <summary>
 		/// Called when the menu is assigned to a control/window
 		/// </summary>
@@ -94,22 +96,6 @@ namespace Eto.Forms
 			base.OnUnLoad(e);
 			foreach (var item in Items)
 				item.OnUnLoad(e);
-		}
-
-		/// <summary>
-		/// Raises the <see cref="BindableWidget.DataContextChanged"/> event
-		/// </summary>
-		/// <remarks>
-		/// Implementors may override this to fire this event on child widgets in a heirarchy. 
-		/// This allows a control to be bound to its own <see cref="BindableWidget.DataContext"/>, which would be set
-		/// on one of the parent control(s).
-		/// </remarks>
-		/// <param name="e">Event arguments</param>
-		protected override void OnDataContextChanged(EventArgs e)
-		{
-			base.OnDataContextChanged(e);
-			foreach (var item in Items)
-				item.TriggerDataContextChanged();
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/Menu/MenuBar.cs
+++ b/src/Eto/Forms/Menu/MenuBar.cs
@@ -36,7 +36,7 @@ namespace Eto.Forms
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	[ContentProperty("Items")]
 	[Handler(typeof(MenuBar.IHandler))]
-	public class MenuBar : Menu, ISubmenu
+	public class MenuBar : Menu, ISubmenu, IBindableWidgetContainer
 	{
 		bool loaded;
 		MenuItemCollection items;
@@ -175,6 +175,8 @@ namespace Eto.Forms
 			get { return HelpMenu.Items; }
 		}
 
+		IEnumerable<BindableWidget> IBindableWidgetContainer.Children => Items;
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Eto.Forms.MenuBar"/> class.
 		/// </summary>
@@ -244,23 +246,6 @@ namespace Eto.Forms
 			foreach (var item in Items)
 				item.OnLoad(e);
 		}
-
-		/// <summary>
-		/// Raises the <see cref="BindableWidget.DataContextChanged"/> event
-		/// </summary>
-		/// <remarks>
-		/// Implementors may override this to fire this event on child widgets in a heirarchy. 
-		/// This allows a control to be bound to its own <see cref="BindableWidget.DataContext"/>, which would be set
-		/// on one of the parent control(s).
-		/// </remarks>
-		/// <param name="e">Event arguments</param>
-		protected override void OnDataContextChanged(EventArgs e)
-		{
-			base.OnDataContextChanged(e);
-			foreach (var item in Items)
-				item.TriggerDataContextChanged();
-		}
-
 
 		/// <summary>
 		/// Handler interface for the <see cref="MenuBar"/>

--- a/src/Eto/Forms/SegmentedButton/ButtonSegmentedItem.cs
+++ b/src/Eto/Forms/SegmentedButton/ButtonSegmentedItem.cs
@@ -1,3 +1,5 @@
+using System.Windows.Input;
+
 namespace Eto.Forms
 {
 	/// <summary>
@@ -7,6 +9,23 @@ namespace Eto.Forms
     public class ButtonSegmentedItem : SegmentedItem
     {
         new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.Forms.ButtonSegmentedItem"/> class.
+		/// </summary>
+		public ButtonSegmentedItem()
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.ButtonSegmentedItem"/> class with the specified command.
+		/// </summary>
+		/// <seealso cref="SegmentedItem(Command)"/>
+		/// <param name="command">Command to initialize the segmented item with.</param>
+		public ButtonSegmentedItem(Command command)
+			: base(command)
+		{
+		}
 
 		/// <summary>
 		/// Handler interface for the <see cref="ButtonSegmentedItem"/>.

--- a/src/Eto/Forms/SegmentedButton/MenuSegmentedItem.cs
+++ b/src/Eto/Forms/SegmentedButton/MenuSegmentedItem.cs
@@ -9,6 +9,24 @@ namespace Eto.Forms
         new IHandler Handler => (IHandler)base.Handler;
 
 		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.Forms.MenuSegmentedItem"/> class.
+		/// </summary>
+		public MenuSegmentedItem()
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.Forms.MenuSegmentedItem"/> class with the specified command.
+		/// </summary>
+		/// <seealso cref="SegmentedItem(Command)"/>
+		/// <param name="command">Command to initialize the segmented item with.</param>
+		public MenuSegmentedItem(Command command)
+			: base(command)
+		{
+			CanSelect = true; // otherwise command would never execute
+		}
+
+		/// <summary>
 		/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.MenuSegmentedItem"/> can be selected.
 		/// </summary>
 		/// <remarks>
@@ -16,7 +34,7 @@ namespace Eto.Forms
 		/// a single click will bring up the menu and the item will never be selected/clicked.
 		/// </remarks>
 		/// <value><c>true</c> if this item can be selected; otherwise, <c>false</c>.</value>
-        public bool CanSelect
+		public bool CanSelect
         {
             get => Handler.CanSelect;
             set => Handler.CanSelect = value;

--- a/src/Eto/Forms/SegmentedButton/SegmentedButton.cs
+++ b/src/Eto/Forms/SegmentedButton/SegmentedButton.cs
@@ -36,7 +36,7 @@ namespace Eto.Forms
 	/// The SegmentedButton allows you to group multiple buttons together visually.
 	/// </remarks>
 	[Handler(typeof(IHandler))]
-	public class SegmentedButton : Control
+	public class SegmentedButton : Control, IBindableWidgetContainer
 	{
 		new IHandler Handler => (IHandler)base.Handler;
 
@@ -267,6 +267,8 @@ namespace Eto.Forms
 			get => Handler.SelectedIndex;
 			set => Handler.SelectedIndex = value;
 		}
+
+		IEnumerable<BindableWidget> IBindableWidgetContainer.Children => Items;
 
 		/// <summary>
 		/// Selects all items when <see cref="SelectionMode"/> is set to Multiple.

--- a/src/Eto/Forms/ThemedControls/ThemedSegmentedButtonHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedSegmentedButtonHandler.cs
@@ -184,6 +184,7 @@ namespace Eto.Forms.ThemedControls
 
 		private void Control_CheckedChanged(object sender, EventArgs e)
 		{
+			Callback.OnSelectedChanged(Widget, EventArgs.Empty);
 			ParentHandler?.TriggerSelectionChanged(Widget);
 			if (Control.Checked)
 				ParentHandler?.EnsureSingleSelected(Widget, false);

--- a/src/Eto/Forms/ToolBar/ToolBar.cs
+++ b/src/Eto/Forms/ToolBar/ToolBar.cs
@@ -63,7 +63,7 @@ namespace Eto.Forms
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	[ContentProperty("Items")]
 	[Handler(typeof(ToolBar.IHandler))]
-	public class ToolBar : Tool
+	public class ToolBar : Tool, IBindableWidgetContainer
 	{
 		internal new IHandler Handler { get { return (IHandler)base.Handler; } }
 
@@ -109,6 +109,8 @@ namespace Eto.Forms
 			set { Handler.TextAlign = value; }
 		}
 
+		IEnumerable<BindableWidget> IBindableWidgetContainer.Children => Items;
+
 		/// <summary>
 		/// Called when the tool item is loaded to be shown on the form.
 		/// </summary>
@@ -137,22 +139,6 @@ namespace Eto.Forms
 		{
 			foreach (var item in Items)
 				item.OnPreLoad(e);
-		}
-
-		/// <summary>
-		/// Raises the <see cref="BindableWidget.DataContextChanged"/> event
-		/// </summary>
-		/// <remarks>
-		/// Implementors may override this to fire this event on child widgets in a heirarchy. 
-		/// This allows a control to be bound to its own <see cref="BindableWidget.DataContext"/>, which would be set
-		/// on one of the parent control(s).
-		/// </remarks>
-		/// <param name="e">Event arguments</param>
-		protected override void OnDataContextChanged(EventArgs e)
-		{
-			base.OnDataContextChanged(e);
-			foreach (var item in Items)
-				item.TriggerDataContextChanged();
 		}
 
 		/// <summary>

--- a/test/Eto.Test/Sections/Controls/SegmentedButtonSection.cs
+++ b/test/Eto.Test/Sections/Controls/SegmentedButtonSection.cs
@@ -10,11 +10,18 @@ namespace Eto.Test.Sections.Controls
 	{
 		public SegmentedButtonSection()
 		{
+			var checkCommand = new CheckCommand
+			{
+				ToolBarText = "CheckCommand"
+			};
+			checkCommand.CheckedChanged += (sender, e) => Log.Write(sender, $"CheckedChanged: {checkCommand.Checked}");
+			checkCommand.Executed += (sender, e) => Log.Write(sender, "Executed");
+
 			var segbutton = new SegmentedButton();
 
 			segbutton.Items.Add(new ButtonSegmentedItem { Image = TestIcons.TestIcon.WithSize(16, 16) });
 			segbutton.Items.Add(new ButtonSegmentedItem { Text = "Some Text", Image = TestIcons.TestImage.WithSize(16, 16) });
-			segbutton.Items.Add(new ButtonSegmentedItem { Text = "Text Only" });
+			segbutton.Items.Add(new ButtonSegmentedItem(checkCommand));
 			segbutton.Items.Add(new ButtonSegmentedItem { Text = "Width=150", Width = 150 });
 			segbutton.Items.Add(new MenuSegmentedItem
 			{
@@ -58,11 +65,15 @@ namespace Eto.Test.Sections.Controls
 			clearSelectionButton.Click += (sender, e) => segbutton.ClearSelection();
 			clearSelectionButton.Bind(c => c.Enabled, selectionModeDropDown.SelectedValueBinding.Convert(r => r != SegmentedSelectionMode.None));
 
+			var checkCommandEnabled = new CheckBox { Text = "CheckCommand.Enabled" };
+			checkCommandEnabled.Bind(c => c.Checked, checkCommand, c => c.Enabled);
+
 
 			// layout
 			BeginCentered();
 			AddSeparateRow("SelectionMode:", selectionModeDropDown);
 			AddSeparateRow(selectAllButton, clearSelectionButton);
+			AddSeparateRow(checkCommandEnabled);
 			EndCentered();
 
 			AddSeparateRow(segbutton);

--- a/test/Eto.Test/UnitTests/Forms/Controls/SegmentedButtonTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/SegmentedButtonTests.cs
@@ -1,6 +1,8 @@
 using System;
 using NUnit.Framework;
 using Eto.Forms;
+using System.Linq;
+
 namespace Eto.Test.UnitTests.Forms.Controls
 {
 	[TestFixture]
@@ -24,7 +26,6 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					SelectionMode = SegmentedSelectionMode.Single,
 					Items = { "First", itemExpected, "Last" }
 				};
-
 
 				segmentedButton.SelectedIndexesChanged += (sender, e) => selectedIndexesChangedCount++;
 				segmentedButton.ItemClick += (sender, e) =>
@@ -253,32 +254,51 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		public void ClickingAnItemWhenModeIsNoneShouldNotRaiseChangedEvents()
 		{
 			int selectedIndexesChangedCount = 0;
+			int itemClickWasRaised = 0;
 			int itemWasClicked = 0;
+			int itemSelectedWasChanged = 0;
+			bool itemIsSelected = false;
+			int[] selectedItems = null;
+			int selectedIndex = 0;
 
-			ManualForm("Click on an item", form =>
+			ManualForm("Click on the Click Me item", form =>
 			{
 				var control = new SegmentedButton();
 				control.SelectedIndexesChanged += (sender, e) => selectedIndexesChangedCount++;
 				control.Items.Add("Item1");
-				control.Items.Add("Item2");
+				var item2 = new ButtonSegmentedItem { Text = "Click Me" };
+				item2.Click += (sender, e) => itemWasClicked++;
+				item2.SelectedChanged += (sender, e) => itemSelectedWasChanged++;
+				control.Items.Add(item2);
 				control.Items.Add("Item3");
 
 				// async in case code runs after this event.
 				control.ItemClick += (sender, e) =>
 				{
-					itemWasClicked++;
+					itemClickWasRaised++;
+					itemIsSelected = item2.Selected;
+					selectedIndex = control.SelectedIndex;
+					selectedItems = control.SelectedIndexes?.ToArray();
 					Application.Instance.AsyncInvoke(form.Close);
 				};
 				return control;
 			}, false);
 
-			Assert.AreEqual(1, itemWasClicked, "#1"); // ensure user actually clicked an item.
-			Assert.AreEqual(0, selectedIndexesChangedCount, "#2");
+			Assert.AreEqual(1, itemClickWasRaised, "#1.1"); // ensure user actually clicked an item.
+			Assert.AreEqual(0, selectedIndexesChangedCount, "#1.2");
+			CollectionAssert.IsEmpty(selectedItems, "#1.3");
+			Assert.AreEqual(-1, selectedIndex, "#1.4");
+
+			// check item events
+			Assert.AreEqual(1, itemWasClicked, "#2.1");
+			Assert.AreEqual(0, itemSelectedWasChanged, "#2.2");
+			Assert.IsFalse(itemIsSelected, "#2.3");
 		}
 
 		class SegmentedModel
 		{
 			int selectedIndex;
+			bool itemIsSelected;
 
 			public int SelectedIndexChangedCount { get; set; }
 			public int SelectedIndex
@@ -290,47 +310,212 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					SelectedIndexChangedCount++;
 				}
 			}
+
+			public int ItemIsSelectedChangedCount { get; set; }
+			public bool ItemIsSelected
+			{
+				get => itemIsSelected;
+				set
+				{
+					itemIsSelected = value;
+					ItemIsSelectedChangedCount++;
+				}
+			}
 		}
 
-		[TestCase(SegmentedSelectionMode.Single)]
-		[TestCase(SegmentedSelectionMode.Multiple)]
+		[TestCase(SegmentedSelectionMode.Single, true)]
+		[TestCase(SegmentedSelectionMode.Single, false)]
+		[TestCase(SegmentedSelectionMode.Multiple, true)]
+		[TestCase(SegmentedSelectionMode.Multiple, false)]
 		[ManualTest]
-		public void ClickingAnItemShouldRaiseChangedEvents(SegmentedSelectionMode selectionMode)
+		public void ClickingAnItemShouldRaiseChangedEvents(SegmentedSelectionMode selectionMode, bool initiallySelected)
 		{
 			int selectedIndexesChangedCount = 0;
 			int selectedIndexChangedCount = 0;
+			int itemClickWasRaised = 0;
+
+			bool itemIsSelected = false;
 			int itemWasClicked = 0;
+			int itemSelectedWasChanged = 0;
+
 			int selectedIndex = -1;
 			var model = new SegmentedModel();
 
-			ManualForm("Click on an item", form =>
+			ManualForm("Click on the Click Me item", form =>
 			{
 				var control = new SegmentedButton();
+				control.DataContext = model;
 				control.SelectionMode = selectionMode;
 
-				control.Bind(c => c.SelectedIndex, model, m => m.SelectedIndex, DualBindingMode.OneWayToSource);
+				control.BindDataContext(c => c.SelectedIndex, (SegmentedModel m) => m.SelectedIndex, DualBindingMode.OneWayToSource);
+				Assert.AreEqual(1, model.SelectedIndexChangedCount, "#1.1"); // set when binding
+
 				control.SelectedIndexesChanged += (sender, e) => selectedIndexesChangedCount++;
 				control.SelectedIndexChanged += (sender, e) => selectedIndexChangedCount++;
 				control.Items.Add("Item1");
-				control.Items.Add("Item2");
+				var item2 = new ButtonSegmentedItem { Text = "Click Me" };
+				item2.BindDataContext(r => r.Selected, (SegmentedModel m) => m.ItemIsSelected, DualBindingMode.OneWayToSource);
+				Assert.AreEqual(0, model.ItemIsSelectedChangedCount, "#1.2");
+				item2.Selected = initiallySelected;
+				item2.Click += (sender, e) =>
+				{
+					itemWasClicked++;
+					itemIsSelected = item2.Selected;
+				};
+				item2.SelectedChanged += (sender, e) =>
+				{
+					itemSelectedWasChanged++;
+				};
+				control.Items.Add(item2);
 				control.Items.Add("Item3");
 
 				// async in case code runs after this event.
 				control.ItemClick += (sender, e) =>
 				{
-					itemWasClicked++;
+					itemClickWasRaised++;
 					selectedIndex = control.SelectedIndex;
 					Application.Instance.AsyncInvoke(form.Close);
 				};
 				return control;
 			}, false);
 
-			Assert.AreEqual(1, itemWasClicked, "#1"); // ensure user actually clicked an item.
-			Assert.AreEqual(1, selectedIndexChangedCount, "#2");
-			Assert.AreEqual(1, selectedIndexesChangedCount, "#3");
-			Assert.IsTrue(selectedIndex >= 0, "#4");
-			Assert.AreEqual(2, model.SelectedIndexChangedCount, "#5"); // one for binding, one when it actually changes.
-			Assert.AreEqual(selectedIndex, model.SelectedIndex, "#6");
+			Assert.Multiple(() =>
+			{
+				// check events on the segmented button control
+				Assert.AreEqual(1, itemClickWasRaised, "#2.1"); // ensure user actually clicked an item.
+				Assert.AreEqual(selectedIndex, model.SelectedIndex, "#2.2");
+
+				// check events on the item itself
+				Assert.AreEqual(1, itemWasClicked, "#2.3");
+
+				if (selectionMode == SegmentedSelectionMode.Multiple)
+				{
+					if (initiallySelected)
+					{
+						Assert.AreEqual(2, selectedIndexChangedCount, "#3.1.1");
+						Assert.AreEqual(2, selectedIndexesChangedCount, "#3.1.2");
+						Assert.IsFalse(selectedIndex >= 0, "#3.1.3");
+						Assert.AreEqual(3, model.SelectedIndexChangedCount, "#3.1.4"); // one for binding, one when item is added, and one when it actually changes.
+						Assert.IsFalse(model.ItemIsSelected, "#3.1.5");
+						Assert.AreEqual(3, model.ItemIsSelectedChangedCount, "#3.1.6"); // one for binding, one when it is set, and one when it actually changes.
+					}
+					else
+					{
+						Assert.AreEqual(1, selectedIndexChangedCount, "#3.2.1");
+						Assert.AreEqual(1, selectedIndexesChangedCount, "#3.2.2");
+						Assert.IsTrue(selectedIndex >= 0, "#3.2.3");
+						Assert.AreEqual(2, model.SelectedIndexChangedCount, "#3.2.4"); // one for binding, one when it actually changes.
+						Assert.IsTrue(model.ItemIsSelected, "#3.2.5");
+						Assert.AreEqual(2, model.ItemIsSelectedChangedCount, "#3.2.6"); // one for binding, and one when it actually changes.
+					}
+
+					Assert.AreEqual(1, itemSelectedWasChanged, "#3.3.1");
+					Assert.AreNotEqual(itemIsSelected, initiallySelected, "#3.3.2");
+				}
+				else
+				{
+					Assert.AreEqual(1, selectedIndexChangedCount, "#4.1.1");
+					Assert.AreEqual(1, selectedIndexesChangedCount, "#4.1.2");
+					Assert.IsTrue(selectedIndex >= 0, "#4.1.3");
+					Assert.AreEqual(2, model.SelectedIndexChangedCount, "#4.1.4"); // one for binding, one when it actually changes.
+					Assert.IsTrue(model.ItemIsSelected, "#4.1.5");
+					Assert.AreEqual(2, model.ItemIsSelectedChangedCount, "#4.1.6"); // set when binding
+
+					if (initiallySelected)
+						Assert.AreEqual(0, itemSelectedWasChanged, "#4.2.1");
+					else
+						Assert.AreEqual(1, itemSelectedWasChanged, "#4.2.2");
+
+					Assert.IsTrue(itemIsSelected, "#4.2.3");
+				}
+			});
+		}
+
+		[Test, InvokeOnUI]
+		public void SelectAllAndClearSelectionShouldTriggerSelectedChanges()
+		{
+			int selectedIndexesChangedCount = 0;
+			int item1SelectedChanged = 0;
+			int item2SelectedChanged = 0;
+			int item3SelectedChanged = 0;
+
+			var control = new SegmentedButton { SelectionMode = SegmentedSelectionMode.Multiple };
+
+			control.SelectedIndexesChanged += (sender, e) => selectedIndexesChangedCount++;
+
+			var item1 = new ButtonSegmentedItem { Text = "Item1" };
+			item1.SelectedChanged += (sender, e) => item1SelectedChanged++;
+			var item2 = new ButtonSegmentedItem { Text = "Item2" };
+			item2.SelectedChanged += (sender, e) => item2SelectedChanged++;
+			item2.Selected = true;
+			var item3 = new ButtonSegmentedItem { Text = "Item3" };
+			item3.SelectedChanged += (sender, e) => item3SelectedChanged++;
+			CollectionAssert.IsEmpty(control.SelectedIndexes, "#1.1");
+			Assert.AreEqual(-1, control.SelectedIndex, "#1.2");
+			Assert.AreEqual(0, selectedIndexesChangedCount, "#1.3");
+			Assert.IsFalse(item1.Selected, "#1.4");
+			Assert.IsTrue(item2.Selected, "#1.5");
+			Assert.IsFalse(item3.Selected, "#1.6");
+			Assert.AreEqual(0, item1SelectedChanged, "#1.7.1");
+			Assert.AreEqual(1, item2SelectedChanged, "#1.7.2");
+			Assert.AreEqual(0, item3SelectedChanged, "#1.7.3");
+
+			control.Items.Add(item1);
+			CollectionAssert.IsEmpty(control.SelectedIndexes, "#2.1");
+			Assert.AreEqual(-1, control.SelectedIndex, "#2.2");
+			Assert.AreEqual(0, selectedIndexesChangedCount, "#2.3");
+			Assert.IsFalse(item1.Selected, "#2.4");
+			Assert.IsTrue(item2.Selected, "#2.5");
+			Assert.IsFalse(item3.Selected, "#2.6");
+			Assert.AreEqual(0, item1SelectedChanged, "#2.7.1");
+			Assert.AreEqual(1, item2SelectedChanged, "#2.7.2");
+			Assert.AreEqual(0, item3SelectedChanged, "#2.7.3");
+
+			control.Items.Add(item2);
+			CollectionAssert.AreEqual(new[] { 1 }, control.SelectedIndexes, "#3.1");
+			Assert.AreEqual(1, control.SelectedIndex, "#3.2");
+			Assert.AreEqual(1, selectedIndexesChangedCount, "#3.3");
+			Assert.IsFalse(item1.Selected, "#3.4");
+			Assert.IsTrue(item2.Selected, "#3.5");
+			Assert.IsFalse(item3.Selected, "#3.6");
+			Assert.AreEqual(0, item1SelectedChanged, "#3.7.1");
+			Assert.AreEqual(1, item2SelectedChanged, "#3.7.2");
+			Assert.AreEqual(0, item3SelectedChanged, "#3.7.3");
+
+			control.Items.Add(item3);
+			// no change
+			CollectionAssert.AreEqual(new[] { 1 }, control.SelectedIndexes, "#4.1");
+			Assert.AreEqual(1, control.SelectedIndex, "#4.2");
+			Assert.AreEqual(1, selectedIndexesChangedCount, "#4.3");
+			Assert.IsFalse(item1.Selected, "#4.4");
+			Assert.IsTrue(item2.Selected, "#4.5");
+			Assert.IsFalse(item3.Selected, "#4.6");
+			Assert.AreEqual(0, item1SelectedChanged, "#4.7.1");
+			Assert.AreEqual(1, item2SelectedChanged, "#4.7.2");
+			Assert.AreEqual(0, item3SelectedChanged, "#4.7.3");
+
+			control.SelectAll();
+			CollectionAssert.AreEquivalent(new[] { 0, 1, 2 }, control.SelectedIndexes, "#5.1");
+			Assert.AreEqual(0, control.SelectedIndex, "#5.2");
+			Assert.AreEqual(2, selectedIndexesChangedCount, "#5.3");
+			Assert.IsTrue(item1.Selected, "#5.4");
+			Assert.IsTrue(item2.Selected, "#5.5");
+			Assert.IsTrue(item3.Selected, "#5.6");
+			Assert.AreEqual(1, item1SelectedChanged, "#5.7.1");
+			Assert.AreEqual(1, item2SelectedChanged, "#5.7.2");
+			Assert.AreEqual(1, item3SelectedChanged, "#5.7.3");
+
+
+			control.ClearSelection();
+			CollectionAssert.IsEmpty(control.SelectedIndexes, "#6.1");
+			Assert.AreEqual(-1, control.SelectedIndex, "#6.2");
+			Assert.AreEqual(3, selectedIndexesChangedCount, "#6.3");
+			Assert.IsFalse(item1.Selected, "#6.4");
+			Assert.IsFalse(item2.Selected, "#6.5");
+			Assert.IsFalse(item3.Selected, "#6.6");
+			Assert.AreEqual(2, item1SelectedChanged, "#6.7.1");
+			Assert.AreEqual(2, item2SelectedChanged, "#6.7.2");
+			Assert.AreEqual(2, item3SelectedChanged, "#6.7.3");
 		}
 	}
 }


### PR DESCRIPTION
- Can now use binding with SegmentedItems to bind to Enabled, Command, etc.
- Added SegmentedItem.Command so you can use Command/RadioCommand/CheckCommand, depending on the SegmentedButton.SelectionMode.
- Added implicit conversions from Command/RadioCommand/CheckCommand to more succinctly define items