### PR TITLE
MacFileDialog: bind Title property to NSSavePanel Message because NSS…

### DIFF
--- a/src/Eto.Mac/Forms/MacFileDialog.cs
+++ b/src/Eto.Mac/Forms/MacFileDialog.cs
@@ -198,8 +198,8 @@ namespace Eto.Mac.Forms
 
 		public string Title
 		{
-			get { return Control.Title; }
-			set { Control.Title = value ?? string.Empty; }
+			get { return Control.Message; }
+			set { Control.Message = value ?? string.Empty; }
 		}
 
 		public DialogResult ShowDialog(Window parent)


### PR DESCRIPTION
…avePanel Title isn't displayed anymore