### PR TITLE
Mac: Window animation and Dialog button fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,7 +15,7 @@ jobs:
     vmImage: 'macOS-10.13'
   
   steps:
-  - script: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 5_16_0
+  - script: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh 5_18_1
     displayName: 'Select Xamarin SDK version'
   - task: msbuild@1
     displayName: Build and Package

--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -42,20 +42,19 @@ namespace Eto.Mac.Forms
 	{
 		Button defaultButton;
 		ModalEventArgs session;
-		const int BUTTON_PADDING = 2;
+		static Padding s_ButtonPadding = new Padding(6, 6);
+		static int s_ButtonSpacing = 12;
 
 		static readonly object UseContentBorder_Key = new object();
 
 		public bool UseContentBorder
 		{
-			get => Widget.Properties.Get(UseContentBorder_Key, true);
+			get => Widget.Properties.Get<bool>(UseContentBorder_Key);
 			set
 			{
-				if (UseContentBorder != value)
+				if (Widget.Properties.TrySet(UseContentBorder_Key, value))
 				{
-					Widget.Properties.Set(UseContentBorder_Key, value, true);
-					if (Widget.Loaded)
-						PositionButtons();
+					InvalidateMeasure();
 				}
 			}
 		}
@@ -103,15 +102,19 @@ namespace Eto.Mac.Forms
 			var buttonSize = SizeF.Empty;
 			if (Widget.NegativeButtons.Count > 0 || Widget.PositiveButtons.Count > 0)
 			{
+				bool addSpacing = false;
 				foreach (var button in Widget.NegativeButtons.Concat(Widget.PositiveButtons))
 				{
 					var preferredSize = button.GetPreferredSize(availableSize);
+					if (addSpacing)
+						buttonSize.Width += s_ButtonSpacing;
+					else
+						addSpacing = true;
 					buttonSize.Width += preferredSize.Width;
 					buttonSize.Height = Math.Max(buttonSize.Height, preferredSize.Height);
 				}
-				buttonSize.Height += BUTTON_PADDING;
 			}
-			return buttonSize;
+			return buttonSize + s_ButtonPadding.Size;
 		}
 
 		protected override SizeF GetNaturalSize(SizeF availableSize)
@@ -248,21 +251,13 @@ namespace Eto.Mac.Forms
 		public void InsertDialogButton(bool positive, int index, Button item)
 		{
 			Control.ContentView.AddSubview(item.ToNative());
-			if (Widget.Loaded)
-				PositionButtons();
+			InvalidateMeasure();
 		}
 
 		public void RemoveDialogButton(bool positive, int index, Button item)
 		{
 			item.ToNative().RemoveFromSuperview();
-			if (Widget.Loaded)
-				PositionButtons();
-		}
-
-		public override void OnLoad(EventArgs e)
-		{
-			base.OnLoad(e);
-			PositionButtons();
+			InvalidateMeasure();
 		}
 
 		protected override CGRect ContentFrame
@@ -281,8 +276,9 @@ namespace Eto.Mac.Forms
 
 		void PositionButtons()
 		{
-			var availableSize = Control.ContentView.Frame.Size.ToEto();
-			var point = new PointF(availableSize.Width, 0);
+			var contentView = Control.ContentView;
+			var availableSize = contentView.Frame.Size.ToEto();
+			var point = new PointF(availableSize.Width - s_ButtonPadding.Right, s_ButtonPadding.Bottom);
 
 			var buttonSize = GetButtonSize(availableSize);
 
@@ -290,12 +286,20 @@ namespace Eto.Mac.Forms
 
 			foreach (var button in Widget.PositiveButtons.Reverse().Concat(Widget.NegativeButtons))
 			{
-				var ctl = button.GetContainerView();
-				var size = button.GetPreferredSize(availableSize);
+				var ctl = button.GetMacViewHandler();
+				var size = ctl.GetPreferredSize(availableSize);
 				point.X -= size.Width;
-				ctl.Frame = new CGRect(point.ToNS(), size.ToNS());
-				ctl.AutoresizingMask = NSViewResizingMask.MinXMargin;
+				ctl.SetAlignmentFrame(new CGRect(point.ToNS(), size.ToNS()));
+				ctl.ContentControl.AutoresizingMask = NSViewResizingMask.MinXMargin;
+
+				point.X -= s_ButtonSpacing;
 			}
+		}
+
+		public override void PerformContentLayout()
+		{
+			base.PerformContentLayout();
+			PositionButtons();
 		}
 
 		public bool IsDisplayedAsSheet => session?.IsSheet == true;

--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -89,6 +89,13 @@ namespace Eto.Mac.Forms
 					}
 				}
 			}
