### PR TITLE
Add PropertyGrid and CollectionEditor controls

### DIFF
--- a/src/Eto.Gtk/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Gtk/Drawing/GraphicsHandler.cs
@@ -34,6 +34,12 @@ namespace Eto.GtkSharp.Drawing
 			this.widget = widget;
 			this.Control = Gdk.CairoHelper.Create (drawable);
 		}
+
+		public GraphicsHandler(Gtk.Widget widget, Cairo.Context context)
+		{
+			this.widget = widget;
+			this.Control = context;
+		}
 #endif
 		public GraphicsHandler(Cairo.Context context, Pango.Context pangoContext, bool dispose = true)
 		{

--- a/src/Eto.Gtk/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/CheckBoxHandler.cs
@@ -77,13 +77,20 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			get { return Control.Inconsistent ? null : (bool?)Control.Active; }
 			set
-			{ 
+			{
 				if (value == null)
+				{
 					Control.Inconsistent = true;
+					Callback.OnCheckedChanged(Widget, EventArgs.Empty);
+				}
 				else
 				{
+					// gtk doesn't trigger an event if just Inconsistent has changed.
+					var hasChanged = (Control.Inconsistent && Control.Active == value.Value);
 					Control.Inconsistent = false;
 					Control.Active = value.Value;
+					if (hasChanged)
+						Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 				}
 			}
 		}
@@ -94,14 +101,21 @@ namespace Eto.GtkSharp.Forms.Controls
 			set;
 		}
 
+#if GTK3
+		Gtk.Widget TextColorWidget => Control;
+#else
+		Gtk.Widget TextColorWidget => Control.Child ?? Control;
+#endif
+
 		public Color TextColor
 		{
-			get { return Control.Child.GetForeground(); }
+			get { return TextColorWidget.GetForeground(); }
 			set
 			{
-				Control.Child.SetForeground(value, GtkStateFlags.Normal);
-				Control.Child.SetForeground(value, GtkStateFlags.Active);
-				Control.Child.SetForeground(value, GtkStateFlags.Prelight);
+				var child = TextColorWidget;
+				child.SetForeground(value, GtkStateFlags.Normal);
+				child.SetForeground(value, GtkStateFlags.Active);
+				child.SetForeground(value, GtkStateFlags.Prelight);
 			}
 		}
 

--- a/src/Eto.Gtk/Platform.cs
+++ b/src/Eto.Gtk/Platform.cs
@@ -172,6 +172,8 @@ namespace Eto.GtkSharp
 			p.Add<MenuSegmentedItem.IHandler>(() => new ThemedMenuSegmentedItemHandler());
 			p.Add<SegmentedButton.IHandler>(() => new ThemedSegmentedButtonHandler());
 			p.Add<ToggleButton.IHandler>(() => new ToggleButtonHandler());
+			p.Add<PropertyGrid.IHandler>(() => new ThemedPropertyGridHandler());
+			p.Add<CollectionEditor.IHandler>(() => new ThemedCollectionEditorHandler());
 
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
@@ -52,7 +52,7 @@ namespace Eto.Mac.Forms.Cells
 
 		public override nfloat GetPreferredWidth(object value, CGSize cellSize, int row, object dataItem)
 		{
-			var args = new CellEventArgs(row, dataItem, CellStates.None);
+			var args = new CellEventArgs(ColumnHandler?.DataViewHandler as Grid, Widget, row, dataItem, CellStates.None);
 			var identifier = Callback.OnGetIdentifier(Widget, args) ?? string.Empty;
 			Control widthCell;
 			if (!widthCells.TryGetValue(identifier, out widthCell))
@@ -131,7 +131,7 @@ namespace Eto.Mac.Forms.Cells
 				state |= CellStates.Selected;
 			if (tableColumn.Editable)
 				state |= CellStates.Editing;
-			var args = new MutableCellEventArgs(row, item, state);
+			var args = new MutableCellEventArgs(ColumnHandler.DataViewHandler as Grid, Widget, row, item, state);
 			var identifier = tableColumn.Identifier;
 			var id = Callback.OnGetIdentifier(Widget, args);
 			if (!string.IsNullOrEmpty(id))

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -193,6 +193,8 @@ namespace Eto.Mac.Forms.Controls
 
 		public GridColumnHandler GetColumn(NSTableColumn tableColumn)
 		{
+			if (tableColumn == null)
+				return null;
 			var str = tableColumn.Identifier;
 			if (!string.IsNullOrEmpty(str))
 			{

--- a/src/Eto.Mac/Forms/Controls/SegmentedButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SegmentedButtonHandler.cs
@@ -68,7 +68,7 @@ namespace Eto.Mac.Forms.Controls
 			{
 				if (Widget.Properties.TrySet(SegmentedItemHandler.Text_Key, value))
 				{
-					SegmentedControl?.SetLabel(value, CurrentSegment);
+					SegmentedControl?.SetLabel(value ?? string.Empty, CurrentSegment);
 				}
 			}
 		}

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1159,7 +1159,13 @@ namespace Eto.Mac.Forms
 			// TODO: block until drag is complete?
 		}
 
-		public Window GetNativeParentWindow() => ContainerControl.Window.ToEtoWindow();
+		public Window GetNativeParentWindow()
+		{
+			var window = ContainerControl.Window;
+
+
+			return window.ToEtoWindow();
+		}
 
 		protected virtual bool DefaultUseAlignmentFrame => false;
 

--- a/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
@@ -116,7 +116,7 @@ namespace Eto.Mac.Forms
 		public string Text
 		{
 			get => GetDataItem<StringItem>(NSPasteboard.NSPasteboardTypeString)?.Value;
-			set => Control[NSPasteboard.NSPasteboardTypeString] = string.IsNullOrEmpty(value) ? null : new StringItem { Value = value };
+			set => Control[NSPasteboard.NSPasteboardTypeString] = value == null ? null : new StringItem { Value = value };
 		}
 
 		public Image Image
@@ -179,7 +179,7 @@ namespace Eto.Mac.Forms
 		{
 			foreach (var item in Control)
 			{
-				item.Value.Apply(pasteboard, item.Key);
+				item.Value?.Apply(pasteboard, item.Key);
 			}
 		}
 

--- a/src/Eto.Mac/MacHelpers.cs
+++ b/src/Eto.Mac/MacHelpers.cs
@@ -89,6 +89,10 @@ namespace Eto.Forms
 		{
 			if (window == null)
 				return null;
+
+			if (window is IMacControl macControl && macControl.WeakHandler?.Target is IMacWindow macWindow)
+				return macWindow.Widget;
+
 			return new Form(new NativeFormHandler(window));
 		}
 

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -23,12 +23,28 @@ using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
+using CoreImage;
 #else
 using MonoMac.AppKit;
 using MonoMac.Foundation;
 using MonoMac.CoreGraphics;
 using MonoMac.ObjCRuntime;
 using MonoMac.CoreAnimation;
+using MonoMac.CoreImage;
+#if Mac64
+using nfloat = System.Double;
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nfloat = System.Single;
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
 #endif
 
 namespace Eto.Mac
@@ -65,6 +81,46 @@ namespace Eto.Mac
 				h.Control.Spacing = new Size(3, 0);
 			});
 
+
+			Style.Add<ThemedPropertyGrid>(null, c =>
+			{
+				c.ShowCategoriesChanged += (sender, e) =>
+				{
+					if (c.FindChild<TreeGridView>()?.Handler is TreeGridViewHandler tvh)
+						tvh.ShowGroups = c.ShowCategories;
+				};
+				c.Styles.Add<TreeGridViewHandler>(null, tvh =>
+				{
+					tvh.ShowGroups = c.ShowCategories;
+					tvh.AllowGroupSelection = false;
+					tvh.Control.AutoresizesOutlineColumn = false;
+				});
+			});
+
+			Style.Add<ThemedCollectionEditor>(null, c =>
+			{
+				c.Styles.Add<SegmentedButtonHandler>(null, sbh =>
+				{
+#if XAMMAC2
+					sbh.Control.ControlSize = NSControlSize.Small;
+#else
+					Messaging.void_objc_msgSend_IntPtr(sbh.Control.Handle, Selector.GetHandle("setControlSize:"), (IntPtr)NSControlSize.Small);
+#endif
+				});
+				c.Styles.Add<ButtonSegmentedItem>(null, bsi =>
+				{
+					if (bsi.Text == "+")
+					{
+						bsi.Text = null;
+						bsi.Image = new Icon(new IconHandler(NSImage.ImageNamed(NSImageName.AddTemplate)));
+					}
+					else if (bsi.Text == "-")
+					{
+						bsi.Text = null;
+						bsi.Image = new Icon(new IconHandler(NSImage.ImageNamed(NSImageName.RemoveTemplate)));
+					}
+				});
+			});
 		}
 
 		public Platform()
@@ -177,6 +233,8 @@ namespace Eto.Mac
 			p.Add<ButtonSegmentedItem.IHandler>(() => new ButtonSegmentedItemHandler());
 			p.Add<MenuSegmentedItem.IHandler>(() => new MenuSegmentedItemHandler());
 			p.Add<ToggleButton.IHandler>(() => new ToggleButtonHandler());
+			p.Add<PropertyGrid.IHandler>(() => new ThemedPropertyGridHandler());
+			p.Add<CollectionEditor.IHandler>(() => new ThemedCollectionEditorHandler());
 
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/src/Eto.WinForms/Platform.cs
+++ b/src/Eto.WinForms/Platform.cs
@@ -114,6 +114,8 @@ namespace Eto.WinForms
 			p.Add<ButtonSegmentedItem.IHandler>(() => new ThemedButtonSegmentedItemHandler());
 			p.Add<MenuSegmentedItem.IHandler>(() => new ThemedMenuSegmentedItemHandler());
 			p.Add<ToggleButton.IHandler>(() => new ToggleButtonHandler());
+			p.Add<PropertyGrid.IHandler>(() => new ThemedPropertyGridHandler());
+			p.Add<CollectionEditor.IHandler>(() => new ThemedCollectionEditorHandler());
 
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/src/Eto.Wpf/Drawing/FontHandler.cs
+++ b/src/Eto.Wpf/Drawing/FontHandler.cs
@@ -23,7 +23,7 @@ namespace Eto.Wpf.Drawing
 			control.FontStyle = WpfFontStyle;
 			control.FontStretch = WpfFontStretch;
 			control.FontWeight = WpfFontWeight;
-			control.FontSize = PixelSize;
+			control.FontSize = WpfSize;
 			if (setDecorations != null && WpfTextDecorationsFrozen != null)
 			{
 				setDecorations(WpfTextDecorationsFrozen);
@@ -36,7 +36,7 @@ namespace Eto.Wpf.Drawing
 			control.FontStyle = WpfFontStyle;
 			control.FontStretch = WpfFontStretch;
 			control.FontWeight = WpfFontWeight;
-			control.FontSize = PixelSize;
+			control.FontSize = WpfSize;
 			if (setDecorations != null && WpfTextDecorationsFrozen != null)
 			{
 				setDecorations(WpfTextDecorationsFrozen);
@@ -49,7 +49,7 @@ namespace Eto.Wpf.Drawing
 			control.FontStyle = WpfFontStyle;
 			control.FontStretch = WpfFontStretch;
 			control.FontWeight = WpfFontWeight;
-			control.FontSize = PixelSize;
+			control.FontSize = WpfSize;
 			if (setDecorations != null && WpfTextDecorationsFrozen != null)
 			{
 				setDecorations(WpfTextDecorationsFrozen);
@@ -62,7 +62,7 @@ namespace Eto.Wpf.Drawing
 			control.ApplyPropertyValue(swd.TextElement.FontStyleProperty, WpfFontStyle);
 			control.ApplyPropertyValue(swd.TextElement.FontStretchProperty, WpfFontStretch);
 			control.ApplyPropertyValue(swd.TextElement.FontWeightProperty, WpfFontWeight);
-			control.ApplyPropertyValue(swd.TextElement.FontSizeProperty, PixelSize);
+			control.ApplyPropertyValue(swd.TextElement.FontSizeProperty, WpfSize);
 			control.ApplyPropertyValue(swd.Inline.TextDecorationsProperty, WpfTextDecorationsFrozen);
 		}
 
@@ -83,7 +83,7 @@ namespace Eto.Wpf.Drawing
 			}
 		}
 
-		public double PixelSize
+		public double WpfSize
 		{
 			get
 			{
@@ -106,7 +106,7 @@ namespace Eto.Wpf.Drawing
 			return points * (96.0 / 72.0);
 		}
 
-		public static double PixelsToPoints(double points, sw.FrameworkElement control = null)
+		public static double PixelsToPoints(double pixels, sw.FrameworkElement control = null)
 		{
 			if (control != null)
 			{
@@ -114,10 +114,10 @@ namespace Eto.Wpf.Drawing
 				if (source != null)
 				{
 					var m = source.CompositionTarget.TransformToDevice;
-					points /= m.M22;
+					pixels /= m.M22;
 				}
 			}
-			return points * (72.0 / 96.0);
+			return pixels * (72.0 / 96.0);
 		}
 
 		public sw.FontStyle WpfFontStyle { get; private set; }
@@ -241,26 +241,26 @@ namespace Eto.Wpf.Drawing
 					Family = new FontFamily(new FontFamilyHandler(sw.SystemFonts.MessageFontFamily));
 					WpfFontStyle = sw.SystemFonts.MessageFontStyle;
 					WpfFontWeight = sw.SystemFonts.MessageFontWeight;
-					PixelSize = sw.SystemFonts.MessageFontSize;
+					WpfSize = sw.SystemFonts.MessageFontSize;
 					break;
 				case SystemFont.Bold:
 					Family = new FontFamily(new FontFamilyHandler(sw.SystemFonts.MessageFontFamily));
 					WpfFontStyle = sw.SystemFonts.MessageFontStyle;
 					WpfFontWeight = sw.FontWeights.Bold;
-					PixelSize = sw.SystemFonts.MessageFontSize;
+					WpfSize = sw.SystemFonts.MessageFontSize;
 					break;
 				case SystemFont.MenuBar:
 				case SystemFont.Menu:
 					Family = new FontFamily(new FontFamilyHandler(sw.SystemFonts.MenuFontFamily));
 					WpfFontStyle = sw.SystemFonts.MenuFontStyle;
 					WpfFontWeight = sw.SystemFonts.MenuFontWeight;
-					PixelSize = sw.SystemFonts.MenuFontSize;
+					WpfSize = sw.SystemFonts.MenuFontSize;
 					break;
 				case SystemFont.StatusBar:
 					Family = new FontFamily(new FontFamilyHandler(sw.SystemFonts.StatusFontFamily));
 					WpfFontStyle = sw.SystemFonts.StatusFontStyle;
 					WpfFontWeight = sw.SystemFonts.StatusFontWeight;
-					PixelSize = sw.SystemFonts.StatusFontSize;
+					WpfSize = sw.SystemFonts.StatusFontSize;
 					break;
 				default:
 					throw new NotSupportedException();
@@ -382,7 +382,7 @@ namespace Eto.Wpf.Drawing
 		{
 			if (measureBrush == null)
 				measureBrush = new swm.SolidColorBrush(swm.Colors.White);
-			var formattedText = new swm.FormattedText(text, CultureInfo.CurrentUICulture, sw.FlowDirection.LeftToRight, WpfTypeface, PixelSize, measureBrush);
+			var formattedText = new swm.FormattedText(text, CultureInfo.CurrentUICulture, sw.FlowDirection.LeftToRight, WpfTypeface, WpfSize, measureBrush);
 			return new SizeF((float)formattedText.WidthIncludingTrailingWhitespace, (float)formattedText.Height);
 		}
 	}

