### PR TITLE
[Gtk] Always use headerbars

### DIFF
--- a/src/Eto.Gtk/Forms/ApplicationHandler.cs
+++ b/src/Eto.Gtk/Forms/ApplicationHandler.cs
@@ -37,7 +37,7 @@ namespace Eto.GtkSharp.Forms
 #if GTKCORE
 			Control = new Gtk.Application(null, GLib.ApplicationFlags.None);
 			Control.Register(GLib.Cancellable.Current);
-			Helper.UseHeaderBar = Control.PrefersAppMenu();
+			Helper.UseHeaderBar = true;
 #else
 			Helper.UseHeaderBar = false;
 #endif


### PR DESCRIPTION
TLDR. AppMenu has been deprecated, and Gtk 3 apps should by general use Headerbars.

On a related note, I'll look into making toolbar be a headerbar for Gtk 3 apps.