+
+			public override double AnimationResizeTime(CGRect newFrame)
+			{
+				if (AnimationBehavior == NSWindowAnimationBehavior.None)
+					return 0;
+				return base.AnimationResizeTime(newFrame);
+			}
 		}
 
 		SizeF GetButtonSize(SizeF availableSize)
@@ -229,6 +236,8 @@ namespace Eto.Mac.Forms
 			else
 				base.Close();
 		}
+
+		protected override bool DefaultSetAsChildWindow => false;
 
 		public override void SetOwner(Window owner)
 		{

--- a/src/Eto.Mac/Forms/FormHandler.cs
+++ b/src/Eto.Mac/Forms/FormHandler.cs
@@ -70,21 +70,7 @@ namespace Eto.Mac.Forms
 			base.Initialize();
 		}
 
-		public override void SetOwner(Window owner)
-		{
-			if (owner != null)
-			{
-				var macWindow = owner.Handler as IMacWindow;
-				if (macWindow != null)
-					macWindow.Control.AddChildWindow(Control, NSWindowOrderingMode.Above);
-			}
-			else
-			{
-				var parentWindow = Control.ParentWindow;
-				if (parentWindow != null)
-					parentWindow.RemoveChildWindow(Control);
-			}
-		}
+		protected override bool DefaultSetAsChildWindow => true;
 
 		public void Show()
 		{

--- a/src/Eto.Mac/Forms/MacPanel.cs
+++ b/src/Eto.Mac/Forms/MacPanel.cs
@@ -125,15 +125,8 @@ namespace Eto.Mac.Forms
 		void SetContent(NSView control)
 		{
 #if OSX
-			if (ContentControl is NSBox box)
-			{
-				box.ContentView = control;
-			}
-			else
-			{
-				control.AutoresizingMask = ContentResizingMask();
-				ContentControl.AddSubview(control); // default
-			}
+			control.AutoresizingMask = ContentResizingMask();
+			ContentControl.AddSubview(control); // default
 #elif IOS
 			control.AutoresizingMask = UIViewAutoresizing.FlexibleDimensions;
 			control.Frame = new CGRect(0, 0, ContentControl.Bounds.Width, ContentControl.Bounds.Height);

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -127,9 +127,12 @@ namespace Eto.Mac.Forms
 
 	static class MacWindow
 	{
-		public static readonly Selector selSetStyleMask = new Selector("setStyleMask:");
-		public static IntPtr selMainMenu = Selector.GetHandle("mainMenu");
-		public static IntPtr selSetMainMenu = Selector.GetHandle("setMainMenu:");
+		internal static readonly object InitialLocation_Key = new object();
+		internal static readonly object PreferredClientSize_Key = new object();
+		internal static readonly Selector selSetStyleMask = new Selector("setStyleMask:");
+		internal static IntPtr selMainMenu = Selector.GetHandle("mainMenu");
+		internal static IntPtr selSetMainMenu = Selector.GetHandle("setMainMenu:");
+		internal static readonly object SetAsChildWindow_Key = new object();
 	}
 
 	public abstract class MacWindow<TControl, TWidget, TCallback> : MacPanel<TControl, TWidget, TCallback>, Window.IHandler, IMacWindow
@@ -148,12 +151,11 @@ namespace Eto.Mac.Forms
 		bool topmost;
 		Point? oldLocation;
 
-		static readonly object InitialLocation_Key = new object();
 
 		Point? InitialLocation
 		{
-			get => Widget.Properties.Get<Point?>(InitialLocation_Key);
-			set => Widget.Properties.Set(InitialLocation_Key, value);
+			get => Widget.Properties.Get<Point?>(MacWindow.InitialLocation_Key);
+			set => Widget.Properties.Set(MacWindow.InitialLocation_Key, value);
 		}
 
 		Window.ICallback IMacWindow.Callback { get { return Callback; } }
@@ -701,11 +703,10 @@ namespace Eto.Mac.Forms
 
 		public string Id { get; set; }
 
-		static readonly object PreferredClientSize_Key = new object();
 		public Size? PreferredClientSize
 		{
-			get { return Widget.Properties.Get<Size?>(PreferredClientSize_Key); }
-			set { Widget.Properties[PreferredClientSize_Key] = value; }
+			get { return Widget.Properties.Get<Size?>(MacWindow.PreferredClientSize_Key); }
+			set { Widget.Properties[MacWindow.PreferredClientSize_Key] = value; }
 		}
 
 		public override Size ClientSize
@@ -996,6 +997,10 @@ namespace Eto.Mac.Forms
 				if (Control.RespondsToSelector(MacWindow.selSetStyleMask))
 				{
 					Control.StyleMask = value.ToNS(Control.StyleMask);
+
+					// don't use animation when there's no border.
+					if (value == WindowStyle.None && Control.AnimationBehavior == NSWindowAnimationBehavior.Default)
+						Control.AnimationBehavior = NSWindowAnimationBehavior.None;
 				}
 			}
 		}