--- a/src/Eto.Wpf/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Wpf/Drawing/GraphicsHandler.cs
@@ -307,7 +307,7 @@ namespace Eto.Wpf.Drawing
 			if (fontHandler != null)
 			{
 				var brush = b.ToWpf();
-				var formattedText = new swm.FormattedText(text, CultureInfo.CurrentUICulture, sw.FlowDirection.LeftToRight, fontHandler.WpfTypeface, fontHandler.PixelSize, brush);
+				var formattedText = new swm.FormattedText(text, CultureInfo.CurrentUICulture, sw.FlowDirection.LeftToRight, fontHandler.WpfTypeface, fontHandler.WpfSize, brush);
 				if (fontHandler.WpfTextDecorationsFrozen != null)
 					formattedText.SetTextDecorations(fontHandler.WpfTextDecorationsFrozen, 0, text.Length);
 				Control.DrawText(formattedText, new sw.Point(x, y));
@@ -322,7 +322,7 @@ namespace Eto.Wpf.Drawing
 			if (fontHandler != null)
 			{
 				var brush = new swm.SolidColorBrush(swm.Colors.White);
-				var formattedText = new swm.FormattedText(text, CultureInfo.CurrentUICulture, sw.FlowDirection.LeftToRight, fontHandler.WpfTypeface, fontHandler.PixelSize, brush);
+				var formattedText = new swm.FormattedText(text, CultureInfo.CurrentUICulture, sw.FlowDirection.LeftToRight, fontHandler.WpfTypeface, fontHandler.WpfSize, brush);
 				result = new SizeF((float)formattedText.WidthIncludingTrailingWhitespace, (float)formattedText.Height);
 			}
 

--- a/src/Eto.Wpf/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CellHandler.cs
@@ -6,6 +6,7 @@ namespace Eto.Wpf.Forms.Cells
 {
 	public interface ICellContainerHandler
 	{
+		Grid Grid { get; }
 		sw.FrameworkElement SetupCell(ICellHandler cell, sw.FrameworkElement defaultContent);
 		void FormatCell(ICellHandler cell, sw.FrameworkElement element, swc.DataGridCell datacell, object dataItem);
 		void CellEdited(ICellHandler cell, sw.FrameworkElement element);
@@ -45,5 +46,22 @@ namespace Eto.Wpf.Forms.Cells
 		{
 			return ContainerHandler != null ? ContainerHandler.SetupCell(this, defaultContent) : defaultContent;
 		}
+
+		protected static T GetControl<T>(swc.DataGridCell cell)
+			where T: sw.DependencyObject
+		{
+			if (cell == null)
+				return null;
+
+			var content = cell.Content;
+			if (content is T ctl)
+				return ctl;
+
+			if (content is sw.DependencyObject dp)
+				return dp.FindChild<T>();
+
+			return null;
+		}
+
 	}
 }

--- a/src/Eto.Wpf/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/DrawableCellHandler.cs
@@ -41,7 +41,7 @@ namespace Eto.Wpf.Forms.Cells
 
 			EtoCanvas Create(swc.DataGridCell cell)
 			{
-				var control = cell.Content as EtoCanvas;
+				var control = GetControl<EtoCanvas>(cell);
 				if (control == null)
 				{
 					control = new EtoCanvas { Column = this };

--- a/src/Eto.Wpf/Forms/Cells/ProgressCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/ProgressCellHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using swc = System.Windows.Controls;
 using swd = System.Windows.Data;
@@ -79,7 +79,7 @@ namespace Eto.Wpf.Forms.Cells
 
 			private swc.Grid GenerateProgressBar(swc.DataGridCell cell, object dataItem)
 			{
-				swc.Grid element = cell?.Content as swc.Grid ?? new swc.Grid();
+				swc.Grid element = GetControl<swc.Grid>(cell) ?? new swc.Grid();
 				cell.Foreground = sw.SystemColors.ControlTextBrush;
 
 				// Add a progress bar to the grid

--- a/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
@@ -7,6 +7,7 @@ namespace Eto.Wpf.Forms.Controls
 {
 	public interface IGridHandler
 	{
+		Grid Widget { get; }
 		bool Loaded { get; }
 		sw.FrameworkElement SetupCell (IGridColumnHandler column, sw.FrameworkElement defaultContent);
 		void FormatCell (IGridColumnHandler column, ICellHandler cell, sw.FrameworkElement element, swc.DataGridCell gridcell, object dataItem);
@@ -128,10 +129,9 @@ namespace Eto.Wpf.Forms.Controls
 				GridHandler.FormatCell (this, cell, element, gridcell, dataItem);
 		}
 
-		swc.DataGridColumn IGridColumnHandler.Control
-		{
-			get { return Control; }
-		}
+		swc.DataGridColumn IGridColumnHandler.Control => Control;
+
+		public Grid Grid => GridHandler?.Widget;
 
 		public void CellEdited(ICellHandler cell, sw.FrameworkElement element)
 		{

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -594,5 +594,7 @@ namespace Eto.Wpf.Forms.Controls
 		}
 
 		bool IGridHandler.Loaded => Widget.Loaded;
+
+		Grid IGridHandler.Widget => Widget;
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
@@ -411,7 +411,7 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				var handler = ((FontHandler)value?.Handler);
 				ApplyFont(handler?.WpfFamily, handler?.WpfTypeface, handler?.WpfFontWeight, handler?.WpfFontStretch, handler?.WpfFontStyle);
-				SetSelectionAttribute(swd.TextElement.FontSizeProperty, handler?.PixelSize);
+				SetSelectionAttribute(swd.TextElement.FontSizeProperty, handler?.WpfSize);
 				SetSelectionAttribute(swd.Inline.TextDecorationsProperty, handler?.WpfTextDecorationsFrozen);
 			}
 		}

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -731,8 +731,6 @@ namespace Eto.Wpf.Forms
 
 		public virtual void OnUnLoad(EventArgs e)
 		{
-			SetScale(false, false);
-
 			if (NeedsPixelSizeNotifications && Win32.PerMonitorDpiSupported)
 			{
 				var parent = Widget.ParentWindow;

--- a/src/Eto.Wpf/Platform.cs
+++ b/src/Eto.Wpf/Platform.cs
@@ -135,7 +135,9 @@ namespace Eto.Wpf
 			p.Add<ButtonSegmentedItem.IHandler>(() => new ThemedButtonSegmentedItemHandler());
 			p.Add<MenuSegmentedItem.IHandler>(() => new ThemedMenuSegmentedItemHandler());
 			p.Add<ToggleButton.IHandler>(() => new ToggleButtonHandler());
-			
+			p.Add<PropertyGrid.IHandler>(() => new ThemedPropertyGridHandler());
+			p.Add<CollectionEditor.IHandler>(() => new ThemedCollectionEditorHandler());
+
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());
 			p.Add<ContextMenu.IHandler>(() => new ContextMenuHandler());

--- a/src/Eto/DisplayAttributeExtensions.cs
+++ b/src/Eto/DisplayAttributeExtensions.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Reflection;
+#if !NETSTANDARD1_0
+using System.ComponentModel.DataAnnotations;
+#endif
+
+namespace Eto
+{
+#if NETSTANDARD1_0
+	class BaseAttributeWrapper<T>
+		where T: BaseAttributeWrapper<T>.AttributeWrapper, new()
+	{
+		public abstract class AttributeWrapper
+		{
+			public object Instance { get; internal set; }
+		}
+
+		protected static T Get(Type attributeType, Type type)
+		{
+			if (attributeType == null)
+				return null;
+			var instance = type.GetTypeInfo().GetCustomAttribute(attributeType);
+			if (instance == null)
+				return null;
+			var attr = new T();
+			attr.Instance = instance;
+			return attr;
+		}
+
+		protected static T Get(Type attributeType, IPropertyDescriptor descriptor)
+		{
+			if (attributeType == null)
+				return null;
+			var instance = descriptor.GetCustomAttribute(attributeType);
+			if (instance == null)
+				return null;
+			var attr = new T();
+			attr.Instance = instance;
+			return attr;
+		}
+	}
+
+	class EditorAttributeWrapper : BaseAttributeWrapper<EditorAttributeWrapper.EditorAttribute>
+	{
+		static Type s_EditorAttributeType =
+				Type.GetType("System.ComponentModel.EditorAttribute, System")
+				?? Type.GetType("System.ComponentModel.EditorAttribute, System.ComponentModel.TypeConverter")
+				?? Type.GetType("System.ComponentModel.EditorAttribute, netstandard");
+		static PropertyInfo s_EditorBaseTypeNameProperty = s_EditorAttributeType?.GetRuntimeProperty("EditorBaseTypeName");
+		static PropertyInfo s_EditorTypeNameProperty = s_EditorAttributeType?.GetRuntimeProperty("EditorTypeName");
+
+		public class EditorAttribute : AttributeWrapper
+		{
+			public string EditorBaseTypeName => s_EditorBaseTypeNameProperty?.GetValue(Instance) as string;
+			public string EditorTypeName => s_EditorTypeNameProperty?.GetValue(Instance) as string;
+		}
+
+		public static EditorAttribute Get(Type type) => Get(s_EditorAttributeType, type);
+
+		public static EditorAttribute Get(IPropertyDescriptor descriptor) => Get(s_EditorAttributeType, descriptor);
+	}
+
+	class DisplayAttributeWrapper : BaseAttributeWrapper<DisplayAttributeWrapper.DisplayAttribute>
+	{
+		static Type s_DisplayAttributeType =
+			Type.GetType("System.ComponentModel.DataAnnotations.DisplayAttribute, System.ComponentModel.DataAnnotations")
+			?? Type.GetType("System.ComponentModel.DataAnnotations.DisplayAttribute, System.ComponentModel.Annotations");
+		static MethodInfo getNameMethod = s_DisplayAttributeType?.GetRuntimeMethod("GetName", new Type[0]);
+		static MethodInfo getGroupNameMethod = s_DisplayAttributeType?.GetRuntimeMethod("GetGroupName", new Type[0]);
+		static MethodInfo getDescriptionMethod = s_DisplayAttributeType?.GetRuntimeMethod("GetDescription", new Type[0]);
+
+		public class DisplayAttribute : AttributeWrapper
+		{
+			public string GetName() => getNameMethod?.Invoke(Instance, null) as string;
+			public string GetGroupName() => getGroupNameMethod?.Invoke(Instance, null) as string;
+			public string GetDescription() => getDescriptionMethod?.Invoke(Instance, null) as string;
+		}
+
+		public static DisplayAttribute Get(Type type) => Get(s_DisplayAttributeType, type);
+
+		public static DisplayAttribute Get(IPropertyDescriptor descriptor) => Get(s_DisplayAttributeType, descriptor);
+	}
+
+#else
+	class BaseAttributeWrapper<T>
+		where T : Attribute
+	{
+		public static T Get(Type type) => type.GetTypeInfo().GetCustomAttribute<T>();
+
+		public static T Get(PropertyDescriptor descriptor) => descriptor.GetCustomAttribute<T>();
+	}
+
+	class EditorAttributeWrapper : BaseAttributeWrapper<EditorAttribute> { }
+
+	class DisplayAttributeWrapper : BaseAttributeWrapper<DisplayAttribute> { }
+#endif
+}

--- a/src/Eto/Forms/Binding/BindingExtensionsNonGeneric.cs
+++ b/src/Eto/Forms/Binding/BindingExtensionsNonGeneric.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// (internal) extensions to bind to types without using generics.
+	/// 
+	/// Could eventually expose a better API for doing this via non-generic interfaces like IIndirectBinding, IDirectBinding, etc
+	/// which could have a property to get the type of the binding.
+	/// </summary>
+	static class BindingExtensionsNonGeneric
+	{
+		public static IBinding BindingOfType(this IBinding binding, Type fromType, Type toType)
+		{
+			var defaultToValue = toType.GetTypeInfo().IsValueType ? Activator.CreateInstance(toType) : null;
+			var defaultFromValue = fromType.GetTypeInfo().IsValueType ? Activator.CreateInstance(fromType) : null;
+			var bindingType = binding.GetType();
+			var ofTypeMethod = bindingType.GetRuntimeMethods().FirstOrDefault(r => r.Name == "OfType" && r.GetParameters().Length == 2);
+			return (IBinding)ofTypeMethod.MakeGenericMethod(toType).Invoke(binding, new object[] { defaultToValue, defaultFromValue });
+		}
+
+		static PropertyInfo GetFirstDeclaredProperty(Type type, string propertyName)
+		{
+			while (type != null)
+			{
+				var property = type.GetTypeInfo().GetDeclaredProperty(propertyName);
+				if (property != null)
+					return property;
+				type = type.GetBaseType();
+			}
+			return null;
+		}
+
+		public static IBinding BindDataContextProperty(this IBindable bindable, string bindingPropertyName, Type valueType, IBinding binding)
+		{
+			var type = bindable.GetType();
+			var bindingProperty = GetFirstDeclaredProperty(type, bindingPropertyName).GetValue(bindable);
+			var types = new Type[] { typeof(IndirectBinding<>).MakeGenericType(valueType), typeof(DualBindingMode), valueType, valueType };
+
+			var bindDataContextMethod = bindingProperty.GetType().GetRuntimeMethod("BindDataContext", types);
+			var defaultValue = Activator.CreateInstance(valueType);
+			return (IBinding)bindDataContextMethod.Invoke(bindingProperty, new object[] { binding, DualBindingMode.TwoWay, defaultValue, defaultValue });
+		}
+
+	}
+}

--- a/src/Eto/Forms/Binding/IndirectBinding.cs
+++ b/src/Eto/Forms/Binding/IndirectBinding.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace Eto.Forms
 {
@@ -191,7 +192,13 @@ namespace Eto.Forms
 		public IndirectBinding<TValue> Cast<TValue>()
 		{
 			return new DelegateBinding<object, TValue>(
-				m => (TValue)(object)GetValue(m),
+				m =>
+				{
+					var value = (object)GetValue(m);
+					if (value == null)
+						return default(TValue);
+					return (TValue)value;
+				},
 				(m, val) => SetValue(m, (T)(object)val),
 				addChangeEvent: (m, ev) => AddValueChangedHandler(m, ev),
 				removeChangeEvent: RemoveValueChangedHandler
@@ -561,6 +568,5 @@ namespace Eto.Forms
 				removeChangeEvent: RemoveValueChangedHandler
 			);
 		}
-
 	}
 }

--- a/src/Eto/Forms/Binding/PropertyBinding.cs
+++ b/src/Eto/Forms/Binding/PropertyBinding.cs
@@ -66,15 +66,17 @@ namespace Eto.Forms
 
 		void EnsureProperty(object dataItem)
 		{
-#if PCL
-			if (dataItem != null 
-				&& (
-					// if not found previously, don't always try to find it if the declaring type is the same
-					(descriptor == null && declaringType == null)
-				    // found previously but incompatible type
-					|| !declaringType.IsInstanceOfType(dataItem))
-				)
+			if (dataItem == null)
+				return;
+
+			if (
+				// found previously, but incompatible type
+				(descriptor != null && !declaringType.IsInstanceOfType(dataItem))
+				// not found yet, and the type is different than last lookup
+				|| (descriptor == null || declaringType != dataItem.GetType())
+			)
 			{
+#if PCL
 				var dataItemType = dataItem.GetType();
 				descriptor = null;
 				// iterate to find non-public properties or with different case
@@ -88,13 +90,11 @@ namespace Eto.Forms
 					}
 				}
 				declaringType = descriptor?.DeclaringType ?? dataItemType;
-			}
 #else
-			if (dataItem != null && (descriptor == null || !descriptor.ComponentType.IsInstanceOfType(dataItem)))
-			{
 				descriptor = TypeDescriptor.GetProperties(dataItem).Find(Property, IgnoreCase);
-			}
+				declaringType = descriptor?.ComponentType ?? dataItemType;
 #endif
+			}
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/Cells/CustomCell.cs
+++ b/src/Eto/Forms/Cells/CustomCell.cs
@@ -92,6 +92,16 @@ namespace Eto.Forms
 			}
 		}
 
