### PR TITLE
TreeGridView/ImageTextCell tweaks

### DIFF
--- a/src/Eto.Mac/Drawing/FontTypefaceHandler.cs
+++ b/src/Eto.Mac/Drawing/FontTypefaceHandler.cs
@@ -116,26 +116,23 @@ namespace Eto.Mac.Drawing
 
 		public FontStyle FontStyle => Traits.ToEto();
 
+		static string SystemFontName => NSFont.SystemFontOfSize(NSFont.SystemFontSize).FontDescriptor.PostscriptName;
+		static string BoldSystemFontName => NSFont.BoldSystemFontOfSize(NSFont.SystemFontSize).FontDescriptor.PostscriptName;
+
 		public NSFont CreateFont(float size)
 		{
 
 			// we have a postcript name, use that to create the font
 			if (!string.IsNullOrEmpty(PostScriptName))
 			{
-				var font = NSFont.FromFontName(PostScriptName, size);
-				if (font == null)
-				{
-					// macOS 10.15 returns null for the above API for system fonts (when compiled using xcode 11).
-					font = NSFont.SystemFontOfSize(size);
-					if (font.FontDescriptor.PostscriptName == PostScriptName)
-						return font;
-					font = NSFont.BoldSystemFontOfSize(size);
-					if (font.FontDescriptor.PostscriptName == PostScriptName)
-						return font;
+				// if we try to get a system font by name we get errors now..
+				if (PostScriptName == SystemFontName)
+					return NSFont.SystemFontOfSize(size);
+				if (PostScriptName == BoldSystemFontName)
+					return NSFont.BoldSystemFontOfSize(size);
 
-					// always return something..?
-					return NSFont.UserFontOfSize(size);
-				}
+				// always return something...
+				var font = NSFont.FromFontName(PostScriptName, size) ?? NSFont.UserFontOfSize(size);
 				return font;
 			}
 

--- a/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
@@ -36,8 +36,8 @@ namespace Eto.Mac.Forms.Cells
 {
 	public class TextBoxCellHandler : CellHandler<TextBoxCell, TextBoxCell.ICallback>, TextBoxCell.IHandler, IMacText
 	{
-		static EtoCellTextField field = new EtoCellTextField { Cell = new EtoLabelFieldCell() };
-		static NSFont defaultFont = field.Font;
+		static readonly CellView field = new CellView();
+		static readonly NSFont defaultFont = field.Font;
 
 		public override nfloat GetPreferredWidth(object value, CGSize cellSize, int row, object dataItem)
 		{
@@ -76,32 +76,32 @@ namespace Eto.Mac.Forms.Cells
 
 		public override Color GetBackgroundColor(NSView view)
 		{
-			return ((EtoLabelFieldCell)((EtoCellTextField)view).Cell).BetterBackgroundColor.ToEto();
+			return ((CellView)view).Cell.BetterBackgroundColor.ToEto();
 		}
 
 		public override void SetBackgroundColor(NSView view, Color color)
 		{
-			((EtoLabelFieldCell)((EtoCellTextField)view).Cell).BetterBackgroundColor = color.ToNSUI();
+			((CellView)view).Cell.BetterBackgroundColor = color.ToNSUI();
 		}
 
 		public override Color GetForegroundColor(NSView view)
 		{
-			return ((EtoCellTextField)view).TextColor.ToEto();
+			return ((CellView)view).TextColor.ToEto();
 		}
 
 		public override void SetForegroundColor(NSView view, Color color)
 		{
-			((EtoCellTextField)view).TextColor = color.ToNSUI();
+			((CellView)view).TextColor = color.ToNSUI();
 		}
 
 		public override Font GetFont(NSView view)
 		{
-			return ((EtoCellTextField)view).Font.ToEto();
+			return ((CellView)view).Font.ToEto();
 		}
 
 		public override void SetFont(NSView view, Font font)
 		{
-			((EtoCellTextField)view).Font = font.ToNS();
+			((CellView)view).Font = font.ToNS();
 		}
 
 		TextAlignment _textAlignment;
@@ -138,11 +138,27 @@ namespace Eto.Mac.Forms.Cells
 		{
 			[Export("item")]
 			public NSObject Item { get; set; }
-			public CellView() { }
+
+			public CellView()
+			{
+				base.Cell = new EtoLabelFieldCell
+				{
+					Wraps = false,
+					Scrollable = true,
+					UsesSingleLineMode = false // true prevents proper vertical alignment 
+				};
+				Selectable = false;
+				DrawsBackground = false;
+				Bezeled = false;
+				Bordered = false;
+				AutoresizingMask = NSViewResizingMask.HeightSizable | NSViewResizingMask.WidthSizable;
+			}
 			public CellView(IntPtr handle) : base(handle) { }
+
+			public new EtoLabelFieldCell Cell => (EtoLabelFieldCell)base.Cell;
 		}
 
-		static NSString editableBinding = new NSString("editable");
+		static readonly NSString editableBinding = new NSString("editable");
 
 		public override NSView GetViewForItem(NSTableView tableView, NSTableColumn tableColumn, int row, NSObject obj, Func<NSObject, int, object> getItem)
 		{
@@ -152,18 +168,7 @@ namespace Eto.Mac.Forms.Cells
 				view = new CellView
 				{
 					WeakHandler = new WeakReference(this),
-					Cell = new EtoLabelFieldCell
-					{
-						Wraps = false,
-						Scrollable = true,
-						UsesSingleLineMode = false // true prevents proper vertical alignment 
-					},
 					Identifier = tableColumn.Identifier,
-					Selectable = false,
-					DrawsBackground = false,
-					Bezeled = false,
-					Bordered = false,
-					AutoresizingMask = NSViewResizingMask.HeightSizable | NSViewResizingMask.WidthSizable
 				};
 
 				var col = Array.IndexOf(tableView.TableColumns(), tableColumn);
@@ -200,7 +205,7 @@ namespace Eto.Mac.Forms.Cells
 				view.Bind(editableBinding, tableColumn, "editable", null);
 			}
 
-			var cell = (EtoLabelFieldCell)view.Cell;
+			var cell = view.Cell;
 			cell.VerticalAlignment = VerticalAlignment;
 			cell.Alignment = TextAlignment.ToNS();
 

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -511,10 +511,7 @@ namespace Eto.Mac.Forms.Controls
 
 		public abstract object GetItem(int row);
 
-		public virtual int RowCount
-		{
-			get { return (int)Control.RowCount; }
-		}
+		public virtual int RowCount => (int)Control.RowCount;
 
 		protected override bool ControlEnabled
 		{
@@ -561,10 +558,7 @@ namespace Eto.Mac.Forms.Controls
 				Widget.Properties[GridHandler.ScrolledToRow_Key] = true;
 		}
 
-		public bool Loaded
-		{
-			get { return Widget.Loaded; }
-		}
+		public bool Loaded => Widget.Loaded;
 
 		public GridLines GridLines
 		{
@@ -599,12 +593,20 @@ namespace Eto.Mac.Forms.Controls
 			SetIsEditing(false);
 			if (e.Item != null)
 				Callback.OnCellEdited(Widget, e);
+
+			// reload this entire row
+			if (e.Row >= 0)
+			{
+				Control.ReloadData(NSIndexSet.FromIndex((nnint)e.Row), NSIndexSet.FromNSRange(new NSRange(0, Control.ColumnCount)));
+			}
+
+			if (e.GridColumn.AutoSize)
+			{
+				AutoSizeColumns(true);
+			}
 		}
 
-		Grid IDataViewHandler.Widget
-		{
-			get { return Widget; }
-		}
+		Grid IDataViewHandler.Widget => Widget;
 
 		protected void SetIsEditing(bool value) => Widget.Properties.Set(GridHandler.IsEditing_Key, value, false);
 

--- a/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
@@ -199,6 +199,7 @@ namespace Eto.Mac.Forms.Controls
 			col.ResizingMask = NSTableColumnResizing.Autoresizing;
 			col.Editable = false;
 			cell = new MacImageListItemCell();
+			cell.VerticalAlignment = VerticalAlignment.Center;
 			cell.Wraps = false;
 			col.DataCell = cell;
 			Control.AddColumn(col);

--- a/src/Eto.Mac/Forms/Controls/MacImageTextView.cs
+++ b/src/Eto.Mac/Forms/Controls/MacImageTextView.cs
@@ -1,0 +1,137 @@
+﻿using System;
+#if XAMMAC2
+using AppKit;
+using CoreGraphics;
+using Foundation;
+#else
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+using MonoMac.CoreGraphics;
+using MonoMac.ObjCRuntime;
+using MonoMac.CoreAnimation;
+#if Mac64
+using nfloat = System.Double;
+using nint = System.Int64;
+using nuint = System.UInt64;
+#else
+using nfloat = System.Single;
+using nint = System.Int32;
+using nuint = System.UInt32;
+#endif
+#if SDCOMPAT
+using CGSize = System.Drawing.SizeF;
+using CGRect = System.Drawing.RectangleF;
+using CGPoint = System.Drawing.PointF;
+#endif
+#endif
+
+namespace Eto.Mac.Forms.Controls
+{
+    public class MacImageTextView : NSView
+    {
+        public const int ImagePadding = 2;
+        CGSize _imageSize;
+        NSTextField _textField;
+        NSImage _image;
+
+        public NSTextField TextField => _textField ?? (_textField = CreateTextFieldInternal());
+
+		[Export("image")]
+        public NSImage Image
+        {
+            get => _image;
+            set
+            {
+                _image = value;
+                SetSizes(Bounds.Size);
+            }
+        }
+
+        void SetSizes(CGSize bounds)
+        {
+            if (_image == null)
+            {
+                TextField.Frame = new CGRect(CGPoint.Empty, bounds);
+                _imageSize = CGSize.Empty;
+            }
+            else
+            {
+                var imageSize = _image.Size;
+                var scaledHeight = Math.Min(imageSize.Height, bounds.Height);
+                var scaledWidth = imageSize.Width * scaledHeight / imageSize.Height;
+                _imageSize = new CGSize(scaledWidth, scaledHeight);
+                TextField.Frame = new CGRect(scaledWidth + ImagePadding, 0, bounds.Width - scaledWidth - ImagePadding, bounds.Height);
+            }
+        }
+
+        public override CGSize FittingSize
+        {
+            get
+            {
+                var size = TextField.Cell.CellSizeForBounds(new CGRect(0, 0, nfloat.MaxValue, Bounds.Height));
+                if (_image != null)
+                {
+                    size.Width += _imageSize.Width + ImagePadding;
+                }
+                return size;
+            }
+        }
+
+        public override void SetFrameSize(CGSize newSize)
+        {
+            base.SetFrameSize(newSize);
+            SetSizes(newSize);
+        }
+
+        public MacImageTextView(IntPtr handle) : base(handle)
+        {
+        }
+
+        public MacImageTextView()
+        {
+        }
+
+        NSTextField CreateTextFieldInternal()
+        {
+            var view = CreateTextField();
+            view.AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
+            AddSubview(view);
+            return view;
+        }
+
+        public NSColor BetterBackgroundColor { get; set; }
+
+		public NSImageInterpolation ImageInterpolation { get; set; }
+
+        public override void DrawRect(CGRect dirtyRect)
+		{
+            if (BetterBackgroundColor != null)
+            {
+                BetterBackgroundColor.SetFill();
+                NSGraphics.RectFill(dirtyRect);
+            }
+
+            if (_image != null)
+            {
+                var context = NSGraphicsContext.CurrentContext;
+                var bounds = Bounds;
+
+                var imageRect = new CGRect(0, bounds.Y, _imageSize.Width, _imageSize.Height);
+                imageRect.Y += (bounds.Height - _imageSize.Height) / 2;
+
+                const float alpha = 1; //Enabled ? 1 : (nfloat)0.5;
+
+                context.ImageInterpolation = ImageInterpolation;
+
+                _image.Draw(imageRect, new CGRect(CGPoint.Empty, _image.Size), NSCompositingOperation.SourceOver, alpha, true, null);
+            }
+
+            base.DrawRect(dirtyRect);
+		}
+
+		protected virtual NSTextField CreateTextField() => new NSTextField();
+
+        protected virtual NSImageView CreateImageView() => new NSImageView();
+    }
+}
+

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -259,11 +259,26 @@ namespace Eto.Mac.Forms.Controls
 				}
 			}
 
+			public override nfloat GetSizeToFitColumnWidth(NSOutlineView outlineView, nint column)
+			{
+				var colHandler = Handler.GetColumn(outlineView.TableColumns()[column]);
+				if (colHandler != null)
+				{
+					// turn on autosizing for this column again
+					Application.Instance.AsyncInvoke(() => colHandler.AutoSize = true);
+					return colHandler.GetPreferredWidth();
+				}
+				return 20;
+			}
+
 			public override void DidClickTableColumn(NSOutlineView outlineView, NSTableColumn tableColumn)
 			{
 				var column = Handler.GetColumn(tableColumn);
-				var args = new GridColumnEventArgs(column.Widget);
-				Handler.Callback.OnColumnHeaderClick(Handler.Widget, args);
+				if (column.Sortable)
+				{
+					var args = new GridColumnEventArgs(column.Widget);
+					Handler.Callback.OnColumnHeaderClick(Handler.Widget, args);
+				}
 			}
 
 			public override NSView GetView(NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item)
@@ -650,7 +665,15 @@ namespace Eto.Mac.Forms.Controls
 							e.Handled = true;
 						}
 					};
