### PR TITLE
Disable warnings (errors in Release) when using Xamarin.Mac 6.6

### DIFF
--- a/src/Eto.Mac/ColorizeView.cs
+++ b/src/Eto.Mac/ColorizeView.cs
@@ -89,6 +89,8 @@ namespace Eto.Mac
 
 			var ciImage = CIImage.FromCGImage(_image.CGImage);
 
+
+#pragma warning disable CS0618 // Image => InputImage in Xamarin.Mac 6.6
 			var filter2 = new CIColorControls();
 			filter2.SetDefaults();
 			filter2.Image = ciImage;
@@ -98,6 +100,8 @@ namespace Eto.Mac
 			var filter3 = new CIColorMatrix();
 			filter3.SetDefaults();
 			filter3.Image = ciImage;
+#pragma warning restore CS0618
+
 			var cgColor = Color.ToCG();
 			var components = cgColor.Components;
 			if (components.Length >= 3)

--- a/src/Eto.Mac/NSImageExtensions.cs
+++ b/src/Eto.Mac/NSImageExtensions.cs
@@ -74,6 +74,7 @@ namespace Eto.Mac
 				Color = CIColor.FromCGColor(tint.ToCG())
 			};
 
+#pragma warning disable CS0618 // Image => InputImage in Xamarin.Mac 6.6
 			var colorFilter = new CIColorControls
 			{
 				Image = (CIImage)colorGenerator.ValueForKey(CIFilterOutputKey.Image),
@@ -94,6 +95,7 @@ namespace Eto.Mac
 				Image = (CIImage)colorFilter.ValueForKey(CIFilterOutputKey.Image),
 				BackgroundImage = (CIImage)monochromeFilter.ValueForKey(CIFilterOutputKey.Image)
 			};
+#pragma warning restore CS0618
 
 			var outputImage = (CIImage)compositingFilter.ValueForKey(CIFilterOutputKey.Image);
 			var extent = outputImage.Extent;


### PR DESCRIPTION
This causes errors when compiling in Release mode (which has warnings as errors turned on).

Can't quite actually use the new API's yet (CI isn't updated to latest toolset, and that will take time), so we just ignore them for now until we can migrate.