### PR TITLE
Separate Control.Width/Height properties.

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
@@ -29,7 +29,6 @@ namespace Eto.GtkSharp.Forms.Controls
 			scroll = new Gtk.ScrolledWindow();
 			scroll.ShadowType = Gtk.ShadowType.In;
 			Control = new Gtk.TreeView(new Gtk.TreeModelAdapter(model));
-			Size = new Size(80, 80);
 			Control.FixedHeightMode = false;
 			Control.ShowExpanders = false;
 			scroll.Add(Control);
@@ -44,6 +43,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		protected override void Initialize()
 		{
 			base.Initialize();
+			Size = new Size(80, 80);
 			Control.ButtonPressEvent += Connector.HandleTreeButtonPressEvent;
 			Control.Selection.Changed += Connector.HandleSelectionChanged;
 			Control.RowActivated += Connector.HandleTreeRowActivated;

--- a/src/Eto.Gtk/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/SplitterHandler.cs
@@ -200,7 +200,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			if (desired)
 			{
-				var size = PreferredSize;
+				var size = UserPreferredSize;
 				var pick = Orientation == Orientation.Horizontal ?
 					size.Width : size.Height;
 				if (pick >= 0)

--- a/src/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
@@ -30,9 +30,14 @@ namespace Eto.GtkSharp.Forms.Controls
 			scroll = new Gtk.ScrolledWindow();
 			scroll.ShadowType = Gtk.ShadowType.In;
 			Control = new TControl();
-			Size = new Size(100, 60);
 			scroll.Add(Control);
 			Wrap = true;
+		}
+
+		protected override void Initialize()
+		{
+			base.Initialize();
+			Size = new Size(100, 60);
 		}
 
 		public override void AttachEvent(string id)

--- a/src/Eto.Gtk/Forms/EtoControls.cs
+++ b/src/Eto.Gtk/Forms/EtoControls.cs
@@ -21,8 +21,9 @@ namespace Eto.GtkSharp.Forms
             var h = Handler;
             if (h != null)
             {
-                if (h.PreferredSize.Width > 0)
-                    natural_width = h.PreferredSize.Width;
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Width > 0)
+                    natural_width = userPreferredSize.Width;
 
                 minimum_width = Math.Min(natural_width, minimum_width);
             }
@@ -34,8 +35,9 @@ namespace Eto.GtkSharp.Forms
             var h = Handler;
             if (h != null)
             {
-                if (h.PreferredSize.Width > 0)
-                    natural_width = h.PreferredSize.Width;
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Width > 0)
+                    natural_width = userPreferredSize.Width;
 
                 minimum_width = Math.Min(natural_width, minimum_width);
             }
@@ -47,8 +49,9 @@ namespace Eto.GtkSharp.Forms
             var h = Handler;
             if (h != null)
             {
-                if (h.PreferredSize.Height > 0)
-                    natural_height = h.PreferredSize.Height;
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Height > 0)
+                    natural_height = userPreferredSize.Height;
 
                 minimum_height = Math.Min(natural_height, minimum_height);
             }
@@ -60,7 +63,7 @@ namespace Eto.GtkSharp.Forms
             var h = Handler;
             if (h != null)
             {
-                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.PreferredSize.Width : h.PreferredSize.Height;
+                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.UserPreferredSize.Width : h.UserPreferredSize.Height;
 
                 if (preferredSize > 0)
                     natural_size = preferredSize;
@@ -75,7 +78,7 @@ namespace Eto.GtkSharp.Forms
             var h = Handler;
             if (h != null)
             {
-                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.PreferredSize.Width : h.PreferredSize.Height;
+                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.UserPreferredSize.Width : h.UserPreferredSize.Height;
 
                 if (preferredSize > 0)
                     natural_size = preferredSize;
@@ -103,8 +106,9 @@ namespace Eto.GtkSharp.Forms
             var h = Handler;
             if (h != null)
             {
-                if (h.PreferredSize.Width > 0)
-                    natural_width = h.PreferredSize.Width;
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Width > 0)
+                    natural_width = userPreferredSize.Width;
 
                 minimum_width = Math.Min(natural_width, minimum_width);
             }
@@ -116,8 +120,9 @@ namespace Eto.GtkSharp.Forms
             var h = Handler;
             if (h != null)
             {
-                if (h.PreferredSize.Width > 0)
-                    natural_width = h.PreferredSize.Width;
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Width > 0)
+                    natural_width = userPreferredSize.Width;
 
                 minimum_width = Math.Min(natural_width, minimum_width);
             }
