### PR TITLE
Add IValueCommand

### DIFF
--- a/src/Eto/Forms/Command.cs
+++ b/src/Eto/Forms/Command.cs
@@ -8,7 +8,7 @@ namespace Eto.Forms
 	/// <summary>
 	/// Command for a menu/tool item that can be checked on or off.
 	/// </summary>
-	public class CheckCommand : Command
+	public class CheckCommand : Command, IValueCommand<bool>
 	{
 #region Events
 
@@ -67,6 +67,16 @@ namespace Eto.Forms
 			: base(execute)
 		{
 		}
+
+		event EventHandler<EventArgs> IValueCommand<bool>.ValueChanged
+		{
+			add => CheckedChanged += value;
+			remove => CheckedChanged -= value;
+		}
+
+		bool IValueCommand<bool>.GetValue(object parameter) => Checked;
+
+		void IValueCommand<bool>.SetValue(object parameter, bool value) => Checked = value;
 
 		/// <summary>
 		/// Creates a new menu item attached to this command.

--- a/src/Eto/Forms/Menu/MenuItem.cs
+++ b/src/Eto/Forms/Menu/MenuItem.cs
@@ -69,8 +69,19 @@ namespace Eto.Forms
 		/// <value>The command to invoke.</value>
 		public ICommand Command
 		{
-			get { return Properties.GetCommand(Command_Key); }
-			set { Properties.SetCommand(Command_Key, value, e => Enabled = e, r => Click += r, r => Click -= r, () => CommandParameter); }
+			get => Properties.GetCommand(Command_Key);
+			set
+			{
+				var oldValue = Command;
+				if (!ReferenceEquals(oldValue, value))
+					SetCommand(oldValue, value);
+			}
+		}
+
+		internal virtual void SetCommand(ICommand oldValue, ICommand newValue)
+		{
+			Properties.SetCommand(Command_Key, newValue, e => Enabled = e, r => Click += r, r => Click -= r, () => CommandParameter);
+			HandleEvent(ValidateEvent);
 		}
 
 		static readonly object CommandParameter_Key = new object();
@@ -128,6 +139,10 @@ namespace Eto.Forms
 		protected virtual void OnValidate(EventArgs e)
 		{
 			Properties.TriggerEvent(ValidateEvent, this, e);
+
+			var command = Command;
+			if (command != null)
+				Enabled = command.CanExecute(CommandParameter);
 		}
 
 		/// <summary>
@@ -154,7 +169,6 @@ namespace Eto.Forms
 			Text = command.MenuText;
 			ToolTip = command.ToolTip;
 			Shortcut = command.Shortcut;
-			Validate += (sender, e) => Enabled = command.Enabled;
 			Command = command;
 		}
 

--- a/src/Eto/Forms/RelayCommand.cs
+++ b/src/Eto/Forms/RelayCommand.cs
@@ -33,7 +33,10 @@ namespace Eto.Forms
 		/// <param name="execute">Delegate to execute the command.</param>
 		/// <param name="canExecute">Delegate to determine the state of whether the command can be executed.</param>
 		public RelayCommand(Action execute, Func<bool> canExecute)
-			: base((obj) => execute(), (obj) => canExecute())
+			: base(
+				obj => execute(), 
+				canExecute != null ? (Predicate<object>)(obj => canExecute()) : null
+			)
 		{
 		}
 	}
@@ -57,8 +60,7 @@ namespace Eto.Forms
 		/// <param name="e">Event arguments</param>
 		protected virtual void OnCanExecuteChanged(EventArgs e)
 		{
-			if (CanExecuteChanged != null)
-				CanExecuteChanged(this, e);
+			CanExecuteChanged?.Invoke(this, e);
 		}
 
 		/// <summary>
@@ -85,10 +87,7 @@ namespace Eto.Forms
 		/// <param name="canExecute">Delegate to determine the state of whether the command can be executed.</param>
 		public RelayCommand(Action<T> execute, Predicate<T> canExecute)
 		{
-			if (execute == null)
-				throw new ArgumentNullException("execute");
-
-			this.execute = execute;
+			this.execute = execute ?? throw new ArgumentNullException(nameof(execute));
 			this.canExecute = canExecute;
 		}
 
@@ -99,7 +98,7 @@ namespace Eto.Forms
 		/// <param name="parameter">Command argument from the control.</param>
 		public bool CanExecute(object parameter)
 		{
-			return canExecute == null || canExecute((T)parameter);
+			return canExecute == null || canExecute(parameter is T tparam ? tparam : default(T));
 		}
 
 		/// <summary>