@@ -1015,8 +1020,37 @@ namespace Eto.Mac.Forms
 			Control.ResignKeyWindow();
 		}
 
+		protected virtual bool DefaultSetAsChildWindow => false;
+
+		/// <summary>
+		/// Gets or sets a value indicating that this window should be set as a child of its owner.
+		/// When it is a child, it will move with the owner.
+		/// This is useful when you want a modal dialog to move with the window, or to disable this
+		/// feature for forms with the owner set.
+		/// </summary>
+		public bool SetAsChildWindow
+		{
+			get => Widget.Properties.Get<bool>(MacWindow.SetAsChildWindow_Key, DefaultSetAsChildWindow);
+			set => Widget.Properties.Set(MacWindow.SetAsChildWindow_Key, value, DefaultSetAsChildWindow);
+		}
+
 		public virtual void SetOwner(Window owner)
 		{
+			if (SetAsChildWindow)
+			{
+				if (owner != null)
+				{
+					var macWindow = owner.Handler as IMacWindow;
+					if (macWindow != null)
+						macWindow.Control.AddChildWindow(Control, NSWindowOrderingMode.Above);
+				}
+				else
+				{
+					var parentWindow = Control.ParentWindow;
+					if (parentWindow != null)
+						parentWindow.RemoveChildWindow(Control);
+				}
+			}
 		}
 
 		public float LogicalPixelSize => Screen?.LogicalPixelSize ?? 1f;

--- a/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
@@ -25,6 +25,7 @@ namespace Eto.Test.Sections.Behaviors
 		CheckBox canFocusCheckBox;
 		CheckBox createMenuBar;
 		EnumCheckBoxList<MenuBarSystemItems> systemMenuItems;
+		EnumDropDown<DialogDisplayMode?> dialogDisplayModeDropDown;
 
 		static readonly object CancelCloseKey = new object();
 		public bool CancelClose
@@ -42,6 +43,7 @@ namespace Eto.Test.Sections.Behaviors
 			layout.AddSeparateRow(null, "Type", CreateTypeControls(), null);
 			layout.AddSeparateRow(null, "Window Style", WindowStyle(), null);
 			layout.AddSeparateRow(null, "Window State", WindowState(), null);
+			layout.AddSeparateRow(null, "Dialog Display Mode", DisplayModeDropDown(), null);
 			layout.AddSeparateRow(null, CreateMenuBarControls(), null);
 			layout.AddSeparateRow(null, CreateInitialLocationControls(), null);
 			layout.AddSeparateRow(null, CreateSizeControls(), null);
@@ -143,6 +145,18 @@ namespace Eto.Test.Sections.Behaviors
 					child.WindowStyle = styleCombo.SelectedValue;
 			};
 			return styleCombo;
+		}
+
+		Control DisplayModeDropDown()
+		{
+			dialogDisplayModeDropDown = new EnumDropDown<DialogDisplayMode?>();
+			dialogDisplayModeDropDown.Bind(c => c.Enabled, typeRadio, Binding.Property((RadioButtonList t) => t.SelectedKey).ToBool("dialog"));
+			dialogDisplayModeDropDown.SelectedValueChanged += (sender, e) =>
+			{
+				if (child is Dialog dlg)
+					dlg.DisplayMode = dialogDisplayModeDropDown.SelectedValue ?? DialogDisplayMode.Default;
+			};
+			return dialogDisplayModeDropDown;
 		}
 
 		Control WindowState()
@@ -448,6 +462,8 @@ namespace Eto.Test.Sections.Behaviors
 
 				child = dialog;
 				show = dialog.ShowModal;
+
+				dialog.DisplayMode = dialogDisplayModeDropDown.SelectedValue ?? DialogDisplayMode.Default;
 			}
 
 			layout.Add(null);


### PR DESCRIPTION
- Fixes regression showing Dialog.PositiveButtons and NegativeButtons after update for dark mode.
- Don't use animation (by default) when showing a Dialog with no border
- Disable animation of Dialog when shown as a sheet when `NSWindow.AnimationBehavior` is `None`.
- Add `FormHandler/DialogHandler.SetAsChildWindow` so you can override if the Form or Dialog is added as a child of the parent/owner.  Form it defaults to true, whereas Dialog it defaults to false.