### PR TITLE
Add Grid.AllowEmptySelection

### DIFF
--- a/build/Common.Build.props
+++ b/build/Common.Build.props
@@ -18,6 +18,8 @@
     <Deterministic Condition="$(Deterministic) == ''">False</Deterministic>
     <!-- RestoreProjectStyle will be supported in VS for Mac 7.4 -->
     <RestoreProjectStyle Condition="'$(RestoreProjectStyle)' == '' AND $(UsePackagesConfig) != 'True'">PackageReference</RestoreProjectStyle>
+    
+    <DefaultItemExcludes>$(DefaultItemExcludes);.DS_Store</DefaultItemExcludes>
   </PropertyGroup>
   <Import Condition="Exists('$(BasePath)..\Eto.Common.props')" Project="$(BasePath)..\Eto.Common.props" />
 </Project>

--- a/src/Eto.Gtk/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridViewHandler.cs
@@ -58,13 +58,15 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public IEnumerable<object> DataStore
 		{
-			get { return collection != null ? collection.Collection : null; }
+			get => collection?.Collection;
 			set
 			{
 				if (collection != null)
 					collection.Unregister();
+				UnselectAll();
 				collection = new CollectionHandler { Handler = this };
 				collection.Register(value);
+				EnsureSelection();
 			}
 		}
 
@@ -243,6 +245,8 @@ namespace Eto.GtkSharp.Forms.Controls
 		protected override WeakConnector CreateConnector() => new GridViewConnector();
 
 		public GridViewDragInfo GetDragInfo(DragEventArgs e) => e.ControlObject as GridViewDragInfo;
+
+		protected override bool HasRows => model.Count > 0;
 
 	}
 }

--- a/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
@@ -104,8 +104,10 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				if (collection != null)
 					collection.Unregister();
+				UnselectAll();
 				collection = new CollectionHandler { Handler = this };
 				collection.Register(value);
+				EnsureSelection();
 			}
 		}
 
@@ -646,5 +648,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		public override IEnumerable<int> SelectedRows => Tree.Selection.GetSelectedRows().Select(GetRowIndexOfPath);
 
 		public IEnumerable<object> SelectedItems => Tree.Selection.GetSelectedRows().Select(GetItem);
+
+		protected override bool HasRows => model.IterHasChild(Gtk.TreeIter.Zero);
 	}
 }

--- a/src/Eto.Gtk/KeyMap.cs
+++ b/src/Eto.Gtk/KeyMap.cs
@@ -28,6 +28,9 @@ namespace Eto.GtkSharp
 			if (modifier.HasFlag(Gdk.ModifierType.ControlMask)) result |= Keys.Control;
 			if (modifier.HasFlag(Gdk.ModifierType.SuperMask)) result |= Keys.Application;
 			if (modifier.HasFlag(Gdk.ModifierType.ShiftMask)) result |= Keys.Shift;
+
+			// map CMD key to Control on macOS
+			if (EtoEnvironment.Platform.IsMac && modifier.HasFlag(Gdk.ModifierType.Mod2Mask)) result |= Keys.Control;
 			return result;
 		}
 