-					Control.DoubleClick += HandleDoubleClick;
+					Widget.MouseDoubleClick += (sender, e) =>
+					{
+						var cell = GetCellAt(e.Location, out var column);
+						if (cell != null)
+						{
+							Callback.OnActivated(Widget, new TreeGridViewItemEventArgs(SelectedItem));
+							e.Handled = true;
+						}
+					};
 					break;
 				case TreeGridView.ExpandedEvent:
 				case TreeGridView.ExpandingEvent:
@@ -672,15 +695,6 @@ namespace Eto.Mac.Forms.Controls
 				default:
 					base.AttachEvent(id);
 					break;
-			}
-		}
-
-		static void HandleDoubleClick(object sender, EventArgs e)
-		{
-			var handler = GetHandler(sender) as TreeGridViewHandler;
-			if (handler != null)
-			{
-				handler.Callback.OnActivated(handler.Widget, new TreeGridViewItemEventArgs(handler.SelectedItem));
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -151,7 +151,7 @@ namespace Eto.Mac.Forms.Controls
 				var etoItem = h.GetEtoItem(item);
 				var row = h.Control.RowForItem(item);
 
-				var args = new GridViewCellEventArgs(colHandler.Widget, (int)row, colHandler.Column, item);
+				var args = new GridViewCellEventArgs(colHandler.Widget, (int)row, colHandler.Column, etoItem);
 				h.Callback.OnCellEditing(h.Widget, args);
 				h.SetIsEditing(true);
 				return true;

--- a/src/Eto.Wpf/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CellHandler.cs
@@ -16,6 +16,8 @@ namespace Eto.Wpf.Forms.Cells
 	{
 		ICellContainerHandler ContainerHandler { get; set; }
 		swc.DataGridColumn Control { get; }
+		bool OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell);
+		bool OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell);
 	}
 
 	static class CellProperties
