### PR TITLE
Mac: Fix issue on macOS Catalina getting the system font

### DIFF
--- a/src/Eto.Mac/Drawing/FontHandler.cs
+++ b/src/Eto.Mac/Drawing/FontHandler.cs
@@ -327,7 +327,7 @@ namespace Eto.Mac.Drawing
 			return NSDictionary.FromObjectsAndKeys(
 				new NSObject[]
 				{
-					Control,
+					Control ?? NSFont.UserFontOfSize(Size),
 					new NSNumber((int)(decoration.HasFlag(FontDecoration.Underline) ? NSUnderlineStyle.Single : NSUnderlineStyle.None)),
 					NSNumber.FromBoolean(decoration.HasFlag(FontDecoration.Strikethrough))
 				},


### PR DESCRIPTION
- When the app is built using xcode 11, NSFont.FromFontName returns null when passing the system font names.