--- a/src/Eto.Mac/Forms/Controls/ExpanderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ExpanderHandler.cs
@@ -49,8 +49,11 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void Layout()
 			{
+				if (MacView.NewLayout)
+					base.Layout();
 				Handler?.PerformLayout();
-				base.Layout();
+				if (!MacView.NewLayout)
+					base.Layout();
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -178,6 +178,12 @@ namespace Eto.Mac.Forms.Controls
 
 		public override NSView DragControl => Control;
 
+		public bool AllowEmptySelection
+		{
+			get => Control.AllowsEmptySelection;
+			set => Control.AllowsEmptySelection = value;
+		}
+
 		protected int SuppressUpdate { get; set; }
 
 		bool IDataViewHandler.SuppressUpdate => SuppressUpdate > 0;

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -141,8 +141,11 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void Layout()
 			{
+				if (MacView.NewLayout)
+					base.Layout();
 				Handler?.PerformLayout();
-				base.Layout();
+				if (!MacView.NewLayout)
+					base.Layout();
 			}
 
 

--- a/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
@@ -76,8 +76,11 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void Layout()
 			{
+				if (MacView.NewLayout)
+					base.Layout();
 				Handler?.PerformScrollLayout();
-				base.Layout();
+				if (!MacView.NewLayout)
+					base.Layout();
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -365,8 +365,11 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void Layout()
 			{
+				if (MacView.NewLayout)
+					base.Layout();
 				Handler?.PerformLayout();
-				base.Layout();
+				if (!MacView.NewLayout)
+					base.Layout();
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -125,8 +125,11 @@ namespace Eto.Mac.Forms.Controls
 
 		public override void Layout()
 		{
+			if (MacView.NewLayout)
+				base.Layout();
 			(Handler as ITextAreaHandler)?.PerformLayout();
-			base.Layout();
+			if (!MacView.NewLayout)
+				base.Layout();
 		}
 	}
 

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -624,8 +624,11 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void Layout()
 			{
+				if (MacView.NewLayout)
+					base.Layout();
 				Handler?.PerformLayout();
-				base.Layout();
+				if (!MacView.NewLayout)
+					base.Layout();
 			}
 		}
 

--- a/src/Eto.Mac/Forms/MacPanel.cs
+++ b/src/Eto.Mac/Forms/MacPanel.cs
@@ -64,8 +64,11 @@ namespace Eto.Mac.Forms
 
 		public override void Layout()
 		{
+			if (MacView.NewLayout)
+				base.Layout();
 			Handler?.PerformContentLayout();
-			base.Layout();
+			if (!MacView.NewLayout)
+				base.Layout();
 		}
 	}
 

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -183,6 +183,10 @@ namespace Eto.Mac.Forms
 		public static readonly IntPtr selSetDataProviderForTypes_Handle = Selector.GetHandle("setDataProvider:forTypes:");
 		public static readonly IntPtr selInitWithPasteboardWriter_Handle = Selector.GetHandle("initWithPasteboardWriter:");
 		public const string FlagsChangedEvent = "MacView.FlagsChangedEvent";
+
+		// before 10.12, we have to call base.Layout() AFTER we do our layout otherwise it doesn't work correctly..
+		// however, that causes (temporary) glitches when resizing especially with Scrollable >= 10.12
+		public static readonly bool NewLayout = MacVersion.IsAtLeast(10, 12);
 	}
 
 	public abstract class MacView<TControl, TWidget, TCallback> : MacObject<TControl, TWidget, TCallback>, Control.IHandler, IMacViewHandler

--- a/src/Eto.Mac/Forms/PixelLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/PixelLayoutHandler.cs
@@ -61,8 +61,11 @@ namespace Eto.Mac.Forms
 
 			public override void Layout()
 			{
+				if (MacView.NewLayout)
+					base.Layout();
 				Handler?.PerformLayout();
-				base.Layout();
+				if (!MacView.NewLayout)
+					base.Layout();
 			}
 		}
 

--- a/src/Eto.Mac/Forms/TableLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/TableLayoutHandler.cs
@@ -79,8 +79,11 @@ namespace Eto.Mac.Forms
 
 			public override void Layout()
 			{
+				if (MacView.NewLayout)
+					base.Layout();
 				Handler?.PerformLayout();
-				base.Layout();
+				if (!MacView.NewLayout)
+					base.Layout();
 			}
 		}
 

--- a/src/Eto.WinForms/Forms/Controls/GridHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridHandler.cs
@@ -30,7 +30,7 @@ namespace Eto.WinForms.Forms.Controls
 
 		protected void ResetSelection()
 		{
-			if (!SelectedRows.Any())
+			if (!SelectedRows.Any() && AllowEmptySelection)
 				isFirstSelection = true;
 		}
 
@@ -117,6 +117,31 @@ namespace Eto.WinForms.Forms.Controls
 
 			Control.SelectionChanged += HandleFirstSelection;
 			Control.DataError += HandleDataError;