@@ -108,7 +107,7 @@ namespace Eto.Forms
 		/// <param name="parameter">Command argument from the control.</param>
 		public void Execute(object parameter)
 		{
-			execute((T)parameter);
+			execute?.Invoke(parameter is T tparam ? tparam : default(T));
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/RelayValueCommand.cs
+++ b/src/Eto/Forms/RelayValueCommand.cs
@@ -1,0 +1,102 @@
+﻿using System;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// A <see cref="IValueCommand{T}"/> class that uses delegates for getting and setting the value of the command
+	/// </summary>
+	/// <remarks>
+	/// This can be used to delegate the getting/setting of the value to separate methods.
+	/// Call <see cref="RelayValueCommand{TParameter, TValue}.UpdateValue"/> to signal that the value has changed.
+	/// </remarks>
+	/// <seealso cref="ValueCommand{T}"/>
+	public class RelayValueCommand<TValue> : RelayValueCommand<object, TValue>
+	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.Forms.RelayValueCommand`1"/> class.
+		/// </summary>
+		/// <param name="getValue">Delegate to get the value.</param>
+		/// <param name="setValue">Delegate to set value.</param>
+		/// <param name="execute">Delegate to call when the command is executed (which usually changes the value).</param>
+		/// <param name="canExecute">Delegate to call to determine if the command can be executed.</param>
+		public RelayValueCommand(Func<TValue> getValue, Action<TValue> setValue, Action execute = null, Func<bool> canExecute = null)
+			: base(
+				obj => getValue(),
+				(obj, value) => setValue(value),
+				execute != null ? (Action<object>)(obj => execute()) : null,
+				canExecute != null ? (Predicate<object>)(obj => canExecute()) : null
+			)
+		{
+		}
+	}
+
+	/// <summary>
+	/// A <see cref="IValueCommand{T}"/> class that uses delegates for getting and setting the value of the command with the command parameter.
+	/// </summary>
+	/// <remarks>
+	/// This can be used to delegate the getting/setting of the value to separate methods.
+	/// Call <see cref="UpdateValue"/> to signal that the value has changed.
+	/// </remarks>
+	/// <seealso cref="ValueCommand{T}"/>
+    public class RelayValueCommand<TParameter, TValue> : RelayCommand<TParameter>, IValueCommand<TValue>
+    {
+        readonly Func<TParameter, TValue> _getValue;
+        readonly Action<TParameter, TValue> _setValue;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="T:Eto.Forms.RelayValueCommand`2"/> class.
+		/// </summary>
+		/// <param name="getValue">Delegate to get the value.</param>
+		/// <param name="setValue">Delegate to set value.</param>
+		/// <param name="execute">Delegate to call when the command is executed, which usually changes the value. (optional).</param>
+		/// <param name="canExecute">Delegate to call to determine if the command can be executed (optional).</param>
+        public RelayValueCommand(Func<TParameter, TValue> getValue, Action<TParameter, TValue> setValue, Action<TParameter> execute = null, Predicate<TParameter> canExecute = null)
+            : base(execute, canExecute)
+        {
+			_getValue = getValue ?? throw new ArgumentNullException(nameof(getValue));
+			_setValue = setValue ?? throw new ArgumentNullException(nameof(setValue));
+		}
+
+		/// <summary>
+		/// Event to signal to the control/widget that the value has been changed.
+		/// </summary>
+		/// <remarks>
+		/// Controls should call <see cref="GetValue(object)"/> when this is raised
+		/// so that they can set the state of the control to match the value provided.
+		/// </remarks>
+		public event EventHandler<EventArgs> ValueChanged;
+
+		/// <summary>
+		/// Raises the <see cref="ValueChanged"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+        protected virtual void OnValueChanged(EventArgs e) => ValueChanged?.Invoke(this, e);
+
+		/// <summary>
+		/// Signals that the value has been updated and the delegate to get the value should be called.
+		/// </summary>
+        public void UpdateValue() => OnValueChanged(EventArgs.Empty);
+
+		/// <summary>
+		/// Gets the value.
+		/// </summary>
+		/// <returns>The value.</returns>
+		/// <param name="parameter">Command Parameter.</param>
+        public TValue GetValue(object parameter)
+        {
+            TParameter param = parameter is TParameter tparam ? tparam : default(TParameter);
+            return _getValue != null ? _getValue(param) : default(TValue);
+        }
+
+		/// <summary>
+		/// Sets the value.
+		/// </summary>
+		/// <param name="parameter">Command Parameter.</param>
+		/// <param name="value">Value to set to.</param>
+        public void SetValue(object parameter, TValue value)
+        {
+            TParameter param = parameter is TParameter tparam ? tparam : default(TParameter);
+            _setValue?.Invoke(param, value);
+        }
+    }
+}

