### PR TITLE
Call Form.Show() when Visible is set to true for the first time

### DIFF
--- a/src/Eto.Mac/Forms/FormHandler.cs
+++ b/src/Eto.Mac/Forms/FormHandler.cs
@@ -93,6 +93,24 @@ namespace Eto.Mac.Forms
 			}
 		}
 
+		public override bool Visible
+		{
+			get => base.Visible;
+			set
+			{
+				if (value && !ShowActivated)
+				{
+					if (value != Visible)
+					{
+						Control.OrderFront(ApplicationHandler.Instance.AppDelegate);
+						FireOnShown();
+					}
+				}
+				else
+					base.Visible = value;
+			}
+		}
+
 		public bool ShowActivated { get; set; } = true;
 
 		public bool CanFocus

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -610,7 +610,7 @@ namespace Eto.Wpf.Forms
 			var handle = WindowHandle;
 			var loc = location.LogicalToScreen();
 
-			Win32.SetWindowPos(WindowHandle, IntPtr.Zero, loc.X, loc.Y, 0, 0, Win32.SWP.NOSIZE);
+			Win32.SetWindowPos(WindowHandle, IntPtr.Zero, loc.X, loc.Y, 0, 0, Win32.SWP.NOSIZE | Win32.SWP.NOACTIVATE);
 		}
 
 		public WindowState WindowState

--- a/src/Eto/Forms/Form.cs
+++ b/src/Eto/Forms/Form.cs
@@ -59,6 +59,29 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="Eto.Forms.Control"/> is visible to the user.
+		/// </summary>
+		/// <remarks>
+		/// When the visibility of a control is set to false, it will still occupy space in the layout, but not be shown.
+		/// The only exception is for controls like the <see cref="Splitter"/>, which will hide a pane if the visibility
+		/// of one of the panels is changed.
+		/// </remarks>
+		/// <value><c>true</c> if visible; otherwise, <c>false</c>.</value>
+		[DefaultValue(true)]
+		public override bool Visible
+		{
+			get => base.Visible;
+			set
+			{
+				// when setting Visible = true for the first time it should be like calling Show()
+				if (value && !Loaded)
+					Show();
+				else
+					base.Visible = value;
+			}
+		}
+
+		/// <summary>
 		/// Show the form
 		/// </summary>
 		public void Show()
@@ -69,9 +92,10 @@ namespace Eto.Forms
 				OnPreLoad(EventArgs.Empty);
 				OnLoad(EventArgs.Empty);
 				OnLoadComplete(EventArgs.Empty);
+
+				Application.Instance.AddWindow(this);
 			}
 
-			Application.Instance.AddWindow(this);
 			Handler.Show();
 		}
 


### PR DESCRIPTION
- Fixes issue where load events aren't fired
- Wpf: Don't activate the window when setting its location

Fixes #1509