### PR TITLE
SelectFolderDialog.Title wraps NSOpenPanel Message instead of Title

### DIFF
--- a/src/Eto.Mac/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Mac/Forms/SelectFolderDialogHandler.cs
@@ -40,10 +40,10 @@ namespace Eto.Mac.Forms
 		
 		public string Title {
 			get {
-				return Control.Title;
+				return Control.Message;
 			}
 			set {
-				Control.Title = value ?? string.Empty;
+				Control.Message = value ?? string.Empty;
 			}
 		}
 		


### PR DESCRIPTION
Because macOS doesn't display Title anymore.