### PR TITLE
Wpf: Don't prevent crashes when subscribing to Application.UnhandledException

### DIFF
--- a/src/Eto.Wpf/Forms/ApplicationHandler.cs
+++ b/src/Eto.Wpf/Forms/ApplicationHandler.cs
@@ -109,7 +109,6 @@ namespace Eto.Wpf.Forms
 		{
 			var unhandledExceptionArgs = new UnhandledExceptionEventArgs(e.Exception, true);
 			Callback.OnUnhandledException(Widget, unhandledExceptionArgs);
-			e.Handled = true;
 		}
 
 		void OnCurrentDomainUnhandledException(object sender, System.UnhandledExceptionEventArgs e)


### PR DESCRIPTION

Cite #1364