+		}
+
+		private void Widget_MouseDown(object sender, MouseEventArgs e)
+		{
+			if (!e.Handled && e.Buttons == MouseButtons.Primary)
+			{
+				var hitTest = Control.HitTest((int)e.Location.X, (int)e.Location.Y);
+				if (AllowEmptySelection)
+				{
+					if (hitTest.Type == swf.DataGridViewHitTestType.None)
+					{
+						if (IsEditing)
+							CancelEdit();
+						UnselectAll();
+					}
+				}
+				else if (e.Modifiers == Keys.Control
+					&& hitTest.RowIndex >= 0 
+					&& Control.SelectedRows.Count == 1 
+					&& Control.SelectedRows[0].Index == hitTest.RowIndex)
+				{
+					// don't allow user to deselect all items
+					e.Handled = true;
+				}
+			}
 		}
 
 		void HandleDataError(object sender, swf.DataGridViewDataErrorEventArgs e)
@@ -284,6 +309,7 @@ namespace Eto.WinForms.Forms.Controls
 			base.Initialize();
 			columns = new ColumnCollection { Handler = this };
 			columns.Register(Widget.Columns);
+			Widget.MouseDown += Widget_MouseDown;
 		}
 
 		class ColumnCollection : EnumerableChangedHandler<GridColumn, GridColumnCollection>
@@ -376,11 +402,13 @@ namespace Eto.WinForms.Forms.Controls
 		public void SelectAll()
 		{
 			Control.SelectAll();
+			isFirstSelection = false;
 		}
 
 		public void SelectRow(int row)
 		{
 			Control.Rows[row].Selected = true;
+			isFirstSelection = false;
 		}
 
 		public void UnselectRow(int row)
@@ -490,6 +518,16 @@ namespace Eto.WinForms.Forms.Controls
 		}
 
 		public bool IsEditing => Control.IsCurrentCellInEditMode;
+
+		public bool AllowEmptySelection { get; set; } = true;
+
+		protected void EnsureSelection()
+		{
+			if (!AllowEmptySelection && Control.RowCount > 0)
+			{
+				SelectRow(0);
+			}
+		}
 	}
 }
 

--- a/src/Eto.WinForms/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridViewHandler.cs
@@ -172,8 +172,10 @@ namespace Eto.WinForms.Forms.Controls
 			{
 				if (collection != null)
 					collection.Unregister();
+				UnselectAll();
 				collection = new CollectionHandler { Handler = this };
 				collection.Register(value);
+				EnsureSelection();
 			}
 		}
 

--- a/src/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
@@ -111,7 +111,9 @@ namespace Eto.WinForms.Forms.Controls
 			get { return controller.Store; }
 			set
 			{
+				UnselectAll();
 				controller.InitializeItems(value);
+				EnsureSelection();
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridViewHandler.cs
@@ -203,6 +203,7 @@ namespace Eto.Wpf.Forms.Controls
 					Control.ItemsSource = store;
 				else
 					Control.ItemsSource = store != null ? new ObservableCollection<object>(store) : null;
+				EnsureSelection();
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -103,6 +103,7 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				controller.InitializeItems(value);
 				Control.ItemsSource = controller;
+				EnsureSelection();
 			}
 		}
 

--- a/src/Eto/Forms/Controls/Grid.cs
+++ b/src/Eto/Forms/Controls/Grid.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using Eto.Drawing;
 
@@ -527,6 +528,24 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Gets or sets a value indicating that the user can clear the selection.
+		/// </summary>
+		/// <remarks>
+		/// When true, the user can deselect the item by cmd/ctrl+click the last selected row, or
+		/// by clicking on the empty space in the Grid. Some platforms may have empty space to the
+		/// right, and some only have space at the bottom.
+		/// When false, this setting will make it so the user cannot deselect the last selected item, and
+		/// the control will initially select the first item when setting the DataStore property.
+		/// This does not affect the ability to clear the selection programmatically.
+		/// </remarks>
+		[DefaultValue(true)]
+		public bool AllowEmptySelection
+		{
+			get => Handler.AllowEmptySelection;
+			set => Handler.AllowEmptySelection = value;
+		}
+
+		/// <summary>
 		/// Selects the row to the specified <paramref name="row"/>, clearing other selections
 		/// </summary>
 		/// <param name="row">Row to select</param>
@@ -818,6 +837,19 @@ namespace Eto.Forms
 			/// </summary>
 			/// <value><c>true</c> if the current cell is in edit mode; otherwise, <c>false</c>.</value>
 			bool IsEditing { get; }