@@ -129,8 +134,9 @@ namespace Eto.GtkSharp.Forms
             var h = Handler;
             if (h != null)
             {
-                if (h.PreferredSize.Height > 0)
-                    natural_height = h.PreferredSize.Height;
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Height > 0)
+                    natural_height = userPreferredSize.Height;
 
                 minimum_height = Math.Min(natural_height, minimum_height);
             }
@@ -142,7 +148,7 @@ namespace Eto.GtkSharp.Forms
             var h = Handler;
             if (h != null)
             {
-                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.PreferredSize.Width : h.PreferredSize.Height;
+                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.UserPreferredSize.Width : h.UserPreferredSize.Height;
 
                 if (preferredSize > 0)
                     natural_size = preferredSize;
@@ -157,7 +163,7 @@ namespace Eto.GtkSharp.Forms
             var h = Handler;
             if (h != null)
             {
-                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.PreferredSize.Width : h.PreferredSize.Height;
+                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.UserPreferredSize.Width : h.UserPreferredSize.Height;
 
                 if (preferredSize > 0)
                     natural_size = preferredSize;

--- a/src/Eto.Gtk/Forms/EtoControls.tt
+++ b/src/Eto.Gtk/Forms/EtoControls.tt
@@ -33,8 +33,9 @@ foreach (var control in controls)
             var h = Handler;
             if (h != null)
             {
-                if (h.PreferredSize.Width > 0)
-                    natural_width = h.PreferredSize.Width;
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Width > 0)
+                    natural_width = userPreferredSize.Width;
 
                 minimum_width = Math.Min(natural_width, minimum_width);
             }
@@ -46,8 +47,9 @@ foreach (var control in controls)
             var h = Handler;
             if (h != null)
             {
-                if (h.PreferredSize.Width > 0)
-                    natural_width = h.PreferredSize.Width;
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Width > 0)
+                    natural_width = userPreferredSize.Width;
 
                 minimum_width = Math.Min(natural_width, minimum_width);
             }
@@ -59,8 +61,9 @@ foreach (var control in controls)
             var h = Handler;
             if (h != null)
             {
-                if (h.PreferredSize.Height > 0)
-                    natural_height = h.PreferredSize.Height;
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Height > 0)
+                    natural_height = userPreferredSize.Height;
 
                 minimum_height = Math.Min(natural_height, minimum_height);
             }
