### PR TITLE
Mac: Don't use NSApplication.SharedApplication.Windows

### DIFF
--- a/src/Eto.Mac/Messaging.cs
+++ b/src/Eto.Mac/Messaging.cs
@@ -104,6 +104,12 @@ namespace Eto.Mac
 		public static extern IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector);
 
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		public static extern IntPtr IntPtr_objc_msgSend_nuint(IntPtr receiver, IntPtr selector, nuint arg1);
+
+		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		public static extern nuint nuint_objc_msgSend(IntPtr receiver, IntPtr selector);
+
+		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
 		public static extern void RectangleF_objc_msgSend_stret(out CGRect rect, IntPtr receiver, IntPtr selector);
 
 		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend_stret")]


### PR DESCRIPTION
- Latest Xamarin.Mac deprecates it so we use handles to avoid creating associated .NET objects.
- Only set last visible window as key, since windows could still be in the list even though they are closed
- Order back after finding new key window so it is ordered correctly