### PR TITLE
Mac: Make a resizable borderless window movable

### DIFF
--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -354,7 +354,7 @@ namespace Eto.Mac
 
 		public static WindowStyle ToEtoWindowStyle(this NSWindowStyle style)
 		{
-			return style.HasFlag(NSWindowStyle.Borderless) ? WindowStyle.None : WindowStyle.Default;
+			return style.HasFlag(NSWindowStyle.Titled) ? WindowStyle.Default : WindowStyle.None;
 		}
 
 		public static NSWindowStyle ToNS(this WindowStyle style, NSWindowStyle existing)


### PR DESCRIPTION
- By default, you can now drag the background of the window to move it when a borderless window is resizable.
- Adjust via a native style setting `MovableByWindowBackground` on the FormHandler or DialogHandler to the desired value.

Since you can resize the window, allowing it to move only makes sense and brings it in line with how it works on WPF.