### PR TITLE
Mac: Use alignment rect for controls with intrinsic padding

### DIFF
--- a/src/Eto.Mac/ColorizeView.cs
+++ b/src/Eto.Mac/ColorizeView.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using Eto.Drawing;
+#if XAMMAC2
+using AppKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using CoreImage;
+#else
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+using MonoMac.CoreGraphics;
+using MonoMac.ObjCRuntime;
+using MonoMac.CoreAnimation;
+using MonoMac.CoreImage;
+#if Mac64
+using nfloat = System.Double;
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nfloat = System.Single;
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
+#endif
+
+namespace Eto.Mac
+{
+	class ColorizeView : IDisposable
+	{
+		NSImage _image;
+		CGSize? _realSize;
+
+		public Color Color { get; set; }
+
+		static readonly NSString CIOutputImage = new NSString("outputImage");
+		static readonly bool supportsConvertSizeToBacking = ObjCExtensions.InstancesRespondToSelector<NSView>("convertSizeToBacking:");
+
+		public static void Create(ref ColorizeView colorize, Color? color)
+		{
+			if (color == null || color.Value.A <= 0)
+			{
+				colorize?.Dispose();
+				colorize = null;
+				return;
+			}
+
+			colorize = colorize ?? new ColorizeView();
+
+			colorize.Color = color.Value;
+		}
+
+		public void Begin(CGRect frame, NSView controlView)
+		{
+			var size = controlView.Frame.Size;
+			if (size.Width <= 0 || size.Height <= 0)
+			{
+				_realSize = null;
+				return;
+			}
+			if (_image == null || size != _image.Size)
+			{
+				if (_image != null)
+					_image.Dispose();
+
+				_image = new NSImage(size);
+			}
+
+			if (supportsConvertSizeToBacking)
+				_realSize = controlView.ConvertSizeToBacking(size);
+			else
+				_realSize = controlView.ConvertSizeToBase(size);
+
+			_image.LockFocusFlipped(!controlView.IsFlipped);
+			NSGraphicsContext.CurrentContext.GraphicsPort.ClearRect(new CGRect(CGPoint.Empty, size));
+		}
+
+		public void End()
+		{
+			if (_image == null || _realSize == null)
+				return;
+
+			_image.UnlockFocus();
+
+			var ciImage = CIImage.FromCGImage(_image.CGImage);
+
+			var filter2 = new CIColorControls();
+			filter2.SetDefaults();
+			filter2.Image = ciImage;
+			filter2.Saturation = 0.0f;
+			ciImage = (CIImage)filter2.ValueForKey(CIOutputImage);
+
+			var filter3 = new CIColorMatrix();
+			filter3.SetDefaults();
+			filter3.Image = ciImage;
+			var cgColor = Color.ToCG();
+			var components = cgColor.Components;
+			if (components.Length >= 3)
+			{
+				filter3.RVector = new CIVector(0, components[0], 0);
+				filter3.GVector = new CIVector(components[1], 0, 0);
+				filter3.BVector = new CIVector(0, 0, components[2]);
+				filter3.AVector = new CIVector(0, 0, 0, cgColor.Alpha);
+			}
+			ciImage = (CIImage)filter3.ValueForKey(CIOutputImage);
+
+			// create separate context so we can force using the software renderer, which is more than fast enough for this
+			var ciContext = CIContext.FromContext(NSGraphicsContext.CurrentContext.GraphicsPort, new CIContextOptions { UseSoftwareRenderer = true });
+			ciContext.DrawImage(ciImage, new CGRect(CGPoint.Empty, _image.Size), new CGRect(CGPoint.Empty, _realSize.Value));
+
+			ciImage.Dispose();
+			ciContext.Dispose();
+			filter2.Dispose();
+			filter3.Dispose();
+		}
+
+		public void Dispose()
+		{
+			_image?.Dispose();
+			_image = null;
+		}
+	}
+}
+

--- a/src/Eto.Mac/Drawing/SolidBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/SolidBrushHandler.cs
@@ -31,31 +31,32 @@ namespace Eto.iOS.Drawing
 	{
 		public override void Draw(object control, GraphicsHandler graphics, bool stroke, FillMode fillMode)
 		{
+			var nscolor = ((Color)control).ToNSUI();
 			if (stroke)
 			{
-				graphics.Control.SetStrokeColor((CGColor)control);
+				nscolor.SetStroke();
 				graphics.Control.StrokePath();
 			}
 			else
 			{
-				graphics.Control.SetFillColor((CGColor)control);
+				nscolor.SetFill();
 				graphics.Fill(fillMode);
 			}
 		}
 
 		public Color GetColor(SolidBrush widget)
 		{
-			return ((CGColor)widget.ControlObject).ToEto();
+			return (Color)widget.ControlObject;
 		}
 
 		public void SetColor(SolidBrush widget, Color color)
 		{
-			widget.ControlObject = color.ToCG();
+			widget.ControlObject = color;
 		}
 
 		object SolidBrush.IHandler.Create(Color color)
 		{
-			return color.ToCG();
+			return color;
 		}
 	}
 }

--- a/src/Eto.Mac/Eto.Mac.csproj
+++ b/src/Eto.Mac/Eto.Mac.csproj
@@ -231,6 +231,7 @@
     <Compile Include="Forms\MemoryDataObjectHandler.cs" />
     <Compile Include="Forms\Controls\SegmentedButtonHandler.cs" />
     <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
+    <Compile Include="ColorizeView.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Eto.Mac/Eto.Mac64.csproj
+++ b/src/Eto.Mac/Eto.Mac64.csproj
@@ -231,6 +231,7 @@
     <Compile Include="Forms\MemoryDataObjectHandler.cs" />
     <Compile Include="Forms\Controls\SegmentedButtonHandler.cs" />
     <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
+    <Compile Include="ColorizeView.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/src/Eto.Mac/Eto.XamMac.csproj
+++ b/src/Eto.Mac/Eto.XamMac.csproj
@@ -249,6 +249,7 @@
     <Compile Include="Forms\MemoryDataObjectHandler.cs" />
     <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
     <Compile Include="Forms\Controls\SegmentedButtonHandler.cs" />
+    <Compile Include="ColorizeView.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ProjectExtensions>

--- a/src/Eto.Mac/Eto.XamMac2-modern.csproj
+++ b/src/Eto.Mac/Eto.XamMac2-modern.csproj
@@ -243,6 +243,7 @@
     <Compile Include="Forms\MemoryDataObjectHandler.cs" />
     <Compile Include="Forms\Controls\SegmentedButtonHandler.cs" />
     <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
