### PR TITLE
Add Widget.IsDisposed

### DIFF
--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1065,7 +1065,7 @@ namespace Eto.Mac.Forms
 
 		static void FireOnShown(Control control)
 		{
-			if (!control.Visible)
+			if (control.IsDisposed || !control.Visible)
 				return;
 
 			// don't use GetMacViewHandler() extension, as that will trigger OnShown for themed controls, which will

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -22,7 +22,7 @@ namespace Eto.Forms
 	[sc.TypeConverter(typeof(ControlConverter))]
 	public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInputSource, ICallbackSource
 	{
-		new IHandler Handler { get { return (IHandler)base.Handler; } }
+		new IHandler Handler => (IHandler)base.Handler;
 
 		/// <summary>
 		/// Gets a value indicating that the control is loaded onto a form, that is it has been created, added to a parent, and shown
@@ -33,7 +33,11 @@ namespace Eto.Forms
 		/// 
 		/// The <see cref="OnUnLoad"/> method will set this value to <c>false</c> when the control is removed from its parent
 		/// </remarks>
-		public bool Loaded { get; private set; }
+		public bool Loaded
+		{
+			get => GetState(StateFlag.Loaded);
+			private set => SetState(StateFlag.Loaded, value);
+		}
 
 		/// <summary>
 		/// Gets an enumeration of controls that are in the visual tree.
@@ -75,7 +79,7 @@ namespace Eto.Forms
 					var foundVisual = false;
 					foreach (var parent in Parents.OfType<Container>())
 					{
-						if (!foundVisual && parent.Properties.Get<bool>(IsVisualControl_Key))
+						if (!foundVisual && parent.GetState(StateFlag.IsVisualControl))
 							foundVisual = true;
 						else
 							return parent;
@@ -85,20 +89,14 @@ namespace Eto.Forms
 			}
 		}
 
-		static object IsVisualControl_Key = new object();
-
 		/// <summary>
 		/// Gets a value indicating this <see cref="T:Eto.Forms.Control"/> is part of the visual tree.
 		/// </summary>
 		/// <value><c>true</c> if is visual control; otherwise, <c>false</c>.</value>
 		public bool IsVisualControl
 		{
-			get {
-				if (Properties.ContainsKey(IsVisualControl_Key))
-					return Properties.Get<bool>(IsVisualControl_Key);
-				return Parent?.IsVisualControl ?? false; // traverse up logical tree
-			}
-			internal set { Properties.Set(IsVisualControl_Key, value); }
+			get => GetState(StateFlag.IsVisualControl, StateFlag.IsVisualControlHasValue) ?? Parent?.IsVisualControl ?? false; // traverse up logical tree
+			internal set => SetState(StateFlag.IsVisualControl, StateFlag.IsVisualControlHasValue, value);
 		}
 
 		static readonly object TagKey = new object();


### PR DESCRIPTION
- Mac: Fix NRE when control is disposed before FireOnShown is called. Since FireOnShown can be called asynchronously, it may be removed/disposed before this is actually called.
- Loaded/IsDisposed/IsVisualControl boolean properties now stored more optimally as flags.
- Now throw an `ObjectDisposedException` when trying to access the `Handler` property if it has been disposed, to avoid NRE's when the actual problem is the widget is disposed.

Fixes #1301