### PR TITLE
Mac: Fix a few UI glitches

### DIFF
--- a/src/Eto.Mac/Forms/Controls/MacLabel.cs
+++ b/src/Eto.Mac/Forms/Controls/MacLabel.cs
@@ -83,6 +83,7 @@ namespace Eto.Mac.Forms.Controls
 				var lineHeight = CellSizeForBounds(theRect).Height;
 				offset = (nfloat)Math.Round(theRect.Height - lineHeight);
 			}
+			offset = (nfloat)Math.Max(0, offset);
 			rect.Y += offset;
 			rect.Height -= offset;
 			return rect;
@@ -128,8 +129,6 @@ namespace Eto.Mac.Forms.Controls
 		public static readonly object FontKey = new object();
 
 		public static readonly object TextColorKey = new object();
-
-		public static readonly bool SupportsSingleLine = ObjCExtensions.ClassInstancesRespondToSelector(Class.GetHandle("NSTextFieldCell"), Selector.GetHandle("setUsesSingleLineMode:"));
 	}
 
 	public abstract class MacLabel<TControl, TWidget, TCallback> : MacView<TControl, TWidget, TCallback>
@@ -210,9 +209,6 @@ namespace Eto.Mac.Forms.Controls
 
 		protected override void Initialize()
 		{
-			if (MacLabel.SupportsSingleLine)
-				Control.Cell.UsesSingleLineMode = false;
-
 			base.Initialize();
 			HandleEvent(Eto.Forms.Control.SizeChangedEvent);
 		}