@@ -63,5 +65,7 @@ namespace Eto.Wpf.Forms.Cells
 			return null;
 		}
 
+		public virtual bool OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell) => false;
+		public virtual bool OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell) => false;
 	}
 }

--- a/src/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
@@ -227,5 +227,26 @@ namespace Eto.Wpf.Forms.Cells
 		}
 
 		public AutoSelectMode AutoSelectMode { get; set; } = AutoSelectMode.OnFocus;
+
+		public override bool OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
+		{
+			if (cell?.IsEditing == true && hitTestResult is swc.Image)
+			{
+				// commit editing when clicking on the image
+				ContainerHandler?.Grid.CommitEdit();
+				return true;
+			}
+
+			return base.OnMouseDown(args, hitTestResult, cell);
+		}
+		public override bool OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
+		{
+			if (cell?.IsEditing == false && !Control.IsReadOnly && hitTestResult is swc.Image)
+			{
+				// prevent default behaviour of editing if we click on the image
+				return true;
+			}
+			return base.OnMouseUp(args, hitTestResult, cell);
+		}
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
@@ -129,6 +129,18 @@ namespace Eto.Wpf.Forms.Controls
 				GridHandler.FormatCell (this, cell, element, gridcell, dataItem);
 		}
 
+		internal ICellHandler DataCellHandler => DataCell?.Handler as ICellHandler;
+
+		internal bool OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
+		{
+			return DataCellHandler?.OnMouseDown(args, hitTestResult, cell) ?? false;
+		}
+
+		internal bool OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
+		{
+			return DataCellHandler?.OnMouseUp(args, hitTestResult, cell) ?? false;
+		}
+
 		swc.DataGridColumn IGridColumnHandler.Control => Control;
 
 		public Grid Grid => GridHandler?.Widget;

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -204,16 +204,21 @@ namespace Eto.Wpf.Forms
 					{
 						var args = new CancelEventArgs { Cancel = e.Cancel };
 						Callback.OnClosing(Widget, args);
-						if (!args.Cancel && sw.Application.Current.Windows.Count == 1)
+						var willShutDown =
+							sw.Application.Current.Windows.Count == 1
+							|| (
+								sw.Application.Current.MainWindow == Control
+								&& sw.Application.Current.ShutdownMode == sw.ShutdownMode.OnMainWindowClose
+							);
+
+						if (!args.Cancel && willShutDown)
 						{
 							// last window closing, so call OnTerminating to let the app abort terminating
 							var app = ((ApplicationHandler)Application.Instance.Handler);
 							app.Callback.OnTerminating(app.Widget, args);
 						}
 						e.Cancel = args.Cancel;
-						IsApplicationClosing = !args.Cancel
-							&& sw.Application.Current.MainWindow == Control
-							&& sw.Application.Current.ShutdownMode == sw.ShutdownMode.OnMainWindowClose;
+						IsApplicationClosing = !args.Cancel && willShutDown;
 					};
 					break;
 				case Window.WindowStateChangedEvent:

--- a/test/Eto.Test.Mac/Startup.cs
+++ b/test/Eto.Test.Mac/Startup.cs
@@ -4,6 +4,7 @@ using Eto.Mac;
 using System.Diagnostics;
 using Eto.Drawing;
 using Eto.Mac.Forms.ToolBar;
+using Eto.Forms;
 
 #if XAMMAC2
 using AppKit;
@@ -46,21 +47,32 @@ namespace Eto.Test.Mac
 			// other styles
 			Style.Add<TreeGridViewHandler>("sectionList", handler =>
 				{
-					handler.ScrollView.BorderType = NSBorderType.NoBorder;
+					handler.Border = BorderType.None;
+
 					handler.Control.SelectionHighlightStyle = NSTableViewSelectionHighlightStyle.SourceList;
+					handler.Control.FloatsGroupRows = false;
+
+					handler.ShowGroups = true;
+					handler.AllowGroupSelection = false;
 				});
 
 			Style.Add<ButtonToolItemHandler>(null, handler =>
-				{
-					// tint the images in grayscale
-					handler.Tint = Colors.Gray;
-				});
+			{
+				// tint the images in grayscale
+				handler.Tint = Colors.Gray;
+			});
+			Style.Add<CheckToolItemHandler>(null, handler =>
+			{
+				// tint the images in grayscale
+				handler.Tint = Colors.Gray;
+			});
 
 			Style.Add<ToolBarHandler>(null, handler =>
 				{ 
 					// change display mode or other options
 					//handler.Control.DisplayMode = NSToolbarDisplayMode.Icon;
 				});