--- a/src/Eto/Forms/ToolBar/CheckToolItem.cs
+++ b/src/Eto/Forms/ToolBar/CheckToolItem.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Windows.Input;
 
 namespace Eto.Forms
 {
@@ -29,10 +30,26 @@ namespace Eto.Forms
 		public CheckToolItem(CheckCommand command)
 			: base(command)
 		{
-			Checked = command.Checked;
-			command.CheckedChanged += (sender, e) => Checked = command.Checked;
-			Click += (sender, e) => command.Checked = Checked;
 			Handler.CreateFromCommand(command);
+		}
+
+		internal override void SetCommand(ICommand oldValue, ICommand newValue)
+		{
+			if (oldValue is IValueCommand<bool> oldValueCommand)
+				oldValueCommand.ValueChanged -= ValueCommand_ValueChanged;
+
+			base.SetCommand(oldValue, newValue);
+			if (newValue is IValueCommand<bool> valueCommand)
+			{
+				Checked = valueCommand.GetValue(CommandParameter);
+				valueCommand.ValueChanged += ValueCommand_ValueChanged;
+			}
+		}
+
+		void ValueCommand_ValueChanged(object sender, EventArgs e)
+		{
+			if (Command is IValueCommand<bool> valueCommand)
+				Checked = valueCommand.GetValue(CommandParameter);
 		}
 
 		/// <summary>
@@ -51,8 +68,10 @@ namespace Eto.Forms
 		/// <param name="e">Event arguments.</param>
 		public void OnCheckedChanged(EventArgs e)
 		{
-			if (CheckedChanged != null)
-				CheckedChanged(this, e);
+			CheckedChanged?.Invoke(this, e);
+
+			if (Command is IValueCommand<bool> valueCommand)
+				valueCommand.SetValue(CommandParameter, Checked);
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/ToolBar/ToolItem.cs
+++ b/src/Eto/Forms/ToolBar/ToolItem.cs
@@ -25,8 +25,18 @@ namespace Eto.Forms
 		/// <value>The command to invoke.</value>
 		public ICommand Command
 		{
-			get { return Properties.GetCommand(Command_Key); }
-			set { Properties.SetCommand(Command_Key, value, e => Enabled = e, r => Click += r, r => Click -= r, () => CommandParameter); }
+			get => Properties.GetCommand(Command_Key);
+			set
+			{
+				var oldValue = Command;
+				if (!ReferenceEquals(oldValue, value))
+					SetCommand(oldValue, value);
+			}
+		}
+
+		internal virtual void SetCommand(ICommand oldValue, ICommand newValue)
+		{
+			Properties.SetCommand(Command_Key, newValue, e => Enabled = e, r => Click += r, r => Click -= r, () => CommandParameter);
 		}
 
 		static readonly object CommandParameter_Key = new object();

--- a/src/Eto/Forms/ValueCommand.cs
+++ b/src/Eto/Forms/ValueCommand.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Interface for a command that can provide a value
+	/// </summary>
+	/// <remarks>
+	/// Some controls can provide a value, which can be difficult to get via the command
+	/// when the value changes.
+	/// This inteface allows you to extend your command to allow getting and setting a value of any
+	/// type and have an event when the value changes programatically.
+	/// </remarks>
+	/// <seealso cref="ValueCommand{T}"/>
+	public interface IValueCommand<T> : ICommand
+	{
+		/// <summary>
+		/// Gets the current value in the command.
+		/// </summary>
+		/// <remarks>
+		/// This is typically called by the control when the <see cref="ValueChanged"/> event is raised.
+		/// </remarks>
+		/// <returns>The value.</returns>
+		/// <param name="parameter">CommandParameter from the control/widget.</param>
+		T GetValue(object parameter);
+
+		/// <summary>
+		/// Sets the value in the command from the control.
+		/// </summary>
+		/// <remarks>
+		/// This is typically invoked when the control has updated its value.
+		/// </remarks>
+		/// <param name="parameter">CommandParameter from the control/widget.</param>
+		/// <param name="value">Value to set to.</param>
+		void SetValue(object parameter, T value);
+
+		/// <summary>
+		/// Event to signal to the control/widget that the value has been changed.
+		/// </summary>
+		/// <remarks>
+		/// Controls should call <see cref="GetValue(object)"/> when this is raised
+		/// so that they can set the state of the control to match the value provided.
+		/// </remarks>
+		event EventHandler<EventArgs> ValueChanged;
+	}
+
+	/// <summary>
+	/// Command that provides a specific value.
+	/// </summary>
+	public class ValueCommand<T> : Command, IValueCommand<T>
+	{
+		T _value;
+
+		/// <summary>
+		/// Gets or sets the value for the command.
+		/// </summary>
+		/// <value>The value.</value>
+		public T Value
+		{
+			get => _value;
+			set
+			{
+				if (!Equals(_value, value))
+				{
+					_value = value;
+					OnValueChanged(EventArgs.Empty);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Event for when the <see cref="Value"/> is changed.
+		/// </summary>
+		public event EventHandler<EventArgs> ValueChanged;
+
+		/// <summary>
+		/// Raises the <see cref="ValueChanged"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnValueChanged(EventArgs e) => ValueChanged?.Invoke(this, e);
+
+		T IValueCommand<T>.GetValue(object parameter) => _value;
+
+		void IValueCommand<T>.SetValue(object parameter, T value) => Value = value;
+	}
+}

--- a/test/Eto.Test/MainForm.cs
+++ b/test/Eto.Test/MainForm.cs
@@ -223,14 +223,22 @@ namespace Eto.Test
 					edit.Items.AddSeparator();
 
 					var checkMenuItem1 = new CheckMenuItem { Text = "Check Menu Item", Shortcut = Keys.Shift | Keys.K };
-					checkMenuItem1.Click += (sender, e) => Log.Write(checkMenuItem1, "Click, {0}, Checked: {1}", checkMenuItem1.Text, checkMenuItem1.Checked);
-					checkMenuItem1.CheckedChanged += (sender, e) => Log.Write(checkMenuItem1, "CheckedChanged, {0}: {1}", checkMenuItem1.Text, checkMenuItem1.Checked);
+					checkMenuItem1.Click += (sender, e) => Log.Write(sender, "Click, {0}, Checked: {1}", checkMenuItem1.Text, checkMenuItem1.Checked);
+					checkMenuItem1.CheckedChanged += (sender, e) => Log.Write(sender, "CheckedChanged, {0}: {1}", checkMenuItem1.Text, checkMenuItem1.Checked);
 					edit.Items.Add(checkMenuItem1);
 
 					var checkMenuItem2 = new CheckMenuItem { Text = "Initially Checked Menu Item", Checked = true };
-					checkMenuItem2.Click += (sender, e) => Log.Write(checkMenuItem2, "Click, {0}, Checked: {1}", checkMenuItem2.Text, checkMenuItem2.Checked);
-					checkMenuItem2.CheckedChanged += (sender, e) => Log.Write(checkMenuItem2, "CheckedChanged, {0}: {1}", checkMenuItem2.Text, checkMenuItem2.Checked);
+					checkMenuItem2.Click += (sender, e) => Log.Write(sender, "Click, {0}, Checked: {1}", checkMenuItem2.Text, checkMenuItem2.Checked);
+					checkMenuItem2.CheckedChanged += (sender, e) => Log.Write(sender, "CheckedChanged, {0}: {1}", checkMenuItem2.Text, checkMenuItem2.Checked);
 					edit.Items.Add(checkMenuItem2);
+
+					var checkMenuItem3 = new CheckCommand { MenuText = "Check Command", Shortcut = Keys.Shift | Keys.K };
+					checkMenuItem3.Executed += (sender, e) => Log.Write(sender, "Executed, {0}, Checked: {1}", checkMenuItem3.MenuText, checkMenuItem3.Checked);
+					checkMenuItem3.CheckedChanged += (sender, e) => Log.Write(sender, "CheckedChanged, {0}: {1}", checkMenuItem3.MenuText, checkMenuItem3.Checked);
+					edit.Items.Add(checkMenuItem3);
+
+					checkMenuItem1.Click += (sender, e) => checkMenuItem3.Checked = !checkMenuItem3.Checked;
+
 				}
 
 				if (Platform.Supports<RadioMenuItem>())
@@ -251,6 +259,21 @@ namespace Eto.Test
 						edit.Items.Add(radio);
 					}
 
+					edit.Items.AddSeparator();
+
+					RadioCommand commandController = null;
+					for (int i = 0; i < 2; i++)
+					{
+						var radio = new RadioCommand { MenuText = "Radio Command " + (i + 1), Controller = commandController };
+						if (commandController == null)
+						{
+							radio.Checked = true; // check the first item initially
+							commandController = radio;
+						}
+						radio.Executed += (sender, e) => Log.Write(radio, "Executed, {0}, Checked: {1}", radio.MenuText, radio.Checked);
+						radio.CheckedChanged += (sender, e) => Log.Write(radio, "CheckedChanged, {0}: {1}", radio.MenuText, radio.Checked);
+						edit.Items.Add(radio);
+					}
 				}
 
 				edit.Items.AddSeparator();


### PR DESCRIPTION
- Support using an IValueCommand<T> for SegmentedItem, Check/RadioMenuItem, and Check/RadioToolItem Command parameter
- Added new IValueCommand<T> and ValueCommand<T> to store value directly
- Added new RelayValueCommand<T, TValue> and RelayValueCommand<TValue> to use get/set methods
- RelayCommand<T> should not type cast parameter if it doesn’t match the desired type
- Fix issue creating SegmentedItem from RadioCommand where it would hook events twice