### PR TITLE
Mac & Wpf fixes

### DIFF
--- a/src/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
@@ -173,7 +173,7 @@ namespace Eto.Mac.Forms.Controls
 				Control.TextStorage.BeginEditing();
 				var current = range;
 				var left = current.Length;
-				do
+				while (left > 0)
 				{
 					var attribs = Control.TextStorage.GetAttributes(current.Location, out effectiveRange, current);
 					attribs = UpdateFontAttributes(attribs, enabled, updateFont);
@@ -183,7 +183,7 @@ namespace Eto.Mac.Forms.Controls
 					current.Location += span;
 					current.Length -= span;
 					left -= span;
-				} while (left > 0);
+				}
 				Control.TextStorage.EndEditing();
 				Control.DidChangeText();
 			}
@@ -322,7 +322,7 @@ namespace Eto.Mac.Forms.Controls
 						nint pos = 0;
 						// when encountering an RTF without a defined foreground, use the system foreground for dark mode
 						var textColor = TextColor.ToNSUI();
-						do
+						while (pos < str.Length)
 						{
 							var color = str.GetAttribute(NSStringAttributeKey.ForegroundColor, pos, out var effectiveRange);
 							pos = effectiveRange.Location + effectiveRange.Length;
@@ -333,7 +333,7 @@ namespace Eto.Mac.Forms.Controls
 
 								mut.AddAttribute(NSStringAttributeKey.ForegroundColor, textColor, effectiveRange);
 							}
-						} while (pos < str.Length);
+						}
 
 						if (mut != null)
 							str = mut;

--- a/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
@@ -57,7 +57,7 @@ namespace Eto.Mac.Forms.Controls
 				if (string.IsNullOrEmpty(Text))
 					position = NSCellImagePosition.ImageOnly;
 				Control.ImagePosition = position;
-				SetBezel();
+				InvalidateMeasure();
 			}
 			else
 				base.SetImagePosition();

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1177,7 +1177,7 @@ namespace Eto.Mac.Forms
 			ContainerControl.SetFrameSize(size);
 		}
 
-		public void SetAlignmentFrame(CGRect frame) => ContainerControl.Frame = GetFrameForAlignmentRect(frame);
+		public virtual void SetAlignmentFrame(CGRect frame) => ContainerControl.Frame = GetFrameForAlignmentRect(frame);
 
 		public virtual CGRect GetFrameForAlignmentRect(CGRect frame)
 		{

--- a/src/Eto/Forms/FilterCollection.cs
+++ b/src/Eto/Forms/FilterCollection.cs
@@ -1062,12 +1062,20 @@ namespace Eto.Forms
 
 		bool IList.Contains(object value)
 		{
-			return Contains((T)value);
+			if (value is T val)
+				return Contains(val);
+			if (value == null)
+				return Contains(default(T)); // null is valid
+			return false;
 		}
 
 		int IList.IndexOf(object value)
 		{
-			return IndexOf((T)value);
+			if (value is T val)
+				return IndexOf(val);
+			if (value == null)
+				return IndexOf(default(T)); // null is valid
+			return -1;
 		}
 
 		void IList.Insert(int index, object value)
@@ -1077,7 +1085,10 @@ namespace Eto.Forms
 
 		void IList.Remove(object value)
 		{
-			Remove((T)value);
+			if (value is T val)
+				Remove(val);
+			if (value == null)
+				Remove(default(T)); // null is valid
 		}
 
 		bool IList.IsFixedSize

--- a/test/Eto.Test.Mac/UnitTests/ButtonTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/ButtonTests.cs
@@ -1,0 +1,102 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+using Eto.Mac.Forms.Controls;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+using System.Runtime.ExceptionServices;
+using System.Threading.Tasks;
+#if XAMMAC2
+using AppKit;
+using CoreGraphics;
+#else
+using MonoMac.AppKit;
+using MonoMac.CoreGraphics;
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
+#endif
+
+namespace Eto.Test.Mac.UnitTests
+{
+	[TestFixture]
+	public class ButtonTests : TestBase
+	{
+		[Test]
+		public void ButtonNaturalSizeShouldBeConsistent()
+		{
+			Exception exception = null;
+			Button button = null;
+			Panel panel = null;
+			Form(form => {
+				button = new Button();
+				button.Text = "Click Me";
+				panel = new Panel { Content = button };
+				form.Content = TableLayout.AutoSized(panel);
+				form.ClientSize = new Size(200, 200);
+
+				var handler = button?.Handler as ButtonHandler;
+				Assert.IsNotNull(handler, "#1.1");
+
+				var b = new EtoButton(NSButtonType.MomentaryPushIn);
+				var originalSize = b.GetAlignmentRectForFrame(new CGRect(CGPoint.Empty, b.FittingSize)).Size;
+				Assert.AreEqual(21, originalSize.Height, "#2.1");
+
+				var preferred = handler.GetPreferredSize(SizeF.PositiveInfinity);
+				Assert.AreEqual(originalSize.Height, preferred.Height, "#2.1");
+				Assert.AreEqual(NSBezelStyle.Rounded, handler.Control.BezelStyle, "#2.2");
+
+				form.Shown += async (sender, e) =>
+				{
+					try
+					{
+						// need to use invokes to wait for the layout pass to complete
+						panel.Size = new Size(-1, 22);
+						await Task.Delay(1000);
+						await Application.Instance.InvokeAsync(() =>
+						{
+							Assert.AreEqual(NSBezelStyle.RegularSquare, handler.Control.BezelStyle, "#3.1");
+							Assert.AreEqual(22, handler.Widget.Height, "#3.2");
+						});
+						panel.Size = new Size(-1, -1);
+						await Application.Instance.InvokeAsync(() =>
+						{
+							Assert.AreEqual(NSBezelStyle.Rounded, handler.Control.BezelStyle, "#4.1");
+							Assert.AreEqual(21, handler.Widget.Height, "#4.2");
+						});
+						panel.Size = new Size(-1, 20);
+						await Task.Delay(1000);
+						await Application.Instance.InvokeAsync(() =>
+						{
+							Assert.AreEqual(NSBezelStyle.SmallSquare, handler.Control.BezelStyle, "#5.1");
+							Assert.AreEqual(20, handler.Widget.Height, "#5.2");
+						});
+						panel.Size = new Size(-1, -1);
+						await Application.Instance.InvokeAsync(() =>
+						{
+							Assert.AreEqual(NSBezelStyle.Rounded, handler.Control.BezelStyle, "#6.1");
+							Assert.AreEqual(21, handler.Widget.Height, "#6.2");
+						});
+
+					}
+					catch (Exception ex)
+					{
+						exception = ex;
+					}
+					finally
+					{
+						form.Close();
+					}
+				};
+
+
+
+			}, -1);
+
+			if (exception != null)
+				ExceptionDispatchInfo.Capture(exception).Throw();
+		}
+	}
+}

--- a/test/Eto.Test/UnitTests/Forms/Controls/ButtonTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ButtonTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Eto.Drawing;
 using Eto.Forms;
 using NUnit.Framework;
 
@@ -21,6 +22,26 @@ namespace Eto.Test.UnitTests.Forms.Controls
 						null
 					}
 				};