+
 		}
 	}
 }

--- a/test/Eto.Test/SectionList.cs
+++ b/test/Eto.Test/SectionList.cs
@@ -74,66 +74,6 @@ namespace Eto.Test
 	}
 
 	/// <summary>
-	/// Tests for dialogs and forms use this.
-	/// </summary>
-	public class WindowSection : Section, ISection
-	{
-		Func<Window> Func { get; set; }
-
-		public WindowSection(string text = null)
-		{
-			Text = text;
-		}
-
-		public WindowSection(string text, Func<Window> f)
-		{
-			Func = f;
-			Text = text;
-		}
-
-		protected virtual Window GetWindow()
-		{
-			return null;
-		}
-
-		public Control CreateContent()
-		{
-			var button = new Button { Text = string.Format("Show the {0} test", Text) };
-			var layout = new DynamicLayout();
-			layout.AddCentered(button);
-			button.Click += (sender, e) =>
-			{
-
-				try
-				{
-					var window = Func != null ? Func() : null ?? GetWindow();
-
-					if (window != null)
-					{
-						var dialog = window as Dialog;
-						if (dialog != null)
-						{
-							dialog.ShowModal(null);
-							return;
-						}
-						var form = window as Form;
-						if (form != null)
-						{
-							form.Show();
-							return;
-						}
-					}
-				}
-				catch (Exception ex)
-				{
-					Log.Write(this, "Error loading section: {0}", ex.GetBaseException());
-				}
-			};
-			return layout;
-		}
-	}
-
-	/// <summary>
 	/// The base class for views that display the set of tests.
 	/// </summary>
 	public abstract class SectionList
