### PR TITLE
Fix Use WinForms and WPF tags

### DIFF
--- a/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
+++ b/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
@@ -17,6 +17,7 @@
     <ApplicationIcon>..\Eto.Test\Images\TestIcon.ico</ApplicationIcon>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <UseWindowsForms Condition="$(HaveWindowsDesktopSdk) == 'True'">true</UseWindowsForms>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
+++ b/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
@@ -18,7 +18,6 @@
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Prefer32Bit>false</Prefer32Bit>
     <UseWPF Condition="$(HaveWindowsDesktopSdk) == 'True'">true</UseWPF>
-    <UseWindowsForms Condition="$(HaveWindowsDesktopSdk) == 'True'">true</UseWindowsForms>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
The test project for WinForms is missing the `UseWindowsForms` property whereas the WPF test project has one to many. This causes a warning during build. This PR fixes this issue.