### PR TITLE
Mac: GridView autosize updates

### DIFF
--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -349,6 +349,7 @@ namespace Eto.Mac.Forms.Controls
 					}
 					autoSizeRange = newRange;
 					IsAutoSizingColumns = false;
+					InvalidateMeasure();
 					return true;
 				}
 			}

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -542,6 +542,10 @@ namespace Eto.Mac.Forms.Controls
 		public void ReloadData(IEnumerable<int> rows)
 		{
 			Control.ReloadData(NSIndexSet.FromArray(rows.Select(r => (nuint)r).ToArray()), NSIndexSet.FromNSRange(new NSRange(0, Control.TableColumns().Length)));
+			if (Widget.Columns.Any(r => r.AutoSize))
+			{
+				AutoSizeColumns(true);
+			}
 		}
 
 		public object GetCellAt(PointF location, out int column, out int row)

--- a/src/Eto.Mac/Forms/TableLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/TableLayoutHandler.cs
@@ -205,6 +205,9 @@ namespace Eto.Mac.Forms
 					if (!xscaled && !yscaled)
 						continue;
 
+					if (final && xscaled && yscaled)
+						continue;
+
 					availableControlSize.Width = xscaled ? remaining.Width : float.PositiveInfinity;
 
 					var view = views[y, x];

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
@@ -144,5 +144,43 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			});
 
 		}
+
+		[Test, ManualTest]
+		public void AutoSizedColumnShouldChangeSizeOfControl()
+		{
+			ManualForm("GridView should auto size to content", form =>
+			{
+				var collection = new ObservableCollection<DataItem>();
+				var gridView = new GridView
+				{
+					Height = 180,
+					DataStore = collection,
+					Columns =
+					{
+						new GridColumn
+						{
+							AutoSize = true,
+							DataCell = new TextBoxCell { Binding = Binding.Property((DataItem m) => m.TextValue) }
+						}
+					}
+				};
+				var item = new DataItem { TextValue = "Some Text" };
+				collection.Add(item);
+
+				var textBox = new TextBox();
+				textBox.Focus();
+				textBox.TextBinding.Bind(item, i => i.TextValue);
+				textBox.TextChanged += (sender, e) => gridView.ReloadData(0);
+
+				var layout = new DynamicLayout();
+				layout.BeginVertical(yscale: true);
+				layout.AddRow(gridView, null); // gridView is auto sized
+				layout.EndVertical();
+
+				layout.AddSeparateRow("Text:", textBox);
+
+				return layout;
+			});
+		}
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/GridViewUtils.cs
+++ b/test/Eto.Test/UnitTests/Forms/GridViewUtils.cs
@@ -10,17 +10,20 @@ namespace Eto.Test.UnitTests.Forms
 {
 	class DataItem
 	{
+		public string TextValue { get; set; }
+
 		public int Id { get; private set; }
+
+		public DataItem()
+		{
+		}
 
 		public DataItem(int id)
 		{
 			Id = id;
 		}
 
-		public override string ToString()
-		{
-			return "Item " + Id;
-		}
+		public override string ToString() => "Item " + Id;
 	}
 
 	static class GridViewUtils


### PR DESCRIPTION
- Autosize the GridView columns when the data is updated.
- Optimize TableLayout so it doesn't get the preferred size of cells when not needed.  In this case, cells that are scaled in both width and height when positioning for layout.