@@ -142,14 +82,7 @@ namespace Eto.Test
 		public abstract ISection SelectedItem { get; set; }
 		public event EventHandler SelectedItemChanged;
 
-		public string SectionTitle
-		{
-			get
-			{
-				var section = SelectedItem as Section;
-				return section != null ? section.Text : null;
-			}
-		}
+		public string SectionTitle => SelectedItem?.Text;
 
 		protected void OnSelectedItemChanged(EventArgs e)
 		{

--- a/test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -5,6 +5,8 @@ using Eto.Drawing;
 using System.Collections;
 using System.Collections.Generic;
 using System.Text.RegularExpressions;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Eto.Test.Sections.Controls
 {
@@ -369,7 +371,6 @@ namespace Eto.Test.Sections.Controls
 
 		List<MyGridItem> CreateItems(int count = 10000)
 		{
-			var rand = new Random();
 			var sw = new System.Diagnostics.Stopwatch();
 			sw.Start();
 
@@ -377,7 +378,7 @@ namespace Eto.Test.Sections.Controls
 
 			for (int i = 0; i < count; i++)
 			{
-				list.Add(new MyGridItem(rand, i));
+				list.Add(new MyGridItem(i));
 			}
 			sw.Stop();
 			Log.Write(null, $"Time: {sw.Elapsed}");
@@ -437,7 +438,7 @@ namespace Eto.Test.Sections.Controls
 			{
 				var i = grid.SelectedItems.First() as MyGridItem;
 				if (i != null)
-					filteredCollection.Insert(0, new MyGridItem(new Random(), 0));
+					filteredCollection.Insert(0, new MyGridItem(0));
 			};
 			menu.Items.Add(insertItem);
 
@@ -480,7 +481,7 @@ namespace Eto.Test.Sections.Controls
 		Button AddItemButton()
 		{
 			var control = new Button { Text = "Add Item" };
-			control.Click += (sender, e) => filteredCollection.Add(new MyGridItem(new Random(), filteredCollection.Count + 1));
+			control.Click += (sender, e) => filteredCollection.Add(new MyGridItem(filteredCollection.Count + 1));
 			return control;
 		}
 
@@ -499,13 +500,22 @@ namespace Eto.Test.Sections.Controls
 		/// <summary>
 		/// POCO (Plain Old CLR Object) to test property bindings
 		/// </summary>
-		protected class MyGridItem
+		protected class MyGridItem : INotifyPropertyChanged
 		{
 			bool? check;
 			string text;
 			string dropDownKey;
 			float? progress;
+			Color color;
+			Image image;
 			Command command;
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			void OnPropertyChanged([CallerMemberName] string propertyName = null)
+			{
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			}
 
 			public int Row { get; set; }
 
@@ -520,6 +530,7 @@ namespace Eto.Test.Sections.Controls
 				set
 				{
 					check = value;
+					OnPropertyChanged();
 					Log("Check", value);
 				}
 			}
@@ -530,11 +541,20 @@ namespace Eto.Test.Sections.Controls
 				set
 				{
 					text = value;
+					OnPropertyChanged();
 					Log("Text", value);
 				}
 			}
 
-			public Image Image { get; set; }
+			public Image Image
+			{
+				get { return image; }
+				set
+				{
+					image = value;
+					OnPropertyChanged();
+				}
+			}
 
 			public string DropDownKey
 			{
@@ -543,11 +563,21 @@ namespace Eto.Test.Sections.Controls
 				{
 					dropDownKey = value;
 					Log("DropDownKey", value);
+					OnPropertyChanged();
 				}
 			}
 
 			// used for drawable cell
-			public Color Color { get; set; }
+			public Color Color
+			{
+				get { return color; }
+				set
+				{
+					color = value;
+					Log("Color", value);
+					OnPropertyChanged();
+				}
+			}
 
 			public float? Progress
 			{
@@ -556,6 +586,7 @@ namespace Eto.Test.Sections.Controls
 				{
 					progress = value;
 					Log("Progress", value);
+					OnPropertyChanged();
 				}
 			}
 
@@ -567,7 +598,7 @@ namespace Eto.Test.Sections.Controls
 				}
 			}
 