@@ -248,7 +244,7 @@ namespace Eto.Mac.Forms.Controls
 		{
 			get
 			{
-				if (MacLabel.SupportsSingleLine && Control.Cell.UsesSingleLineMode)
+				if (paragraphStyle.LineBreakMode == NSLineBreakMode.Clipping)
 					return WrapMode.None;
 				if (paragraphStyle.LineBreakMode == NSLineBreakMode.ByWordWrapping)
 					return WrapMode.Word;
@@ -259,18 +255,12 @@ namespace Eto.Mac.Forms.Controls
 				switch (value)
 				{
 					case WrapMode.None:
-						if (MacLabel.SupportsSingleLine)
-							Control.Cell.UsesSingleLineMode = true;
 						paragraphStyle.LineBreakMode = NSLineBreakMode.Clipping;
 						break;
 					case WrapMode.Word:
-						if (MacLabel.SupportsSingleLine)
-							Control.Cell.UsesSingleLineMode = false;
 						paragraphStyle.LineBreakMode = NSLineBreakMode.ByWordWrapping;
 						break;
 					case WrapMode.Character:
-						if (MacLabel.SupportsSingleLine)
-							Control.Cell.UsesSingleLineMode = false;
 						paragraphStyle.LineBreakMode = NSLineBreakMode.CharWrapping;
 						break;
 					default:

--- a/src/Eto.Mac/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/RadioButtonHandler.cs
@@ -70,6 +70,27 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
+		public class EtoRadioCenteredButtonCell : EtoCenteredButtonCell
+		{
+			// radio buttons get clipped at the top in small/mini mode using the alignment rects. macOS 10.14.6
+			// see Eto.Test.Mac.UnitTests.RadioButtonTests.ButtonShouldNotBeClipped()
+			protected override nfloat Offset => ControlSize != NSControlSize.Regular ? 0.5f : 0;
+
+			protected override nfloat GetDefaultHeight()
+			{
+				switch (ControlSize)
+				{
+					default:
+					case NSControlSize.Regular:
+						return 14;
+					case NSControlSize.Small:
+						return 12;
+					case NSControlSize.Mini:
+						return 10;
+				}
+			}
+		}
+
 		public class EtoRadioButton : NSButton, IMacControl
 		{
 			public WeakReference WeakHandler { get; set; }
@@ -88,11 +109,9 @@ namespace Eto.Mac.Forms.Controls
 				defaultHeight = b.Frame.Height;
 			}
 
-			static readonly Selector s_selClicked = new Selector("clicked");
-
 			public EtoRadioButton()
 			{
-				Cell = new EtoCenteredButton(defaultHeight);
+				Cell = new EtoRadioCenteredButtonCell();
 				Title = string.Empty;
 				SetButtonType(NSButtonType.Radio);
 			}

--- a/src/Eto.Mac/Forms/MacPanel.cs
+++ b/src/Eto.Mac/Forms/MacPanel.cs
@@ -162,7 +162,7 @@ namespace Eto.Mac.Forms
 		{
 			var contentControl = content.GetMacControl();
 			if (contentControl != null && content.Visible)
-				return contentControl.GetPreferredSize(availableSize - Padding.Size) + Padding.Size;
+				return contentControl.GetPreferredSize(SizeF.Max(SizeF.Empty, availableSize - Padding.Size)) + Padding.Size;
 			
 			return Padding.Size;
 		}

--- a/test/Eto.Test.Mac/Eto.Test.XamMac.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac.csproj
@@ -147,6 +147,7 @@
     <Compile Include="UnitTests\RadioButtonTests.cs" />
     <Compile Include="UnitTests\RichTextAreaHandlerTests.cs" />
     <Compile Include="UnitTests\ScrollableTests.cs" />
+    <Compile Include="UnitTests\LabelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/test/Eto.Test.Mac/Eto.Test.XamMac.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac.csproj
@@ -137,10 +137,16 @@
     <Reference Include="nunit.framework">
       <HintPath>..\..\artifacts\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
+    <Reference Include="System.Drawing" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Startup.cs" />
+    <Compile Include="UnitTests\ButtonTests.cs" />
+    <Compile Include="UnitTests\CheckBoxTests.cs" />
+    <Compile Include="UnitTests\NativeParentWindowTests.cs" />
+    <Compile Include="UnitTests\RadioButtonTests.cs" />
     <Compile Include="UnitTests\RichTextAreaHandlerTests.cs" />
+    <Compile Include="UnitTests\ScrollableTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2-modern.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2-modern.csproj
@@ -68,6 +68,7 @@
     <Compile Include="UnitTests\NativeParentWindowTests.cs" />
     <Compile Include="UnitTests\RadioButtonTests.cs" />
     <Compile Include="UnitTests\ScrollableTests.cs" />
+    <Compile Include="UnitTests\LabelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2-modern.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2-modern.csproj
@@ -63,6 +63,11 @@
   <ItemGroup>
     <Compile Include="Startup.cs" />
     <Compile Include="UnitTests\RichTextAreaHandlerTests.cs" />
+    <Compile Include="UnitTests\ButtonTests.cs" />
+    <Compile Include="UnitTests\CheckBoxTests.cs" />
+    <Compile Include="UnitTests\NativeParentWindowTests.cs" />
+    <Compile Include="UnitTests\RadioButtonTests.cs" />
+    <Compile Include="UnitTests\ScrollableTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2-net461.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2-net461.csproj
@@ -64,6 +64,8 @@
     <Compile Include="Startup.cs" />
     <Compile Include="UnitTests\RichTextAreaHandlerTests.cs" />
     <Compile Include="UnitTests\NativeParentWindowTests.cs" />
+    <Compile Include="UnitTests\RadioButtonTests.cs" />
+    <Compile Include="UnitTests\CheckBoxTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2-net461.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2-net461.csproj
@@ -66,6 +66,7 @@
     <Compile Include="UnitTests\NativeParentWindowTests.cs" />
     <Compile Include="UnitTests\RadioButtonTests.cs" />
     <Compile Include="UnitTests\CheckBoxTests.cs" />
+    <Compile Include="UnitTests\LabelTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Info.plist" />

--- a/test/Eto.Test.Mac/UnitTests/CheckBoxTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/CheckBoxTests.cs
@@ -1,0 +1,57 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+using Eto.Mac.Forms.Controls;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+#if XAMMAC2
+using AppKit;
+using CoreGraphics;
+#else
+using MonoMac.AppKit;
+using MonoMac.CoreGraphics;
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
+#endif
+
+namespace Eto.Test.Mac.UnitTests
+{
+	[TestFixture]
+	public class CheckBoxTests : TestBase
+	{
+		[Test, ManualTest]
+		public void ButtonShouldNotBeClipped()
+		{
+			ManualForm("All buttons should be fully visible without any clipping", form =>
+			{
+				form.Styles.Add<CheckBoxHandler>("small", c =>
+				{
+					c.Control.Cell.ControlSize = NSControlSize.Small;
+					c.Control.Font = NSFont.SystemFontOfSize(NSFont.SystemFontSizeForControlSize(NSControlSize.Small));
+				});
+				form.Styles.Add<CheckBoxHandler>("mini", c =>
+				{
+					c.Control.Cell.ControlSize = NSControlSize.Mini;
+					c.Control.Font = NSFont.SystemFontOfSize(NSFont.SystemFontSizeForControlSize(NSControlSize.Mini));
+				});
+
+				return new TableLayout
+				{
+					Rows =
+					{
+						new Panel { Height = 10, BackgroundColor = Colors.White },
+						new TableLayout(new TableRow(null, new CheckBox { Text = "Normal" }, null)),
+						new Panel { Height = 10, BackgroundColor = Colors.White },
+						new TableLayout(new TableRow(null, new CheckBox { Text = "Small", Style = "small" }, null)),
+						new Panel { Height = 10, BackgroundColor = Colors.White },
+						new TableLayout(new TableRow(null, new CheckBox { Text = "Mini", Style = "mini" }, null)),
+						new Panel { Height = 10, BackgroundColor = Colors.White },
+					}
+				};
+			});
+		}
+	}
+}

--- a/test/Eto.Test.Mac/UnitTests/LabelTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/LabelTests.cs
@@ -1,0 +1,33 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+
+namespace Eto.Test.Mac.UnitTests
+{
+	[TestFixture]
+	public class LabelTests : TestBase
+	{
+		[Test, ManualTest]
+		public void LabelWithDifferentFontSizesShouldShowCorrectly()
+		{
+			ManualForm("Labels should show correctly.", form =>
+			{
+				return new TableLayout
+				{
+					Rows =
+					{
+						new Panel {BackgroundColor = Colors.White, Height = 10},
+						new TableLayout(new Label { Text = "Small Font", Wrap = WrapMode.None, Font = SystemFonts.Default(8) }),
+						new Panel {BackgroundColor = Colors.White, Height = 10},
+						new TableLayout(new Label { Text = "Normal Font", Wrap = WrapMode.None }),
+						new Panel {BackgroundColor = Colors.White, Height = 10},
+						new TableLayout(new Label { Text = "Large Font", Wrap = WrapMode.None, Font = SystemFonts.Default(48) }),
+						new Panel {BackgroundColor = Colors.White, Height = 10},
+					}
+				};
+			});
+		}
+	}
+}

--- a/test/Eto.Test.Mac/UnitTests/NativeParentWindowTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/NativeParentWindowTests.cs
@@ -10,6 +10,11 @@ using CoreGraphics;
 #else
 using MonoMac.AppKit;
 using MonoMac.CoreGraphics;
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
 #endif
 
 namespace Eto.Test.Mac.UnitTests

--- a/test/Eto.Test.Mac/UnitTests/RadioButtonTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/RadioButtonTests.cs
@@ -1,0 +1,57 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+using Eto.Mac.Forms.Controls;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+#if XAMMAC2
+using AppKit;
+using CoreGraphics;
+#else
+using MonoMac.AppKit;
+using MonoMac.CoreGraphics;
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
+#endif
+
+namespace Eto.Test.Mac.UnitTests
+{
+	[TestFixture]
+	public class RadioButtonTests : TestBase
+	{
+		[Test, ManualTest]
+		public void ButtonShouldNotBeClipped()
+		{
+			ManualForm("All buttons should be fully visible without any clipping", form =>
+			{
+				form.Styles.Add<RadioButtonHandler>("small", c =>
+				{
+					c.Control.Cell.ControlSize = NSControlSize.Small;
+					c.Control.Font = NSFont.SystemFontOfSize(NSFont.SystemFontSizeForControlSize(NSControlSize.Small));
+				});
+				form.Styles.Add<RadioButtonHandler>("mini", c =>
+				{
+					c.Control.Cell.ControlSize = NSControlSize.Mini;
+					c.Control.Font = NSFont.SystemFontOfSize(NSFont.SystemFontSizeForControlSize(NSControlSize.Mini));
+				});
+
+				return new TableLayout
+				{
+					Rows =
+					{
+						new Panel { Height = 10, BackgroundColor = Colors.White },
+						new TableLayout(new TableRow(null, new RadioButton { Text = "Normal" }, null)),
+						new Panel { Height = 10, BackgroundColor = Colors.White },
+						new TableLayout(new TableRow(null, new RadioButton { Text = "Small", Style = "small" }, null)),
+						new Panel { Height = 10, BackgroundColor = Colors.White },
+						new TableLayout(new TableRow(null, new RadioButton { Text = "Mini", Style = "mini" }, null)),
+						new Panel { Height = 10, BackgroundColor = Colors.White },
+					}
+				};
+			});
+		}
+	}
+}


### PR DESCRIPTION
- Non-wrapping labels set to a different system font size would have their text offset to a fixed base offset instead of showing the label completely.
- RadioButton and CheckBox controls would sometimes get clipped as the alignment rectangle doesn't exactly encompass the control.