### PR TITLE
Detach control when disposed

### DIFF
--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -932,6 +932,18 @@ namespace Eto.Forms
 				VisualParent.Remove(this);
 		}
 
+		static readonly object IsAttached_Key = new object();
+
+		/// <summary>
+		/// Gets or sets a value indicating this control has been attached to a native container
+		/// </summary>
+		/// <seealso cref="AttachNative"/>
+		bool IsAttached
+		{
+			get => Properties.Get<bool>(IsAttached_Key);
+			set => Properties.Set(IsAttached_Key, value);
+		}
+
 		/// <summary>
 		/// Attaches the control for direct use in a native application
 		/// </summary>
@@ -945,8 +957,12 @@ namespace Eto.Forms
 		public void AttachNative()
 		{
 			if (VisualParent != null)
-				throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "You can only attach a parentless control"));
+				throw new InvalidOperationException("You can only attach a parentless control");
+			
+			if (IsAttached)
+				return;
 
+			IsAttached = true;
 			using (Platform.Context)
 			{
 				OnPreLoad(EventArgs.Empty);
@@ -971,6 +987,10 @@ namespace Eto.Forms
 		/// </remarks>
 		public void DetachNative()
 		{
+			if (!IsAttached)
+				return;
+
+			IsAttached = false;
 			using (Platform.Context)
 			{
 				OnUnLoad(EventArgs.Empty);
@@ -1329,6 +1349,8 @@ namespace Eto.Forms
 			if (disposing)
 			{
 				Unbind();
+				Detach();
+				DetachNative();
 			}
 
 			base.Dispose(disposing);


### PR DESCRIPTION
- If control has a visual parent, it'll be removed to prevent exceptions due to the control being disposed.
- If control is attached natively it'll detach it (and call OnUnLoad)