-			public MyGridItem(Random rand, int row)
+			public MyGridItem(int row)
 			{
 				// initialize to random values
 				this.Row = row;
@@ -575,11 +606,14 @@ namespace Eto.Test.Sections.Controls
 				check = val == 0 ? (bool?)false : val == 1 ? (bool?)true : null;
 
 				val = row % 2;
-				Image = val == 0 ? image1 : val == 1 ? (Image)image2 : null;
+				image = val == 0 ? image1 : val == 1 ? (Image)image2 : null;
+				OnPropertyChanged(nameof(Image));
 
 				text = string.Format("Col 1 Row {0}", row);
+				OnPropertyChanged(nameof(Text));
 
-				Color = Color.FromElementId(row);
+				color = Color.FromElementId(row);
+				OnPropertyChanged(nameof(Color));
 
 				val = row % 5;
 				if (val < 4)

--- a/test/Eto.Test/Settings.cs
+++ b/test/Eto.Test/Settings.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Diagnostics;
+using System.IO;
+
+namespace Eto.Test
+{
+    public class Settings
+    {
+        static string AppSettingsFolder => EtoEnvironment.GetFolderPath(EtoSpecialFolder.ApplicationSettings);
+        static string SettingsFile => Path.Combine(AppSettingsFolder, "mainform.json");
+
+        public string InitialSection { get; set; }
+
+        public bool SaveInitialSection { get; set; }
+
+        public static Settings Load()
+        {
+            try
+            {
+                if (File.Exists(SettingsFile))
+                    return Newtonsoft.Json.JsonConvert.DeserializeObject<Settings>(File.ReadAllText(SettingsFile)) ?? new Settings();
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error reading settings: {ex}");
+            }
+            return new Settings();
+        }
+
+        public void Save()
+        {
+            try
+            {
+                var str = Newtonsoft.Json.JsonConvert.SerializeObject(this);
+                File.WriteAllText(SettingsFile, str);
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"Error writing settings: {ex}");
+            }
+
+        }
+    }
+}
+

--- a/test/Eto.Test/TestApplication.cs
+++ b/test/Eto.Test/TestApplication.cs
@@ -11,6 +11,10 @@ namespace Eto.Test
 {
 	public class TestApplication : Application
 	{
+		static Settings settings;
+
+		public static Settings Settings => settings ?? (settings = Settings.Load());
+
 		public static IEnumerable<Assembly> DefaultTestAssemblies()
 		{
 #if PCL
@@ -69,16 +73,18 @@ namespace Eto.Test
 #endif
 		}
 
-		/*
 		protected override void OnTerminating(CancelEventArgs e)
 		{
 			base.OnTerminating(e);
 			Log.Write(this, "Terminating");
+			Settings.Save();
 
+			/*
 			var result = MessageBox.Show(MainForm, "Are you sure you want to quit?", MessageBoxButtons.YesNo, MessageBoxType.Question);
 			if (result == DialogResult.No)
 				e.Cancel = true;
-		}*/
+			*/
+		}
 	}
 }
 


### PR DESCRIPTION
- Mac: Image should be visible when editing
- Editing should only start when clicking the text
- Editing should commit when clicking the image
- Mac: Fix double click to autosize with TreeGridView

Also: 
- Wpf: Fix Application.Terminating when closing the main window
- Mac: Avoid warnings when using system fonts