+			});
+		}
+
+		[Test, ManualTest]
+		public void ButtonShouldNotFlicker()
+		{
+			// on MacOS the style of the button changes based on the size.
+			// This caused the button to flicker constantly by changing the style over and over.
+			ManualForm("Button should not flicker and appear as a single style", form =>
+			{
+				var layout = new TableLayout()
+				{
+					Padding = 10,
+					Spacing = new Size(5, 5),
+					Rows =
+					{
+						new TableRow(new NumericStepper(), new Button{ Text = "Test"})
+					}
+				};
+				return layout;
 			});
 		}
 	}

--- a/test/Eto.Test/UnitTests/Forms/Controls/RichTextAreaTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/RichTextAreaTests.cs
@@ -601,5 +601,17 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			Assert.AreEqual("Arial", richText.SelectionFamily.Name, "#2");
 			Assert.AreEqual("Black Oblique", richText.SelectionTypeface.Name, "#3");
 		}
+
+		[Test]
+		[InvokeOnUI]
+		public void EmptyRtfShouldNotCrash()
+		{
+			var richText = new RichTextArea();
+
+			var rtf = @"{\rtf1\ansi\ansicpg1252{\fonttbl}{\colortbl;\red255\green255\blue255;}}";
+			richText.Rtf = rtf;
+
+			Assert.AreEqual(string.Empty, richText.Text);
+		}
 	}
 }

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -32,7 +32,7 @@ namespace Eto.Test.UnitTests
 	}
 
 	[System.AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, Inherited = true, AllowMultiple = false)]
-	sealed class InvokeOnUIAttribute : Attribute, IWrapSetUpTearDown
+	public sealed class InvokeOnUIAttribute : Attribute, IWrapSetUpTearDown
 	{
 		public TestCommand Wrap(TestCommand command) => new RunOnUICommand(command);
 


### PR DESCRIPTION
Mac: Fix crash when loading empty RTF into RichTextArea
Mac: Fix flicker with Button with new alignment rect infrastructure
Wpf: Fix crash with FilterCollection as apparently Wpf likes to test if the collection contains certain objects that could not possibly be part of the collection.