### PR TITLE
Mac: Enabled should be set on all visual children

### DIFF
--- a/src/Eto.Mac/Forms/MacContainer.cs
+++ b/src/Eto.Mac/Forms/MacContainer.cs
@@ -73,7 +73,7 @@ namespace Eto.Mac.Forms
 			set
 			{
 				base.ControlEnabled = value;
-				foreach (var child in Widget.Controls)
+				foreach (var child in Widget.VisualControls)
 				{
 					child.GetMacViewHandler()?.SetEnabled(value);
 				}

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -808,8 +808,8 @@ namespace Eto.Mac.Forms
 
 		protected virtual bool ControlEnabled
 		{
-			get => Widget.Properties.Get<bool?>(MacView.ActualEnabled_Key) ?? true;
-			set => Widget.Properties.Set<bool?>(MacView.ActualEnabled_Key, value);
+			get => Widget.Properties.Get<bool>(MacView.ActualEnabled_Key, true);
+			set => Widget.Properties.Set<bool>(MacView.ActualEnabled_Key, value, true);
 		}
 
 		public bool? ShouldHaveFocus


### PR DESCRIPTION
- Controls check the visual parent if it is enabled, so when setting enabled it should traverse the visual tree, not just the logical tree.
- Added repro to test behaviour