### PR TITLE
Enable dark mode when using mkbunde

### DIFF
--- a/build/MacTemplate/MacTemplate.targets
+++ b/build/MacTemplate/MacTemplate.targets
@@ -347,6 +347,11 @@
         if (!string.IsNullOrEmpty(MonoMinimumVersion)) {
           AddStringProperty("MonoMinimumVersion", MonoMinimumVersion);
         }
+        
+        // support dark mode even when using mkbundle.
+        // As of mono 5.18, it appears to be compiled with macOS 10.12 SDK
+        // So dark mode would be disabled by default.
+        AddStringProperty("NSRequiresAquaSystemAppearance", "False");
 
         using (var sw = new NullSubsetXmlTextWriter(PListFile, Encoding.UTF8))
           xml.Save(sw);

--- a/test/Eto.Test.Mac/Info.plist
+++ b/test/Eto.Test.Mac/Info.plist
@@ -11,9 +11,11 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.7</string>
+	<string>10.9</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<string>False</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>


### PR DESCRIPTION
When using mkbundle it creates an executable that is compiled with SDK 10.12, which means dark mode is not automatically supported.
This ensures dark mode is supported even when compiling for release.