### PR TITLE
Mac: Fix infinite layout issue with Label on Catalina

### DIFF
--- a/src/Eto.Mac/Forms/Controls/MacLabel.cs
+++ b/src/Eto.Mac/Forms/Controls/MacLabel.cs
@@ -187,7 +187,7 @@ namespace Eto.Mac.Forms.Controls
 				return;
 			isSizing = true;
 			var size = Size;
-			if (Wrap != WrapMode.None && lastSize.Width != size.Width)
+			if (Wrap != WrapMode.None && lastSize.Width != size.Width && !Control.IsHiddenOrHasHiddenAncestor)
 			{
 				// when wrapping we use the current size, if it changes we check if we need another layout pass
 				// this is needed when resizing a form/label so it can wrap correctly as GetNaturalSize()


### PR DESCRIPTION
We can sometimes get into an infinite layout cycle when the label size changes (especially with hidden labels), so we only invalidate the measure again if it is actually visible.  This should also speed things up when labels aren't initially shown.