### PR TITLE
Mac: Fix binding with TabPage.Text

### DIFF
--- a/src/Eto.Mac/Forms/Controls/TabPageHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TabPageHandler.cs
@@ -96,7 +96,7 @@ namespace Eto.Mac.Forms.Controls
 		public string Text
 		{
 			get { return Control.Label; }
-			set { Control.Label = value; }
+			set { Control.Label = value ?? string.Empty; }
 		}
 
 		public Image Image


### PR DESCRIPTION
Allow Text to be set to null.
Fixes #1375