+
+			/// <summary>
+			/// Gets or sets a value indicating that the user can clear the selection.
+			/// </summary>
+			/// <remarks>
+			/// When true, the user can deselect the item by cmd/ctrl+click the last selected row, or
+			/// by clicking on the empty space in the Grid. Some platforms may have empty space to the
+			/// right, and some only have space at the bottom.
+			/// When false, this setting will make it so the user cannot deselect the last selected item, and
+			/// the control will initially select the first item when setting the DataStore property.
+			/// This does not affect the ability to clear the selection programmatically.
+			/// </remarks>
+			bool AllowEmptySelection { get; set; }
 
 			/// <summary>
 			/// Scrolls to show the specified row in the view

--- a/src/Eto/Forms/Layout/DynamicLayout.cs
+++ b/src/Eto/Forms/Layout/DynamicLayout.cs
@@ -394,6 +394,42 @@ namespace Eto.Forms
 		public void EndGroup() => EndVertical();
 
 		/// <summary>
+		/// Begins a the scrollable section in the dynamic layout with a specified border.
+		/// </summary>
+		/// <remarks>
+		/// Should be balanced with a call to <see cref="EndScrollable"/>.
+		/// </remarks>
+		/// <returns>The scrollable instance.</returns>
+		/// <param name="border">BorderType for the Scrollable.</param>
+		/// <param name="padding">Padding around the children in the scrollable.</param>
+		/// <param name="spacing">Spacing between the children in the scrollable.</param>
+		/// <param name="xscale">Xscale of the scrollable itself.</param>
+		/// <param name="yscale">Yscale of the scrollable itself.</param>
+		public DynamicScrollable BeginScrollable(BorderType border = BorderType.Bezel, Padding? padding = null, Size? spacing = null, bool? xscale = null, bool? yscale = null)
+		{
+			var newItem = new DynamicScrollable
+			{
+				Border = border,
+				Padding = padding,
+				Spacing = spacing,
+				XScale = xscale,
+				YScale = yscale
+			};
+			currentItem.Add(newItem);
+			currentItem = newItem;
+			return newItem;
+		}
+
+		/// <summary>
+		/// Ends a scrollable section.
+		/// </summary>
+		/// <remarks>
+		/// Should be balanced with a previous call to <see cref="BeginScrollable"/>.
+		/// </remarks>
+		public void EndScrollable() => EndVertical();
+
+
+		/// <summary>
 		/// Add the control with the optional scaling
 		/// </summary>
 		/// <remarks>

--- a/src/Eto/Forms/Layout/DynamicTable.cs
+++ b/src/Eto/Forms/Layout/DynamicTable.cs
@@ -493,4 +493,47 @@ namespace Eto.Forms
 			};
 		}
 	}
+
+	/// <summary>
+	/// Used to easily insert a <see cref="Scrollable"/> into a dynamic layout
+	/// </summary>
+	public class DynamicScrollable : DynamicTable
+	{
+		BorderType _border;
+
+		/// <summary>
+		/// Gets or sets the border for the contained scrollable
+		/// </summary>
+		public BorderType Border
+		{
+			get => _border;
+			set
+			{
+				_border = value;
+				if (Scrollable != null)
+					Scrollable.Border = _border;
+			}
+		}
+
+		/// <summary>
+		/// Gets the Scrollable instance when the layout has been generated.
+		/// </summary>
+		/// <value>The Scrollable instance.</value>
+		public Scrollable Scrollable { get; private set; }
+
+		/// <summary>
+		/// Creates the group box layout.
+		/// </summary>
+		/// <returns>The control created for this item.</returns>
+		/// <param name="layout">Layout we are creating this item for.</param>
+		public override Control Create(DynamicLayout layout)
+		{
+			return Scrollable = new Scrollable
+			{
+				Border = _border,
+				Content = base.Create(layout)
+			};
+		}
+	}
+
 }

--- a/test/Eto.Test.Mac/Eto.Test.Mac.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac.csproj
@@ -21,7 +21,6 @@
     <Content Include="TestIcon.icns" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Info.plist" />
     <None Remove="TestIcon.icns" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
@@ -21,7 +21,6 @@
     <Content Include="TestIcon.icns" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="Info.plist" />
     <None Remove="TestIcon.icns" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Eto.Test/SectionList.cs
