### PR TITLE
Wpf: Fix crash when setting Tree/GridView data to empty collection

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -743,7 +743,9 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected void EnsureSelection()
 		{
-			if (!AllowEmptySelection && (Control.SelectedItems?.Count ?? 0) == 0)
+			if (!AllowEmptySelection 
+				&& (Control.SelectedItems?.Count ?? 0) == 0
+				&& (Control.ItemsSource as IList)?.Count > 0)
 			{
 				SelectRow(0);
 			}

--- a/test/Eto.Test/UnitTests/Forms/Controls/ControlTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ControlTests.cs
@@ -344,7 +344,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					layout.AddCentered(textBox);
 
 					return layout;
-				}, allowPassFail: false);
+				}, allowPass: false, allowFail: false);
 			}
 			finally
 			{

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
@@ -238,5 +238,47 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				Application.Instance.Invoke(() => f?.Close());
 			}
 		}
+
+		[TestCase(true, true)]
+		[TestCase(true, false)]
+		[TestCase(false, true)]
+		[TestCase(false, false)]
+		public void ClickingWithEmptyDataShouldNotCrash(bool allowEmptySelection, bool allowMultipleSelection)
+		{
+			Exception exception = null;
+			Form(form =>
+			{
+				var dd = new List<GridItem>();
+
+				dd.Add(new GridItem { Values = new[] { "Hello" } });
+				var control = new GridView();
+				control.AllowEmptySelection = allowEmptySelection;
+				control.AllowMultipleSelection = allowMultipleSelection;
+				control.Columns.Add(new GridColumn
+				{
+					DataCell = new TextBoxCell(0),
+					Width = 100,
+					HeaderText = "Text Cell"
+				});
+				control.DataStore = dd;
+				Application.Instance.AsyncInvoke(() => {
+					// can crash when had selection initially but no selection after.
+					try
+					{
+						control.DataStore = new List<GridItem>();
+					}
+					catch (Exception ex)
+					{
+						exception = ex;
+					}
+					Application.Instance.AsyncInvoke(form.Close);
+				});
+
+				form.Content = control;
+			});
+
+			if (exception != null)
+				ExceptionDispatchInfo.Capture(exception).Throw();
+		}
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/Controls/SegmentedButtonTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/SegmentedButtonTests.cs
@@ -282,7 +282,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					Application.Instance.AsyncInvoke(form.Close);
 				};
 				return control;
-			}, false);
+			}, allowPass: false);
 
 			Assert.AreEqual(1, itemClickWasRaised, "#1.1"); // ensure user actually clicked an item.
 			Assert.AreEqual(0, selectedIndexesChangedCount, "#1.2");
@@ -377,7 +377,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					Application.Instance.AsyncInvoke(form.Close);
 				};
 				return control;
-			}, false);
+			}, allowPass: false);
 
 			Assert.Multiple(() =>
 			{

--- a/test/Eto.Test/UnitTests/Forms/Controls/TreeGridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TreeGridViewTests.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
 using NUnit.Framework;
 using Eto.Forms;
 using System.Linq;
 using Eto.Drawing;
+using System.Runtime.ExceptionServices;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {
@@ -107,6 +108,49 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		{
 			var control = new TreeGridView();
 			control.DataStore = null; // when binding, this will be done so it should not crash!
+		}
+
+		[TestCase(true, true)]
+		[TestCase(true, false)]
+		[TestCase(false, true)]
+		[TestCase(false, false)]
+		public void ClickingWithEmptyDataShouldNotCrash(bool allowEmptySelection, bool allowMultipleSelection)
+		{
+			Exception exception = null;
+			Form(form =>
+			{
+				var dd = new TreeGridItemCollection();
+
+				dd.Add(new TreeGridItem { Values = new[] { "Hello" } });
+				var control = new TreeGridView();
+				control.AllowEmptySelection = allowEmptySelection;
+				control.AllowMultipleSelection = allowMultipleSelection;
+				control.Columns.Add(new GridColumn
+				{
+					DataCell = new TextBoxCell(0),
+					Width = 100,
+					HeaderText = "Text Cell"
+				});
+				control.DataStore = dd;
+				Application.Instance.AsyncInvoke(() => {
+					// can crash when had selection initially but no selection after.
+					try
+					{
+						control.DataStore = new TreeGridItemCollection();
+					}
+					catch (Exception ex)
+					{
+						exception = ex;
+					}
+				Application.Instance.AsyncInvoke(form.Close);
+				});
+
+				form.Content = control;
+			});
+
+			if (exception != null)
+				ExceptionDispatchInfo.Capture(exception).Throw();
+
 		}
 	}
 }

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -285,12 +285,12 @@ namespace Eto.Test.UnitTests
 			);
 		}
 
-		public static void ManualForm(string description, Func<Form, Control> init, bool allowPassFail = true)
+		public static void ManualForm(string description, Func<Form, Control> init, bool allowPass = true, bool allowFail = true)
 		{
-			ManualForm(description, (form, Label) => init(form), allowPassFail);
+			ManualForm(description, (form, Label) => init(form), allowPass, allowFail);
 		}
 
-		public static void ManualForm(string description, Func<Form, Label, Control> init, bool allowPassFail = true)
+		public static void ManualForm(string description, Func<Form, Label, Control> init, bool allowPass = true, bool allowFail = true)
 		{
 			Exception exception = null;
 			Form(form =>
@@ -308,28 +308,40 @@ namespace Eto.Test.UnitTests
 					}
 				};
 
-				if (allowPassFail)
+				if (allowFail || allowPass)
 				{
-					var failButton = new Button { Text = "Fail" };
-					failButton.Click += (sender, e) =>
-					{
-						try
-						{
-							Assert.Fail(description);
-						}
-						catch (Exception ex)
-						{
-							exception = ex;
-						}
-						finally
-						{
-							form.Close();
-						}
-					};
+					var table = new TableLayout { Spacing = new Size(2, 2) };
+					var row = new TableRow();
+					table.Rows.Add(row);
 
-					var passButton = new Button { Text = "Pass" };
-					passButton.Click += (sender, e) => form.Close();
-					layout.Items.Add(new StackLayoutItem(TableLayout.Horizontal(2, failButton, passButton), HorizontalAlignment.Center));
+					if (allowFail)
+					{
+						var failButton = new Button { Text = "Fail" };
+						failButton.Click += (sender, e) =>
+						{
+							try
+							{
+								Assert.Fail(description);
+							}
+							catch (Exception ex)
+							{
+								exception = ex;
+							}
+							finally
+							{
+								form.Close();
+							}
+						};
+						row.Cells.Add(failButton);
+					}
+
+					if (allowPass)
+					{
+						var passButton = new Button { Text = "Pass" };
+						passButton.Click += (sender, e) => form.Close();
+						row.Cells.Add(passButton);
+					}
+					layout.Items.Add(new StackLayoutItem(table, HorizontalAlignment.Center));
 				}
 
 				form.Content = layout;


### PR DESCRIPTION
This regression happened because we tried to select the first row even though there is no data when AllowEmptySelection is false and AllowMultipleSelection is true.

Added unit tests to verify fix and other modes.