### PR TITLE
Add other configurations for vscode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,15 +2,47 @@
    "version": "0.2.0",
    "configurations": [
         {
+            "name": "Eto.Test.Mac64",
+            "type": "mono",
+			"request": "launch",
+			"preLaunchTask": "build-mac64",
+			"useRuntime": false,
+            "program": "${workspaceFolder}/artifacts/test/Debug/net461/Eto.Test.Mac64.app/Contents/MacOS/Eto.Test.Mac64",
+            "args": [],
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
             "name": "Eto.Test.Gtk",
             "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build_gtk",
+			"request": "launch",
+			"preLaunchTask": "build-gtk",
             "program": "${workspaceFolder}/artifacts/test/Debug/netcoreapp2.0/Eto.Test.Gtk.dll",
             "args": [],
             "console": "internalConsole",
             "stopAtEntry": false,
             "internalConsoleOptions": "openOnSessionStart"
-        }
-    ]
+        },
+        {
+            "name": "Eto.Test.Gtk2",
+			"type": "clr",
+			"osx": {"type": "mono"},
+            "request": "launch",
+			"preLaunchTask": "build-gtk2",
+            "program": "${workspaceFolder}/artifacts/test/Debug/net461/Eto.Test.Gtk2.exe",
+            "args": [],
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": "Eto.Test.Wpf",
+			"type": "clr",
+			"request": "launch",
+			"preLaunchTask": "build-wpf",
+            "program": "${workspaceFolder}/artifacts/test/Debug/net461/Eto.Test.Wpf.exe",
+            "args": [],
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+	]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,13 @@
 {
+	"omnisharp.defaultLaunchSolution": "Eto.sln",
     "editor.insertSpaces": false,
-    "editor.detectIndentation": false
+	"editor.detectIndentation": false,
+	"files.exclude": {
+		"**/.vs": true,
+		"**/obj": true,
+		"**/bin": true,
+		"**/*.user": true,
+		"**/packages": true
+	},
+	"vssolution.trackActiveItem": true
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,15 +1,91 @@
 {
-    "version": "2.0.0",
-    "tasks": [
-        {
-            "label": "build_gtk",
-            "command": "dotnet",
-            "type": "process",
-            "args": [
-                "build",
-                "${workspaceFolder}/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj"
-            ],
-            "problemMatcher": "$msCompile"
-        }
-    ]
+	"version": "2.0.0",
+	"tasks": [
+		{
+			"label": "build",
+			"command": "msbuild",
+			"windows": { "command": "build/msbuild.cmd" },
+			"type": "process",
+			"args": [
+				"/t:Build",
+				"/p:Configuration=${input:configuration}",
+				"${workspaceFolder}/build/Build.proj"
+			],
+			"problemMatcher": "$msCompile",
+			"group": {
+				"kind": "build",
+				"isDefault": true
+			}
+		},
+		{
+			"label": "build-gtk",
+			"command": "dotnet",
+			"type": "process",
+			"args": [
+				"build",
+				"/p:Configuration=Debug",
+				"${workspaceFolder}/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj"
+			],
+			"group": "build",
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "build-gtk2",
+			"command": "msbuild",
+			"windows": { "command": "build/msbuild.cmd" },
+			"type": "process",
+			"args": [
+				"/p:Configuration=Debug",
+				"${workspaceFolder}/test/Eto.Test.Gtk2/Eto.Test.Gtk2.csproj"
+			],
+			"group": "build",
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "build-mac64",
+			"command": "msbuild",
+			"windows": { "command": "build/msbuild.cmd" },
+			"type": "process",
+			"args": [
+				"/p:Configuration=Debug",
+				"${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.Mac64.csproj"
+			],
+			"group": "build",
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "build-wpf",
+			"command": "msbuild",
+			"windows": { "command": "build/msbuild.cmd" },
+			"type": "process",
+			"args": [
+				"/p:Configuration=Debug",
+				"${workspaceFolder}/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj"
+			],
+			"group": "build",
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "restore",
+			"command": "nuget",
+			"type": "process",
+			"args": [
+				"restore",
+				"${workspaceFolder}/src/Eto.sln"
+			],
+			"problemMatcher": "$msCompile"
+		}
+	],
+	"inputs": [
+		{
+			"id": "configuration",
+			"type": "pickString",
+			"default": "Debug",
+			"description": "Build Configuration",
+			"options": [
+				"Debug",
+				"Release"
+			]
+		}
+	]
 }

--- a/build/msbuild.cmd
+++ b/build/msbuild.cmd
@@ -1,0 +1,10 @@
+@echo off
+setlocal enabledelayedexpansion
+
+set vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
+set version=15.0
+
+for /f "usebackq tokens=*" %%i in (`"%vswhere%" -version %version% -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
+  "%%i" %*
+  exit /b !errorlevel!
+)

--- a/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
+++ b/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
@@ -13,6 +13,7 @@
     <AssemblyName>Eto.Test.Wpf</AssemblyName>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <TargetFrameworkProfile />
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup>
     <FileAlignment>512</FileAlignment>


### PR DESCRIPTION
- Can now run Wpf on windows and no longer prefers 32 bit so it can be debugged
- Mac64 and Gtk2 on Mac or Linux both run using a modified vscode-mono-debug extension