+++ b/test/Eto.Test/SectionList.cs
@@ -201,9 +201,10 @@ namespace Eto.Test
 			this.treeView = new TreeGridView();
 			treeView.Style = "sectionList";
 			treeView.ShowHeader = false;
+			treeView.AllowEmptySelection = false;
 			treeView.Columns.Add(new GridColumn { DataCell = new TextBoxCell { Binding = new DelegateBinding<SectionTreeItem, string>(r => r.Text) } });
-			treeView.DataStore = new SectionTreeItem(new Section("Top", topNodes));
 			treeView.SelectedItemChanged += (sender, e) => OnSelectedItemChanged(e);
+			treeView.DataStore = new SectionTreeItem(new Section("Top", topNodes));
 		}
 	}
 

--- a/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
@@ -236,6 +236,7 @@ namespace Eto.Test.Sections.Behaviors
 
 			layout.BeginHorizontal();
 
+			layout.BeginScrollable(BorderType.None);
 			layout.BeginCentered();
 
 			layout.AddSeparateRow(showDragOverEvents);
@@ -264,6 +265,7 @@ namespace Eto.Test.Sections.Behaviors
 			layout.AddSpace();
 
 			layout.EndCentered();
+			layout.EndScrollable();
 
 			layout.BeginVertical(xscale: true);
 			layout.AddRange("Drag sources:", buttonSource, panelSource);

--- a/test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -29,20 +29,23 @@ namespace Eto.Test.Sections.Controls
 	{
 		static Icon image1 = new Icon(1, TestIcons.TestImage).WithSize(16, 16);
 		static Icon image2 = TestIcons.TestIcon.WithSize(16, 16);
+		GridView gridView;
+		SelectableFilterCollection<MyGridItem> filteredCollection;
 
 		public GridViewSection()
 		{
-			var gridView = CreateGrid();
+			Styles.Add<Label>(null, l => l.VerticalAlignment = VerticalAlignment.Center);
+
+			gridView = CreateGrid();
 			var selectionGridView = CreateGrid();
 
 			// hook up selection of main grid to the selection grid
 			gridView.SelectionChanged += (s, e) => selectionGridView.DataStore = gridView.SelectedItems.ToList();
 
-			var filteredCollection = new SelectableFilterCollection<MyGridItem>(gridView, CreateItems().ToList());
-			gridView.DataStore = filteredCollection;
+			SetDataStore();
 
 			if (Platform.Supports<ContextMenu>())
-				gridView.ContextMenu = CreateContextMenu(gridView, filteredCollection);
+				gridView.ContextMenu = CreateContextMenu(gridView);
 
 			Content = new TableLayout
 			{
@@ -53,14 +56,20 @@ namespace Eto.Test.Sections.Controls
 					new TableRow(
 						"Grid",
 						new TableLayout(
-							CreateOptions(gridView, filteredCollection),
+							CreateOptions(gridView),
 							new TableRow(gridView) { ScaleHeight = true },
-                            CreatePositionLabel(gridView)
+							CreatePositionLabel(gridView)
 						)
 					) { ScaleHeight = true },
 					new TableRow("Selected Items", selectionGridView)
 				}
 			};
+		}
+
+		private void SetDataStore()
+		{
+			filteredCollection = new SelectableFilterCollection<MyGridItem>(gridView, CreateItems());
+			gridView.DataStore = filteredCollection;
 		}
 
 		Label CreatePositionLabel(GridView grid)
@@ -74,57 +83,46 @@ namespace Eto.Test.Sections.Controls
 			return label;
 		}
 
