### PR TITLE
Wpf: fix issue with label in some cases

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/LabelHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using Eto.Drawing;
 using swc = System.Windows.Controls;
@@ -29,7 +29,7 @@ namespace Eto.Wpf.Forms.Controls
 	public class LabelHandler : WpfControl<swc.Label, Label, Label.ICallback>, Label.IHandler
 	{
 		readonly swc.AccessText accessText;
-		sw.Size? previousRenderSize;
+		int? previousWidth;
 		string text;
 
 		protected override void SetDecorations(sw.TextDecorationCollection decorations)
@@ -52,21 +52,28 @@ namespace Eto.Wpf.Forms.Controls
 
 		void Control_SizeChanged(object sender, sw.SizeChangedEventArgs e)
 		{
-			if (previousRenderSize == null)
+			// not loaded? don't worry about it.
+			if (!Control.IsLoaded)
+				return;
+			// convert to int as in some scales (e.g. 150%) it can cause an endless update cycle
+			var newWidth = (int)Control.ActualWidth;
+			if (previousWidth == null)
 			{
 				// don't update preferred sizes when called the first time.
 				// when there's many labels this causes a major slowdown
 				// the initial size should already have been taken care of by 
 				// the initial layout pass.
-				previousRenderSize = Control.RenderSize;
+				previousWidth = newWidth;
 				return;
 			}
 
-			if (previousRenderSize == Control.RenderSize)
+			if (previousWidth == newWidth)
 				return;
-			// update parents only when the render size has changed
-			previousRenderSize = Control.RenderSize;
-            if (Wrap != WrapMode.None)
+			// update parents when the actual width has changed
+			// otherwise it won't shrink vertically when it gets wider
+			// when wrapped
+			previousWidth = newWidth;
+			if (Wrap != WrapMode.None)
                 UpdatePreferredSize();
 		}
 

--- a/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
+++ b/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
@@ -55,6 +55,7 @@
   <ItemGroup>
     <Compile Include="Startup.cs" />
     <Compile Include="UnitTests\DataContextTests.cs" />
+    <Compile Include="UnitTests\LabelTests.cs" />
     <Compile Include="UnitTests\MenuBarTests.cs" />
     <Compile Include="UnitTests\NativeParentWindowTests.cs" />
     <Compile Include="UnitTests\ScreenTests.cs" />

--- a/test/Eto.Test.Wpf/UnitTests/LabelTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/LabelTests.cs
@@ -1,0 +1,41 @@
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Eto.Forms;
+using Eto.Drawing;
+
+namespace Eto.Test.Wpf.UnitTests
+{
+	[TestFixture]
+	public class LabelTests : TestBase
+	{
+		[ManualTest, Test]
+		public void LabelShouldNotConstantlyInvalidateMeasure()
+		{
+			ManualForm("Set screen resolution to 150% and ensure it doesn't constantly use CPU", form =>
+			{
+				return new Panel
+				{
+					Content = new Scrollable
+					{
+						Border = BorderType.None,
+						Content = new TableLayout
+						{
+							Spacing = new Size(5, 5),
+							Rows =
+							{
+							  new TableRow("A", new Label { Text = "Increment:" }),
+							  new TableRow("B", new TextStepper { Width = 70 }, null),
+							  null
+							}
+						}
+					}
+				};
+			});
+		}
+	}
+}


### PR DESCRIPTION
- In some scales (e.g. 150%) a wrapped label can cause an endless layout update as the width would differ minutely between layout passes.  To fix this, we compare a truncated value and only worry about if the width changes.
- Also added an optimization so that it doesn't bother updating the preferred size if the label isn't loaded yet