### PR TITLE
Mac: Remove padding at bottom of dialog when there are no buttons

### DIFF
--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -113,8 +113,9 @@ namespace Eto.Mac.Forms
 					buttonSize.Width += preferredSize.Width;
 					buttonSize.Height = Math.Max(buttonSize.Height, preferredSize.Height);
 				}
+				buttonSize += s_ButtonPadding.Size;
 			}
-			return buttonSize + s_ButtonPadding.Size;
+			return buttonSize;
 		}
 
 		protected override SizeF GetNaturalSize(SizeF availableSize)


### PR DESCRIPTION
Fixes #1379