+		/// <summary>
+		/// Gets the cell that triggered this event
+		/// </summary>
+		public Cell Cell { get; }
+
+		/// <summary>
+		/// Gets the grid that this event was triggered from
+		/// </summary>
+		public Grid Grid { get; }
+
 		Color cellTextColor = SystemColors.ControlText;
         
 		/// <summary>
@@ -117,8 +127,24 @@ namespace Eto.Forms
 		/// <param name="row">Row for the cell.</param>
 		/// <param name="item">Item the cell is displaying.</param>
 		/// <param name="cellState">State of the cell.</param>
+		[Obsolete("Use overload that passes the custom cell these arguments are for")]
 		public CellEventArgs(int row, object item, CellStates cellState)
+			: this(null, null, row, item, cellState)
 		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.CellEventArgs"/> class.
+		/// </summary>
+		/// <param name="grid">Grid the event is triggered for.</param>
+		/// <param name="cell">Cell the event is triggered for.</param>
+		/// <param name="row">Row for the cell.</param>
+		/// <param name="item">Item the cell is displaying.</param>
+		/// <param name="cellState">State of the cell.</param>
+		public CellEventArgs(Grid grid, Cell cell, int row, object item, CellStates cellState)
+		{
+			Grid = grid;
+			Cell = cell;
 			Row = row;
 			Item = item;
 			CellState = cellState;

--- a/src/Eto/Forms/Cells/DrawableCell.cs
+++ b/src/Eto/Forms/Cells/DrawableCell.cs
@@ -49,6 +49,21 @@ namespace Eto.Forms
 		{
 			get { return CellState.HasFlag(CellStates.Selected); }
 		}
+
+		internal void DrawCenteredText(string value, Color? color = null, Font font = null, RectangleF? rect = null)
+		{
+			var c = color ?? (IsSelected ? SystemColors.HighlightText : SystemColors.ControlText);
+			var f = font ?? SystemFonts.Default();
+			DrawCenteredText(rect ?? ClipRectangle, c, f, value);
+		}
+
+		internal void DrawCenteredText(RectangleF rect, Color color, Font font, string value)
+		{
+			var size = Graphics.MeasureString(font, value);
+			var y = (rect.Height - size.Height) / 2;
+			var location = rect.Location + new PointF(0, y);
+			Graphics.DrawText(font, color, location, value);
+		}
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/Controls/CollectionEditor.cs
+++ b/src/Eto/Forms/Controls/CollectionEditor.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Control to edit a collection of objects
+	/// </summary>
+	/// <remarks>
+	/// This control allows the user to edit the specified <see cref="CollectionEditor.DataStore"/> by adding
+	/// and removing entries of <see cref="ElementType"/>.
+	/// </remarks>
+	[Handler(typeof(IHandler))]
+	public class CollectionEditor : Control
+	{
+		new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Data store of the items to edit
+		/// </summary>
+		public IEnumerable<object> DataStore
+		{
+			get => Handler.DataStore;
+			set => Handler.DataStore = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the type of element to create when adding new elements to the data store
+		/// </summary>
+		public Type ElementType
+		{
+			get => Handler.ElementType;
+			set => Handler.ElementType = value;
+		}
+
+		/// <summary>
+		/// Handler for the <see cref="CollectionEditor"/>.
+		/// </summary>
+		public new interface IHandler : Control.IHandler
+		{
+			/// <summary>
+			/// Data store of the items to edit
+			/// </summary>
+			IEnumerable<object> DataStore { get; set; }
+
+			/// <summary>
+			/// Gets or sets the type of element to create when adding new elements to the data store
+			/// </summary>
+			Type ElementType { get; set; }
+		}
+	}
+}

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -1305,7 +1305,7 @@ namespace Eto.Forms
 		/// </remarks>
 		/// <param name="widget">Widget to style.</param>
 		/// <param name="style">Style of the widget to apply.</param>
-		protected virtual void ApplyStyles(object widget, string style) => Parent?.ApplyStyles(this, Style);
+		protected virtual void ApplyStyles(object widget, string style) => Parent?.ApplyStyles(widget, Style);
 
 
 		/// <summary>

--- a/src/Eto/Forms/Controls/Grid.cs
+++ b/src/Eto/Forms/Controls/Grid.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Eto.Drawing;
@@ -154,9 +154,9 @@ namespace Eto.Forms
 		/// <param name="row">Row number being formatted</param>
 		protected GridCellFormatEventArgs(GridColumn column, object item, int row)
 		{
-			this.Column = column;
-			this.Item = item;
-			this.Row = row;
+			Column = column;
+			Item = item;
+			Row = row;
 		}
 	}
 

