### PR TITLE
Wpf: Handle drag/drop scenarios better with multiple selection

### DIFF
--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -742,7 +742,7 @@ namespace Eto.Wpf.Forms
 			e.Handled = args.Handled;
 		}
 
-		void HandleMouseUp(object sender, swi.MouseButtonEventArgs e)
+		protected virtual void HandleMouseUp(object sender, swi.MouseButtonEventArgs e)
 		{
 			var args = e.ToEto(Control, swi.MouseButtonState.Released);
 			Callback.OnMouseUp(Widget, args);
@@ -761,7 +761,7 @@ namespace Eto.Wpf.Forms
 			e.Handled = args.Handled;
 		}
 
-		void HandleMouseDown(object sender, swi.MouseButtonEventArgs e)
+		protected virtual void HandleMouseDown(object sender, swi.MouseButtonEventArgs e)
 		{
 			var args = e.ToEto(Control);
 			if (!(Control is swc.Control) && e.ClickCount == 2)

--- a/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
@@ -300,14 +300,14 @@ namespace Eto.Test.Sections.Behaviors
 		{
 			tree.ShowHeader = false;
 			tree.AllowMultipleSelection = true;
-			tree.Columns.Add(new GridColumn { DataCell = new TextBoxCell(0) });
+			tree.Columns.Add(new GridColumn { DataCell = new TextBoxCell(0), Editable = true });
 		}
 
 		void SetupGridColumns(GridView grid)
 		{
 			grid.ShowHeader = false;
 			grid.AllowMultipleSelection = true;
-			grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(0) });
+			grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(0), Editable = true });
 		}
 
 		TreeGridItemCollection CreateTreeData()


### PR DESCRIPTION
- When dragging a selected row it will not clear all other selected rows until mouse up
- When dragging an editable cell it will not begin editing until mouse up