### PR TITLE
Wpf: Fix regressions with GridView click events with editable cells.

### DIFF
--- a/src/Eto.Wpf/Forms/WpfShellDropBehavior.cs
+++ b/src/Eto.Wpf/Forms/WpfShellDropBehavior.cs
@@ -104,7 +104,6 @@ namespace Eto.Wpf.Forms
 			}
 			else
 			{
-				//e.Effects = sw.DragDropEffects.None;
 				sw.DropTargetHelper.DragOver(e.GetPosition(element), e.Effects);
 			}
 		}

--- a/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
@@ -98,7 +98,7 @@ namespace Eto.Test.Sections.Behaviors
 			SetupTreeColumns(treeSource);
 			treeSource.MouseMove += (sender, e) =>
 			{
-				if (e.Buttons == MouseButtons.Primary)
+				if (e.Buttons == MouseButtons.Primary && !treeSource.IsEditing)
 				{
 					var cell = treeSource.GetCellAt(e.Location);
 					if (cell.Item == null || cell.ColumnIndex == -1)
@@ -118,8 +118,11 @@ namespace Eto.Test.Sections.Behaviors
 			gridSource.DataStore = CreateGridData();
 			gridSource.MouseMove += (sender, e) =>
 			{
-				if (e.Buttons == MouseButtons.Primary)
+				if (e.Buttons == MouseButtons.Primary && !gridSource.IsEditing)
 				{
+					var cell = gridSource.GetCellAt(e.Location);
+					if (cell.RowIndex == -1 || cell.ColumnIndex == -1)
+						return;
 					var data = CreateDataObject();
 					var selected = gridSource.SelectedItems.OfType<GridItem>().Select(r => (string)r.Values[0]);
 					data.SetString(string.Join(";", selected), "my-grid-data");

--- a/test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -439,6 +439,9 @@ namespace Eto.Test.Sections.Controls
 			control.ColumnHeaderClick += (sender, e) => Log.Write(control, $"Column Header Clicked: {e.Column.HeaderText}");
 			control.CellClick += (sender, e) => Log.Write(control, $"Cell Clicked, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
 			control.CellDoubleClick += (sender, e) => Log.Write(control, $"Cell Double Clicked, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
+
+			control.MouseDown += (sender, e) => Log.Write(control, $"MouseDown, Buttons: {e.Buttons}, Location: {e.Location}");
+			control.MouseDoubleClick += (sender, e) => Log.Write(control, $"MouseDoubleClick, Buttons: {e.Buttons}, Location: {e.Location}");
 		}
 
 		static string SelectedRowsString(GridView grid)


### PR DESCRIPTION
With the change in behaviour of the GridView to allow for drag/drop it broke the CellClick and CellDoubleClick events when the cell is editable.  Now the new behaviour takes into account how many clicks caused the cell to be edited and also will only start the editing if the cell already has focus to bring it back to previous/default behaviour.