### PR TITLE
[Gtk] Minnor fixups to NumericStepper and TextBox

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
@@ -13,8 +13,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		public NumericStepperHandler()
 		{
 			Control = new Gtk.SpinButton(double.MinValue, double.MaxValue, 1);
-			Control.WidthRequest = 120;
-			Control.Wrap = true;
+			Control.WidthChars = 0;
 			Value = 0;
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
@@ -11,6 +11,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			Control = new Gtk.Entry();
 			Control.WidthRequest = 100;
+			Control.WidthChars = 0;
 		}
 
 	}


### PR DESCRIPTION
Stuff done:
- Set `WidthChars ` to` 0`, this property is used as determining the minimum size for Gtk.Entry
- Removed Wrap, it was causing a bug, plus that is not how a Gtk stepper is supposed to act by default