--- a/src/Eto/Forms/Controls/PropertyGrid.cs
+++ b/src/Eto/Forms/Controls/PropertyGrid.cs
@@ -1,0 +1,215 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Event arguments for the <see cref="PropertyGrid"/> when a value changes.
+	/// </summary>
+	public sealed class PropertyValueChangedEventArgs : EventArgs
+    {
+		/// <summary>
+		/// Gets the old value of the property
+		/// </summary>
+        public object OldValue { get; }
+
+		/// <summary>
+		/// Name of the property that was changed
+		/// </summary>
+        public string PropertyName { get; }
+
+		/// <summary>
+		/// Item that the property was set on
+		/// </summary>
+		public object Item { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the PropertyValueChangedEventArgs class.
+		/// </summary>
+		/// <param name="propertyName">Name of the property that was changed</param>
+		/// <param name="oldValue">Old value before the change</param>
+		/// <param name="item">Item that the property was set on.</param>
+        public PropertyValueChangedEventArgs(string propertyName, object oldValue, object item)
+        {
+            PropertyName = propertyName;
+            OldValue = oldValue;
+			Item = item;
+        }
+    }
+
+	/// <summary>
+	/// Interface for custom editors of the <see cref="PropertyGrid"/>
+	/// </summary>
+	/// <remarks>
+	/// Use the System.ComponentModel.EditorAttribute to specify the editor for a particular property or type.
+	/// For example:
+	/// <code>
+	/// [Editor(typeof(MyEditorClass), typeof(IPropertyGridEditor))]
+	/// </code>
+	/// </remarks>
+    public interface IPropertyGridEditor
+    {
+		/// <summary>
+		/// Creates the control for editing (and viewing for platforms that support it)
+		/// </summary>
+		/// <param name="args">Arguments to create the control</param>
+		/// <returns>The control instance to set to the cell</returns>
+        Control CreateControl(CellEventArgs args);
+
+		/// <summary>
+		/// Paints the cell when viewing for platforms that don't support custom controls for non-editing cells (E.g. Gtk, WinForms).
+		/// </summary>
+		/// <param name="args">Arguments to paint the cell</param>
+        void PaintCell(CellPaintEventArgs args);
+    }
+
+	/// <summary>
+	/// Control to edit the properties of one or more objects.
+	/// </summary>
+	[Handler(typeof(IHandler))]
+	public class PropertyGrid : Control
+	{
+		new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Gets or sets the selected object for the grid to edit
+		/// </summary>
+		public object SelectedObject
+		{
+			get => Handler.SelectedObject;
+			set => Handler.SelectedObject = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the selected objects for the grid to edit
+		/// </summary>
+		/// <remarks>
+		/// Only common properties (with the same name and type) will be shown.
+		/// </remarks>
+		public IEnumerable<object> SelectedObjects
+		{
+			get => Handler.SelectedObjects;
+			set => Handler.SelectedObjects = value;
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating that the categories should be shown
+		/// </summary>
+		[DefaultValue(true)]
+		public bool ShowCategories
+		{
+			get => Handler.ShowCategories;
+			set => Handler.ShowCategories = value;
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating that the description panel should be shown
+		/// </summary>
+		/// <remarks>
+		/// The description panel shows the name and description of the selected property
+		/// </remarks>
+		[DefaultValue(true)]
+		public bool ShowDescription
+		{
+			get => Handler.ShowDescription;
+			set => Handler.ShowDescription = value;
+		}
+
+		/// <summary>
+		/// Refreshes the grid with new values from the selected object(s)
+		/// </summary>
+		public void Refresh() => Handler.Refresh();
+
+		/// <summary>
+		/// Event identifier for the <see cref="PropertyValueChanged"/> event.
+		/// </summary>
+		public const string PropertyValueChangedEvent = "PropertyGrid.PropertyValueChanged";
+
+		/// <summary>
+		/// Event to handle when a property value has been changed.
+		/// </summary>
+		public event EventHandler<PropertyValueChangedEventArgs> PropertyValueChanged
+		{
+			add => Properties.AddHandlerEvent(PropertyValueChangedEvent, value);
+			remove => Properties.RemoveEvent(PropertyValueChangedEvent, value);
+		}
+
+		/// <summary>
+		/// Raises the <see cref="PropertyValueChanged"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnPropertyValueChanged(PropertyValueChangedEventArgs e)
+		{
+			Properties.TriggerEvent(PropertyValueChangedEvent, this, e);
+		}
+
+		static Callback s_callback = new Callback();
+
+		/// <summary>
+		/// Gets the callback object for this control to raise events.
+		/// </summary>
+		/// <returns>The callback object for this control.</returns>
+		protected override object GetCallback() => s_callback;
+
+		/// <summary>
+		/// Callback implementation for the <see cref="PropertyGrid"/>.
+		/// </summary>
+		protected new class Callback : Control.Callback, ICallback
+		{
+			/// <summary>
+			/// Raises the PropertyValueChanged event.
+			/// </summary>
+			public void OnPropertyValueChanged(PropertyGrid widget, PropertyValueChangedEventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnPropertyValueChanged(e);
+			}
+		}
+
+		/// <summary>
+		/// Callback interface for the <see cref="PropertyGrid"/>
+		/// </summary>
+		public new interface ICallback : Control.ICallback
+		{
+			/// <summary>
+			/// Raises the PropertyValueChanged event.
+			/// </summary>
+			void OnPropertyValueChanged(PropertyGrid widget, PropertyValueChangedEventArgs e);
+		}
+
+		/// <summary>
+		/// Handler interface for the <see cref="PropertyGrid"/>
+		/// </summary>
+		public new interface IHandler : Control.IHandler
+		{
+			/// <summary>
+			/// Gets or sets the selected object for the grid to edit
+			/// </summary>
+			object SelectedObject { get; set; }
+			/// <summary>
+			/// Gets or sets the selected objects for the grid to edit
+			/// </summary>
+			/// <remarks>
+			/// Only common properties (with the same name and type) will be shown.
+			/// </remarks>
+			IEnumerable<object> SelectedObjects { get; set; }
+			/// <summary>
+			/// Gets or sets a value indicating that the categories should be shown
+			/// </summary>
+			bool ShowCategories { get; set; }
+			/// <summary>
+			/// Gets or sets a value indicating that the description panel should be shown
+			/// </summary>
+			/// <remarks>
+			/// The description panel shows the name and description of the selected property
+			/// </remarks>
+			bool ShowDescription { get; set; }
+
+			/// <summary>
+			/// Refreshes the grid with new values from the selected object(s)
+			/// </summary>
+			void Refresh();
+		}
+	}
+}

--- a/src/Eto/Forms/Layout/TableRow.cs
+++ b/src/Eto/Forms/Layout/TableRow.cs
@@ -20,6 +20,32 @@ namespace Eto.Forms
 		Collection<TableCell> cells;
 
 		/// <summary>
+		/// Creates a scaled table row with the specified <paramref name="cells"/>
+		/// </summary>
+		/// <remarks>
+		/// This is the same as creating a new TableRow and setting ScaleHeight = true.
+		/// </remarks>
+		/// <param name="cells">Cells for the table row</param>
+		/// <returns>A new scaled TableRow with the specified cells</returns>
+		public static TableRow Scaled(params TableCell[] cells)
+		{
+			return new TableRow(cells) { ScaleHeight = true };
+		}
+
+		/// <summary>
+		/// Creates a scaled table row with the specified <paramref name="cells"/>
+		/// </summary>
+		/// <remarks>
+		/// This is the same as creating a new TableRow and setting ScaleHeight = true.
+		/// </remarks>
+		/// <param name="cells">Cells for the table row</param>
+		/// <returns>A new scaled TableRow with the specified cells</returns>
+		public static TableRow Scaled(IEnumerable<TableCell> cells)
+		{
+			return new TableRow(cells) { ScaleHeight = true };
+		}
+
+		/// <summary>
 		/// Gets or sets a value indicating whether this <see cref="Eto.Forms.TableCell"/> will scale its height
 		/// </summary>
 		/// <remarks>

--- a/src/Eto/Forms/MaskedTextProvider/NumericMaskedTextProvider.cs
+++ b/src/Eto/Forms/MaskedTextProvider/NumericMaskedTextProvider.cs
@@ -28,8 +28,8 @@ namespace Eto.Forms
 		Dictionary<Type, Info> numericTypes = new Dictionary<Type, Info>
 		{
 			{ typeof(decimal), new Info { Parse = s => { decimal d; return decimal.TryParse(s, out d) ? (object)d : null; }, AllowSign = true, AllowDecimal = true } },
-			{ typeof(double), new Info { Parse = s => { double d; return double.TryParse(s, out d) ? (object)d : null; }, ToText = v => ((double)v).ToString("F99").TrimEnd('0', '.'), AllowSign = true, AllowDecimal = true } },
-			{ typeof(float), new Info { Parse = s => { float d; return float.TryParse(s, out d) ? (object)d : null; }, ToText = v => ((float)v).ToString("F99").TrimEnd('0', '.'), AllowSign = true, AllowDecimal = true } },
+			{ typeof(double), new Info { Parse = s => { double d; return double.TryParse(s, out d) ? (object)d : null; }, ToText = v => ((double?)v)?.ToString("F99").TrimEnd('0', '.'), AllowSign = true, AllowDecimal = true } },
+			{ typeof(float), new Info { Parse = s => { float d; return float.TryParse(s, out d) ? (object)d : null; }, ToText = v => ((float?)v)?.ToString("F99").TrimEnd('0', '.'), AllowSign = true, AllowDecimal = true } },
 			{ typeof(int), new Info { Parse = s => { int d; return int.TryParse(s, out d) ? (object)d : null; }, AllowSign = true } },
 			{ typeof(uint), new Info { Parse = s => { uint d; return uint.TryParse(s, out d) ? (object)d : null; } } },
 			{ typeof(long), new Info { Parse = s => { long d; return long.TryParse(s, out d) ? (object)d : null; }, AllowSign = true } },

--- a/src/Eto/Forms/MaskedTextProvider/VariableMaskedTextProvider.cs
+++ b/src/Eto/Forms/MaskedTextProvider/VariableMaskedTextProvider.cs
@@ -118,10 +118,13 @@ namespace Eto.Forms
 			set
 			{
 				sb.Clear();
-				int pos = 0;
-				foreach (char ch in value)
+				if (value != null)
 				{
-					Insert(ch, ref pos);
+					int pos = 0;
+					foreach (char ch in value)
+					{
+						Insert(ch, ref pos);
+					}
 				}
 			}
 		}

--- a/src/Eto/Forms/ThemedControls/ThemedCollectionEditorHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedCollectionEditorHandler.cs
@@ -1,0 +1,375 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Reflection;
+using Eto.Drawing;
+
+namespace Eto.Forms.ThemedControls
+{
+	/// <summary>
+	/// Handler for the <see cref="CollectionEditor"/> control.
+	/// </summary>
+	public class ThemedCollectionEditorHandler : ThemedControlHandler<ThemedCollectionEditor, CollectionEditor, CollectionEditor.ICallback>, CollectionEditor.IHandler
+	{
+		/// <summary>
+		/// Creates the control for this handler.
+		/// </summary>
+		/// <returns>A new instance of the control for the handler</returns>
+		protected override ThemedCollectionEditor CreateControl() => new ThemedCollectionEditor();
+
+		/// <summary>
+		/// Data store of the items to edit
+		/// </summary>
+		public IEnumerable<object> DataStore
+		{
+			get => Control.DataStore;
+			set => Control.DataStore = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the type of element to create when adding new elements to the data store
+		/// </summary>
+		public Type ElementType
+		{
+			get => Control.ElementType;
+			set => Control.ElementType = value;
+		}
+	}
+
+	interface IValueTypeWrapper
+	{
+		object Key { get; }
+	}
+
+	interface IValueTypeWrapperHost
+	{
+		object GetValue(object key);
+		void SetValue(object key, object value);
+	}
+
+	static class ValueTypeWrapper
+	{
+		class Wrapper<T> : IValueTypeWrapper
+		{
+			object _key;
+			IValueTypeWrapperHost _host;
+			public Wrapper(IValueTypeWrapperHost host, object key)
+			{
+				_host = host;
+				_key = key;
+			}
+
+			object IValueTypeWrapper.Key => _key;
+
+			public T Value
+			{
+				get
+				{
+					var val = _host.GetValue(_key);
+					if (val == null)
+						return default(T);
+					return (T)val;
+				}
+				set => _host.SetValue(_key, value);
+			}
+		}
+
+		public static bool NeedsWrap(Type type)
+		{
+			if (type == null)
+				return false;
+			if (type == typeof(string))
+				return true;
+			var typeInfo = type.GetTypeInfo();
+			if (typeInfo.IsValueType)
+				return true;
+			if (typeInfo.IsArray)
+				return true;
+			return false;
+		}
+
+
+		public static IValueTypeWrapper Create(IValueTypeWrapperHost host, Type type, object key)
+		{
+			var wrapperType = typeof(Wrapper<>).MakeGenericType(type);
+			return Activator.CreateInstance(wrapperType, host, key) as IValueTypeWrapper;
+		}
+
+		public static object Wrap(IValueTypeWrapperHost host, object key, object value)
+		{
+			if (value == null)
+				return null;
+			var type = value.GetType();
+			if (!NeedsWrap(type))
+				return value;
+			return Create(host, type, key);
+		}
+	}
+
+	/// <summary>
+	/// Implementation of the CollectionEditor using a GridView and PropertyGrid.
+	/// </summary>
+	public class ThemedCollectionEditor : Panel, IValueTypeWrapperHost
+	{
+		GridView _list;
+		object _selectedObject;
+		InternalCollection<object> _dataStore;
+		PropertyGrid _propertyGrid;
+		Panel _extraContent;
+
+		class InternalCollection<T> : ObservableCollection<T>
+		{
+			public bool EnableNotifications { get; set; } = true;
+
+			public InternalCollection(IEnumerable<T> collection) : base(collection)
+			{
+			}
+
+			protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+			{
+				if (EnableNotifications)
+					base.OnCollectionChanged(e);
+			}
+
+		}
+
+		/// <summary>
+		/// Data store of the items to edit
+		/// </summary>
+		public IEnumerable<object> DataStore
+		{
+			get => _dataStore;
+			set
+			{
+				_dataStore = new InternalCollection<object>(value ?? Enumerable.Empty<object>());
+				_list.DataStore = _dataStore;
+				if (_dataStore.Count > 0)
+					_list.SelectedRow = 0;
+			}
+		}
+
+		object Wrap(object value, int index)
+		{
+			if (ValueTypeWrapper.NeedsWrap(ElementType))
+			{
+				return ValueTypeWrapper.Create(this, ElementType, index);
+			}
+			return value;
+		}
+
+		object SelectedObject
+		{
+			get => _selectedObject;
+			set
+			{
+				_selectedObject = Wrap(value, _list.SelectedRow);
+				_propertyGrid.SelectedObject = _selectedObject;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the type of element to create when adding new elements to the data store
+		/// </summary>
+		public Type ElementType { get; set; }
+
+		/// <summary>
+		/// Gets or sets a control for extra content in this control.  This appears below the property grid in the same line as the add/remove buttons.
+		/// </summary>
+		public Control ExtraContent
+		{
+			get => _extraContent.Content;
+			set => _extraContent.Content = value;
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the ThemedCollectionEditor
+		/// </summary>
+		public ThemedCollectionEditor()
+		{
+			_list = new GridView
+			{
+				Width = 200,
+				ShowHeader = false,
+				AllowDrop = true,
+				Columns =
+				{
+					new GridColumn
+					{
+						AutoSize = true,
+						DataCell = new TextBoxCell { Binding = Binding.Delegate((object o) => Convert.ToString(o)) }
+					}
+				}
+			};
+			_list.MouseMove += list_MouseMove;
+			_list.DragOver += list_DragOver;
+			_list.DragDrop += list_DragDrop;
+
+
+			var addButton = new ButtonSegmentedItem { Text = Application.Instance.Localize(this, "+") };
+			addButton.Click += AddButton_Click;
+
+			var removeButton = new ButtonSegmentedItem { Text = Application.Instance.Localize(this, "-") };
+			removeButton.Click += RemoveButton_Click;
+
+			var segments = new SegmentedButton { Items = { addButton, removeButton } };
+
+
+			var listButtons = new Panel();
+			listButtons.Padding = new Padding(0, 4, 0, 0);
+			listButtons.Content = TableLayout.AutoSized(segments);
+
+			_propertyGrid = new PropertyGrid { ShowDescription = false };
+
+			_list.SelectedItemBinding.Bind(this, t => t.SelectedObject);
+
+			_extraContent = new Panel();
+
+			Content = new TableLayout(
+				TableRow.Scaled(new Splitter
+				{
+					Orientation = Orientation.Horizontal,
+					FixedPanel = SplitterFixedPanel.None,
+					Panel1MinimumSize = 100,
+					Panel2MinimumSize = 100,
+					RelativePosition = 0.4,
+					Panel1 = new TableLayout
+					{
+						Rows =
+						{
+							Application.Instance.Localize(this, "Members"),
+							new TableRow(_list) { ScaleHeight = true }
+						}
+					},
+					Panel2 = new TableLayout
+					{
+						Rows =
+						{
+							Application.Instance.Localize(this, "Properties"),
+							new TableRow(_propertyGrid) { ScaleHeight = true },
+						}
+					}
+				}),
+				new TableLayout(new TableRow(listButtons, null, _extraContent))
+			);
+		}
+
+		static string s_DragDataName = typeof(ThemedCollectionEditor).FullName;
+
+		private void list_DragOver(object sender, DragEventArgs e)
+		{
+			var info = _list.GetDragInfo(e);
+			if (info == null || !e.Data.Contains(s_DragDataName))
+				return;
+
+			info.RestrictToInsert();
+			if (e.Data.Contains(s_DragDataName))
+				e.Effects = DragEffects.Move;
+		}
+
+		private void list_DragDrop(object sender, DragEventArgs e)
+		{
+			var info = _list.GetDragInfo(e);
+			if (info == null)
+				return;
+
+			var index = info.InsertIndex;
+			if (index >= 0)
+			{
+				//_dataStore.EnableNotifications = false;
+				var sourceRows = e.Data.GetObject(s_DragDataName) as int[];
+				var data = new List<object>();
+				foreach (var row in sourceRows.OrderByDescending(r => r))
+				{
+					var item = _dataStore[row];
+					data.Add(item);
+					_dataStore.RemoveAt(row);
+					if (row < index)
+						index--;
+				}
+				var selectIndex = index;
+				foreach (var item in data)
+				{
+					_dataStore.Insert(index++, item);
+				}
+				_list.SelectedRow = selectIndex;
+				//_dataStore.EnableNotifications = true;
+				//_dataStore.Reset();
+			}
+
+		}
+
+		private void list_MouseMove(object sender, MouseEventArgs e)
+		{
+			if (e.Buttons == MouseButtons.Primary)
+			{
+				var cell = _list.GetCellAt(e.Location);
+				if (cell.Item == null)
+					return;
+
+				var data = new DataObject();
+				data.SetObject(_list.SelectedRows.ToArray(), s_DragDataName);
+				data.Text = _list.SelectedItem?.ToString() ?? "";
+				_list.DoDragDrop(data, DragEffects.Move);
+				e.Handled = true;
+			}
+		}
+
+		private void RemoveButton_Click(object sender, EventArgs e)
+		{
+			var rows = _list.SelectedRows.ToList();
+			for (int i = rows.Count - 1; i >= 0; i--)
+			{
+				_dataStore.RemoveAt(rows[i]);
+			}
+			if (rows.Count > 0)
+			{
+				_list.SelectRow(Math.Min(_dataStore.Count - 1, rows[0]));
+			}
+		}
+
+		object CreateNewInstance()
+		{
+			var type = ElementType;
+			var typeInfo = type.GetTypeInfo();
+			if (typeInfo.IsValueType || type.GetConstructor() != null)
+			{
+				return Activator.CreateInstance(type);
+			}
+			// special case string so we can add them to the list
+			if (type == typeof(string))
+				return string.Empty;
+			return null;
+		}
+
+		private void AddButton_Click(object sender, EventArgs e)
+		{
+			var item = CreateNewInstance();
+			if (item == null)
+			{
+				var msg = Application.Instance.Localize(this, "Could not create an instance of {0}. No default constructor found.");
+				MessageBox.Show(this, string.Format(msg, ElementType.Name), MessageBoxType.Warning);
+				return;
+			}
+
+			_dataStore.Add(item);
+			_list.SelectRow(_dataStore.Count - 1);
+		}
+
+		object IValueTypeWrapperHost.GetValue(object key)
+		{
+			var index = (int)key;
+			return index >= 0 ? _dataStore[index] : null;
+		}
+
+		void IValueTypeWrapperHost.SetValue(object key, object value)
+		{
+			var index = (int)key;
+			_dataStore.EnableNotifications = false;
+			_dataStore[index] = value;
+			_list.ReloadData(index);
+			_dataStore.EnableNotifications = true;
+		}
+	}
+}

--- a/src/Eto/Forms/ThemedControls/ThemedPropertyGridHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedPropertyGridHandler.cs
@@ -1,0 +1,1327 @@
+using System;
+using Eto.Drawing;
+using System.Linq;
+using System.Reflection;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using System.Collections;
+using System.Runtime.CompilerServices;
+using System.Collections.ObjectModel;
+using sc = System.ComponentModel;
+#if !NETSTANDARD1_0
+using System.ComponentModel.DataAnnotations;
+#endif
+
+namespace Eto.Forms.ThemedControls
+{
+	/// <summary>
+	/// Themed handler for the <see cref="PropertyGrid"/> control.
+	/// </summary>
+	public class ThemedPropertyGridHandler : ThemedControlHandler<ThemedPropertyGrid, PropertyGrid, PropertyGrid.ICallback>, PropertyGrid.IHandler
+	{
+		/// <summary>
+		/// Gets or sets the selected object for the grid to edit
+		/// </summary>
+		public object SelectedObject
+		{
+			get => Control.SelectedObject;
+			set => Control.SelectedObject = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the selected objects for the grid to edit
+		/// </summary>
+		/// <remarks>
+		/// Only common properties (with the same name and type) will be shown.
+		/// </remarks>
+		public IEnumerable<object> SelectedObjects
+		{
+			get => Control.SelectedObjects;
+			set => Control.SelectedObjects = value;
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating that the categories should be shown
+		/// </summary>
+		public bool ShowCategories
+		{
+			get => Control.ShowCategories;
+			set => Control.ShowCategories = value;
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating that the description panel should be shown
+		/// </summary>
+		/// <remarks>
+		/// The description panel shows the name and description of the selected property
+		/// </remarks>
+		public bool ShowDescription
+		{
+			get => Control.ShowDescription;
+			set => Control.ShowDescription = value;
+		}
+
+		/// <summary>
+		/// Refreshes the grid with new values from the selected object(s)
+		/// </summary>
+		public void Refresh() => Control.Refresh();
+
+		/// <summary>
+		/// Creates the control for this handler
+		/// </summary>
+		/// <returns>The control instance</returns>
+		protected override ThemedPropertyGrid CreateControl() => new ThemedPropertyGrid();
+
+	}
+
+	/// <summary>
+	/// Implementation of the PropertyGrid using the TreeGridView and PropertyCell
+	/// </summary>
+	public class ThemedPropertyGrid : Panel, IValueTypeWrapperHost
+	{
+		List<object> _selectedObjects;
+		IComparer<IPropertyDescriptor> _propertySort = Comparer<IPropertyDescriptor>.Create((x, y) => string.Compare(x.Name, y.Name, StringComparison.CurrentCulture));
+		IComparer<string> _categorySort = Comparer<string>.Default;
+		bool _showCategories = true;
+		bool _showDescription = true;
+		TreeGridView _tree;
+		PropertyCell _propertyCell;
+		ObservableCollection<PropertyCellType> _customTypes;
+
+		static Font s_DefaultFont = SystemFonts.Default();
+		static Font s_BoldFont = SystemFonts.Bold();
+
+		/// <summary>
+		/// Event to handle when a property value has changed
+		/// </summary>
+		public event EventHandler<PropertyValueChangedEventArgs> PropertyValueChanged;
+
+		/// <summary>
+		/// Creates a cell value binding for a particular type when you want to add your own cell types to <see cref="PropertyCellTypes"/>
+		/// </summary>
+		/// <typeparam name="T">Value type</typeparam>
+		/// <returns>A binding to use for custom cell types</returns>
+		public IndirectBinding<T> CreateCellValueBinding<T>() => Binding.Property<T>(nameof(PropertyItem.Value));
+
+		/// <summary>
+		/// Gets a collection of custom property cell types to use as well as the built-in types.
+		/// </summary>
+		public IList<PropertyCellType> PropertyCellTypes => _customTypes ?? (_customTypes = CreateCustomTypes());
+
+
+		ObservableCollection<PropertyCellType> CreateCustomTypes()
+		{
+			_customTypes = new ObservableCollection<PropertyCellType>();
+			_customTypes.CollectionChanged += customTypes_CollectionChanged;
+			return _customTypes;
+
+		}
+
+		private void customTypes_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			SetupTypes();
+		}
+
+		void SetupTypes()
+		{
+			if (_propertyCell == null)
+				return;
+
+			_propertyCell.Types.Clear();
+			var itemTypeBinding = Binding.Property((PropertyItem p) => p.PropertyType);
+
+			if (_customTypes != null)
+			{
+				for (int i = 0; i < _customTypes.Count; i++)
+				{
+					_propertyCell.Types.Add(_customTypes[i]);
+				}
+			}
+
+			_propertyCell.Types.Add(new PropertyCellTypeArray());
+			_propertyCell.Types.Add(new PropertyCellTypeCustom());
+			_propertyCell.Types.Add(new PropertyCellTypeReadOnly());
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeColor()));
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeString()));
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeNumber { ItemTypeBinding = itemTypeBinding }));
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeBoolean { ItemThreeStateBinding = Binding.Property((PropertyItem p) => p.IsNullable) }));
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeDateTime()));
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeEnum { ItemTypeBinding = itemTypeBinding }));
+			_propertyCell.Types.Add(new PropertyCellTypeObject());
+		}
+
+		/// <summary>
+		/// Gets or sets the selected objects for the grid to edit
+		/// </summary>
+		/// <remarks>
+		/// Only common properties (with the same name and type) will be shown.
+		/// </remarks>
+		public IEnumerable<object> SelectedObjects
+		{
+			get => _selectedObjects?.Select(UnwrapValueType);
+			set
+			{
+				_selectedObjects = WrapValueType(value);
+				UpdateProperties();
+			}
+		}
+
+		object UnwrapValueType(object value)
+		{
+			if (value is IValueTypeWrapper wrapper)
+				return _selectedObjects[(int)wrapper.Key];
+			return value;
+		}
+
+		List<object> WrapValueType(IEnumerable<object> values)
+		{
+			if (values == null)
+				return null;
+			var newValues = new List<object>();
+			var index = 0;
+			foreach (var value in values)
+			{
+				newValues.Add(WrapValueType(value, index++));
+			}
+			return newValues;
+		}
+
+		object WrapValueType(object value, int index)
+		{
+			if (value == null)
+				return null;
+			// can't mutate it, so we wrap!
+			return ValueTypeWrapper.Wrap(this, index, value);
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating that value types should use their default to determine if the property is changed (shown as bold)
+		/// </summary>
+		public bool UseValueTypeDefaults { get; set; } = true;
+
+		/// <summary>
+		/// Gets or sets the selected object 
+		/// </summary>
+		public object SelectedObject
+		{
+			get => _selectedObjects?.FirstOrDefault();
+			set => SelectedObjects = value != null ? new[] { value } : null;
+		}
+
+		/// <summary>
+		/// Event to handle when the <see cref="ShowCategories"/> property has changed.
+		/// </summary>
+		public event EventHandler<EventArgs> ShowCategoriesChanged;
+
+		/// <summary>
+		/// Gets or sets a value indicating that the categories should be shown
+		/// </summary>
+		[DefaultValue(true)]
+		public bool ShowCategories
+		{
+			get => _showCategories;
+			set
+			{
+				if (_showCategories != value)
+				{
+					_showCategories = value;
+					UpdateProperties();
+					ShowCategoriesChanged?.Invoke(this, EventArgs.Empty);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating that the description panel should be shown
+		/// </summary>
+		/// <remarks>
+		/// The description panel shows the name and description of the selected property
+		/// </remarks>
+		[DefaultValue(true)]
+		public bool ShowDescription
+		{
+			get => _showDescription;
+			set
+			{
+				if (_showDescription != value)
+				{
+					_showDescription = value;
+					CreateLayout();
+				}
+			}
+		}
+
+		IComparer<IPropertyDescriptor> PropertySort
+		{
+			get => _propertySort;
+			set
+			{
+				_propertySort = value;
+				UpdateProperties();
+			}
+		}
+
+		IComparer<string> CategorySort
+		{
+			get => _categorySort;
+			set
+			{
+				_categorySort = value;
+				UpdateProperties();
+			}
+		}
+
+		interface IItem
+		{
+			string Name { get; }
+			Color TitleTextColor { get; }
+			Font TitleFont { get; }
+		}
+
+		class CategoryItem : TreeGridItem, IItem
+		{
+			public string Name { get; set; }
+
+			public Color TitleTextColor => SystemColors.ControlText;
+
+			public Font TitleFont => s_BoldFont;
+		}
+
+		class PropertyItem : TreeGridItem, INotifyPropertyChanged, ITreeGridStore<ITreeGridItem>, IItem
+		{
+			ThemedPropertyGrid _grid;
+			string _description;
+			bool? _isReadOnly;
+			object _propertyCellType;
+			object _defaultValue;
+			string _name;
+			Lazy<string> _dataTypeText;
+			Lazy<Type> _elementType;
+			Lazy<IPropertyGridEditor> _editor;
+			bool? _expandable;
+			Lazy<sc.TypeConverter> _converter;
+			bool _childrenInitialized;
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			void OnPropertyChanged([CallerMemberName] string name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+			public IPropertyDescriptor Property { get; set; }
+
+			public object GetPropertyValue(object instance)
+			{
+				if (Parent is PropertyItem propertyItem)
+				{
+					instance = propertyItem.GetPropertyValue(instance);
+				}
+				var prop = GetProperty(instance);
+				if (prop == null)
+					return DefaultValue;
+				return prop.GetValue(instance);
+			}
+
+			public bool SetPropertyValue(object instance, object value)
+			{
+				if (Parent is PropertyItem propertyItem)
+				{
+					instance = propertyItem.GetPropertyValue(instance);
+				}
+				var prop = GetProperty(instance);
+				if (prop == null || prop.IsReadOnly)
+					return false;
+
+				prop.SetValue(instance, value);
+
+				_childrenInitialized = false;
+
+				return true;
+			}
+
+			public IPropertyDescriptor GetProperty(object instance)
+			{
+				if (instance == null)
+					return null;
+
+				// cache per type?
+				var instanceType = instance.GetType();
+				var prop = Property;
+				if (!prop.ComponentType.GetTypeInfo().IsAssignableFrom(instanceType.GetTypeInfo()))
+				{
+					prop = EtoTypeDescriptor.GetProperty(instanceType, prop.Name);
+				}
+				return prop;
+			}
+
+			public string Name => _name ?? (_name = GetName());
+			public string Description => _description ?? (_description = GetDescription());
+
+			public bool IsReadOnly => _isReadOnly ?? (_isReadOnly = GetIsReadOnly()) ?? false;
+
+			public object DefaultValue => _defaultValue ?? (_defaultValue = GetDefaultValue());
+
+			public object PropertyCellType => _propertyCellType ?? (_propertyCellType = GetPropertyCellType());
+
+			public Type ElementType => (_elementType ?? (_elementType = new Lazy<Type>(GetElementType))).Value;
+
+			public Type PropertyType => Property.PropertyType;
+
+			public string ReadOnlyValue => GetDisplayString();
+
+			public bool IsNullable => PropertyType.GetTypeInfo().IsClass || Nullable.GetUnderlyingType(PropertyType) != null;
+
+			public IPropertyGridEditor Editor => (_editor ?? (_editor = new Lazy<IPropertyGridEditor>(CreateEditor))).Value;
+
+			IPropertyGridEditor CreateEditor()
+			{
+				var editorType = GetEditorType();
+				if (editorType == null)
+					return null;
+				return Activator.CreateInstance(editorType) as IPropertyGridEditor;
+			}
+
+			Type GetEditorType()
+			{
+				var editor = EditorAttributeWrapper.Get(Property) ?? EditorAttributeWrapper.Get(PropertyType);
+				if (editor == null || editor.EditorBaseTypeName != typeof(IPropertyGridEditor).AssemblyQualifiedName)
+					return null;
+				return Type.GetType(editor.EditorTypeName);
+			}
+
+			object GetPropertyCellType()
+			{
+				if (GetEditorType() != null)
+					return typeof(PropertyCellTypeCustom);
+
+				if (IsReadOnly)
+					return typeof(PropertyCellTypeReadOnly);
+
+				var type = PropertyType;
+				if (type == typeof(object))
+				{
+					// use current value for type
+					type = Value?.GetType() ?? type;
+				}
+				return type;
+			}
+
+			public sc.TypeConverter Converter => (_converter ?? (_converter = new Lazy<sc.TypeConverter>(GetConverter))).Value;
+
+			public string DisplayText => GetDisplayString();
+
+			string GetDisplayString()
+			{
+				return Converter?.ConvertToString(Value) ?? Convert.ToString(Value);
+			}
+
+			sc.TypeConverter GetConverter()
+			{
+				return sc.TypeDescriptor.GetConverter(PropertyType);
+			}
+
+			Type GetElementType()
+			{
+				if (PropertyType.HasElementType)
+					return PropertyType.GetElementType();
+				else
+				{
+					var interfaces = PropertyType.GetTypeInfo().ImplementedInterfaces;
+					foreach (var i in interfaces)
+					{
+						if (i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+							&& i.GenericTypeArguments.Length == 1)
+						{
+							return i.GenericTypeArguments[0];
+						}
+					}
+				}
+
+				return null;
+			}
+
+			string GetName()
+			{
+				return DisplayAttributeWrapper.Get(Property)?.GetName()
+					?? Property.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName
+					?? Property.Name;
+			}
+
+			public PropertyItem(ThemedPropertyGrid grid, PropertyInfo property)
+				: this(grid, new PropertyInfoDescriptor(property))
+			{
+			}
+
+			public PropertyItem(ThemedPropertyGrid grid, IPropertyDescriptor property)
+			{
+				_grid = grid;
+				Property = property;
+			}
+
+			public bool HasValue => Value != null;
+
+			public object Value
+			{
+				get => _grid.GetValue(this);
+				set
+				{
+					_grid.SetValue(this, value);
+					OnPropertyChanged(nameof(DisplayFont));
+					_dataTypeText = null;
+					OnPropertyChanged(nameof(DataTypeText));
+					OnPropertyChanged(nameof(DisplayText));
+				}
+			}
+
+			public override bool Expandable => _expandable ?? (_expandable = GetIsExpandable()).Value && HasValue;
+
+			public string DataTypeText => (_dataTypeText ?? (_dataTypeText = new Lazy<string>(GetDataTypeText))).Value;
+
+			string GetDataTypeText()
+			{
+				if (!HasValue)
+					return null;
+				if (PropertyType.IsArray)
+					return string.Format(Application.Instance.Localize(_grid, "{0} Array"), PropertyType.Name);
+				if (typeof(IList).GetTypeInfo().IsAssignableFrom(PropertyType.GetTypeInfo()))
+					return Application.Instance.Localize(_grid, "(Collection)");
+
+				return null;
+			}
+
+			static MethodInfo s_GetPropertiesSupportedMethod = typeof(sc.TypeConverter).GetRuntimeMethod("GetPropertiesSupported", new Type[0]);
+			static MethodInfo s_GetPropertiesMethod = typeof(sc.TypeConverter).GetRuntimeMethod("GetProperties", new Type[] { typeof(object) });
+
+			public bool GetIsExpandable()
+			{
+				if (s_GetPropertiesSupportedMethod == null || Converter == null)
+					return false;
+				return (bool)s_GetPropertiesSupportedMethod.Invoke(Converter, null);
+			}
+
+			public bool CanSetCollection
+			{
+				get
+				{
+					if (PropertyType.IsArray)
+						return !IsReadOnly;
+
+					return !IsReadOnly || HasValue;
+				}
+			}
+
+			public bool IsDefaultValue => Equals(Value, DefaultValue);
+
+			public Font DisplayFont => IsReadOnly || IsDefaultValue
+				? s_DefaultFont
+				: s_BoldFont;
+
+			public Color DisplayTextColor
+			{
+				get
+				{
+					if (IsReadOnly)
+						return IsSelected ? new Color(SystemColors.HighlightText, 0.8f) : SystemColors.DisabledText;
+					else
+						return IsSelected ? SystemColors.HighlightText : SystemColors.ControlText;
+				}
+			}
+
+			object GetDefaultValue()
+			{
+				var attr = Property.GetCustomAttribute<DefaultValueAttribute>();
+				if (attr != null)
+				{
+					var val = attr.Value;
+					if (val != null)
+					{
+						var tc = sc.TypeDescriptor.GetConverter(PropertyType);
+						if (tc != null && tc.CanConvertFrom(val.GetType()))
+							val = tc.ConvertFrom(val);
+					}
+					return val;
+				}
+				if (_grid.UseValueTypeDefaults && PropertyType.GetTypeInfo().IsValueType)
+				{
+					// is it nullable?  return null for default.
+					if (IsNullable)
+						return null;
+					return Activator.CreateInstance(PropertyType);
+				}
+				return null;
+			}
+
+			string GetDescription()
+			{
+				return DisplayAttributeWrapper.Get(Property)?.GetDescription()
+					?? Property.GetCustomAttribute<DescriptionAttribute>()?.Description;
+			}
+
+			bool IsArray => PropertyType.IsArray;
+
+			bool IsCollection
+			{
+				get
+				{
+					if (typeof(IList).GetTypeInfo().IsAssignableFrom(PropertyType.GetTypeInfo()))
+						return true;
+					return false;
+				}
+			}
+
+			bool GetIsReadOnly()
+			{
+				var isReadOnlyAttribute = Property.GetCustomAttribute<ReadOnlyAttribute>();
+				if (isReadOnlyAttribute != null)
+					return isReadOnlyAttribute.IsReadOnly;
+
+				if (!Property.IsReadOnly)
+					return false;
+
+				// can't use object editor for string
+				if (PropertyType == typeof(string))
+					return true;
+
+				// array editor
+				if (IsCollection && !IsArray)
+					return !HasValue;
+
+				var typeInfo = PropertyType.GetTypeInfo();
+
+				// we can use the object editor to edit a read-only property
+				if (!(typeInfo.IsValueType || typeInfo.IsArray || typeInfo.IsInterface))
+					return !HasValue;
+
+				return true;
+			}
+
+			public object CreateNewValue()
+			{
+				if (PropertyType.GetConstructor() == null)
+					return null;
+				return Activator.CreateInstance(PropertyType);
+			}
+
+			public void SetCollection(IEnumerable<object> newCollection)
+			{
+				if (PropertyType.IsArray)
+				{
+					// it's an array, we need to replace the whole thing
+					var coll = newCollection.ToList();
+					var newArray = Array.CreateInstance(ElementType, coll.Count);
+					int index = 0;
+					for (int i = 0; i < coll.Count; i++)
+					{
+						newArray.SetValue(coll[i], index++);
+					}
+					Value = newArray;
+				}
+
+				var value = Value;
+				bool setValue = false;
+				if (value == null)
+				{
+					value = CreateNewValue();
+					setValue = true;
+				}
+
+				if (value is IList saveList && !saveList.IsFixedSize)
+				{
+					saveList.Clear();
+
+					foreach (var item in newCollection)
+					{
+						saveList.Add(item);
+					}
+
+					if (setValue)
+					{
+						Value = value;
+					}
+				}
+
+			}
+
+			void EnsureChildren()
+			{
+				if (_childrenInitialized || s_GetPropertiesMethod == null || Converter == null || !HasValue || !PropertyDescriptorDescriptor.IsSupported)
+					return;
+
+				_childrenInitialized = true;
+				Children.Clear();
+				var properties = (IList)s_GetPropertiesMethod.Invoke(Converter, new object[] { Value });
+				if (properties == null)
+					return;
+
+				var descriptors = new List<IPropertyDescriptor>();
+				for (int i = 0; i < properties.Count; i++)
+				{
+					descriptors.Add(new PropertyDescriptorDescriptor(properties[i]));
+				}
+
+				if (_grid.PropertySort != null)
+					descriptors.Sort(_grid.PropertySort);
+
+				for (int i = 0; i < descriptors.Count; i++)
+				{
+					Children.Add(new PropertyItem(_grid, descriptors[i]));
+				}
+			}
+
+			int IDataStore<ITreeGridItem>.Count
+			{
+				get
+				{
+					EnsureChildren();
+					return base.Count;
+				}
+			}
+
+			bool _isSelected;
+			public bool IsSelected
+			{
+				get => _isSelected;
+				set
+				{
+					if (_isSelected != value)
+					{
+						_isSelected = value;
+						OnPropertyChanged();
+						OnPropertyChanged(nameof(DisplayTextColor));
+					}
+				}
+			}
+
+			public Color TitleTextColor => DisplayTextColor;
+
+			public Font TitleFont => s_DefaultFont;
+		}
+
+		private void SetValue(PropertyItem propertyItem, object value)
+		{
+			if (_selectedObjects == null)
+				return;
+
+			var wasUpdated = false;
+			for (int i = 0; i < _selectedObjects.Count; i++)
+			{
+				object obj = _selectedObjects[i];
+				var oldValue = propertyItem.GetPropertyValue(obj);
+				if (propertyItem.SetPropertyValue(obj, value))
+				{
+					wasUpdated = true;
+					PropertyValueChanged?.Invoke(this, new PropertyValueChangedEventArgs(propertyItem.Name, oldValue, obj));
+				}
+			}
+			if (wasUpdated && propertyItem.Expandable)
+				_tree.ReloadItem(propertyItem, true);
+		}
+
+		private object GetValue(PropertyItem propertyItem)
+		{
+			if (_selectedObjects?.Count > 0)
+			{
+				return propertyItem?.GetPropertyValue(_selectedObjects[0]);
+			}
+			return propertyItem.DefaultValue;
+		}
+
+		PropertyCellType<T> Setup<T>(PropertyCellType<T> cell)
+		{
+			cell.ItemBinding = CreateCellValueBinding<T>();
+			return cell;
+		}
+
+		class CollectionEditorDialog : Dialog<bool>
+		{
+			public CollectionEditor Editor { get; }
+
+			static Size? s_defaultSize;
+
+			public CollectionEditorDialog(CollectionEditor editor)
+			{
+				Editor = editor;
+				Resizable = true;
+				Padding = 6;
+				MinimumSize = new Size(200, 200);
+				ClientSize = new Size(600, 400);
+				if (s_defaultSize != null)
+					Size = s_defaultSize.Value;
+
+				var cancelButton = new Button { Text = Application.Instance.Localize(this, "Cancel") };
+				cancelButton.Click += CancelButton_Click;
+				var okButton = new Button { Text = Application.Instance.Localize(this, Platform.IsMac ? "Apply" : "OK") };
+				okButton.Click += OkButton_Click;
+				DefaultButton = okButton;
+				AbortButton = cancelButton;
+
+				if (editor.ControlObject is ThemedCollectionEditor themedCollectionEditor)
+				{
+					var buttons = new TableLayout
+					{
+						Padding = 4,
+						Spacing = new Size(6, 0),
+						Rows = { null, new TableRow(cancelButton, okButton), null }
+					};
+					themedCollectionEditor.ExtraContent = buttons;
+					Content = editor;
+				}
+				else
+				{
+					Content = editor;
+					PositiveButtons.Add(okButton);
+					NegativeButtons.Add(cancelButton);
+				}
+			}
+
+			protected override void OnClosing(CancelEventArgs e)
+			{
+				base.OnClosing(e);
+				s_defaultSize = RestoreBounds.Size;
+			}
+
+			private void OkButton_Click(object sender, EventArgs e) => Close(true);
+
+			private void CancelButton_Click(object sender, EventArgs e) => Close(false);
+		}
+
+
+		class PropertyCellTypeArray : PropertyCellType
+		{
+			public override string Identifier => "PropertyCellTypeArray";
+
+			public override bool CanDisplay(object itemType)
+			{
+				var type = itemType as Type;
+				if (type == null)
+					return false;
+				if (type.IsArray)
+					return true;
+				if (typeof(IList).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+					return true;
+				return false;
+			}
+
+			public override Control OnCreate(CellEventArgs args)
+			{
+				var label = new Label();
+				label.VerticalAlignment = VerticalAlignment.Center;
+				label.TextBinding.BindDataContext((PropertyItem p) => p.DataTypeText);
+				var button = new Button { MinimumSize = Size.Empty, Text = "…" };
+				button.BindDataContext(c => c.Enabled, (PropertyItem p) => p.CanSetCollection);
+				button.Click += (sender, e) =>
+				{
+					var b = sender as Button;
+					if (b.DataContext is PropertyItem pi)
+					{
+						var elementType = pi.ElementType;
+						var value = pi.Value ?? pi.CreateNewValue();
+						var collection = value as IEnumerable<object>;
+						if (collection == null && value is IList list)
+							collection = list.OfType<object>();
+
+						var editor = new CollectionEditor();
+						editor.ElementType = pi.ElementType;
+						editor.DataStore = collection;
+						var editorDialog = new CollectionEditorDialog(editor);
+						editorDialog.Title = $"{pi.ElementType.Name} Collection Editor";
+
+						if (editorDialog.ShowModal(button))
+						{
+							pi.SetCollection(editor.DataStore);
+
+						}
+					}
+				};
+				return new TableLayout(new TableRow(new TableCell(label, true), button));
+			}
+
+			public override void OnPaint(CellPaintEventArgs args)
+			{
+				if (args.Item is PropertyItem pi)
+				{
+					pi.IsSelected = args.IsSelected;
+					var color = pi.DisplayTextColor;
+					var font = pi.DisplayFont;
+					args.DrawCenteredText(pi.DataTypeText, color, font);
+				}
+			}
+		}
+
+
+		class PropertyGridDialog : Dialog<bool>
+		{
+			public ThemedPropertyGrid Editor { get; }
+
+			static Size? s_defaultSize;
+
+			public PropertyGridDialog(ThemedPropertyGrid editor)
+			{
+				Editor = editor;
+				Resizable = true;
+				MinimumSize = new Size(200, 200);
+				ClientSize = new Size(400, 400);
+				if (s_defaultSize != null)
+					Size = s_defaultSize.Value;
+
+				var cancelButton = new Button { Text = Application.Instance.Localize(this, "Cancel") };
+				cancelButton.Click += CancelButton_Click;
+				var okButton = new Button { Text = Application.Instance.Localize(this, Platform.IsMac ? "Apply" : "OK") };
+				okButton.Click += OkButton_Click;
+				DefaultButton = okButton;
+				AbortButton = cancelButton;
+
+				var layout = new DynamicLayout();
+				layout.DefaultSpacing = new Size(4, 4);
+				layout.Add(editor, yscale: true);
+				layout.AddSeparateRow(spacing: new Size(6, 0), controls: new[] { null, cancelButton, okButton });
+				Padding = 6;
+				Content = layout;
+			}
+
+			protected override void OnClosing(CancelEventArgs e)
+			{
+				base.OnClosing(e);
+				s_defaultSize = RestoreBounds.Size;
+			}
+
+			private void OkButton_Click(object sender, EventArgs e) => Close(true);
+
+			private void CancelButton_Click(object sender, EventArgs e) => Close(false);
+		}
+
+		class PropertyCellTypeObject : PropertyCellType
+		{
+			public override string Identifier => "PropertyCellTypeObject";
+
+			public override bool CanDisplay(object itemType)
+			{
+				var type = itemType as Type;
+				if (type == null)
+					return false;
+				var typeInfo = type.GetTypeInfo();
+				if (typeInfo.IsValueType || typeInfo.IsArray || typeInfo.IsInterface)
+					return false;
+				return true;
+			}
+
+			public override Control OnCreate(CellEventArgs args)
+			{
+				var label = new Label();
+				label.VerticalAlignment = VerticalAlignment.Center;
+				label.TextBinding.BindDataContext((PropertyItem p) => p.DisplayText);
+				var button = new Button { MinimumSize = Size.Empty, Text = "…" };
+				button.BindDataContext(c => c.Enabled, Binding.Property((PropertyItem p) => p.IsReadOnly).ToBool(false, true));
+				button.BindDataContext(c => c.Visible, Binding.Property((PropertyItem p) => p.Expandable).ToBool(false, true));
+				button.Click += (sender, e) =>
+				{
+					var b = sender as Button;
+					if (b.DataContext is PropertyItem pi)
+					{
+						var editor = new ThemedPropertyGrid();
+						var value = pi.Value ?? pi.CreateNewValue();
+						editor.SelectedObject = value;
+						var editorDialog = new PropertyGridDialog(editor);
+						editorDialog.Title = $"{pi.PropertyType.Name} Editor";
+
+						if (editorDialog.ShowModal(button))
+						{
+							if (!pi.HasValue)
+								pi.Value = value;
+
+						}
+					}
+				};
+				return new TableLayout(new TableRow(new TableCell(label, true), button));
+			}
+
+			public override void OnPaint(CellPaintEventArgs args)
+			{
+				if (args.Item is PropertyItem pi)
+				{
+					pi.IsSelected = args.IsSelected;
+					var color = pi.DisplayTextColor;
+					var font = pi.DisplayFont;
+					args.DrawCenteredText(pi.DisplayText, color, font);
+				}
+			}
+		}
+
+		class PropertyCellTypeReadOnly : PropertyCellType
+		{
+			public override string Identifier => "PropertyCellTypeReadOnly";
+
+			public override bool CanDisplay(object itemType) => itemType == typeof(PropertyCellTypeReadOnly);
+
+			public override Control OnCreate(CellEventArgs args)
+			{
+				var control = new TextBox { ShowBorder = false, BackgroundColor = Colors.Transparent, ReadOnly = true };
+				control.BindDataContext(c => c.Text, (PropertyItem p) => p.ReadOnlyValue);
+				control.BindDataContext(c => c.ToolTip, (PropertyItem p) => p.ReadOnlyValue);
+				return control;
+			}
+
+			public override void OnConfigure(CellEventArgs args, Control control)
+			{
+				base.OnConfigure(args, control);
+				if (control is TextBox tb)
+				{
+					if (args.IsSelected && !Eto.Platform.Instance.IsMac)
+						tb.TextColor = new Color(SystemColors.HighlightText, 0.8f);
+					else
+						tb.TextColor = SystemColors.DisabledText;
+				}
+			}
+
+			public override void OnPaint(CellPaintEventArgs args)
+			{
+				if (args.Item is PropertyItem pi)
+				{
+					pi.IsSelected = args.IsSelected;
+					var color = pi.DisplayTextColor;
+					var font = pi.DisplayFont;
+					args.DrawCenteredText(pi.ReadOnlyValue, color, font);
+				}
+			}
+		}
+
+		class PropertyCellTypeCustom : PropertyCellType
+		{
+			public override string Identifier => "PropertyCellTypeCustom";
+
+			public override bool CanDisplay(object itemType) => Equals(itemType, typeof(PropertyCellTypeCustom));
+
+			public override Control OnCreate(CellEventArgs args)
+			{
+				if (args.Item is PropertyItem propertyItem)
+				{
+					return propertyItem.Editor?.CreateControl(args);
+				}
+
+				return null;
+			}
+
+			public override void OnPaint(CellPaintEventArgs args)
+			{
+				if (args.Item is PropertyItem propertyItem)
+				{
+					propertyItem.Editor?.PaintCell(args);
+				}
+			}
+		}
+
+		class NameCell : CustomCell
+		{
+			Grid _parent;
+			public NameCell(Grid parent)
+			{
+				_parent = parent;
+			}
+			protected override Control OnCreateCell(CellEventArgs args)
+			{
+				var control = new Label();
+				control.VerticalAlignment = VerticalAlignment.Center;
+				control.TextBinding.BindDataContext(Binding.Delegate((IItem c) => c.Name));
+				control.BindDataContext(c => c.TextColor, (IItem m) => m.TitleTextColor);
+				control.BindDataContext(c => c.Font, (IItem m) => m.TitleFont);
+				args.PropertyChanged += (sender, e) =>
+				{
+					if (e.PropertyName == nameof(args.IsSelected) && control.DataContext is PropertyItem pi)
+					{
+						pi.IsSelected = args.IsSelected && _parent.HasFocus;
+					}
+				};
+				return control;
+			}
+
+			protected override void OnPaint(CellPaintEventArgs args)
+			{
+				if (args.Item is IItem item)
+				{
+					if (args.Item is PropertyItem pi)
+						pi.IsSelected = args.IsSelected;
+					args.DrawCenteredText(item.Name, item.TitleTextColor, item.TitleFont);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the ThemedPropertyGrid
+		/// </summary>
+		public ThemedPropertyGrid()
+		{
+			var orientation = Orientation.Vertical;
+
+			switch (orientation)
+			{
+				case Orientation.Horizontal:
+					break;
+				case Orientation.Vertical:
+					break;
+				default:
+					break;
+			}
+
+			_tree = new TreeGridView();
+			_tree.ShowHeader = false;
+			_tree.SizeChanged += tree_SizeChanged;
+			_tree.Columns.Add(new GridColumn
+			{
+				AutoSize = false,
+				DataCell = new NameCell(_tree)
+			});
+			_propertyCell = new GridPropertyCell(this);
+			_propertyCell.TypeBinding = Binding.Property((PropertyItem p) => p.PropertyCellType);
+			SetupTypes();
+
+			_tree.Columns.Add(new GridColumn
+			{
+				AutoSize = false,
+				Editable = true,
+				DataCell = _propertyCell
+			});
+			CreateLayout();
+		}
+
+		void CreateLayout()
+		{
+			if (ShowDescription)
+			{
+				var helpTitle = new Label { Font = SystemFonts.Bold() };
+				helpTitle.TextBinding.BindDataContext((PropertyItem p) => p.Name);
+
+				var helpText = new Label { Wrap = WrapMode.Word };
+				helpText.TextBinding.BindDataContext((PropertyItem p) => p.Description);
+
+				var helpPanel = new TableLayout(helpTitle, helpText);
+				helpPanel.Bind(c => c.DataContext, _tree, t => t.SelectedItem);
+
+				var splitter = new Splitter
+				{
+					Orientation = Orientation.Vertical,
+					FixedPanel = SplitterFixedPanel.Panel2,
+					RelativePosition = 60,
+					Panel1 = _tree,
+					Panel2 = helpPanel
+				};
+				Content = splitter;
+			}
+			else
+			{
+				Content = _tree;
+			}
+		}
+
+		class GridPropertyCell : PropertyCell
+		{
+			private ThemedPropertyGrid _grid;
+
+			public GridPropertyCell(ThemedPropertyGrid grid)
+			{
+				_grid = grid;
+			}
+
+			protected override Control OnCreateCell(CellEventArgs args)
+			{
+				var ctl = base.OnCreateCell(args);
+				if (ctl is Container container)
+				{
+					container.Styles.Add<CommonControl>(null, child =>
+					{
+						if (child is Button)
+							return;
+						child.BindDataContext(c => c.Font, (PropertyItem p) => p.DisplayFont);
+					});
+					container.Styles.Add<TextControl>(null, child =>
+					{
+						if (child is Button)
+							return;
+						child.BindDataContext(c => c.TextColor, (PropertyItem p) => p.DisplayTextColor);
+					});
+				}
+				return ctl;
+			}
+
+		}
+
+
+		private void tree_SizeChanged(object sender, EventArgs e)
+		{
+			SetColumnWidths();
+		}
+
+		private void SetColumnWidths()
+		{
+			var width = _tree.Size.Width;
+			if (_tree.Border != BorderType.None)
+				width -= 2;
+			if (Platform.IsWinForms || Platform.IsWpf)
+				width -= 18; // hack: for scrollbar, should use something like _tree.ClientSize
+			width /= 2;
+			var columns = _tree.Columns;
+			for (int i = 0; i < columns.Count; i++)
+			{
+				columns[i].Width = width;
+			}
+		}
+
+		/// <summary>
+		/// Refreshes the properties of the grid
+		/// </summary>
+		public void Refresh()
+		{
+			UpdateProperties();
+		}
+
+		/// <summary>
+		/// Called when the grid is loaded onto a form
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+			UpdateProperties();
+		}
+
+		void UpdateProperties()
+		{
+			if (!Loaded)
+				return;
+			Task.Run(() =>
+			{
+				// do this stuff in the background
+				var properties = GetCommonProperties();
+				var top = new TreeGridItem();
+				if (ShowCategories)
+				{
+					var categories = SplitIntoCategories(properties);
+					//if (categories.Count > 1)
+					ToTreeWithCategories(top, categories);
+					//else
+					//    ToTreeWithProperties(top, categories.Values.FirstOrDefault());
+				}
+				else
+				{
+					ToTreeWithProperties(top, properties);
+				}
+				Application.Instance.Invoke(() =>
+				{
+					_tree.DataStore = top;
+
+					// on mac, the width is enlarged by the expanded nodes.. needs to be fixed.
+					SetColumnWidths();
+				});
+			});
+		}
+
+		private void ToTreeWithCategories(TreeGridItem top, Dictionary<string, IList<IPropertyDescriptor>> categories)
+		{
+			IEnumerable<string> categoryKeys = categories.Keys;
+			if (CategorySort != null)
+				categoryKeys = categoryKeys.OrderBy(c => c, CategorySort);
+			foreach (var category in categoryKeys)
+			{
+				var categoryItem = new CategoryItem();
+				categoryItem.Expanded = true;
+				categoryItem.Name = category;
+
+				ToTreeWithProperties(categoryItem, categories[category]);
+				top.Children.Add(categoryItem);
+			}
+		}
+
+		private void ToTreeWithProperties(TreeGridItem categoryItem, IEnumerable<IPropertyDescriptor> properties)
+		{
+			if (properties == null)
+				return;
+			if (PropertySort != null)
+				properties = properties.OrderBy(c => c, PropertySort);
+			foreach (var property in properties)
+			{
+				var propertyItem = new PropertyItem(this, property);
+
+				categoryItem.Children.Add(propertyItem);
+			}
+		}
+
+		Dictionary<string, IList<IPropertyDescriptor>> SplitIntoCategories(IEnumerable<IPropertyDescriptor> properties)
+		{
+			var categories = new Dictionary<string, IList<IPropertyDescriptor>>();
+			foreach (var prop in properties)
+			{
+				string categoryName =
+					DisplayAttributeWrapper.Get(prop)?.GetGroupName()
+					?? prop.GetCustomAttribute<CategoryAttribute>()?.Category
+					?? Application.Instance.Localize(this, "Misc");
+
+				if (!categories.TryGetValue(categoryName, out var categoryProperties))
+				{
+					categories[categoryName] = categoryProperties = new List<IPropertyDescriptor>();
+				}
+				categoryProperties.Add(prop);
+			}
+
+			return categories;
+		}
+
+		List<IPropertyDescriptor> GetTypeProperties(Type type)
+		{
+			List<IPropertyDescriptor> properties = new List<IPropertyDescriptor>();
+			foreach (var prop in EtoTypeDescriptor.GetProperties(type))
+			{
+				if (!prop.CanRead)
+					continue;
+
+				var browsable = prop.GetCustomAttribute<BrowsableAttribute>();
+				if (browsable?.Browsable == false)
+					continue;
+
+				properties.Add(prop);
+			}
+			return properties;
+		}
+
+		IEnumerable<IPropertyDescriptor> GetCommonProperties()
+		{
+			if (_selectedObjects == null)
+				return Enumerable.Empty<IPropertyDescriptor>();
+			List<IPropertyDescriptor> properties = null;
+			var types = new HashSet<Type>();
+			for (int i = 0; i < _selectedObjects.Count; i++)
+			{
+				object obj = _selectedObjects[i];
+				if (obj == null)
+					continue;
+				var type = obj.GetType();
+				if (types.Contains(type))
+					continue;
+				types.Add(type);
+				var currentProperties = GetTypeProperties(type);
+
+				if (properties == null)
+					properties = currentProperties;
+				else
+				{
+					for (int j = properties.Count - 1; j >= 0; j--)
+					{
+						var prop = properties[j];
+
+						var currentProp = currentProperties.FirstOrDefault(r => r.Name == prop.Name);
+						if (currentProp == null || currentProp.PropertyType != prop.PropertyType)
+							properties.RemoveAt(j);
+					}
+				}
+			}
+			return properties ?? Enumerable.Empty<IPropertyDescriptor>();
+		}
+
+		object IValueTypeWrapperHost.GetValue(object key)
+		{
+			return _selectedObjects[(int)key];
+		}
+
+		void IValueTypeWrapperHost.SetValue(object key, object value)
+		{
+			_selectedObjects[(int)key] = value;
+		}
+	}
+}

--- a/src/Eto/PropertyDescriptorHelpers.cs
+++ b/src/Eto/PropertyDescriptorHelpers.cs
@@ -1,0 +1,171 @@
+using System;
+using System.Reflection;
+using sc = System.ComponentModel;
+using System.ComponentModel;
+using System.Collections;
+using System.Linq;
+using System.Collections.Generic;
+
+namespace Eto
+{
+	// generic property descriptor wrapper needed to support using PropertyDescriptor in .NET Standard 1.0
+	// Can be removed after .NET Standard 1.0 support is dropped.
+	interface IPropertyDescriptor
+	{
+		Type ComponentType { get; }
+		object GetValue(object obj);
+		void SetValue(object obj, object value);
+		Type PropertyType { get; }
+		string Name { get; }
+		string DisplayName { get; }
+		bool IsReadOnly { get; }
+		bool CanRead { get; }
+		bool IsBrowsable { get; }
+		sc.TypeConverter Converter { get; }
+		Attribute GetCustomAttribute(Type attributeType);
+		T GetCustomAttribute<T>() where T : Attribute;
+	}
+
+	class PropertyInfoDescriptor : IPropertyDescriptor
+	{
+		PropertyInfo _property;
+
+		public Type ComponentType => _property.DeclaringType;
+
+		public Type PropertyType => _property.PropertyType;
+
+		public string Name => _property.Name;
+
+		public string DisplayName => _property.Name;
+
+		public bool IsReadOnly => !_property.CanWrite || _property.SetMethod?.IsPrivate == true;
+
+		public bool IsBrowsable => _property.GetCustomAttribute<BrowsableAttribute>()?.Browsable != false;
+
+		public sc.TypeConverter Converter => sc.TypeDescriptor.GetConverter(PropertyType);
+
+		public bool CanRead => _property.CanRead && _property.GetMethod?.IsPublic == true;
+
+		public PropertyInfoDescriptor(PropertyInfo property)
+		{
+			_property = property;
+		}
+
+		public T GetCustomAttribute<T>()
+			where T : System.Attribute
+		{
+			return _property.GetCustomAttribute<T>();
+		}
+
+		public Attribute GetCustomAttribute(Type attributeType)
+		{
+			return _property.GetCustomAttribute(attributeType);
+		}
+
+		public object GetValue(object obj) => _property.GetValue(obj);
+
+		public void SetValue(object obj, object value) => _property.SetValue(obj, value);
+	}
+
+#if NETSTANDARD1_0
+	class PropertyDescriptorDescriptor : IPropertyDescriptor
+	{
+		object _propertyDescriptor;
+		static Type s_PropertyDescriptorType =
+			Type.GetType("System.ComponentModel.PropertyDescriptor, System")
+			?? Type.GetType("System.ComponentModel.PropertyDescriptor, System.ComponentModel.TypeConverter")
+			?? Type.GetType("System.ComponentModel.PropertyDescriptor, netstandard");
+
+		static PropertyInfo s_ComponentTypeProperty = s_PropertyDescriptorType?.GetRuntimeProperty("ComponentType");
+		static PropertyInfo s_PropertyTypeProperty = s_PropertyDescriptorType?.GetRuntimeProperty("PropertyType");
+		static PropertyInfo s_NameProperty = s_PropertyDescriptorType?.GetRuntimeProperty("Name");
+		static PropertyInfo s_DisplayNameProperty = s_PropertyDescriptorType?.GetRuntimeProperty("DisplayName");
+		static PropertyInfo s_ReadOnlyProperty = s_PropertyDescriptorType?.GetRuntimeProperty("IsReadOnly");
+		static PropertyInfo s_IsBrowsableProperty = s_PropertyDescriptorType?.GetRuntimeProperty("IsBrowsable");
+		static PropertyInfo s_ConverterProperty = s_PropertyDescriptorType?.GetRuntimeProperty("Converter");
+		static MethodInfo s_GetValueMethod = s_PropertyDescriptorType?.GetRuntimeMethod("GetValue", new Type[] { typeof(object) });
+		static MethodInfo s_SetValueMethod = s_PropertyDescriptorType?.GetRuntimeMethod("SetValue", new Type[] { typeof(object), typeof(object) });
+		static PropertyInfo s_AttributesProperty = s_PropertyDescriptorType?.GetRuntimeProperty("Attributes");
+
+		public static bool IsSupported => s_PropertyDescriptorType != null;
+
+		public static PropertyDescriptorDescriptor Get(object obj)
+		{
+			if (!IsSupported)
+				return null;
+			return new PropertyDescriptorDescriptor(obj);
+		}
+
+		public PropertyDescriptorDescriptor(object descriptor)
+		{
+			_propertyDescriptor = descriptor;
+		}
+
+		public Type ComponentType => s_ComponentTypeProperty?.GetValue(_propertyDescriptor) as Type;
+
+		public Type PropertyType => s_PropertyTypeProperty?.GetValue(_propertyDescriptor) as Type;
+
+		public string Name => s_NameProperty?.GetValue(_propertyDescriptor) as string;
+
+		public string DisplayName => s_DisplayNameProperty?.GetValue(_propertyDescriptor) as string;
+
+		public bool IsReadOnly => Equals(s_ReadOnlyProperty?.GetValue(_propertyDescriptor), true);
+
+		public bool CanRead => true;
+
+		public bool IsBrowsable => Equals(s_IsBrowsableProperty?.GetValue(_propertyDescriptor), true);
+
+		public sc.TypeConverter Converter => s_ConverterProperty?.GetValue(_propertyDescriptor) as sc.TypeConverter;
+
+		public object GetValue(object obj) => s_GetValueMethod?.Invoke(_propertyDescriptor, new object[] { obj });
+
+		public void SetValue(object obj, object value) => s_SetValueMethod?.Invoke(_propertyDescriptor, new object[] { obj, value });
+
+		ICollection Attributes
+		{
+			get => s_AttributesProperty?.GetValue(_propertyDescriptor) as ICollection;
+		}
+
+		public Attribute GetCustomAttribute(Type attributeType)
+		{
+			return Attributes.OfType<Attribute>().FirstOrDefault(r => r.GetType() == attributeType);
+		}
+
+		public T GetCustomAttribute<T>() where T : Attribute
+		{
+			return Attributes.OfType<T>().FirstOrDefault();
+		}
+	}
+#else
+	TODO: implement .net standard 2.0 property descriptor
+#endif
+	static class EtoTypeDescriptor
+	{
+		public static IPropertyDescriptor Get(object obj)
+		{
+			if (obj is PropertyInfo propertyInfo)
+				return new PropertyInfoDescriptor(propertyInfo);
+			else
+				return PropertyDescriptorDescriptor.Get(obj);
+		}
+
+		static MethodInfo s_GetPropertiesMethod = typeof(sc.TypeDescriptor).GetRuntimeMethod("GetProperties", new Type[] { typeof(Type) });
+
+		public static IEnumerable<IPropertyDescriptor> GetProperties(Type type)
+		{
+			if (s_GetPropertiesMethod != null)
+				((ICollection)s_GetPropertiesMethod.Invoke(null, new object[] { type })).OfType<object>().Select(r => Get(r));
+			return type.GetRuntimeProperties().Select(r => Get(r));
+		}
+
+		public static IPropertyDescriptor GetProperty(Type type, string name)
+		{
+			foreach (var property in GetProperties(type))
+			{
+				if (property.Name == name)
+					return property;
+			}
+			return null;
+		}
+	}
+}

--- a/src/Shared/MutableCellEventArgs.cs
+++ b/src/Shared/MutableCellEventArgs.cs
@@ -6,8 +6,8 @@ namespace Eto.Shared
 {
 	public class MutableCellEventArgs : CellEventArgs
 	{
-		public MutableCellEventArgs(int row, object item, CellStates cellState)
-			: base(row, item, cellState)
+		public MutableCellEventArgs(Grid grid, Cell cell, int row, object item, CellStates cellState)
+			: base(grid, cell, row, item, cellState)
 		{
 		}
 

--- a/test/Eto.Test/Eto.Test.csproj
+++ b/test/Eto.Test/Eto.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.6</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -34,6 +34,7 @@
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Sections\Serialization\Xaml\Test.xeto" />

--- a/test/Eto.Test/Sections/Controls/PropertyGridSection.cs
+++ b/test/Eto.Test/Sections/Controls/PropertyGridSection.cs
@@ -1,0 +1,328 @@
+﻿using System;using System.Globalization;using System.ComponentModel;using System.Collections.Generic;
+#if PCLusing Eto.Drawing;using Eto.Forms;
+#elseusing System.Drawing;
+using Colors = System.Drawing.Color;
+#endifusing System.Linq;using sc = System.ComponentModel;
+using System.ComponentModel.DataAnnotations;
+
+#if PCLnamespace Eto.Test.Sections.Controls{
+	[Section("Controls", typeof(PropertyGrid))]
+	public class PropertyGridSection : Panel
+	{
+		public PropertyGridSection()
+		{
+
+			var grid = new PropertyGrid();
+			grid.SelectedObjects = new[]
+			{
+				new MyPropertyObject()
+			};
+
+
+			var showCategoriesCheckBox = new CheckBox { Text = "ShowCategories" };
+			showCategoriesCheckBox.CheckedBinding.Bind(grid, c => c.ShowCategories);
+
+			var showDescriptionCheckBox = new CheckBox { Text = "ShowDescription" };
+			showDescriptionCheckBox.CheckedBinding.Bind(grid, c => c.ShowDescription);
+
+			var layout = new DynamicLayout();
+			layout.DefaultSpacing = new Size(4, 4);
+			layout.AddSeparateRow(null, showCategoriesCheckBox, showDescriptionCheckBox, null);
+
+			layout.Add(grid, yscale: true);
+
+			Content = layout;
+		}
+	}}
+
+#endif
+namespace Eto.Test.Sections.Controls{
+
+
+
+#if PCL    public class CustomEditor : IPropertyGridEditor	{		public Control CreateControl(CellEventArgs args)		{			return new Label { Text = "Custom Editor!" };		}		public void PaintCell(CellPaintEventArgs args)		{		}	}
+#endif
+	public enum MyEnum
+	{
+		FirstEnum,
+		SecondEnum,
+		ThirdEnum
+	}
+
+	[Flags]
+	public enum MyFlagsEnum
+	{
+		None = 0,
+		FirstEnum = 1,
+		SecondEnum = 2,
+		ThirdEnum = 4
+	}
+
+	public class MyPropertyObjectConverter : sc.TypeConverter
+	{
+		public override bool CanConvertTo(sc.ITypeDescriptorContext context, Type destinationType)
+		{
+			if (destinationType == typeof(string))
+				return true;
+			return base.CanConvertTo(context, destinationType);
+		}
+
+		public override object ConvertTo(sc.ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+		{
+			if (destinationType == typeof(string) && value is MyPropertyObject obj)
+				return obj.TextProperty;
+			return base.ConvertTo(context, culture, value, destinationType);
+		}
+	}
+
+	[sc.TypeConverter(typeof(MyPropertyObjectConverter))]
+	public class MyPropertyObject
+	{
+		string _textProperty = "Hello!";
+		bool _boolProperty;
+		int[] _intArray = { 1, 2, 3 };
+
+		[Display(Name = "Display Property Name", GroupName = "Display Group", Description = "Yeppers, this is a description")]
+		public string PropertyWithDisplayAttributeThatShouldNotDisplayTheName { get; set; }
+
+		public string TextProperty
+		{
+			get => _textProperty;
+			set => _textProperty = value;
+		}
+
+		[DefaultValue(false)]
+		public bool BoolProperty
+		{
+			get => _boolProperty;
+			set => _boolProperty = value;
+		}
+
+		[Category("Objects")]
+		public MyPropertyObject ObjectProperty { get; set; }
+
+		[Category("Objects")]
+		public MyOtherObject ObjectPropertyWithValue { get; set; } = new MyOtherObject();
+
+		[Category("Objects")]
+		public MyPropertyObject ReadOnlyObjectPropertyThatsNull { get; }
+
+		[Category("Objects")]
+		public MyOtherObject ReadOnlyObjectPropertyThatsNotNull { get; } = new MyOtherObject();
+
+		[Category("Arrays")]
+		public int[] IntArray
+		{
+			get => _intArray;
+			set => _intArray = value;
+		}
+
+		[Category("Lists")]
+		public IList<int> IntArrayAsIListProperty
+		{
+			get => _intArray;
+			set => _intArray = value?.ToArray();
+		}
+
+		[Category("Lists")]
+		public List<int> ListOfInt { get; set; } = new List<int> { 1, 3, 5 };
+
+		[Category("Lists")]
+		public List<string> ListOfString { get; set; } = new List<string> { "First", "Second", "Third" };
+
+		[Category("Lists")]
+		public List<MyOtherObject> ListOfObject { get; set; } = new List<MyOtherObject>
+		{
+			new MyOtherObject { TextProperty = "Hi" },
+			new MyOtherObject { TextProperty = "There" }
+		};
+
+		[Category("Lists")]
+		public IList<int> IListOfInt { get; set; } = new List<int> { 3, 4, 5 };
+		[Category("Lists")]
+		public IList<int> IListOfIntThatsNull { get; set; }
+
+
+		[Category("Arrays")]
+		public int[][] IntIntArray { get; set; } = new int[][] { new int[] { 1, 2, 3 }, new int[] { 4, 5, 6 } };
+
+		[DefaultValue("#000000")]
+		public Color ColorProperty { get; set; } = Colors.Black;
+
+		public Color? NullableColorProperty { get; set; } = Colors.Black;
+
+		public MyEnum EnumProperty { get; set; }
+
+		public MyEnum? NullableEnumProperty { get; set; }
+
+		public MyFlagsEnum FlagsEnumProperty { get; set; }
+
+		public MyFlagsEnum? NullableFlagsEnumProperty { get; set; }
+
+		[Category("Some Category")]
+		public bool SomeOtherProperty { get; set; }
+
+		public bool? NullableBoolProperty { get; set; }
+
+		public DateTime DateTimeProperty { get; set; }
+
+		public DateTime? NullableDateTimeProperty { get; set; }
+
+		[DisplayName("Some Other Name")]
+		public string PropertyWithNameThatShouldNotBeShown { get; set; }
+
+		[Editor(typeof(CustomEditor), typeof(IPropertyGridEditor))]
+		public string PropertyWithEditor { get; set; }
+
+		[Description("This is a description.  It should be shown.")]
+		public string PropertyWithDescription { get; set; }
+
+		public bool ReadOnlyBoolean => true;
+
+		public string ReadOnlyString => "You can't edit me!";
+
+		public int ReadOnlyInt => 20;
+
+		[ReadOnly(true)]
+		public string ReadOnlyStringWithAttribute { get; set; } = "You can't edit me either!";
+
+		public Color ReadOnlyColor => Colors.Blue;
+
+		[Category("Lists")]
+		public List<MyPropertyObject> ReadOnlyObjectListThatsNull { get; }
+
+		[Category("Lists")]
+		public List<MyPropertyObject> ReadOnlyObjectListWithValue { get; } = new List<MyPropertyObject>();
+
+		[Category("Lists")]
+		public List<int> ReadOnlyIntListWithValue { get; } = new List<int> { 5, 6, 7 };
+
+		[Category("Lists")]
+		public IList<float> ReadOnlyFloatIListWithValue { get; } = new List<float> { 3, 4, 5 };
+
+		[Category("Arrays")]
+		public int[] ReadOnlyIntArray { get; } = new int[] { 10, 11, 12 };
+
+
+		[Category("Numbers")]
+		public byte ByteValue { get; set; }
+		[Category("Numbers")]
+		public short ShortValue { get; set; }
+		[Category("Numbers")]
+		public int IntValue { get; set; }
+		[Category("Numbers")]
+		public long LongValue { get; set; }
+		[Category("Numbers")]
+		public decimal DecimalValue { get; set; }
+		[Category("Numbers")]
+		public float FloatValue { get; set; }
+		[Category("Numbers")]
+		public double DoubleValue { get; set; }
+
+
+		[Category("Numbers")]
+		public byte? NullableByteValue { get; set; }
+		[Category("Numbers")]
+		public short? NullableShortValue { get; set; }
+		[Category("Numbers")]
+		public int? NullableIntValue { get; set; }
+		[Category("Numbers")]
+		public long? NullableLongValue { get; set; }
+		[Category("Numbers")]
+		public decimal? NullableDecimalValue { get; set; }
+		[Category("Numbers")]
+		public float? NullableFloatValue { get; set; }
+		[Category("Numbers")]
+		public double? NullableDoubleValue { get; set; }
+
+
+		[Category("Objects")]
+		public MyExpandableObject ExpandableObjectNull { get; set; }
+		[Category("Objects")]
+		public MyExpandableObject ExpandableObject { get; set; } = new MyExpandableObject();
+		[Category("Objects")]
+		public MyExpandableObject ReadOnlyExpandableObject { get; } = new MyExpandableObject();
+		[Category("Objects")]
+		public MyExpandableObject ReadOnlyExpandableObjectNull { get; }
+	}
+
+	class MyOtherObjectConverter : sc.TypeConverter
+	{
+		public override bool CanConvertTo(sc.ITypeDescriptorContext context, Type destinationType)
+		{
+			if (destinationType == typeof(string))
+				return true;
+			return base.CanConvertTo(context, destinationType);
+		}
+
+		public override object ConvertTo(sc.ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+		{
+			if (value is MyOtherObject otherObject && destinationType == typeof(string))
+				return otherObject.TextProperty;
+			return base.ConvertTo(context, culture, value, destinationType);
+		}
+	}
+
+	[sc.TypeConverter(typeof(MyOtherObjectConverter))]
+	public class MyOtherObject
+	{
+		string _textProperty;
+		bool _boolProperty;
+		public string TextProperty
+		{
+			get => _textProperty;
+			set => _textProperty = value;
+		}
+
+		public bool BoolProperty
+		{
+			get => _boolProperty;
+			set => _boolProperty = value;
+		}
+
+		public int[] IntArrayProperty { get; set; }
+
+		public List<int> IntListProperty { get; set; }
+	}
+
+	public class MyExpandableObjectConverter : sc.ExpandableObjectConverter
+	{
+
+		public override bool CanConvertTo(sc.ITypeDescriptorContext context, Type destinationType)
+		{
+			return false;
+			//return base.CanConvertTo(context, destinationType);
+		}
+		public override object ConvertTo(sc.ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+		{
+			return "Hello";
+			//return base.ConvertTo(context, culture, value, destinationType);
+		}
+
+		public override PropertyDescriptorCollection GetProperties(sc.ITypeDescriptorContext context, object value, Attribute[] attributes)
+		{
+			return base.GetProperties(context, value, attributes);
+		}
+	}
+
+	[sc.TypeConverter(typeof(MyExpandableObjectConverter))]
+	public class MyExpandableObject
+	{
+		string _textProperty;
+		bool _boolProperty;
+		public string TextProperty
+		{
+			get => _textProperty;
+			set => _textProperty = value;
+		}
+
+		public bool BoolProperty
+		{
+			get => _boolProperty;
+			set => _boolProperty = value;
+		}
+
+		public int[] IntArrayProperty { get; set; }
+
+		public List<int> IntListProperty { get; set; }
+	}}

--- a/test/Eto.Test/TestApplication.cs
+++ b/test/Eto.Test/TestApplication.cs
@@ -64,8 +64,8 @@ namespace Eto.Test
 			// show the main form
 			MainForm.Show();
 #if NETSTANDARD2_0
-			var elapsedTime = DateTime.UtcNow - Process.GetCurrentProcess().StartTime.ToUniversalTime();
-			Log.Write(this, $"Startup time: {elapsedTime}");
+//			var elapsedTime = DateTime.UtcNow - Process.GetCurrentProcess().StartTime.ToUniversalTime();
+	//		Log.Write(this, $"Startup time: {elapsedTime}");
 #endif
 		}
 

--- a/test/Eto.Test/UnitTests/Forms/ContainerTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ContainerTests.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Eto.Drawing;
 using Eto.Forms;
 using NUnit.Framework;
+using Container = Eto.Forms.Container;
 
 namespace Eto.Test.UnitTests.Forms
 {

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -17,6 +17,7 @@ using System.ComponentModel;
 using NUnit.Framework.Interfaces;
 using NUnit.Framework.Internal.Commands;
 using NUnit.Framework.Internal;
+using Container = Eto.Forms.Container;
 
 namespace Eto.Test.UnitTests
 {


### PR DESCRIPTION
- Upgrade Eto.Test to netstandard 2.0 assembly
- Uses a TreeGridView/PropertyCell for the default implementation.
- NumericMaskedTextProvider no longer crashes with a nullable float or double
- Added TableRow.Scaled() static method to more succinctly make a row with scaled height.
- Added DataObject.GetObject/SetObject that can be used with serializable .NET objects.
- Fixed applying styles to children when a new cascading style is added
- Added new PropertyCellTypeNumber and non-generic PropertyCellTypeEnum that works for any enum type
- Fix issue with PropertyBinding if the property was not found but the new class is a subclass of the last checked type
- IndirectBinding.Cast() should not crash with value types if the source value is null but rather return the default value.
- Fix CustomCell drawing with Gtk & Gtk3 platforms.