-		StackLayout CreateOptions(GridView grid, SelectableFilterCollection<MyGridItem> filtered)
+		Control CreateOptions(GridView grid)
 		{
-			return new StackLayout
-			{
-				Spacing = 5,
-				HorizontalContentAlignment = HorizontalAlignment.Stretch,
-				Items =
-				{
-					TableLayout.Horizontal(
-						5,
-						null,
+			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5) };
+
+			layout.AddSeparateRow(null,
 						EnabledCheckBox(grid),
 						EditableCheckBox(grid),
-						AllowMultiSelectCheckBox(grid),
 						ShowHeaderCheckBox(grid),
 						GridLinesDropDown(grid),
+						null);
+			layout.AddSeparateRow(null,
+						AllowMultiSelectCheckBox(grid),
+						AllowEmptySelectionCheckBox(grid),
 						null
-					),
-					TableLayout.Horizontal(
-						5,
-						null,
-						AddItemButton(filtered),
+					);
+			layout.AddSeparateRow(null,
+						AddItemButton(),
 						CreateScrollToRow(grid),
 						CreateBeginEditButton(grid),
 						"Border",
 						CreateBorderType(grid),
 						null
-					),
-					TableLayout.Horizontal(
-						5,
-						null,
+					);
+			layout.AddSeparateRow(null,
 						ReloadDataButton(grid),
+						SetDataButton(grid),
 						null
-					),
-					TableLayout.Horizontal(
-						5,
-						null,
+					);
+			layout.AddSeparateRow(null,
 						"TextBoxCell:",
 						"TextAlignment", TextAlignmentDropDown(grid),
 						"VerticalAlignment", VerticalAlignmentDropDown(grid),
 						null
-					),
-					TableLayout.Horizontal(
-						5,
-						null,
+					);
+			layout.AddSeparateRow(null,
 						"AutoSelectMode", AutoSelectModeDropDown(grid),
 						null
-					),
-					CreateSearchBox(filtered)
-				}
-			};
+					);
+			layout.Add(CreateSearchBox());
+			return layout;
 		}
 
 		Control TextAlignmentDropDown(GridView grid)
@@ -163,6 +161,13 @@ namespace Eto.Test.Sections.Controls
 			return control;
 		}
 
+		Control AllowEmptySelectionCheckBox(GridView grid)
+		{
+			var control = new CheckBox { Text = "AllowEmptySelection" };
+			control.CheckedBinding.Bind(grid, g => g.AllowEmptySelection);
+			return control;
+		}
+
 		ComboBoxCell MyDropDown(string bindingProperty)
 		{
 			var combo = new ComboBoxCell(bindingProperty);
@@ -194,6 +199,13 @@ namespace Eto.Test.Sections.Controls
 		{
 			var control = new Button { Text = "ReloadData" };
 			control.Click += (sender, e) => grid.ReloadData(grid.SelectedRows);
+			return control;
+		}
+
+		Control SetDataButton(GridView grid)
+		{
+			var control = new Button { Text = "SetDataStore" };
+			control.Click += (sender, e) => SetDataStore();
 			return control;
 		}
 
@@ -229,7 +241,7 @@ namespace Eto.Test.Sections.Controls
 			return control;
 		}
 
