### PR TITLE
Wpf/Mac: Fix initial position of dialog in some cases

### DIFF
--- a/src/Eto.Mac/Forms/MacModal.cs
+++ b/src/Eto.Mac/Forms/MacModal.cs
@@ -147,8 +147,14 @@ namespace Eto.Mac.Forms
 
 		public void RunSession()
 		{
+			var etoWindow = NativeWindow as EtoWindow;
+			if (etoWindow != null && etoWindow.DisableCenterParent)
+				etoWindow.DisableSetOrigin = true;
+
 			Session = app.BeginModalSession(NativeWindow);
 			bool result;
+			if (etoWindow != null)
+				etoWindow.DisableSetOrigin = false;
 
 			// Loop until some result other than continues:
 			do

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -93,6 +93,14 @@ namespace Eto.Mac.Forms
 			Handler.Callback.OnWindowStateChanged(Handler.Widget, EventArgs.Empty);
 		}
 
+		public bool DisableSetOrigin { get; set; }
+
+		public override void SetFrameOrigin(CGPoint aPoint)
+		{
+			if (!DisableSetOrigin)
+				base.SetFrameOrigin(aPoint);
+		}
+
 		public override void RecalculateKeyViewLoop()
 		{
 			base.RecalculateKeyViewLoop();
@@ -821,16 +829,14 @@ namespace Eto.Mac.Forms
 			// location is relative to the main screen, translate to bottom left, inversed
 			var mainFrame = NSScreen.Screens[0].Frame;
 			var frame = Control.Frame;
-			var point = new CGPoint((nfloat)value.X, (nfloat)(mainFrame.Height - value.Y - frame.Height));
-			Control.SetFrameOrigin(point);
+			var point = new CGPoint((nfloat)value.X, (nfloat)(mainFrame.Height - value.Y));
 			if (Control.Screen == null)
 			{
 				// ensure that the control lands on a screen
 				point.X = (nfloat)Math.Min(Math.Max(mainFrame.X, point.X), mainFrame.Right - frame.Width);
 				point.Y = (nfloat)Math.Min(Math.Max(mainFrame.Y, point.Y), mainFrame.Bottom - frame.Height);
-
-				Control.SetFrameOrigin(point);
 			}
+			Control.SetFrameTopLeftPoint(point);
 		}
 
 		public WindowState WindowState
@@ -940,7 +946,8 @@ namespace Eto.Mac.Forms
 				SetLocation(InitialLocation.Value);
 				InitialLocation = null;
 			}
-			Control.Center();
+			else
+				Control.Center();
 		}
 
 		#region IMacContainer implementation

--- a/src/Eto.Wpf/Forms/DialogHandler.cs
+++ b/src/Eto.Wpf/Forms/DialogHandler.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Eto.Forms;
 using sw = System.Windows;
 using swc = System.Windows.Controls;
@@ -48,7 +48,11 @@ namespace Eto.Wpf.Forms
 		{
             ReloadButtons();
 
-			if (Widget.Owner != null)
+			if (LocationSet)
+			{
+				Control.WindowStartupLocation = sw.WindowStartupLocation.Manual;
+			}
+			else if (Widget.Owner != null)
 			{
 				// CenterOwner does not work in certain cases (e.g. with autosizing)
 				Control.WindowStartupLocation = sw.WindowStartupLocation.Manual;

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -591,6 +591,7 @@ namespace Eto.Wpf.Forms
 				}
 				else
 				{
+					LocationSet = true;
 					SetLocation(value);
 				}
 			}

--- a/test/Eto.Test/UnitTests/Forms/WindowTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/WindowTests.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using Eto.Forms;
 using System.Collections.Generic;
@@ -67,6 +67,35 @@ namespace Eto.Test.UnitTests.Forms
 				form.Shown += (sender, e) => form.Close();
 			});
 			Assert.AreEqual(1, closed, "Closed event should only fire once");
+		}
+
+		[TestCase(true)]
+		[TestCase(false)]
+		[ManualTest]
+		public void InitialLocationOfFormShouldBeCorrect(bool withOwner)
+		{
+			ManualForm("This form should be located at the top left of the screen", form =>
+			{
+				if (withOwner)
+					form.Owner = Application.Instance.MainForm;
+				form.Location = new Point(0, 0);
+
+				return new Panel { Size = new Size(200, 200) };
+			});
+		}
+		[TestCase(true)]
+		[TestCase(false)]
+		[ManualTest]
+		public void InitialLocationOfDialogShouldBeCorrect(bool withOwner)
+		{
+			ManualDialog("This dialog should be located at the top left of the screen", form =>
+			{
+				if (withOwner)
+					form.Owner = Application.Instance.MainForm;
+				form.Location = new Point(0, 0);
+
+				return new Panel { Size = new Size(200, 200) };
+			});
 		}
 	}
 }


### PR DESCRIPTION
- Wpf: Location was ignored if you set the owner on a Dialog
- Mac: Location could be offset if showing a dialog at the same location as a previous dialog