@@ -72,7 +75,7 @@ foreach (var control in controls)
             var h = Handler;
             if (h != null)
             {
-                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.PreferredSize.Width : h.PreferredSize.Height;
+                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.UserPreferredSize.Width : h.UserPreferredSize.Height;
 
                 if (preferredSize > 0)
                     natural_size = preferredSize;
@@ -87,7 +90,7 @@ foreach (var control in controls)
             var h = Handler;
             if (h != null)
             {
-                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.PreferredSize.Width : h.PreferredSize.Height;
+                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.UserPreferredSize.Width : h.UserPreferredSize.Height;
 
                 if (preferredSize > 0)
                     natural_size = preferredSize;

--- a/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
@@ -269,17 +269,14 @@ namespace Eto.Mac.Forms.Controls
 			var size = frameSize ?? GetAlignmentFrame().Size.ToEtoSize();
 
 			// use the preferred size to determine style to use, if set
-			var preferredSize = PreferredSize;
+			var userPreferredSize = UserPreferredSize;
 			bool autoSize = true;
-			if (preferredSize != null)
+			if (userPreferredSize.Width > -1)
+				size.Width = userPreferredSize.Width;
+			if (userPreferredSize.Height > -1)
 			{
-				if (preferredSize.Value.Width > -1)
-					size.Width = preferredSize.Value.Width;
-				if (preferredSize.Value.Height > -1)
-				{
-					size.Height = preferredSize.Value.Height;
-					autoSize = false;
-				}
+				size.Height = userPreferredSize.Height;
+				autoSize = false;
 			}
 
 			if (Widget.Loaded || !size.IsEmpty)

--- a/src/Eto.Mac/Forms/Controls/MacLabel.cs
+++ b/src/Eto.Mac/Forms/Controls/MacLabel.cs
@@ -153,19 +153,19 @@ namespace Eto.Mac.Forms.Controls
 				if (naturalSizeInfinity != null)
 					return naturalSizeInfinity.Value;
 
-			    var width = PreferredSize?.Width ?? int.MaxValue;
+				var width = UserPreferredSize.Width;
 				if (width < 0) width = int.MaxValue;
 				var size = Control.Cell.CellSizeForBounds(new CGRect(0, 0, width, int.MaxValue)).ToEto();
 				naturalSizeInfinity = Size.Ceiling(size);
 				return naturalSizeInfinity.Value;
 			}
 
-			if (Widget.Loaded && Wrap != WrapMode.None && PreferredSize?.Width > 0)
+			if (Widget.Loaded && Wrap != WrapMode.None && UserPreferredSize.Width > 0)
 			{
 				/*if (!float.IsPositiveInfinity(availableSize.Width))
 					availableSize.Width = Math.Max(Size.Width, availableSize.Width);
 				else*/
-				availableSize.Width = PreferredSize.Value.Width;
+				availableSize.Width = UserPreferredSize.Width;
 				availableSize.Height = float.PositiveInfinity;
 			}
 

--- a/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -511,9 +511,12 @@ namespace Eto.Mac.Forms.Controls
 						break;
 				}
 			}
