### PR TITLE
Mac: Add constructor to EtoButton that takes handle

### DIFF
--- a/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
@@ -75,7 +75,11 @@ namespace Eto.Mac.Forms.Controls
 
 		public EtoButtonCell()
 		{
-			ImageScale = NSImageScale.ProportionallyDown;//.ProportionallyUpOrDown;
+			ImageScale = NSImageScale.ProportionallyDown;
+		}
+
+		public EtoButtonCell(IntPtr handle) : base(handle)
+		{
 		}
 	}
 
@@ -135,6 +139,10 @@ namespace Eto.Mac.Forms.Controls
 				Application.Instance.AsyncInvoke(() => h.InvalidateMeasure());
 
 			h.TriggerSizeChanged();
+		}
+
+		public EtoButton(IntPtr handle) : base(handle)
+		{
 		}
 
 		public EtoButton() : this(NSButtonType.MomentaryPushIn)


### PR DESCRIPTION
This can prevent exceptions when the button is already GC’d but is needed for some window delegate that may happen after the window is closed.  This theoretically shouldn't happen on Xamarin.Mac as (I believe) it uses refcounting to clean up objects, but in some cases it still does.