### PR TITLE
Wpf: Create a copy of the attributes when applying

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/RichTextAreaHandler.cs
@@ -203,10 +203,12 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			if (attributes == null)
 				return;
-			foreach (var attribute in attributes)
+			Control.BeginChange();
+			foreach (var attribute in attributes.ToList())
 			{
 				range.ApplyPropertyValue(attribute.Key, attribute.Value);
 			}
+			Control.EndChange();
 		}
 
 		protected override void Dispose(bool disposing)


### PR DESCRIPTION
Applying the attributes can raise other events which could in turn change the source attribute list.  Also wrap in a Begin/End change so they are grouped together into one change set if there are more than one attribute to apply.