-			else if (PreferredSize != null)
+			else
 			{
-				var preferredSize = Orientation == Orientation.Horizontal ? PreferredSize.Value.Width : PreferredSize.Value.Height;
+				var preferredSize = Orientation == Orientation.Horizontal ? UserPreferredSize.Width : UserPreferredSize.Height;
+				if (preferredSize == -1)
+					return;
+
 				var size = Orientation == Orientation.Horizontal ? Size.Width : Size.Height;
 				switch (fixedPanel)
 				{

--- a/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
@@ -51,7 +51,7 @@ namespace Eto.Mac.Forms.Controls
 
 		protected override void SetImagePosition()
 		{
-			if ((PreferredSize?.Width ?? -1) == -1)
+			if (UserPreferredSize.Width == -1)
 			{
 				var position = ImagePosition.ToNS();
 				if (string.IsNullOrEmpty(Text))

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -577,7 +577,7 @@ namespace Eto.Mac.Forms
 			get
 			{
 				if (!Widget.Loaded)
-					return PreferredSize ?? new Size(-1, -1);
+					return UserPreferredSize;
 				return Control.Frame.Size.ToEtoSize();
 			}
 			set
@@ -586,16 +586,15 @@ namespace Eto.Mac.Forms
 				var newFrame = oldFrame.SetSize(value);
 				newFrame.Y = (nfloat)Math.Max(0, oldFrame.Y - (value.Height - oldFrame.Height));
 				Control.SetFrame(newFrame, true);
-				PreferredSize = value;
+				UserPreferredSize = value;
 				SetAutoSize();
 			}
 		}
 
-		void SetAutoSize()
+
+		protected override void SetAutoSize()
 		{
-			AutoSize = true;
-			if (PreferredSize != null)
-				AutoSize &= PreferredSize.Value.Width == -1 || PreferredSize.Value.Height == -1;
+			base.SetAutoSize();
 			if (PreferredClientSize != null)
 				AutoSize &= PreferredClientSize.Value.Width == -1 || PreferredClientSize.Value.Height == -1;
 		}
@@ -754,16 +753,12 @@ namespace Eto.Mac.Forms
 				if (!Widget.Loaded)
 				{
 					PreferredClientSize = value;
-					if (PreferredSize != null)
-					{
-						if (value.Width != -1 && value.Height != -1)
-							PreferredSize = null;
-						else if (value.Width != -1)
-							PreferredSize = new Size(-1, PreferredSize.Value.Height);
-						else if (value.Height != -1)
-							PreferredSize = new Size(PreferredSize.Value.Width, -1);
-
-					}
+					if (value.Width != -1 && value.Height != -1)
+						UserPreferredSize = new Size(-1, -1);
+					else if (value.Width != -1)
+						UserPreferredSize = new Size(-1, UserPreferredSize.Height);
+					else if (value.Height != -1)
+						UserPreferredSize = new Size(UserPreferredSize.Width, -1);
 				}
 				SetAutoSize();
 			}
@@ -901,18 +896,14 @@ namespace Eto.Mac.Forms
 			{
 				AutoSize = false;
 				var availableSize = SizeF.PositiveInfinity;
-				if (PreferredSize != null)
-				{
-					var borderSize = GetBorderSize();
-					if (PreferredSize.Value.Width != -1)
-						availableSize.Width = PreferredSize.Value.Width - borderSize.Width;
-					if (PreferredSize.Value.Height != -1)
-						availableSize.Height = PreferredSize.Value.Height - borderSize.Height;
-				}
+				var borderSize = GetBorderSize();
+				if (UserPreferredSize.Width != -1)
+					availableSize.Width = UserPreferredSize.Width - borderSize.Width;
+				if (UserPreferredSize.Height != -1)
+					availableSize.Height = UserPreferredSize.Height - borderSize.Height;
 				var size = GetPreferredSize(availableSize);
 				SetContentSize(size.ToNS());
 				setInitialSize = true;
-
 			}
 			PositionWindow();
 			base.OnLoad(e);

--- a/src/Eto.WinForms/Forms/Controls/GridHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridHandler.cs
@@ -45,7 +45,7 @@ namespace Eto.WinForms.Forms.Controls
 			public override sd.Size GetPreferredSize(sd.Size proposedSize)
 			{
 				var size = base.GetPreferredSize(proposedSize);
-				var def = Handler.UserDesiredSize;
+				var def = Handler.UserPreferredSize;
 				if (def.Width >= 0)
 					size.Width = def.Width;
 				if (def.Height >= 0)

--- a/src/Eto.WinForms/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/ScrollableHandler.cs
@@ -114,7 +114,7 @@ namespace Eto.WinForms.Forms.Controls
 
 		public override Size GetPreferredSize(Size availableSize, bool useCache)
 		{
-			var baseSize = UserDesiredSize;
+			var baseSize = UserPreferredSize;
 			var size = base.GetPreferredSize(availableSize, useCache);
 			size -= Padding.Size;
 			// if we have set to a specific size, then try to use that

--- a/src/Eto.WinForms/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/SplitterHandler.cs
@@ -197,7 +197,7 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			if (desired)
 			{
-				var size = UserDesiredSize;
+				var size = UserPreferredSize;
 				var pick = Orientation == Orientation.Horizontal ? size.Width : size.Height;
 				if (pick >= 0)
 					return pick - Control.SplitterWidth;

--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -400,6 +400,24 @@ namespace Eto.WinForms.Forms
 			}
 		}
 
+		public virtual int Width
+		{
+			get => Size.Width;
+			set
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		public virtual int Height
+		{
+			get => Size.Height;
+			set
+			{
+				throw new NotImplementedException();
+			}
+		}
+
 		public bool Enabled
 		{
 			get

--- a/src/Eto.WinForms/Forms/WindowsPanel.cs
+++ b/src/Eto.WinForms/Forms/WindowsPanel.cs
@@ -39,7 +39,7 @@ namespace Eto.WinForms.Forms
 
 		public override Size GetPreferredSize(Size availableSize, bool useCache)
 		{
-            var userSize = UserDesiredSize;
+            var userSize = UserPreferredSize;
 			var desiredSize = base.GetPreferredSize(availableSize, useCache);
 
 			var handler = content.GetWindowsHandler();
@@ -69,7 +69,7 @@ namespace Eto.WinForms.Forms
 		public override void SetScale(bool xscale, bool yscale)
 		{
 			base.SetScale(xscale, yscale);
-			SetContentScale(xscale || UserDesiredSize.Width >= 0, yscale || UserDesiredSize.Height >= 0);
+			SetContentScale(xscale || UserPreferredSize.Width >= 0, yscale || UserPreferredSize.Height >= 0);
 		}
 
 		protected virtual void SetContentScale(bool xscale, bool yscale)

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -140,7 +140,18 @@ namespace Eto.Wpf.Forms
 			return size;
 		}
 
-		protected sw.Size UserPreferredSize { get; set; } = new sw.Size(double.NaN, double.NaN);
+		sw.Size _userPreferredSize = new sw.Size(double.NaN, double.NaN);
+		protected sw.Size UserPreferredSize
+		{
+			get => _userPreferredSize;
+			set
+			{
+				_userPreferredSize = value;
+				SetSize();
+				ContainerControl.InvalidateMeasure();
+				UpdatePreferredSize();
+			}
+		}
 
 		protected virtual sw.Size DefaultSize => new sw.Size(double.NaN, double.NaN);
 
@@ -186,10 +197,36 @@ namespace Eto.Wpf.Forms
 			}
 			set
 			{
-				UserPreferredSize = value.ToWpf();
-				SetSize();
-				ContainerControl.InvalidateMeasure();
-				UpdatePreferredSize();
+				var newSize = value.ToWpf();
+				if (UserPreferredSize == newSize)
+					return;
+				UserPreferredSize = newSize;
+			}
+		}
+
+		public virtual int Width
+		{
+			get => Size.Width;
+			set
+			{
+				var newWidth = value == -1 ? double.NaN : value;
+				var userPreferredSize = UserPreferredSize;
+				if (userPreferredSize.Width == newWidth)
+					return;
+				UserPreferredSize = new sw.Size(newWidth, userPreferredSize.Height);
+			}
+		}
+
+		public virtual int Height
+		{
+			get => Size.Height;
+			set
+			{
+				var newHeight = value == -1 ? double.NaN : value;
+				var userPreferredSize = UserPreferredSize;
+				if (userPreferredSize.Height == newHeight)
+					return;
+				UserPreferredSize = new sw.Size(userPreferredSize.Width, newHeight);
 			}
 		}
 

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -803,8 +803,8 @@ namespace Eto.Forms
 		/// </summary>
 		public virtual int Width
 		{
-			get { return Handler.Size.Width; }
-			set { Size = new Size(value, Size.Height); }
+			get => Handler.Width;
+			set => Handler.Width = value;
 		}
 
 		/// <summary>
@@ -812,8 +812,8 @@ namespace Eto.Forms
 		/// </summary>
 		public virtual int Height
 		{
-			get { return Handler.Size.Height; }
-			set { Size = new Size(Size.Width, value); }
+			get => Handler.Height;
+			set => Handler.Height = value;
 		}
 
 		/// <summary>
@@ -1635,6 +1635,16 @@ namespace Eto.Forms
 			/// </remarks>
 			/// <value>The current size of the control</value>
 			Size Size { get; set; }
+
+			/// <summary>
+			/// Gets or sets the width of the control size.
+			/// </summary>
+			int Width { get; set; }
+
+			/// <summary>
+			/// Gets or sets the height of the control size.
+			/// </summary>
+			int Height { get; set; }
 
 			/// <summary>
 			/// Gets or sets a value indicating whether this <see cref="Eto.Forms.Control"/> is enabled and accepts user input.

--- a/src/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/src/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -83,6 +83,24 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Gets or sets the width of the control size.
+		/// </summary>
+		public virtual int Width
+		{
+			get => Control.Width;
+			set => Control.Width = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the height of the control size.
+		/// </summary>
+		public virtual int Height
+		{
+			get => Control.Height;
+			set => Control.Height = value;
+		}
+
+		/// <summary>
 		/// Gets or sets a value indicating whether this control is enabled
 		/// </summary>
 		/// <value><c>true</c> if enabled; otherwise, <c>false</c>.</value>


### PR DESCRIPTION
- Use the same nomenclature for UserPreferredSize on each platform implementation
- When changing Width or Height individually, it won't set the other dimension to its current (actual) value when loaded
Fixes #723