-		SearchBox CreateSearchBox(SelectableFilterCollection<MyGridItem> filtered)
+		SearchBox CreateSearchBox()
 		{
 			var filterText = new SearchBox { PlaceholderText = "Filter" };
 			filterText.TextChanged += (s, e) =>
@@ -237,13 +249,14 @@ namespace Eto.Test.Sections.Controls
 				var filterItems = (filterText.Text ?? "").Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
 
 				if (filterItems.Length == 0)
-					filtered.Filter = null;
+					filteredCollection.Filter = null;
 				else
-					filtered.Filter = i =>
+					filteredCollection.Filter = i =>
 				{
 					// Every item in the split filter string should be within the Text property
-					foreach (var filterItem in filterItems)
+					for (int i1 = 0; i1 < filterItems.Length; i1++)
 					{
+						string filterItem = filterItems[i1];
 						if (i.Text.IndexOf(filterItem, StringComparison.OrdinalIgnoreCase) == -1)
 						{
 							return false;
@@ -354,16 +367,24 @@ namespace Eto.Test.Sections.Controls
 			return control;
 		}
 
-		IEnumerable<MyGridItem> CreateItems()
+		List<MyGridItem> CreateItems(int count = 10000)
 		{
 			var rand = new Random();
-			for (int i = 0; i < 10000; i++)
+			var sw = new System.Diagnostics.Stopwatch();
+			sw.Start();
+
+			var list = new List<MyGridItem>(count);
+
+			for (int i = 0; i < count; i++)
 			{
-				yield return new MyGridItem(rand, i);
+				list.Add(new MyGridItem(rand, i));
 			}
+			sw.Stop();
+			Log.Write(null, $"Time: {sw.Elapsed}");
+			return list;
 		}
 
-		ContextMenu CreateContextMenu(GridView grid, SelectableFilterCollection<MyGridItem> filtered)
+		ContextMenu CreateContextMenu(GridView grid)
 		{
 			// Context menu
 			var menu = new ContextMenu();
@@ -406,7 +427,7 @@ namespace Eto.Test.Sections.Controls
 			{
 				var i = grid.SelectedItems.First() as MyGridItem;
 				if (i != null)
-					filtered.Remove(i);
+					filteredCollection.Remove(i);
 			};
 			menu.Items.Add(deleteItem);
 
@@ -416,7 +437,7 @@ namespace Eto.Test.Sections.Controls
 			{
 				var i = grid.SelectedItems.First() as MyGridItem;
 				if (i != null)
-					filtered.Insert(0, new MyGridItem(new Random(), 0));
+					filteredCollection.Insert(0, new MyGridItem(new Random(), 0));
 			};
 			menu.Items.Add(insertItem);
 
@@ -456,10 +477,10 @@ namespace Eto.Test.Sections.Controls
 			return control;
 		}
 
-		Button AddItemButton(SelectableFilterCollection<MyGridItem> filtered)
+		Button AddItemButton()
 		{
 			var control = new Button { Text = "Add Item" };
-			control.Click += (sender, e) => filtered.Add(new MyGridItem(new Random(), filtered.Count + 1));
+			control.Click += (sender, e) => filteredCollection.Add(new MyGridItem(new Random(), filteredCollection.Count + 1));
 			return control;
 		}
 

--- a/test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
@@ -31,8 +31,8 @@ namespace Eto.Test.Sections.Controls
 				null
 			);
 			layout.AddSeparateRow(null, InsertButton(), AddChildButton(), RemoveButton(), ExpandButton(), CollapseButton(), null);
-			layout.AddSeparateRow(null, EnabledCheck(), AllowMultipleSelect(), "Border", CreateBorderType(grid), null);
-			layout.AddSeparateRow(null, ReloadDataButton(grid), null);
+			layout.AddSeparateRow(null, EnabledCheck(), AllowMultipleSelect(), AllowEmptySelectionCheckBox(), "Border", CreateBorderType(grid), null);
+			layout.AddSeparateRow(null, ReloadDataButton(grid), SetDataButton(grid), null);
 
 			layout.Add(grid, yscale: true);
 			layout.Add(HoverNodeLabel());
@@ -51,6 +51,13 @@ namespace Eto.Test.Sections.Controls
 		{
 			var control = new Button { Text = "ReloadData" };
 			control.Click += (sender, e) => grid.ReloadData();
+			return control;
+		}
+
+		Control SetDataButton(TreeGridView grid)
+		{
+			var control = new Button { Text = "SetDataStore" };
+			control.Click += (sender, e) => SetDataStore(grid);
 			return control;
 		}
 
@@ -206,6 +213,14 @@ namespace Eto.Test.Sections.Controls
 			return control;
 		}
 
+		Control AllowEmptySelectionCheckBox()
+		{
+			var control = new CheckBox { Text = "AllowEmptySelection" };
+			control.CheckedBinding.Bind(grid, g => g.AllowEmptySelection);
+			return control;
+		}
+
+
 		TreeGridItem CreateComplexTreeItem(int level, string name, Image image)
 		{
 			var item = new TreeGridItem
@@ -249,9 +264,14 @@ namespace Eto.Test.Sections.Controls
 				control.ContextMenu = menu;
 			}
 
-			control.DataStore = CreateComplexTreeItem(0, "", Image);
+			SetDataStore(control);
 			LogEvents(control);
 			return control;
+		}
+
+		private void SetDataStore(TreeGridView control)
+		{
+			control.DataStore = CreateComplexTreeItem(0, "", Image);
 		}
 
 		static string SelectedRowsString(TreeGridView grid)


### PR DESCRIPTION
This property makes it so the user cannot remove the last selected item in a GridView or TreeGridView.  By default it is true.  Other enhancements include:

- Wpf/Winforms/Gtk: Can now deselect all items by clicking on empty space when AllowEmptySelection is true.
- Mac: Fixed resizing Scrollable vertically where it would make the content "jump" temporarily.  It should now resize more smoothly.
- Added new DynamicLayout.Begin/EndScrollable to add a scrollable section to your layout more easily.