+    <Compile Include="ColorizeView.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/src/Eto.Mac/Eto.XamMac2-net45.csproj
+++ b/src/Eto.Mac/Eto.XamMac2-net45.csproj
@@ -253,6 +253,7 @@
     <Compile Include="Forms\MemoryDataObjectHandler.cs" />
     <Compile Include="Forms\Controls\SegmentedButtonHandler.cs" />
     <Compile Include="Forms\Controls\ToggleButtonHandler.cs" />
+    <Compile Include="ColorizeView.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
@@ -37,8 +37,12 @@ namespace Eto.Mac.Forms.Controls
 	public class ButtonHandler : ButtonHandler<Button, Button.ICallback>, Button.IHandler
 	{
 		public static int MinimumWidth = 80;
+		internal static readonly object CustomBezelStyle_Key = new object();
+		internal static readonly object Image_Key = new object();
+		internal static readonly object ImagePosition_Key = new object();
 
-		static readonly Size originalSize;
+
+		internal static readonly Size originalSize;
 		protected override NSButtonType DefaultButtonType => NSButtonType.MomentaryPushIn;
 
 		protected override Size DefaultMinimumSize => new Size(MinimumWidth, originalSize.Height);
@@ -47,7 +51,8 @@ namespace Eto.Mac.Forms.Controls
 		{
 			// store the normal size for a rounded button, so we can determine what style to give it based on actual size
 			var b = new EtoButton(NSButtonType.MomentaryPushIn);
-			originalSize = b.FittingSize.ToEtoSize();
+			originalSize = b.GetAlignmentRectForFrame(new CGRect(CGPoint.Empty, b.FittingSize)).Size.ToEtoSize();
+
 			/*
 			var b = new NSButton(); 
 			b.SetButtonType(NSButtonType.MomentaryPushIn);
@@ -58,19 +63,18 @@ namespace Eto.Mac.Forms.Controls
 
 	public class EtoButtonCell : NSButtonCell
 	{
-		public Color? Color { get; set; }
+		ColorizeView colorize;
+		public Color? Color
+		{
+			get => colorize?.Color;
+			set => ColorizeView.Create(ref colorize, value);
+		}
 
 		public override void DrawBezelWithFrame(CGRect frame, NSView controlView)
 		{
-			if (Color != null)
-			{
-				MacEventView.Colourize(controlView, Color.Value, delegate
-				{
-					base.DrawBezelWithFrame(frame, controlView);
-				});
-			}
-			else
-				base.DrawBezelWithFrame(frame, controlView);
+			colorize?.Begin(frame, controlView);
+			base.DrawBezelWithFrame(frame, controlView);
+			colorize?.End();
 		}
 
 		public EtoButtonCell()
@@ -213,14 +217,12 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		static readonly object Image_Key = new object();
-
 		public Image Image
 		{
-			get { return Widget.Properties.Get<Image>(Image_Key); }
+			get { return Widget.Properties.Get<Image>(ButtonHandler.Image_Key); }
 			set
 			{
-				if (Widget.Properties.TrySet(Image_Key, value))
+				if (Widget.Properties.TrySet(ButtonHandler.Image_Key, value))
 				{
 					Control.Image = value.ToNS();
 					SetImagePosition();
@@ -229,6 +231,8 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
+		protected override bool DefaultUseAlignmentFrame => true; //Control.BezelStyle != NSBezelStyle.SmallSquare;
+
 		/// <summary>
 		/// Gets the bezel style of the button based on its size and image position
 		/// </summary>
@@ -236,19 +240,41 @@ namespace Eto.Mac.Forms.Controls
 		{
 			if (BezelStyle != null)
 				return BezelStyle.Value;
-			var size = Control.Frame.Size.ToEtoSize();
-			if (size.IsEmpty)
-				return Control.BezelStyle;
+			var size = GetAlignmentFrame().Size.ToEtoSize();
+			// when bezel is RegularSquare, it reports different than other bezels
+			// only add two if we got the height from the alignment frame
+			if (Control.BezelStyle == NSBezelStyle.RegularSquare)
+				size.Height -= 2;
 
-			var defaultHeight = DefaultMinimumSize.Height;
-			if (size.Height < defaultHeight || size.Width < defaultHeight)
-				return NSBezelStyle.SmallSquare;
-			if (size.Height > defaultHeight)
-				return NSBezelStyle.RegularSquare;
+			// use the preferred size to determine style to use, if set
+			var preferredSize = PreferredSize;
+			bool autoSize = true;
+			if (preferredSize != null)
+			{
+				if (preferredSize.Value.Width > -1)
+					size.Width = preferredSize.Value.Width;
+				if (preferredSize.Value.Height > -1)
+				{
+					size.Height = preferredSize.Value.Height;
+					autoSize = false;
+				}
+			}
+
+			if (Widget.Loaded || !size.IsEmpty)
+			{
+				if (size.IsEmpty)
+					return Control.BezelStyle;
+
+				var originalSize = ButtonHandler.originalSize;
+				if (size.Height < originalSize.Height || size.Width < originalSize.Width)
+					return NSBezelStyle.SmallSquare;
+				if (size.Height > originalSize.Height)
+					return NSBezelStyle.RegularSquare;
+			}
 			var image = Image;
 			if (image == null)
 				return NSBezelStyle.Rounded;
-			if (image.Size.Height > 18)
+			if (autoSize && image.Size.Height > 18)
 				return NSBezelStyle.RegularSquare;
 			switch (Control.ImagePosition)
 			{
@@ -289,11 +315,6 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		protected override SizeF GetNaturalSize(SizeF availableSize)
-		{
-			return base.GetNaturalSize(availableSize);
-		}
-
 		protected virtual void SetImagePosition()
 		{
 			var position = ImagePosition.ToNS();
@@ -308,14 +329,12 @@ namespace Eto.Mac.Forms.Controls
 			SetBezel();
 		}
 
-		static readonly object ImagePosition_Key = new object();
-
 		public ButtonImagePosition ImagePosition
 		{
-			get { return Widget.Properties.Get<ButtonImagePosition>(ImagePosition_Key); }
+			get { return Widget.Properties.Get<ButtonImagePosition>(ButtonHandler.ImagePosition_Key); }
 			set
 			{
-				if (Widget.Properties.TrySet(ImagePosition_Key, value))
+				if (Widget.Properties.TrySet(ButtonHandler.ImagePosition_Key, value))
 				{
 					SetImagePosition();
 					InvalidateMeasure();
@@ -323,14 +342,12 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		static readonly object CustomBezelStyle_Key = new object();
-
 		public NSBezelStyle? BezelStyle
 		{
-			get { return Widget.Properties.Get<NSBezelStyle?>(CustomBezelStyle_Key); }
+			get { return Widget.Properties.Get<NSBezelStyle?>(ButtonHandler.CustomBezelStyle_Key); }
 			set
 			{
-				if (Widget.Properties.TrySet(CustomBezelStyle_Key, value))
+				if (Widget.Properties.TrySet(ButtonHandler.CustomBezelStyle_Key, value))
 				{
 					SetBezel();
 					InvalidateMeasure();

--- a/src/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using Eto.Forms;
+using Eto.Drawing;
 
 #if XAMMAC2
 using AppKit;
@@ -86,10 +87,9 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		protected override NSButton CreateControl()
-		{
-			return new EtoCheckBoxButton();
-		}
+		protected override bool DefaultUseAlignmentFrame => true;
+
+		protected override NSButton CreateControl() => new EtoCheckBoxButton();
 
 		protected override void Initialize()
 		{
@@ -138,6 +138,12 @@ namespace Eto.Mac.Forms.Controls
 		{
 			get { return Control.AllowsMixedState; }
 			set { Control.AllowsMixedState = value; }
+		}
+
+		protected override void SetBackgroundColor(Color? color)
+		{
+			base.SetBackgroundColor(color);
+			InvalidateMeasure();
 		}
 	}
 }

--- a/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
@@ -93,10 +93,9 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		protected override NSComboBox CreateControl()
-		{
-			return new EtoComboBox();
-		}
+		protected override bool DefaultUseAlignmentFrame => true;
+
+		protected override NSComboBox CreateControl() => new EtoComboBox();
 
 		protected override void Initialize()
 		{
@@ -156,7 +155,8 @@ namespace Eto.Mac.Forms.Controls
 		protected override SizeF GetNaturalSize(SizeF availableSize)
 		{
 			var size = base.GetNaturalSize(availableSize);
-			return new SizeF(Math.Max(size.Width, 100), size.Height);
+			// note: natural height reported by NSComboBox.FittingSize is 25, but should be 26.
+			return new SizeF(Math.Max(size.Width, 100), size.Height + 1);
 		}
 
 		static void SelectionDidChange(ObserverActionEventArgs e)

--- a/src/Eto.Mac/Forms/Controls/DateTimePickerHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DateTimePickerHandler.cs
@@ -64,9 +64,9 @@ namespace Eto.Mac.Forms.Controls
 			public WeakReference WeakHandler { get; set; }
 
 			public DateTimePickerHandler Handler
-			{ 
+			{
 				get { return (DateTimePickerHandler)WeakHandler.Target; }
-				set { WeakHandler = new WeakReference(value); } 
+				set { WeakHandler = new WeakReference(value); }
 			}
 
 			public EtoDatePicker()
@@ -77,10 +77,9 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		protected override NSDatePicker CreateControl()
-		{
-			return new EtoDatePicker();
-		}
+		protected override bool DefaultUseAlignmentFrame => true;
+
+		protected override NSDatePicker CreateControl() => new EtoDatePicker();
 
 		protected override void Initialize()
 		{
@@ -218,8 +217,8 @@ namespace Eto.Mac.Forms.Controls
 		{
 			get { return Control.Bordered; }
 			set
-			{ 
-				Control.Bordered = value; 
+			{
+				Control.Bordered = value;
 
 				Control.DatePickerStyle = value ? NSDatePickerStyle.TextFieldAndStepper : NSDatePickerStyle.TextField;
 			}

--- a/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
@@ -71,8 +71,12 @@ namespace Eto.Mac.Forms.Controls
 		{
 			NSDictionary textAttributes;
 			Color? textColor;
-
-			public Color? Color { get; set; }
+			ColorizeView colorize;
+			public Color? Color
+			{
+				get => colorize?.Color;
+				set => ColorizeView.Create(ref colorize, value);
+			}
 
 			public Color? TextColor
 			{
@@ -86,15 +90,9 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void DrawBezelWithFrame(CGRect frame, NSView controlView)
 			{
-				if (Color != null)
-				{
-					MacEventView.Colourize(controlView, Color.Value, delegate
-					{
-						base.DrawBezelWithFrame(frame, controlView);
-					});
-				}
-				else
-					base.DrawBezelWithFrame(frame, controlView);
+				colorize?.Begin(frame, controlView);
+				base.DrawBezelWithFrame(frame, controlView);
+				colorize?.End();
 			}
 
 			public override CGRect DrawTitle(NSAttributedString title, CGRect frame, NSView controlView)
@@ -125,10 +123,9 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		protected override NSPopUpButton CreateControl()
-		{
-			return new EtoPopUpButton();
-		}
+		protected override bool DefaultUseAlignmentFrame => true;
+
+		protected override NSPopUpButton CreateControl() => new EtoPopUpButton();
 
 		protected override void Initialize()
 		{

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -95,7 +95,7 @@ namespace Eto.Mac.Forms.Controls
 				var handler = Handler;
 				if (handler != null)
 				{
-					var args = MacConversions.GetMouseEvent(handler.ContainerControl, theEvent, false);
+					var args = MacConversions.GetMouseEvent(handler, theEvent, false);
 					if (theEvent.ClickCount >= 2)
 						handler.Callback.OnMouseDoubleClick(handler.Widget, args);
 					else
@@ -261,7 +261,7 @@ namespace Eto.Mac.Forms.Controls
 					// give MouseMove event a chance to start the drag
 					h.DragPasteboard = pboard;
 					h.CustomSelectedRows = rowIndexes.Select(r => (int)r).ToList();
-					var args = MacConversions.GetMouseEvent(h.ContainerControl, NSApplication.SharedApplication.CurrentEvent, false);
+					var args = MacConversions.GetMouseEvent(h, NSApplication.SharedApplication.CurrentEvent, false);
 					h.Callback.OnMouseMove(h.Widget, args);
 					h.DragPasteboard = null;
 					h.CustomSelectedRows = null;

--- a/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
@@ -54,6 +54,8 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
+		protected override bool DefaultUseAlignmentFrame => true;
+
 		protected override NSBox CreateControl() => new EtoBox(this);
 
 		protected override void Initialize()
@@ -126,5 +128,7 @@ namespace Eto.Mac.Forms.Controls
 				Control.SetNeedsDisplay();
 			}
 		}
+
+		protected override bool UseNSBoxBackgroundColor => false;
 	}
 }

--- a/src/Eto.Mac/Forms/Controls/MacEventView.cs
+++ b/src/Eto.Mac/Forms/Controls/MacEventView.cs
@@ -35,9 +35,6 @@ namespace Eto.Mac.Forms.Controls
 {
 	public class MacEventView : NSBox, IMacControl
 	{
-		static readonly NSString CIOutputImage = new NSString("outputImage");
-		static readonly Selector selConvertSizeToBacking = new Selector("convertSizeToBacking:");
-
 		public MacEventView()
 		{
 			BoxType = NSBoxType.NSBoxCustom;
@@ -50,45 +47,6 @@ namespace Eto.Mac.Forms.Controls
 		public MacEventView(IntPtr handle)
 			: base(handle)
 		{
-		}
-
-		public static void Colourize(NSView control, Color color, Action drawAction)
-		{
-			var size = control.Frame.Size;
-			if (size.Width <= 0 || size.Height <= 0)
-				return;
-			var image = new NSImage(size);
-			
-			image.LockFocusFlipped(!control.IsFlipped);
-			drawAction();
-			image.UnlockFocus();
-
-			var ciImage = CIImage.FromCGImage(image.CGImage);
-
-			CGSize realSize;
-			if (control.RespondsToSelector(selConvertSizeToBacking))
-				realSize = control.ConvertSizeToBacking(size);
-			else
-				realSize = control.ConvertSizeToBase(size);
-
-			var filter2 = new CIColorControls();
-			filter2.SetDefaults();
-			filter2.Image = ciImage;
-			filter2.Saturation = 0.0f;
-			ciImage = (CIImage)filter2.ValueForKey(CIOutputImage);
-
-			var filter3 = new CIColorMatrix();
-			filter3.SetDefaults();
-			filter3.Image = ciImage;
-			filter3.RVector = new CIVector(0, color.R, 0);
-			filter3.GVector = new CIVector(color.G, 0, 0);
-			filter3.BVector = new CIVector(0, 0, color.B);
-			filter3.AVector = new CIVector(0, 0, 0, color.A);
-			ciImage = (CIImage)filter3.ValueForKey(CIOutputImage);
-
-			// create separate context so we can force using the software renderer, which is more than fast enough for this
-			var ciContext = CIContext.FromContext(NSGraphicsContext.CurrentContext.GraphicsPort, new CIContextOptions { UseSoftwareRenderer = true });
-			ciContext.DrawImage(ciImage, new CGRect(CGPoint.Empty, size), new CGRect(CGPoint.Empty, realSize));
 		}
 
 		public WeakReference WeakHandler { get; set; }

--- a/src/Eto.Mac/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/RadioButtonHandler.cs
@@ -2,6 +2,7 @@ using System;
 using Eto.Forms;
 using System.Collections.Generic;
 using System.Linq;
+using Eto.Drawing;
 
 #if XAMMAC2
 using AppKit;
@@ -104,6 +105,8 @@ namespace Eto.Mac.Forms.Controls
 				return true;
 			}
 		}
+
+		protected override bool DefaultUseAlignmentFrame => true;
 
 		protected override NSButton CreateControl() => new EtoRadioButton();
 

--- a/src/Eto.Mac/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SliderHandler.cs
@@ -49,10 +49,9 @@ namespace Eto.Mac.Forms.Controls
 			public override nint IsVertical => Handler?.Orientation == Orientation.Vertical ? 1 : 0;
 		}
 
-		protected override NSSlider CreateControl()
-		{
-			return new EtoSlider();
-		}
+		protected override bool DefaultUseAlignmentFrame => true;
+
+		protected override NSSlider CreateControl() => new EtoSlider();
 
 		protected override void Initialize()
 		{

--- a/src/Eto.Mac/Forms/Controls/StepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/StepperHandler.cs
@@ -37,17 +37,17 @@ namespace Eto.Mac.Forms.Controls
 		public class EtoStepper : NSStepper, IMacControl
 		{
 			public WeakReference WeakHandler { get; set; }
+
+			public EtoStepper()
+			{
+				MinValue = 0;
+				MaxValue = 2;
+			}
 		}
 
-		public StepperHandler()
-		{
-			Control = new EtoStepper
-			{
-				WeakHandler = new WeakReference(this),
-				MinValue = 0,
-				MaxValue = 2
-			};
-		}
+		protected override bool DefaultUseAlignmentFrame => true;
+
+		protected override NSStepper CreateControl() => new EtoStepper();
 
 		static object ValidDirection_Key = new object();
 

--- a/src/Eto.Mac/Forms/Controls/TabControlHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TabControlHandler.cs
@@ -43,10 +43,9 @@ namespace Eto.Mac.Forms.Controls
 		// CWEN: should have some form of implementation here
 		public virtual Size ClientSize { get { return Size; } set { Size = value; } }
 
-		protected override NSTabView CreateControl()
-		{
-			return new EtoTabView();
-		}
+		protected override bool DefaultUseAlignmentFrame => true;
+
+		protected override NSTabView CreateControl() => new EtoTabView();
 
 		protected override void Initialize()
 		{

--- a/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
@@ -46,7 +46,7 @@ namespace Eto.Mac.Forms.Controls
 		{
 			// store the normal size for a rounded button, so we can determine what style to give it based on actual size
 			var b = new EtoButton(NSButtonType.PushOnPushOff);
-			s_defaultMinimumSize = b.FittingSize.ToEtoSize();
+			s_defaultMinimumSize = b.GetAlignmentRectForFrame(new CGRect(CGPoint.Empty, b.FittingSize)).Size.ToEtoSize();
 		}
 
 		protected override void SetImagePosition()

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -135,7 +135,7 @@ namespace Eto.Mac.Forms.Controls
 				if (theEvent.ButtonMask != 0)
 				{
 					// user is dragging the mouse, fire mouse move notifications
-					var args = MacConversions.GetMouseEvent(Handler.ContainerControl, theEvent, false);
+					var args = MacConversions.GetMouseEvent(Handler, theEvent, false);
 
 				}
 			}
@@ -438,7 +438,7 @@ namespace Eto.Mac.Forms.Controls
 					// give MouseMove event a chance to start the drag
 					h.DragPasteboard = pboard;
 					h.CustomSelectedItems = GetItems(items).ToList();
-					var args = MacConversions.GetMouseEvent(h.ContainerControl, NSApplication.SharedApplication.CurrentEvent, false);
+					var args = MacConversions.GetMouseEvent(h, NSApplication.SharedApplication.CurrentEvent, false);
 					h.Callback.OnMouseMove(h.Widget, args);
 					h.DragPasteboard = null;
 					h.CustomSelectedItems = null;
@@ -472,7 +472,7 @@ namespace Eto.Mac.Forms.Controls
 				var handler = Handler;
 				if (handler != null)
 				{
-					var args = MacConversions.GetMouseEvent(handler.ContainerControl, theEvent, false);
+					var args = MacConversions.GetMouseEvent(handler, theEvent, false);
 					if (theEvent.ClickCount >= 2)
 						handler.Callback.OnMouseDoubleClick(handler.Widget, args);
 					else

--- a/src/Eto.Mac/Forms/MacBase.cs
+++ b/src/Eto.Mac/Forms/MacBase.cs
@@ -172,6 +172,8 @@ namespace Eto.Mac.Forms
 
 		List<ObserverHelper> observers;
 
+		public static object GetHandler(IntPtr sender) => GetHandler(Runtime.GetNSObject(sender));
+
 		public static object GetHandler(object control)
 		{
 			var notification = control as NSNotification;
@@ -184,7 +186,7 @@ namespace Eto.Mac.Forms
 			return macControl.WeakHandler.Target;
 		}
 
-		public void AddMethod(IntPtr selector, Delegate action, string arguments, object control)
+		public bool AddMethod(IntPtr selector, Delegate action, string arguments, object control)
 		{
 			var type = control.GetType();
 			#if OSX
@@ -194,14 +196,14 @@ namespace Eto.Mac.Forms
 				throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Control '{0}' has a null handler", type));
 			#endif
 			var classHandle = Class.GetHandle(type);
-			ObjCExtensions.AddMethod(classHandle, selector, action, arguments);
+			return ObjCExtensions.AddMethod(classHandle, selector, action, arguments);
 		}
 
 		public bool HasMethod(IntPtr selector, object control)
 		{
 			var type = control.GetType();
 			var classHandle = Class.GetHandle(type);
-			return ObjCExtensions.GetMethod(classHandle, selector) != IntPtr.Zero;
+			return ObjCExtensions.GetInstanceMethod(classHandle, selector) != IntPtr.Zero;
 		}
 
 

--- a/src/Eto.Mac/Forms/MacObject.cs
+++ b/src/Eto.Mac/Forms/MacObject.cs
@@ -63,9 +63,9 @@ namespace Eto.Mac.Forms
 		///   <item>{CGSize=ff} - CGSize struct with float values</item>
 		/// </list>
 		/// </summary>
-		public new void AddMethod (IntPtr selector, Delegate action, string arguments, object control = null)
+		public new bool AddMethod (IntPtr selector, Delegate action, string arguments, object control = null)
 		{
-			base.AddMethod (selector, action, arguments, control ?? EventObject);
+			return base.AddMethod (selector, action, arguments, control ?? EventObject);
 		}
 
 		public new bool HasMethod(IntPtr selector, object control = null)

--- a/src/Eto.Mac/Forms/MacPanel.cs
+++ b/src/Eto.Mac/Forms/MacPanel.cs
@@ -191,10 +191,10 @@ namespace Eto.Mac.Forms
 		/// </summary>
 		public virtual void PerformContentLayout()
 		{
-			var view = Content.GetContainerView();
-			if (view != null)
+			var viewHandler = Content.GetMacViewHandler();
+			if (viewHandler != null)
 			{
-				view.Frame = ContentFrame;
+				viewHandler.SetAlignmentFrame(ContentFrame);
 			}
 		}
 	}

--- a/src/Eto.Mac/Forms/PixelLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/PixelLayoutHandler.cs
@@ -91,10 +91,9 @@ namespace Eto.Mac.Forms
 
 		void SetPosition(Control control, PointF point)
 		{
-			var macControl = control.GetMacControl();
-			var childView = macControl.ContainerControl;
-			var availableSize = Widget.Loaded ? Size.MaxValue : Control.Frame.Size.ToEtoSize();
-			var preferredSize = macControl.GetPreferredSize(availableSize);
+			var macView = control.GetMacViewHandler();
+			var availableSize = Widget.Loaded ? Size.MaxValue : macView.GetAlignmentFrame().Size.ToEtoSize();
+			var preferredSize = macView.GetPreferredSize(availableSize);
 
 			var origin = point.ToNS();
 			if (!Control.IsFlipped)
@@ -102,7 +101,7 @@ namespace Eto.Mac.Forms
 				origin.Y = Control.Frame.Height - origin.Y - preferredSize.Height;
 			}
 
-			childView.Frame = new CGRect(origin, preferredSize.ToNS());
+			macView.SetAlignmentFrame(new CGRect(origin, preferredSize.ToNS()));
 		}
 
 		public override void InvalidateMeasure()
@@ -115,13 +114,14 @@ namespace Eto.Mac.Forms
 		{
 			// set sizes of controls when resizing since available size changes, 
 			// it may change the preferred size of the children.
-			foreach (var control in Widget.Controls.Select(r => r.GetMacControl()))
+			foreach (var control in Widget.Controls)
 			{
-				if (control == null)
+				var macView = control.GetMacViewHandler();
+				if (macView == null)
 					continue;
 
-				var preferredSize = control.GetPreferredSize(SizeF.PositiveInfinity);
-				control.ContainerControl.SetFrameSize(preferredSize.ToNS());
+				var preferredSize = macView.GetPreferredSize(SizeF.PositiveInfinity);
+				macView.SetAlignmentFrameSize(preferredSize.ToNS());
 			}
 		}
 

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -220,17 +220,17 @@ namespace Eto.Mac
 			return new GridCellMouseEventArgs(column, row, col, item, buttons, modifiers, location);
 		}
 
-		public static PointF GetLocation(NSView view, NSEvent theEvent) => theEvent.LocationInWindow.ToEto(view);
-
-		public static MouseEventArgs GetMouseEvent(NSView view, NSEvent theEvent, bool includeWheel)
+		public static MouseEventArgs GetMouseEvent(IMacViewHandler handler, NSEvent theEvent, bool includeWheel)
 		{
-			var pt = MacConversions.GetLocation(view, theEvent);
+			var view = handler.ContainerControl;
+			var pt = theEvent.LocationInWindow;
+			pt = handler.GetAlignmentPointForFramePoint(pt);
 			Keys modifiers = theEvent.ModifierFlags.ToEto();
 			MouseButtons buttons = theEvent.GetMouseButtons();
 			SizeF? delta = null;
 			if (includeWheel)
 				delta = new SizeF((float)theEvent.DeltaX, (float)theEvent.DeltaY);
-			return new MouseEventArgs(buttons, modifiers, pt, delta);
+			return new MouseEventArgs(buttons, modifiers, pt.ToEto(view), delta);
 		}
 
 		public static MouseButtons GetMouseButtons(this NSEvent theEvent)
@@ -397,6 +397,11 @@ namespace Eto.Mac
 		public static SizeF ToEtoSize(this NSEdgeInsets insets)
 		{
 			return new SizeF((float)(insets.Left + insets.Right), (float)(insets.Top + insets.Bottom));
+		}
+
+		public static Padding ToEto(this NSEdgeInsets insets)
+		{
+			return new Padding((int)insets.Left, (int)insets.Top, (int)insets.Right, (int)insets.Bottom);
 		}
 
 		public static CalendarMode ToEto(this NSDatePickerMode mode)

--- a/src/Eto.Mac/MacConversions.ns.cs
+++ b/src/Eto.Mac/MacConversions.ns.cs
@@ -43,6 +43,9 @@ namespace Eto.Mac
 
 		public static NSColor ToNS(this CGColor color)
 		{
+			if (color == null)
+				return null;
+
 			if (MacVersion.IsAtLeast(10, 8))
 				return NSColor.FromCGColor(color);
 

--- a/src/Eto.Mac/MacExtensions.cs
+++ b/src/Eto.Mac/MacExtensions.cs
@@ -98,6 +98,8 @@ namespace Eto.Mac
 
 		public static NSColor UsingColorSpaceFast(this NSColor color, NSString colorSpace)
 		{
+			if (color == null)
+				return null;
 			var intPtr = Messaging.IntPtr_objc_msgSend_IntPtr(color.Handle, selColorUsingColorSpaceName_Handle, colorSpace.Handle);
 			return Runtime.GetNSObject<NSColor>(intPtr);
 		}

--- a/src/Eto.Mac/MacHelpers.cs
+++ b/src/Eto.Mac/MacHelpers.cs
@@ -49,8 +49,9 @@ namespace Eto.Forms
 			if (attach && !control.Loaded)
 			{
 				control.AttachNative();
-				var macControl = control.GetMacControl();
-				macControl?.ContainerControl.SetFrameSize(macControl.GetPreferredSize(SizeF.PositiveInfinity).ToNS());
+				var macView = control.GetMacViewHandler();
+
+				macView?.SetAlignmentFrameSize(macView.GetPreferredSize(SizeF.PositiveInfinity).ToNS());
 			}
 			return control.GetContainerView();
 		}

--- a/src/Eto.Mac/Messaging.cs
+++ b/src/Eto.Mac/Messaging.cs
@@ -79,6 +79,9 @@ namespace Eto.Mac
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
 		public static extern void void_objc_msgSendSuper_CGRect(IntPtr receiver, IntPtr selector, CGRect arg1);
 
+		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		public static extern void void_objc_msgSendSuper(IntPtr receiver, IntPtr selector);
+
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
 		public static extern bool bool_objc_msgSend(IntPtr receiver, IntPtr selector);
 

--- a/src/Eto.Mac/ObjCExtensions.cs
+++ b/src/Eto.Mac/ObjCExtensions.cs
@@ -22,11 +22,11 @@ namespace Eto.Mac
 	public static class ObjCExtensions
 	{
 		[DllImport("/usr/lib/libobjc.dylib")]
-		static extern IntPtr class_getClassMethod(IntPtr cls, IntPtr sel);
+		static extern IntPtr class_getInstanceMethod(IntPtr cls, IntPtr sel);
 
-		public static IntPtr GetMethod(this Class cls, IntPtr selector) => class_getClassMethod(cls.Handle, selector);
+		public static IntPtr GetInstanceMethod(this Class cls, IntPtr selector) => class_getInstanceMethod(cls.Handle, selector);
 
-		public static IntPtr GetMethod(IntPtr cls, IntPtr selector) => class_getClassMethod(cls, selector);
+		public static IntPtr GetInstanceMethod(IntPtr cls, IntPtr selector) => class_getInstanceMethod(cls, selector);
 
 		[DllImport("/usr/lib/libobjc.dylib")]
 		static extern bool class_addMethod(IntPtr cls, IntPtr sel, Delegate method, string argTypes);
@@ -46,8 +46,8 @@ namespace Eto.Mac
 
 		public static void ExchangeMethod(this Class cls, IntPtr selMethod1, IntPtr selMethod2)
 		{
-			var method1 = class_getClassMethod(cls.Handle, selMethod1);
-			var method2 = GetMethod(cls, selMethod2);
+			var method1 = class_getInstanceMethod(cls.Handle, selMethod1);
+			var method2 = GetInstanceMethod(cls, selMethod2);
 			method_exchangeImplementations(method1, method2);
 		}
 

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -58,6 +58,15 @@ namespace Eto.Mac
 			| PlatformFeatures.CustomCellSupportsControlView
 			| PlatformFeatures.TabIndexWithCustomContainers;
 
+		static Platform()
+		{
+			Style.Add<ThemedTextStepperHandler>(null, h =>
+			{
+				h.Control.Spacing = new Size(3, 0);
+			});
+
+		}
+
 		public Platform()
 		{
 #if Mac64

--- a/src/Eto/Forms/Controls/Button.cs
+++ b/src/Eto/Forms/Controls/Button.cs
@@ -149,7 +149,8 @@ namespace Eto.Forms
 						size.Width = min.Width;
 					if (size.Height == -1)
 						size.Height = min.Height;
-					MinimumSize = size;
+					if (size != min)
+						MinimumSize = size;
 				}
 			}
 		}

--- a/src/Eto/Forms/Menu/RadioMenuItem.cs
+++ b/src/Eto/Forms/Menu/RadioMenuItem.cs
@@ -50,6 +50,7 @@ namespace Eto.Forms
 			Handler.Create(controller);
 			Initialize();
 			Handler.CreateFromCommand(command);
+			HandleEvent(CheckedChangedEvent);
 		}
 
 		internal override void SetCommand(ICommand oldValue, ICommand newValue)
@@ -65,7 +66,11 @@ namespace Eto.Forms
 			{
 				Checked = valueCommand.GetValue(CommandParameter);
 				valueCommand.ValueChanged += ValueCommand_ValueChanged;
-				HandleEvent(CheckedChangedEvent);
+
+				// HACK: should be checked some other way, perhaps during initialize
+				// this is why we don't call virtual methods from constructors..
+				if (ControlObject != null)
+					HandleEvent(CheckedChangedEvent);
 			}
 		}
 

--- a/src/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
@@ -20,7 +20,7 @@ namespace Eto.Forms.ThemedControls
 			textBox = new TextBox();
 			stepper = new Stepper();
 			Control = TableLayout.Horizontal(
-				new TableCell(new TableLayout(null, textBox, null), true),
+				new TableCell(textBox, true),
 				stepper
 			);
 			Control.EndInit();

--- a/test/Eto.Test/MainForm.cs
+++ b/test/Eto.Test/MainForm.cs
@@ -150,7 +150,7 @@ namespace Eto.Test
 			layout.BeginHorizontal();
 			layout.Add(EventLog, true);
 
-			layout.BeginVertical(new Padding(0, 0, 5, 0));
+			layout.BeginVertical(new Padding(0, 5, 5, 0));
 			layout.Add(ClearButton());
 			layout.Add(MemoryButton());
 			layout.Add(null);

--- a/test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
+++ b/test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
@@ -15,8 +15,8 @@ namespace Eto.Test.Sections.Behaviors
 				layout.Add(options);
 
 			layout.BeginVertical();
-			layout.AddRow(null, LabelControl(), ButtonControl(), LinkButtonControl(), new Panel(), null);
-			layout.AddRow(null, TextBoxControl(), PasswordBoxControl());
+			layout.AddRow(null, LabelControl(), ButtonControl(), ToggleButtonControl(), LinkButtonControl(), new Panel(), null);
+			layout.AddRow(null, TextBoxControl(), PasswordBoxControl(), SegmentedButtonControl());
 
 			layout.BeginHorizontal();
 			layout.Add(null);
@@ -27,13 +27,9 @@ namespace Eto.Test.Sections.Behaviors
 
 			layout.AddRow(null, CheckBoxControl(), RadioButtonControl());
 			layout.AddRow(null, DateTimeControl(), DropDownControl(), ComboBoxControl());
-			layout.AddRow(null, NumericStepperControl(), TextStepperControl());
+			layout.AddRow(null, NumericStepperControl(), TextStepperControl(), StepperControl());
 
-			layout.BeginHorizontal();
-			layout.Add(null);
-			layout.Add(ColorPickerControl());
-			layout.Add(SliderControl());
-			layout.EndHorizontal();
+			layout.AddRow(null, ColorPickerControl(), SliderControl());
 
 			layout.BeginHorizontal();
 			layout.Add(null);
@@ -58,49 +54,56 @@ namespace Eto.Test.Sections.Behaviors
 
 		Control LabelControl()
 		{
-			var control = new Label { Text = "Label Control" };
+			var control = new Label { Text = "Label" };
 			LogEvents(control);
 			return control;
 		}
 
 		Control ButtonControl()
 		{
-			var control = new Button { Text = "Button Control" };
+			var control = new Button { Text = "Button" };
+			LogEvents(control);
+			return control;
+		}
+
+		Control ToggleButtonControl()
+		{
+			var control = new ToggleButton { Text = "ToggleButton " };
 			LogEvents(control);
 			return control;
 		}
 
 		Control TextBoxControl()
 		{
-			var control = new TextBox { Text = "TextBox Control" };
+			var control = new TextBox { Text = "TextBox" };
 			LogEvents(control);
 			return control;
 		}
 
 		Control PasswordBoxControl()
 		{
-			var control = new PasswordBox { Text = "PasswordBox Control" };
+			var control = new PasswordBox { Text = "PasswordBox" };
 			LogEvents(control);
 			return control;
 		}
 
 		Control TextAreaControl()
 		{
-			var control = new TextArea { Text = "TextArea Control" };
+			var control = new TextArea { Text = "TextArea" };
 			LogEvents(control);
 			return control;
 		}
 
 		Control CheckBoxControl()
 		{
-			var control = new CheckBox { Text = "CheckBox Control" };
+			var control = new CheckBox { Text = "CheckBox" };
 			LogEvents(control);
 			return control;
 		}
 
 		Control RadioButtonControl()
 		{
-			var control = new RadioButton { Text = "RadioButton Control" };
+			var control = new RadioButton { Text = "RadioButton" };
 			LogEvents(control);
 			return control;
 		}
@@ -121,7 +124,14 @@ namespace Eto.Test.Sections.Behaviors
 
 		Control TextStepperControl()
 		{
-			var control = new TextStepper();
+			var control = new TextStepper { Text = "TextStepper" };
+			LogEvents(control);
+			return control;
+		}
+
+		Control StepperControl()
+		{
+			var control = new Stepper();
 			LogEvents(control);
 			return control;
 		}
@@ -129,10 +139,10 @@ namespace Eto.Test.Sections.Behaviors
 		Control DropDownControl()
 		{
 			var control = new DropDown();
-			control.Items.Add(new ListItem { Text = "Item 1" });
+			control.Items.Add(new ListItem { Text = "DropDown" });
 			control.Items.Add(new ListItem { Text = "Item 2" });
 			control.Items.Add(new ListItem { Text = "Item 3" });
-			control.SelectedKey = "Item 1";
+			control.SelectedKey = "DropDown";
 			LogEvents(control);
 			return control;
 		}
@@ -140,10 +150,10 @@ namespace Eto.Test.Sections.Behaviors
 		Control ComboBoxControl()
 		{
 			var control = new ComboBox();
-			control.Items.Add(new ListItem { Text = "Item 1" });
+			control.Items.Add(new ListItem { Text = "ComboBox" });
 			control.Items.Add(new ListItem { Text = "Item 2" });
 			control.Items.Add(new ListItem { Text = "Item 3" });
-			control.SelectedKey = "Item 1";
+			control.SelectedKey = "ComboBox";
 			LogEvents(control);
 			return control;
 		}
@@ -151,7 +161,7 @@ namespace Eto.Test.Sections.Behaviors
 		Control ListBoxControl()
 		{
 			var control = new ListBox();
-			control.Items.Add(new ListItem { Text = "Item 1" });
+			control.Items.Add(new ListItem { Text = "ListBox" });
 			control.Items.Add(new ListItem { Text = "Item 2" });
 			control.Items.Add(new ListItem { Text = "Item 3" });
 			LogEvents(control);
@@ -183,7 +193,8 @@ namespace Eto.Test.Sections.Behaviors
 			var control = new Drawable { Size = new Size(100, 30), CanFocus = true };
 			control.Paint += delegate(object sender, PaintEventArgs pe)
 			{
-				pe.Graphics.FillRectangle(Brushes.Blue, pe.ClipRectangle);
+				if (control.BackgroundColor.A <= 0)
+					pe.Graphics.FillRectangle(Brushes.Blue, pe.ClipRectangle);
 				var size = pe.Graphics.MeasureString(SystemFonts.Label(), "Drawable");
 				pe.Graphics.DrawText(SystemFonts.Label(), Brushes.White, (PointF)((control.Size - size) / 2), "Drawable");
 			};
@@ -193,7 +204,7 @@ namespace Eto.Test.Sections.Behaviors
 
 		Control GroupBoxControl()
 		{
-			var control = new GroupBox { Text = "Some Group Box" };
+			var control = new GroupBox { Text = "GroupBox" };
 			control.Content = new Label { Text = "Content" };
 			LogEvents(control);
 			return control;
@@ -201,7 +212,7 @@ namespace Eto.Test.Sections.Behaviors
 
 		Control LinkButtonControl()
 		{
-			var control = new LinkButton { Text = "Link Button" };
+			var control = new LinkButton { Text = "LinkButton" };
 			LogEvents(control);
 			return control;
 		}
@@ -224,6 +235,13 @@ namespace Eto.Test.Sections.Behaviors
 		{
 			var control = new ImageView();
 			control.Image = TestIcons.TestImage;
+			LogEvents(control);
+			return control;
+		}
+
+		Control SegmentedButtonControl()
+		{
+			var control = new SegmentedButton { Items = { "Item1", "Item2" } };
 			LogEvents(control);
 			return control;
 		}

--- a/test/Eto.Test/Sections/Behaviors/MouseEventsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/MouseEventsSection.cs
@@ -19,7 +19,8 @@ namespace Eto.Test.Sections.Behaviors
 		{
 			if (!showParentEvents.Checked == true && sender == this)
 				return;
-			Log.Write(sender, "{0}, Location: {1}, Buttons: {2}, Modifiers: {3}, Delta: {4}", type, e.Location, e.Buttons, e.Modifiers, e.Delta);
+			var control = sender as Control;
+			Log.Write(sender, $"{type}, Location: {e.Location}, Buttons: {e.Buttons}, Modifiers: {e.Modifiers}, Delta: {e.Delta}, Screen: {control?.PointToScreen(e.Location)}");
 			if (handleEvents.Checked == true)
 				e.Handled = true;
 		}

--- a/test/Eto.Test/Sections/Controls/ControlColorsSection.cs
+++ b/test/Eto.Test/Sections/Controls/ControlColorsSection.cs
@@ -22,7 +22,7 @@ namespace Eto.Test.Sections.Controls
 					update(foregroundPicker.Value);
 			};
 
-			var backgroundPicker = new ColorPicker { AllowAlpha = false }; // alpha not supported for all controls
+			var backgroundPicker = new ColorPicker { AllowAlpha = true }; // alpha not supported for all controls
 			backgroundPicker.ValueChanged += (sender, e) =>
 			{
 				foreach (var update in backgroundUpdates)

--- a/test/Eto.Test/Sections/Controls/DropDownSection.cs
+++ b/test/Eto.Test/Sections/Controls/DropDownSection.cs
@@ -31,8 +31,8 @@ namespace Eto.Test.Sections.Controls
 
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5) };
 			layout.Add(TableLayout.AutoSized(control));
-			layout.AddSeparateRow(null, AddRowsButton(control), AddWithImagesCheckBox(), RemoveRowsButton(control), ClearButton(control), null);
-			layout.AddSeparateRow(null, EnabledCheckBox(control), SetSelected(control), ClearSelected(control), null);
+			layout.AddSeparateRow(AddRowsButton(control), AddWithImagesCheckBox(), RemoveRowsButton(control), ClearButton(control), null);
+			layout.AddSeparateRow(EnabledCheckBox(control), SetSelected(control), ClearSelected(control), null);
 
 			return layout;
 		}

--- a/test/Eto.Test/UnitTests/Forms/Controls/ButtonTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ButtonTests.cs
@@ -1,0 +1,27 @@
+using System;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	[TestFixture]
+	public class ButtonTests : TestBase
+	{
+		[Test, ManualTest]
+		public void ButtonShouldAlignWithTextBox()
+		{
+			ManualForm("Buttons should align to the left and right of the text box,\nwithout being clipped.", form =>
+			{
+				return new TableLayout
+				{
+					Rows =
+					{
+						new TableRow(new TableCell(new TextBox { Text = "TextBox"}, true), new TableCell(new Button { Text = "Button 1"}, true)),
+						new TableRow(new Button { Text = "Button 2"}),
+						null
+					}
+				};
+			});
+		}
+	}
+}

--- a/test/Eto.Test/UnitTests/Forms/Controls/ControlTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ControlTests.cs
@@ -278,5 +278,24 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				}
 			});
 		}
+
+		[TestCaseSource(nameof(GetControlTypes)), ManualTest]
+		public void ControlsShouldNotHaveIntrinsicPadding(IControlTypeInfo<Control> info)
+		{
+			ManualForm("Controls should be touching horizontally and vertically,\nwithout being clipped.", form =>
+			{
+				return new TableLayout
+				{
+					Rows =
+					{
+						new TableRow(new TableCell(info.CreatePopulatedControl(), true), new TableCell(info.CreatePopulatedControl(), true)),
+						new TableRow(new Panel { Content = info.CreatePopulatedControl() }, info.CreatePopulatedControl()),
+						new TableRow(info.CreatePopulatedControl(), new Drawable { Content = info.CreatePopulatedControl() }),
+						null
+					}
+				};
+			});
+		}
+
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/Controls/DropDownTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/DropDownTests.cs
@@ -125,5 +125,23 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				Assert.IsNull(dropDown.SelectedValue, "#2.2");
 			});
 		}
+
+		[Test, ManualTest]
+		public void DropDownShouldAlignWithTextBox()
+		{
+			ManualForm("DropDown should align to the left and right of the text box,\nwithout being clipped.", form =>
+			{
+				return new TableLayout
+				{
+					Rows =
+					{
+						new TableRow(new TableCell(new TextBox { Text = "TextBox"}, true), new TableCell(new DropDown { }, true)),
+						new TableRow(new DropDown { }),
+						null
+					}
+				};
+			});
+		}
+
 	}
 }

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -658,6 +658,7 @@ namespace Eto.Test.UnitTests
 			T CreateControl();
 			Container CreateContainer(Control control);
 			void PopulateControl(Control control);
+			T CreatePopulatedControl();
 		}
 
 		public interface IContainerTypeInfo<out T> : IControlTypeInfo<T>
@@ -779,6 +780,13 @@ namespace Eto.Test.UnitTests
 			}
 
 			public override string ToString() => Type.Name;
+
+			public T CreatePopulatedControl()
+			{
+				var c = CreateControl();
+				PopulateControl(c);
+				return c;
+			}
 		}
 
 		public static class ContainerTypeInfo


### PR DESCRIPTION
- Alignment rectangle is used for many controls with intrinsic padding, such as NSButton, NSStepper, NSSlider, etc.  This allows the controls to align with other controls and now behaves much more similarly to other platforms.  Even though the control has a different frame, the alignment frame is used instead.  This should all be transparent to the user, these controls now have a smaller natural size and do not have any intrinsic padding.
- Add MacView.UseAlignmentFrame so you can override using the alignment frame with any control.
- Fix issue with TableLayout where it wouldn’t deal with partial pixels properly
- Fix problems setting background color on some controls the first time they are created
- Fix setting background color on GroupBox
- Use NSColor.SetFill() when possible
- DateTimePicker, TextStepper, and NumericStepper now have same spacing/padding with the stepper
- Ensure mouse events report the correct position relative to the alignment rect, not the frame.
- Fix issue with RadioMenuItem in Gtk