### PR TITLE
Wpf: Fix crash when using a TableLayout in a CustomCell

### DIFF
--- a/src/Eto.Wpf/Forms/TableLayoutHandler.cs
+++ b/src/Eto.Wpf/Forms/TableLayoutHandler.cs
@@ -226,7 +226,7 @@ namespace Eto.Wpf.Forms
 					}
 				}
 			}
-			Control.UpdateLayout();
+			Control.InvalidateMeasure();
 		}
 
 		void SetChildrenSizes(bool force)


### PR DESCRIPTION
- When using a CustomCell and the selected state changes, it can cause an UpdateLayout() call which crashes the GridView as it tries to update all rows while it's refreshing the data.
- Added test for the crash