### PR TITLE
Mac: Fix mouse down/up events with TextBox

### DIFF
--- a/src/Eto.Mac/Forms/MacFieldEditor.cs
+++ b/src/Eto.Mac/Forms/MacFieldEditor.cs
@@ -60,6 +60,80 @@ namespace Eto.Mac.Forms
 			base.KeyDown(theEvent);
 		}
 
+		public override void FlagsChanged(NSEvent theEvent)
+		{
+			var handler = Handler as IMacViewHandler;
+			if (handler != null && MacEventView.FlagsChanged(handler.Widget, theEvent))
+				return;
+
+			base.FlagsChanged(theEvent);
+		}
+
+		bool MouseDownEvent(NSEvent theEvent)
+		{
+			var handler = Handler as IMacViewHandler;
+			if (handler == null)
+				return false;
+
+			var args = MacConversions.GetMouseEvent(handler, theEvent, false);
+			if (theEvent.ClickCount >= 2)
+				handler.Callback.OnMouseDoubleClick(handler.Widget, args);
+
+			if (!args.Handled)
+			{
+				handler.Callback.OnMouseDown(handler.Widget, args);
+			}
+
+			return args.Handled;
+		}
+
+		bool MouseUpEvent(NSEvent theEvent)
+		{
+			var handler = Handler as IMacViewHandler;
+			if (handler == null)
+				return false;
+
+			var args = MacConversions.GetMouseEvent(handler, theEvent, false);
+			handler.Callback.OnMouseUp(handler.Widget, args);
+			return args.Handled;
+		}
+
+		public override void MouseDown(NSEvent theEvent)
+		{
+			if (!MouseDownEvent(theEvent))
+				base.MouseDown(theEvent);
+		}
+
+		public override void MouseUp(NSEvent theEvent)
+		{
+			if (!MouseUpEvent(theEvent))
+				base.MouseUp(theEvent);
+		}
+
+		public override void RightMouseDown(NSEvent theEvent)
+		{
+			if (!MouseDownEvent(theEvent))
+				base.RightMouseDown(theEvent);
+		}
+
+		public override void RightMouseUp(NSEvent theEvent)
+		{
+			if (!MouseUpEvent(theEvent))
+				base.RightMouseUp(theEvent);
+		}
+
+		public override void OtherMouseDown(NSEvent theEvent)
+		{
+			if (!MouseDownEvent(theEvent))
+				base.OtherMouseDown(theEvent);
+		}
+
+		public override void OtherMouseUp(NSEvent theEvent)
+		{
+			if (!MouseUpEvent(theEvent))
+				base.OtherMouseUp(theEvent);
+		}
+
 		public override bool ShouldChangeText(NSRange affectedCharRange, string replacementString)
 		{
 			var handler = Handler as IMacTextBoxHandler;

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -123,6 +123,9 @@ namespace Eto.Mac.Forms
 		public static readonly IntPtr selRightMouseDown = Selector.GetHandle("rightMouseDown:");
 		public static readonly IntPtr selRightMouseUp = Selector.GetHandle("rightMouseUp:");
 		public static readonly IntPtr selRightMouseDragged = Selector.GetHandle("rightMouseDragged:");
+		public static readonly IntPtr selOtherMouseDown = Selector.GetHandle("otherMouseDown:");
+		public static readonly IntPtr selOtherMouseUp = Selector.GetHandle("otherMouseUp:");
+		public static readonly IntPtr selOtherMouseDragged = Selector.GetHandle("otherMouseDragged:");
 		public static readonly IntPtr selScrollWheel = Selector.GetHandle("scrollWheel:");
 		public static readonly IntPtr selFlagsChanged = Selector.GetHandle("flagsChanged:");
 		public static readonly IntPtr selKeyDown = Selector.GetHandle("keyDown:");
@@ -403,6 +406,7 @@ namespace Eto.Mac.Forms
 					CreateTracking();
 					AddMethod(MacView.selMouseDragged, new Action<IntPtr, IntPtr, IntPtr>(TriggerMouseDragged), "v@:@");
 					AddMethod(MacView.selRightMouseDragged, new Action<IntPtr, IntPtr, IntPtr>(TriggerMouseDragged), "v@:@");
+					AddMethod(MacView.selOtherMouseDragged, new Action<IntPtr, IntPtr, IntPtr>(TriggerMouseDragged), "v@:@");
 					break;
 				case Eto.Forms.Control.SizeChangedEvent:
 					AddMethod(MacView.selSetFrameSize, new Action<IntPtr, IntPtr, CGSize>(SetFrameSizeAction), EtoEnvironment.Is64BitProcess ? "v@:{CGSize=dd}" : "v@:{CGSize=ff}", ContainerControl);
@@ -410,10 +414,12 @@ namespace Eto.Mac.Forms
 				case Eto.Forms.Control.MouseDownEvent:
 					AddMethod(MacView.selMouseDown, new Action<IntPtr, IntPtr, IntPtr>(TriggerMouseDown), "v@:@");
 					AddMethod(MacView.selRightMouseDown, new Action<IntPtr, IntPtr, IntPtr>(TriggerMouseDown), "v@:@");
+					AddMethod(MacView.selOtherMouseDown, new Action<IntPtr, IntPtr, IntPtr>(TriggerMouseDown), "v@:@");
 					break;
 				case Eto.Forms.Control.MouseUpEvent:
 					AddMethod(MacView.selMouseUp, new Action<IntPtr, IntPtr, IntPtr>(TriggerMouseUp), "v@:@");
 					AddMethod(MacView.selRightMouseUp, new Action<IntPtr, IntPtr, IntPtr>(TriggerMouseUp), "v@:@");
+					AddMethod(MacView.selOtherMouseUp, new Action<IntPtr, IntPtr, IntPtr>(TriggerMouseUp), "v@:@");
 					break;
 				case Eto.Forms.Control.MouseDoubleClickEvent:
 					HandleEvent(Eto.Forms.Control.MouseDownEvent);
@@ -676,8 +682,6 @@ namespace Eto.Mac.Forms
 				Callback.OnMouseMove(Widget, MacConversions.GetMouseEvent(this, evt, false));
 			}
 		}
-
-
 
 		static void TriggerMouseUp(IntPtr sender, IntPtr sel, IntPtr e)
 		{

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -255,7 +255,19 @@ namespace Eto.Mac
 				case NSEventType.OtherMouseUp:
 				case NSEventType.OtherMouseDown:
 				case NSEventType.OtherMouseDragged:
-					buttons |= MouseButtons.Middle;
+					var buttonNumber = (int)theEvent.ButtonNumber;
+                    switch (buttonNumber)
+                    {
+						case 0:
+							buttons |= MouseButtons.Primary;
+							break;
+						case 1:
+							buttons |= MouseButtons.Alternate;
+							break;
+						case 2:
+							buttons |= MouseButtons.Middle;
+							break;
+					}
 					break;
 			}
 			return buttons;


### PR DESCRIPTION
- Also handle OtherMouse* methods to enable middle button presses or primary/alternate mouse events from a tablet.