### PR TITLE
Use unified namespaces for MonoMac

### DIFF
--- a/src/Eto.Mac/AppDelegate.cs
+++ b/src/Eto.Mac/AppDelegate.cs
@@ -1,35 +1,17 @@
 using Eto.Forms;
 using System.ComponentModel;
 using Eto.Mac.Forms;
-
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac

--- a/src/Eto.Mac/AppDelegate.cs
+++ b/src/Eto.Mac/AppDelegate.cs
@@ -8,12 +8,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac
 {
 	[Register("EtoAppDelegate")]

--- a/src/Eto.Mac/AsyncQueue.cs
+++ b/src/Eto.Mac/AsyncQueue.cs
@@ -59,11 +59,7 @@ namespace Eto.Mac
 			if (_actionQueue.Count == 1)
 			{
 				// first one added, schedule a layout!
-#if XAMMAC1
-				NSApplication.SharedApplication.BeginInvokeOnMainThread(new NSAction(FlushQueue));
-#else
 				NSApplication.SharedApplication.BeginInvokeOnMainThread(FlushQueue);
-#endif
 			}
 		}
 

--- a/src/Eto.Mac/AsyncQueue.cs
+++ b/src/Eto.Mac/AsyncQueue.cs
@@ -2,12 +2,7 @@ using System;
 using System.Collections.Generic;
 using Eto.Forms;
 using Eto.Mac.Forms;
-#if XAMMAC2
 using AppKit;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-#endif
 
 namespace Eto.Mac
 {

--- a/src/Eto.Mac/CGConversions.cs
+++ b/src/Eto.Mac/CGConversions.cs
@@ -6,12 +6,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if OSX
 using Eto.Mac.Drawing;
 

--- a/src/Eto.Mac/CGConversions.cs
+++ b/src/Eto.Mac/CGConversions.cs
@@ -1,32 +1,15 @@
 using System;
 using Eto.Drawing;
-
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if OSX

--- a/src/Eto.Mac/ColorizeView.cs
+++ b/src/Eto.Mac/ColorizeView.cs
@@ -6,12 +6,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac
 {
 	class ColorizeView : IDisposable

--- a/src/Eto.Mac/ColorizeView.cs
+++ b/src/Eto.Mac/ColorizeView.cs
@@ -1,32 +1,15 @@
 ﻿using System;
 using Eto.Drawing;
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac

--- a/src/Eto.Mac/Drawing/BitmapHandler.cs
+++ b/src/Eto.Mac/Drawing/BitmapHandler.cs
@@ -14,12 +14,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Drawing
 {
 	/// <summary>

--- a/src/Eto.Mac/Drawing/BitmapHandler.cs
+++ b/src/Eto.Mac/Drawing/BitmapHandler.cs
@@ -7,35 +7,17 @@ using Eto.Mac.Forms;
 using Eto.Shared.Drawing;
 using System.Collections.Generic;
 using Eto.Forms;
-
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Drawing

--- a/src/Eto.Mac/Drawing/EtoFontManager.cs
+++ b/src/Eto.Mac/Drawing/EtoFontManager.cs
@@ -4,12 +4,6 @@ using Foundation;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Drawing
 {
 	public class EtoFontManager : NSFontManager

--- a/src/Eto.Mac/Drawing/EtoFontManager.cs
+++ b/src/Eto.Mac/Drawing/EtoFontManager.cs
@@ -1,31 +1,13 @@
 using System;
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Drawing

--- a/src/Eto.Mac/Drawing/FontExtensions.cs
+++ b/src/Eto.Mac/Drawing/FontExtensions.cs
@@ -7,12 +7,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if OSX
 namespace Eto.Mac.Drawing
 #elif IOS

--- a/src/Eto.Mac/Drawing/FontExtensions.cs
+++ b/src/Eto.Mac/Drawing/FontExtensions.cs
@@ -1,32 +1,16 @@
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if OSX

--- a/src/Eto.Mac/Drawing/FontFamilyHandler.cs
+++ b/src/Eto.Mac/Drawing/FontFamilyHandler.cs
@@ -2,19 +2,12 @@ using System;
 using Eto.Drawing;
 using System.Collections.Generic;
 using System.Linq;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Drawing
 {

--- a/src/Eto.Mac/Drawing/FontHandler.cs
+++ b/src/Eto.Mac/Drawing/FontHandler.cs
@@ -2,34 +2,17 @@ using System;
 using System.Globalization;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if IOS

--- a/src/Eto.Mac/Drawing/FontHandler.cs
+++ b/src/Eto.Mac/Drawing/FontHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if IOS
 
 using UIKit;

--- a/src/Eto.Mac/Drawing/FontTypefaceHandler.cs
+++ b/src/Eto.Mac/Drawing/FontTypefaceHandler.cs
@@ -3,22 +3,12 @@ using Eto.Drawing;
 using System.Linq;
 using System.Runtime.InteropServices;
 
-
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreText;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreText;
-#endif
 
 namespace Eto.Mac.Drawing
 {

--- a/src/Eto.Mac/Drawing/FontsHandler.cs
+++ b/src/Eto.Mac/Drawing/FontsHandler.cs
@@ -3,19 +3,12 @@ using Eto.Drawing;
 using System.Collections.Generic;
 using System.Linq;
 #if OSX
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Drawing
 #elif IOS

--- a/src/Eto.Mac/Drawing/FormattedTextHandler.cs
+++ b/src/Eto.Mac/Drawing/FormattedTextHandler.cs
@@ -10,12 +10,6 @@ using CoreAnimation;
 using CoreImage;
 using CoreText;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if OSX
 namespace Eto.Mac.Drawing
 #elif IOS

--- a/src/Eto.Mac/Drawing/FormattedTextHandler.cs
+++ b/src/Eto.Mac/Drawing/FormattedTextHandler.cs
@@ -1,7 +1,7 @@
 ﻿using Eto.Drawing;
 using System;
 using System.Runtime.InteropServices;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
@@ -9,28 +9,11 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 using CoreText;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
-using MonoMac.CoreText;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if OSX

--- a/src/Eto.Mac/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Mac/Drawing/GraphicsHandler.cs
@@ -5,45 +5,23 @@ using Eto.Drawing;
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
-using MonoMac;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if OSX
 using Eto.Mac.Forms;
 
-#if XAMMAC2
 using GraphicsBase = Eto.Mac.Forms.MacBase<CoreGraphics.CGContext, Eto.Drawing.Graphics, Eto.Drawing.Graphics.ICallback>;
-#else
-using GraphicsBase = Eto.Mac.Forms.MacBase<MonoMac.CoreGraphics.CGContext, Eto.Drawing.Graphics, Eto.Drawing.Graphics.ICallback>;
-#endif
 
 namespace Eto.Mac.Drawing
 #elif IOS

--- a/src/Eto.Mac/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Mac/Drawing/GraphicsHandler.cs
@@ -12,12 +12,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if OSX
 using Eto.Mac.Forms;
 

--- a/src/Eto.Mac/Drawing/GraphicsPathHandler.cs
+++ b/src/Eto.Mac/Drawing/GraphicsPathHandler.cs
@@ -5,36 +5,16 @@ using Eto.Drawing;
 using System.Diagnostics;
 
 #if OSX
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
-#endif
-
-#if !UNIFIED
-using sd = System.Drawing;
 #endif
 
 using Eto.Mac;

--- a/src/Eto.Mac/Drawing/GraphicsPathHandler.cs
+++ b/src/Eto.Mac/Drawing/GraphicsPathHandler.cs
@@ -11,12 +11,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 using Eto.Mac;
 namespace Eto.Mac.Drawing
 #elif IOS
@@ -230,11 +224,7 @@ namespace Eto.iOS.Drawing
 
 		public void AddEllipse (float x, float y, float width, float height)
 		{
-			#if XAMMAC || XAMMAC2 || IOS
 			Control.AddEllipseInRect(new CGRect(x, y, width, height));
-			#else
-			Control.AddElipseInRect (new CGRect(x, y, width, height));
-			#endif
 			startFigure = true;
 			isFirstFigure = false;
 		}

--- a/src/Eto.Mac/Drawing/IconFrameHandler.cs
+++ b/src/Eto.Mac/Drawing/IconFrameHandler.cs
@@ -6,34 +6,17 @@ using System.Collections.Generic;
 using System.Linq;
 using Eto.Forms;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Drawing

--- a/src/Eto.Mac/Drawing/IconFrameHandler.cs
+++ b/src/Eto.Mac/Drawing/IconFrameHandler.cs
@@ -13,12 +13,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Drawing
 {
 

--- a/src/Eto.Mac/Drawing/IconHandler.cs
+++ b/src/Eto.Mac/Drawing/IconHandler.cs
@@ -6,34 +6,17 @@ using System.Collections.Generic;
 using System.Linq;
 using Eto.Forms;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Drawing

--- a/src/Eto.Mac/Drawing/IconHandler.cs
+++ b/src/Eto.Mac/Drawing/IconHandler.cs
@@ -13,12 +13,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Drawing
 {
 	public class IconHandler : ImageHandler<NSImage, Icon>, Icon.IHandler

--- a/src/Eto.Mac/Drawing/ImageHandler.cs
+++ b/src/Eto.Mac/Drawing/ImageHandler.cs
@@ -1,34 +1,17 @@
 using Eto.Drawing;
 using Eto.Mac.Forms;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Drawing

--- a/src/Eto.Mac/Drawing/ImageHandler.cs
+++ b/src/Eto.Mac/Drawing/ImageHandler.cs
@@ -8,12 +8,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Drawing
 {
 	interface IImageSource

--- a/src/Eto.Mac/Drawing/IndexedBitmapHandler.cs
+++ b/src/Eto.Mac/Drawing/IndexedBitmapHandler.cs
@@ -5,34 +5,17 @@ using System.Runtime.InteropServices;
 using Eto.Drawing;
 using Eto.Shared.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Drawing

--- a/src/Eto.Mac/Drawing/IndexedBitmapHandler.cs
+++ b/src/Eto.Mac/Drawing/IndexedBitmapHandler.cs
@@ -12,12 +12,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Drawing
 {
 	public class IndexedBitmapDataHandler : BaseBitmapData

--- a/src/Eto.Mac/Drawing/LinearGradientBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/LinearGradientBrushHandler.cs
@@ -3,33 +3,16 @@ using Eto.Drawing;
 using System.Collections.Generic;
 using System.Linq;
 
-#if XAMMAC2
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if OSX

--- a/src/Eto.Mac/Drawing/LinearGradientBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/LinearGradientBrushHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if OSX
 
 namespace Eto.Mac.Drawing

--- a/src/Eto.Mac/Drawing/MatrixHandler.cs
+++ b/src/Eto.Mac/Drawing/MatrixHandler.cs
@@ -1,34 +1,17 @@
 using System;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if OSX

--- a/src/Eto.Mac/Drawing/MatrixHandler.cs
+++ b/src/Eto.Mac/Drawing/MatrixHandler.cs
@@ -8,12 +8,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if OSX
 
 namespace Eto.Mac.Drawing

--- a/src/Eto.Mac/Drawing/PenHandler.cs
+++ b/src/Eto.Mac/Drawing/PenHandler.cs
@@ -1,34 +1,17 @@
 using System;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if OSX

--- a/src/Eto.Mac/Drawing/PenHandler.cs
+++ b/src/Eto.Mac/Drawing/PenHandler.cs
@@ -8,12 +8,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if OSX
 
 namespace Eto.Mac.Drawing

--- a/src/Eto.Mac/Drawing/RadialGradientBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/RadialGradientBrushHandler.cs
@@ -3,33 +3,16 @@ using Eto.Drawing;
 using System.Collections.Generic;
 using System.Linq;
 
-#if XAMMAC2
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if OSX

--- a/src/Eto.Mac/Drawing/RadialGradientBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/RadialGradientBrushHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if OSX
 
 namespace Eto.Mac.Drawing

--- a/src/Eto.Mac/Drawing/SolidBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/SolidBrushHandler.cs
@@ -1,19 +1,11 @@
 using Eto.Drawing;
 
 #if OSX
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Drawing
 #elif IOS

--- a/src/Eto.Mac/Drawing/SystemColorsHandler.cs
+++ b/src/Eto.Mac/Drawing/SystemColorsHandler.cs
@@ -2,19 +2,11 @@ using System;
 using Eto.Drawing;
 using System.Threading;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Drawing
 {

--- a/src/Eto.Mac/Drawing/TextureBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/TextureBrushHandler.cs
@@ -7,12 +7,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if OSX
 
 namespace Eto.Mac.Drawing

--- a/src/Eto.Mac/Drawing/TextureBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/TextureBrushHandler.cs
@@ -1,33 +1,16 @@
 using System;
 using Eto.Drawing;
 
-#if XAMMAC2
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if OSX

--- a/src/Eto.Mac/EtoBundle.cs
+++ b/src/Eto.Mac/EtoBundle.cs
@@ -1,18 +1,11 @@
 using System;
 using System.Runtime.InteropServices;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac
 {

--- a/src/Eto.Mac/EtoEnvironmentHandler.cs
+++ b/src/Eto.Mac/EtoEnvironmentHandler.cs
@@ -1,18 +1,11 @@
 using System;
 using System.Linq;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac
 {

--- a/src/Eto.Mac/Forms/Actions/MacCommand.cs
+++ b/src/Eto.Mac/Forms/Actions/MacCommand.cs
@@ -1,17 +1,10 @@
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Actions
 {

--- a/src/Eto.Mac/Forms/ApplicationHandler.cs
+++ b/src/Eto.Mac/Forms/ApplicationHandler.cs
@@ -6,7 +6,6 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using Eto.Mac.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
@@ -14,27 +13,11 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 using System.Runtime.CompilerServices;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/ApplicationHandler.cs
+++ b/src/Eto.Mac/Forms/ApplicationHandler.cs
@@ -14,12 +14,6 @@ using CoreAnimation;
 using CoreImage;
 using System.Runtime.CompilerServices;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class ApplicationHandler : WidgetHandler<NSApplication, Application, Application.ICallback>, Application.IHandler
@@ -130,21 +124,13 @@ namespace Eto.Mac.Forms
 				action();
 			else
 			{
-#if XAMMAC1
-				Control.InvokeOnMainThread(new NSAction(action));
-#else
 				Control.InvokeOnMainThread(action);
-#endif
 			}
 		}
 
 		public void AsyncInvoke(Action action)
 		{
-#if XAMMAC1
-			Control.BeginInvokeOnMainThread(new NSAction(action));
-#else
 			Control.BeginInvokeOnMainThread(action);
-#endif
 		}
 
 		public void Restart()

--- a/src/Eto.Mac/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CellHandler.cs
@@ -3,32 +3,16 @@ using Eto.Drawing;
 using System;
 using Eto.Mac.Forms.Controls;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if XAMMAC2

--- a/src/Eto.Mac/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CellHandler.cs
@@ -9,12 +9,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if XAMMAC2
 using nnuint = System.nint;
 #else

--- a/src/Eto.Mac/Forms/Cells/CheckBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CheckBoxCellHandler.cs
@@ -9,12 +9,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Cells
 {
 	public class CheckBoxCellHandler : CellHandler<CheckBoxCell, CheckBoxCell.ICallback>, CheckBoxCell.IHandler

--- a/src/Eto.Mac/Forms/Cells/CheckBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CheckBoxCellHandler.cs
@@ -3,32 +3,16 @@ using Eto.Forms;
 using Eto.Drawing;
 using Eto.Mac.Forms.Controls;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Cells

--- a/src/Eto.Mac/Forms/Cells/ComboBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ComboBoxCellHandler.cs
@@ -11,12 +11,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Cells
 {
 	public class ComboBoxCellHandler : CellHandler<ComboBoxCell, ComboBoxCell.ICallback>, ComboBoxCell.IHandler

--- a/src/Eto.Mac/Forms/Cells/ComboBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ComboBoxCellHandler.cs
@@ -5,33 +5,16 @@ using System.Linq;
 using Eto.Drawing;
 using Eto.Mac.Forms.Controls;
 
-
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Cells

--- a/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
@@ -12,12 +12,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Cells
 {
 	public class CustomCellHandler : CellHandler<CustomCell, CustomCell.ICallback>, CustomCell.IHandler

--- a/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
@@ -5,34 +5,17 @@ using System.Collections.Generic;
 using Eto.Mac.Forms.Controls;
 using Eto.Shared;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Cells

--- a/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
@@ -12,13 +12,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
-
 namespace Eto.Mac.Forms.Cells
 {
 	public class DrawableCellHandler : CellHandler<DrawableCell, DrawableCell.ICallback>, DrawableCell.IHandler

--- a/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
@@ -5,34 +5,17 @@ using Eto.Mac.Drawing;
 using System.Runtime.InteropServices;
 using Eto.Mac.Forms.Controls;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 

--- a/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
@@ -4,32 +4,16 @@ using Eto.Drawing;
 using Eto.Mac.Drawing;
 using Eto.Mac.Forms.Controls;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Cells

--- a/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
@@ -10,12 +10,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Cells
 {
 	public class ImageTextCellHandler : CellHandler<ImageTextCell, ImageTextCell.ICallback>, ImageTextCell.IHandler, IMacText

--- a/src/Eto.Mac/Forms/Cells/ImageViewCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageViewCellHandler.cs
@@ -4,32 +4,16 @@ using Eto.Drawing;
 using Eto.Mac.Drawing;
 using Eto.Mac.Forms.Controls;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Cells

--- a/src/Eto.Mac/Forms/Cells/ImageViewCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageViewCellHandler.cs
@@ -10,12 +10,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Cells
 {
 	public class ImageViewCellHandler : CellHandler<ImageViewCell, ImageViewCell.ICallback>, ImageViewCell.IHandler

--- a/src/Eto.Mac/Forms/Cells/ProgressCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ProgressCellHandler.cs
@@ -10,12 +10,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Cells
 {
 	public class ProgressCellHandler : CellHandler<ProgressCell, ProgressCell.ICallback>, ProgressCell.IHandler

--- a/src/Eto.Mac/Forms/Cells/ProgressCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ProgressCellHandler.cs
@@ -4,33 +4,16 @@ using Eto.Drawing;
 using Eto.Mac.Drawing;
 using Eto.Mac.Forms.Controls;
 
-
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Cells

--- a/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
@@ -4,32 +4,16 @@ using Eto.Drawing;
 using Eto.Mac.Forms.Controls;
 using Eto.Mac.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Cells

--- a/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
@@ -10,12 +10,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Cells
 {
 	public class TextBoxCellHandler : CellHandler<TextBoxCell, TextBoxCell.ICallback>, TextBoxCell.IHandler, IMacText

--- a/src/Eto.Mac/Forms/ClipboardHandler.cs
+++ b/src/Eto.Mac/Forms/ClipboardHandler.cs
@@ -4,32 +4,16 @@ using System.IO;
 using Eto.Mac.Drawing;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/ClipboardHandler.cs
+++ b/src/Eto.Mac/Forms/ClipboardHandler.cs
@@ -10,12 +10,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class ClipboardHandler : DataObjectHandler<Clipboard, Clipboard.ICallback>, Clipboard.IHandler

--- a/src/Eto.Mac/Forms/ColorDialogHandler.cs
+++ b/src/Eto.Mac/Forms/ColorDialogHandler.cs
@@ -1,19 +1,12 @@
 using System;
 using Eto.Forms;
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
@@ -4,34 +4,17 @@ using System;
 using Eto.Drawing;
 using Eto.Forms;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
@@ -11,12 +11,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class ButtonHandler : ButtonHandler<Button, Button.ICallback>, Button.IHandler

--- a/src/Eto.Mac/Forms/Controls/CalendarHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/CalendarHandler.cs
@@ -1,18 +1,11 @@
 ﻿using System;
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Controls
 {

--- a/src/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 

--- a/src/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
@@ -2,34 +2,17 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/ColorPickerHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ColorPickerHandler.cs
@@ -4,19 +4,12 @@ using Eto.Drawing;
 using Eto.Mac.Drawing;
 using System.Text.RegularExpressions;
 using System.Linq;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Controls
 {

--- a/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
@@ -12,12 +12,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class ComboBoxHandler : MacControl<NSComboBox, ComboBox, ComboBox.ICallback>, ComboBox.IHandler

--- a/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
@@ -5,34 +5,17 @@ using System.Collections.Generic;
 using System.Collections;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/DateTimePickerHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DateTimePickerHandler.cs
@@ -8,12 +8,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class DateTimePickerHandler : MacControl<NSDatePicker, DateTimePicker, DateTimePicker.ICallback>, DateTimePicker.IHandler

--- a/src/Eto.Mac/Forms/Controls/DateTimePickerHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DateTimePickerHandler.cs
@@ -1,32 +1,17 @@
 using System;
 using Eto.Forms;
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -8,12 +8,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class DrawableHandler : MacPanel<DrawableHandler.EtoDrawableView, Drawable, Drawable.ICallback>, Drawable.IHandler

--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -1,32 +1,17 @@
 using Eto.Drawing;
 using Eto.Forms;
 using Eto.Mac.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
@@ -12,12 +12,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class DropDownHandler : MacControl<NSPopUpButton, DropDown, DropDown.ICallback>, DropDown.IHandler

--- a/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
@@ -5,34 +5,17 @@ using System.Collections.Generic;
 using System.Collections;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/ExpanderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ExpanderHandler.cs
@@ -10,12 +10,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class ExpanderHandler : MacPanel<NSView, Expander, Expander.ICallback>, Expander.IHandler

--- a/src/Eto.Mac/Forms/Controls/ExpanderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ExpanderHandler.cs
@@ -3,34 +3,17 @@ using Eto.Drawing;
 using Eto.Forms;
 using System.Linq;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
@@ -10,12 +10,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public interface IDataViewHandler

--- a/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
@@ -4,33 +4,16 @@ using Eto.Drawing;
 using Eto.Mac.Drawing;
 using Eto.Mac.Forms.Cells;
 
-
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -13,12 +13,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if XAMMAC
 using nnint = System.Int32;
 #elif Mac64

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -7,32 +7,16 @@ using Eto.Drawing;
 using Eto.Mac.Drawing;
 using Eto.Mac.Forms.Cells;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if XAMMAC

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -12,12 +12,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class GridViewHandler : GridHandler<GridViewHandler.EtoTableView, GridView, GridView.ICallback>, GridView.IHandler

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -6,32 +6,16 @@ using System.Collections;
 using System.Linq;
 using Eto.Mac.Forms.Cells;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
@@ -10,12 +10,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class GroupBoxHandler : MacPanel<NSBox, GroupBox, GroupBox.ICallback>, GroupBox.IHandler

--- a/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
@@ -3,34 +3,17 @@ using Eto.Forms;
 using Eto.Drawing;
 using Eto.Mac.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/ImageViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ImageViewHandler.cs
@@ -3,34 +3,17 @@ using Eto.Forms;
 using Eto.Drawing;
 using Eto.Mac.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/ImageViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ImageViewHandler.cs
@@ -10,12 +10,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class ImageViewHandler : MacControl<NSImageView, ImageView, ImageView.ICallback>, ImageView.IHandler

--- a/src/Eto.Mac/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/LabelHandler.cs
@@ -12,20 +12,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
-#if XAMMAC2
-using nnint = System.nint;
-#elif Mac64
-using nnint = System.UInt64;
-#else
-using nnint = System.Int32;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class LabelHandler : MacLabel<NSTextField, Label, Label.ICallback>, Label.IHandler

--- a/src/Eto.Mac/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/LabelHandler.cs
@@ -5,34 +5,17 @@ using Eto.Mac.Drawing;
 using System.Text.RegularExpressions;
 using System.Linq;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if XAMMAC2

--- a/src/Eto.Mac/Forms/Controls/LinkButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/LinkButtonHandler.cs
@@ -10,12 +10,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	/// <summary>

--- a/src/Eto.Mac/Forms/Controls/LinkButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/LinkButtonHandler.cs
@@ -4,32 +4,16 @@ using Eto.Forms;
 using Eto.Mac.Drawing;
 using System.Runtime.InteropServices;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
@@ -7,32 +7,16 @@ using Eto.Mac.Drawing;
 using System.Collections;
 using System.Linq;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if XAMMAC

--- a/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
@@ -13,12 +13,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if XAMMAC
 using nnint = System.Int32;
 #elif Mac64

--- a/src/Eto.Mac/Forms/Controls/MacButton.cs
+++ b/src/Eto.Mac/Forms/Controls/MacButton.cs
@@ -1,22 +1,12 @@
 using Eto.Forms;
 using Eto.Drawing;
 
-
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreText;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreText;
-#endif
 
 namespace Eto.Mac.Forms.Controls
 {

--- a/src/Eto.Mac/Forms/Controls/MacControl.cs
+++ b/src/Eto.Mac/Forms/Controls/MacControl.cs
@@ -1,19 +1,12 @@
 using Eto.Forms;
 using Eto.Drawing;
 using Eto.Mac.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Controls
 {

--- a/src/Eto.Mac/Forms/Controls/MacEventView.cs
+++ b/src/Eto.Mac/Forms/Controls/MacEventView.cs
@@ -10,12 +10,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class MacEventView : NSBox, IMacControl

--- a/src/Eto.Mac/Forms/Controls/MacEventView.cs
+++ b/src/Eto.Mac/Forms/Controls/MacEventView.cs
@@ -2,34 +2,18 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 using System.Diagnostics;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
+++ b/src/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
@@ -2,32 +2,17 @@ using System;
 using Eto.Forms;
 using Eto.Mac.Drawing;
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
+++ b/src/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
@@ -9,12 +9,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class MacImageData : NSObject, ICloneable

--- a/src/Eto.Mac/Forms/Controls/MacImageTextView.cs
+++ b/src/Eto.Mac/Forms/Controls/MacImageTextView.cs
@@ -1,28 +1,13 @@
 ﻿using System;
-#if XAMMAC2
+
 using AppKit;
 using CoreGraphics;
 using Foundation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/MacImageTextView.cs
+++ b/src/Eto.Mac/Forms/Controls/MacImageTextView.cs
@@ -4,12 +4,6 @@ using AppKit;
 using CoreGraphics;
 using Foundation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
     public class MacImageTextView : NSView

--- a/src/Eto.Mac/Forms/Controls/MacLabel.cs
+++ b/src/Eto.Mac/Forms/Controls/MacLabel.cs
@@ -5,34 +5,17 @@ using Eto.Mac.Drawing;
 using System.Text.RegularExpressions;
 using System.Linq;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if XAMMAC

--- a/src/Eto.Mac/Forms/Controls/MacLabel.cs
+++ b/src/Eto.Mac/Forms/Controls/MacLabel.cs
@@ -12,20 +12,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
-#if XAMMAC
-using nnint = System.Int32;
-#elif Mac64
-using nnint = System.UInt64;
-#else
-using nnint = System.UInt32;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 

--- a/src/Eto.Mac/Forms/Controls/MacText.cs
+++ b/src/Eto.Mac/Forms/Controls/MacText.cs
@@ -4,19 +4,11 @@ using Eto.Mac.Drawing;
 using System;
 using System.Diagnostics;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Controls
 {

--- a/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
@@ -3,33 +3,16 @@ using System.Globalization;
 using Eto.Forms;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-using nnint = System.nint;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
@@ -9,12 +9,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class NativeControlHandler : MacView<NSView, Control, Control.ICallback>

--- a/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
@@ -14,12 +14,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if XAMMAC
 using nnint = System.Int32;
 #elif Mac64

--- a/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
@@ -8,32 +8,16 @@ using System.Text.RegularExpressions;
 using System.Runtime.InteropServices;
 using System.Reflection;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if XAMMAC

--- a/src/Eto.Mac/Forms/Controls/PanelHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/PanelHandler.cs
@@ -1,19 +1,12 @@
 using System;
 using Eto.Forms;
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Controls
 {

--- a/src/Eto.Mac/Forms/Controls/PasswordBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/PasswordBoxHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class PasswordBoxHandler : MacText<NSTextField, PasswordBox, PasswordBox.ICallback>, PasswordBox.IHandler, ITextBoxWithMaxLength

--- a/src/Eto.Mac/Forms/Controls/PasswordBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/PasswordBoxHandler.cs
@@ -2,34 +2,17 @@ using System;
 using Eto.Forms;
 using Eto.Mac.Forms.Controls;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/ProgressBarHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ProgressBarHandler.cs
@@ -2,34 +2,17 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/ProgressBarHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ProgressBarHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class ProgressBarHandler : MacView<NSProgressIndicator, ProgressBar, ProgressBar.ICallback>, ProgressBar.IHandler

--- a/src/Eto.Mac/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/RadioButtonHandler.cs
@@ -11,12 +11,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class RadioButtonHandler : MacButton<NSButton, RadioButton, RadioButton.ICallback>, RadioButton.IHandler

--- a/src/Eto.Mac/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/RadioButtonHandler.cs
@@ -4,34 +4,17 @@ using System.Collections.Generic;
 using System.Linq;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
@@ -13,12 +13,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if XAMMAC
 using nnint = System.Int32;
 #elif Mac64

--- a/src/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/RichTextAreaHandler.cs
@@ -6,34 +6,17 @@ using System.IO;
 using System.Collections.Generic;
 using System.Text;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if XAMMAC

--- a/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
@@ -12,12 +12,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class ScrollableHandler : MacPanel<NSScrollView, Scrollable, Scrollable.ICallback>, Scrollable.IHandler

--- a/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
@@ -5,32 +5,17 @@
 using System;
 using Eto.Drawing;
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/SearchBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SearchBoxHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	/// <summary>

--- a/src/Eto.Mac/Forms/Controls/SearchBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SearchBoxHandler.cs
@@ -2,34 +2,17 @@ using System;
 using Eto.Drawing;
 using Eto.Forms;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/SegmentedButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SegmentedButtonHandler.cs
@@ -4,34 +4,17 @@ using System.Collections.Generic;
 using Eto.Drawing;
 using System.Linq;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/SegmentedButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SegmentedButtonHandler.cs
@@ -11,12 +11,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	interface ISegmentedItemHandler

--- a/src/Eto.Mac/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SliderHandler.cs
@@ -2,34 +2,17 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SliderHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class SliderHandler : MacControl<NSSlider, Slider, Slider.ICallback>, Slider.IHandler

--- a/src/Eto.Mac/Forms/Controls/SpinnerHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SpinnerHandler.cs
@@ -1,19 +1,12 @@
 using System;
 using Eto.Forms;
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Controls
 {

--- a/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -8,12 +8,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class SplitterHandler : MacContainer<NSSplitView, Splitter, Splitter.ICallback>, Splitter.IHandler

--- a/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -2,32 +2,16 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/StepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/StepperHandler.cs
@@ -2,32 +2,16 @@
 using Eto.Forms;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/StepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/StepperHandler.cs
@@ -8,12 +8,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class StepperHandler : MacControl<NSStepper, Stepper, Stepper.ICallback>, Stepper.IHandler

--- a/src/Eto.Mac/Forms/Controls/TabControlHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TabControlHandler.cs
@@ -3,19 +3,12 @@ using System.Linq;
 using Eto.Forms;
 using Eto.Drawing;
 using System.Collections.Generic;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Controls
 {

--- a/src/Eto.Mac/Forms/Controls/TabPageHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TabPageHandler.cs
@@ -2,32 +2,16 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/TabPageHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TabPageHandler.cs
@@ -8,12 +8,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class TabPageHandler : MacPanel<NSTabViewItem, TabPage, TabPage.ICallback>, TabPage.IHandler

--- a/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -9,20 +9,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
-#if XAMMAC
-using nnint = System.Int32;
-#elif Mac64
-using nnint = System.UInt64;
-#else
-using nnint = System.UInt32;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class TextAreaHandler : TextAreaHandler<TextArea, TextArea.ICallback>, TextArea.IHandler

--- a/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -3,32 +3,16 @@ using Eto.Forms;
 using Eto.Drawing;
 using Eto.Mac.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if XAMMAC

--- a/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
@@ -2,19 +2,12 @@ using System;
 using Eto.Forms;
 using Eto.Mac.Forms.Controls;
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Controls
 {

--- a/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Controls
 {
 	public class ToggleButtonHandler : ButtonHandler<ToggleButton, ToggleButton.ICallback>, ToggleButton.IHandler

--- a/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ToggleButtonHandler.cs
@@ -2,34 +2,17 @@ using System;
 using Eto.Drawing;
 using Eto.Forms;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Controls

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -11,12 +11,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if XAMMAC
 using nnint = System.Int32;
 using nnint2 = System.Int32;

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -5,32 +5,16 @@ using System.Linq;
 using Eto.Mac.Forms.Cells;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if XAMMAC

--- a/src/Eto.Mac/Forms/Controls/TreeViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeViewHandler.cs
@@ -5,34 +5,17 @@ using Eto.Mac.Forms.Menu;
 using System.Linq;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if XAMMAC

--- a/src/Eto.Mac/Forms/Controls/TreeViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeViewHandler.cs
@@ -12,12 +12,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if XAMMAC
 using nnint = System.Int32;
 #elif Mac64

--- a/src/Eto.Mac/Forms/Controls/WebViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/WebViewHandler.cs
@@ -2,21 +2,13 @@ using System;
 using Eto.Forms;
 using System.Linq;
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using wk = WebKit;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using wk = MonoMac.WebKit;
-#endif
 
 namespace Eto.Mac.Forms.Controls
 {

--- a/src/Eto.Mac/Forms/CursorHandler.cs
+++ b/src/Eto.Mac/Forms/CursorHandler.cs
@@ -11,12 +11,6 @@ using CoreAnimation;
 using CoreImage;
 using ImageIO;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class CursorHandler : WidgetHandler<NSCursor, Cursor>, Cursor.IHandler

--- a/src/Eto.Mac/Forms/CursorHandler.cs
+++ b/src/Eto.Mac/Forms/CursorHandler.cs
@@ -2,7 +2,7 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 using System.IO;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
@@ -10,29 +10,11 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 using ImageIO;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
-using MonoMac.ImageIO;
-using NSRectEdge = MonoMac.AppKit.NSRectEdge;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/DataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/DataObjectHandler.cs
@@ -7,32 +7,16 @@ using System.Linq;
 using System.Runtime.InteropServices;
 using System.Collections.Generic;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/DataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/DataObjectHandler.cs
@@ -13,12 +13,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public interface IDataObjectHandler

--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -12,13 +12,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class DialogHandler : MacWindow<EtoWindow, Dialog, Dialog.ICallback>, Dialog.IHandler

--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -5,35 +5,18 @@ using System.Threading.Tasks;
 using Eto.Forms;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
-using NSRectEdge = MonoMac.AppKit.NSRectEdge;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
+
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/EtoDragSource.cs
+++ b/src/Eto.Mac/Forms/EtoDragSource.cs
@@ -4,12 +4,6 @@
 using AppKit;
 using Foundation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	class EtoDragSource : NSDraggingSource

--- a/src/Eto.Mac/Forms/EtoDragSource.cs
+++ b/src/Eto.Mac/Forms/EtoDragSource.cs
@@ -1,29 +1,13 @@
 ﻿using System;
 
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/FontDialogHandler.cs
+++ b/src/Eto.Mac/Forms/FontDialogHandler.cs
@@ -2,19 +2,12 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 using Eto.Mac.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/Forms/FormHandler.cs
+++ b/src/Eto.Mac/Forms/FormHandler.cs
@@ -7,11 +7,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/Forms/FormHandler.cs
+++ b/src/Eto.Mac/Forms/FormHandler.cs
@@ -1,34 +1,16 @@
 using System;
 using Eto.Forms;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/KeyboardHandler.cs
+++ b/src/Eto.Mac/Forms/KeyboardHandler.cs
@@ -1,11 +1,7 @@
 ﻿using System;
 using Eto.Forms;
 using System.Collections.Generic;
-#if XAMMAC2
 using AppKit;
-#else
-using MonoMac.AppKit;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/Forms/MacBase.cs
+++ b/src/Eto.Mac/Forms/MacBase.cs
@@ -3,22 +3,12 @@ using System.Collections.Generic;
 using System.Globalization;
 using Eto.Drawing;
 using Eto.Forms;
+using Foundation;
+using ObjCRuntime;
 #if IOS
 using NSView = UIKit.UIView;
-using ObjCRuntime;
-using Foundation;
-#elif XAMMAC2
+#else
 using AppKit;
-using Foundation;
-using CoreGraphics;
-using ObjCRuntime;
-using CoreAnimation;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/MacCommon.cs
+++ b/src/Eto.Mac/Forms/MacCommon.cs
@@ -1,17 +1,10 @@
 using System;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/Forms/MacContainer.cs
+++ b/src/Eto.Mac/Forms/MacContainer.cs
@@ -11,12 +11,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if IOS
 using Foundation;
 using CoreGraphics;

--- a/src/Eto.Mac/Forms/MacContainer.cs
+++ b/src/Eto.Mac/Forms/MacContainer.cs
@@ -4,34 +4,17 @@ using System.Linq;
 using Eto.Drawing;
 using System.Collections.Generic;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if IOS

--- a/src/Eto.Mac/Forms/MacControlExtensions.cs
+++ b/src/Eto.Mac/Forms/MacControlExtensions.cs
@@ -3,35 +3,17 @@ using Eto.Forms;
 using System;
 using System.Text.RegularExpressions;
 
-
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreText;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreText;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if IOS

--- a/src/Eto.Mac/Forms/MacControlExtensions.cs
+++ b/src/Eto.Mac/Forms/MacControlExtensions.cs
@@ -10,12 +10,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreText;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if IOS
 using NSView = UIKit.UIView;
 using NSControl = UIKit.UIControl;

--- a/src/Eto.Mac/Forms/MacFieldEditor.cs
+++ b/src/Eto.Mac/Forms/MacFieldEditor.cs
@@ -2,30 +2,13 @@ using System;
 using Eto.Forms;
 using Eto.Mac.Forms.Controls;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/MacFieldEditor.cs
+++ b/src/Eto.Mac/Forms/MacFieldEditor.cs
@@ -5,12 +5,6 @@ using Eto.Mac.Forms.Controls;
 using AppKit;
 using Foundation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class MacFieldEditor : NSTextView, IMacControl

--- a/src/Eto.Mac/Forms/MacFileDialog.cs
+++ b/src/Eto.Mac/Forms/MacFileDialog.cs
@@ -4,34 +4,17 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/MacFileDialog.cs
+++ b/src/Eto.Mac/Forms/MacFileDialog.cs
@@ -11,12 +11,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	interface IMacFileDialog

--- a/src/Eto.Mac/Forms/MacModal.cs
+++ b/src/Eto.Mac/Forms/MacModal.cs
@@ -1,18 +1,11 @@
 using System;
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/Forms/MacObject.cs
+++ b/src/Eto.Mac/Forms/MacObject.cs
@@ -7,16 +7,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
-#if IOS
-using Foundation;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class MacObject<TControl, TWidget, TCallback> : MacBase<TControl, TWidget, TCallback>

--- a/src/Eto.Mac/Forms/MacObject.cs
+++ b/src/Eto.Mac/Forms/MacObject.cs
@@ -1,33 +1,16 @@
 using System;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if IOS

--- a/src/Eto.Mac/Forms/MacPanel.cs
+++ b/src/Eto.Mac/Forms/MacPanel.cs
@@ -2,32 +2,16 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if IOS

--- a/src/Eto.Mac/Forms/MacPanel.cs
+++ b/src/Eto.Mac/Forms/MacPanel.cs
@@ -8,12 +8,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if IOS
 using NSResponder = UIKit.UIResponder;
 using NSView = UIKit.UIView;

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -7,7 +7,6 @@ using Eto.Mac.Forms.Printing;
 using System.Linq;
 using System.Runtime.InteropServices;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
@@ -15,29 +14,11 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 using MobileCoreServices;
-#else
-using MonoMac;
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
-using MonoMac.MobileCoreServices;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -15,12 +15,6 @@ using CoreAnimation;
 using CoreImage;
 using MobileCoreServices;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	class MouseDelegate : NSObject

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -5,7 +5,6 @@ using Eto.Drawing;
 using Eto.Forms;
 using System.Threading;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
@@ -13,27 +12,11 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 using Eto.Mac.Forms.Controls;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -13,12 +13,6 @@ using CoreAnimation;
 using CoreImage;
 using Eto.Mac.Forms.Controls;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class EtoWindow : NSWindow, IMacControl

--- a/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
@@ -5,30 +5,14 @@ using Eto.Mac.Drawing;
 using System.Linq;
 using System.Collections.Generic;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using ObjCRuntime;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
@@ -9,12 +9,6 @@ using AppKit;
 using Foundation;
 using ObjCRuntime;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class MemoryDataObjectHandler : WidgetHandler<Dictionary<string, MemoryDataObjectHandler.BaseItem>, DataObject, DataObject.ICallback>, DataObject.IHandler, IDataObject, IDataObjectHandler

--- a/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
@@ -2,19 +2,12 @@ using System;
 using Eto.Drawing;
 using Eto.Forms;
 using Eto.Mac.Forms.Actions;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Menu
 {

--- a/src/Eto.Mac/Forms/Menu/CheckMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/CheckMenuItemHandler.cs
@@ -1,20 +1,11 @@
 using System;
 using Eto.Forms;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Menu
 {

--- a/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
@@ -1,34 +1,18 @@
 using System;
 using Eto.Forms;
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Menu

--- a/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Menu
 {
 	class ContextHandler : NSMenuDelegate

--- a/src/Eto.Mac/Forms/Menu/MenuActionHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/MenuActionHandler.cs
@@ -1,18 +1,11 @@
 using System;
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Menu
 {

--- a/src/Eto.Mac/Forms/Menu/MenuBarHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/MenuBarHandler.cs
@@ -6,19 +6,11 @@ using Eto.Mac.Forms;
 using System.Collections.ObjectModel;
 using System;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Menu
 {

--- a/src/Eto.Mac/Forms/Menu/MenuHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/MenuHandler.cs
@@ -2,19 +2,11 @@ using Eto.Forms;
 using Eto.Mac.Forms.Actions;
 using System;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Menu
 {

--- a/src/Eto.Mac/Forms/Menu/RadioMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/RadioMenuItemHandler.cs
@@ -3,20 +3,11 @@ using Eto.Forms;
 using System.Collections.Generic;
 using System.Linq;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Menu
 {

--- a/src/Eto.Mac/Forms/Menu/SeparatorMenuItem.cs
+++ b/src/Eto.Mac/Forms/Menu/SeparatorMenuItem.cs
@@ -1,18 +1,11 @@
 using System;
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Menu
 {

--- a/src/Eto.Mac/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Mac/Forms/MessageBoxHandler.cs
@@ -1,34 +1,17 @@
 using System;
 using Eto.Forms;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Mac/Forms/MessageBoxHandler.cs
@@ -8,12 +8,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class MessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler

--- a/src/Eto.Mac/Forms/MouseHandler.cs
+++ b/src/Eto.Mac/Forms/MouseHandler.cs
@@ -2,35 +2,17 @@ using System;
 using Eto.Forms;
 using System.Runtime.InteropServices;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac;
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/MouseHandler.cs
+++ b/src/Eto.Mac/Forms/MouseHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class MouseHandler : Mouse.IHandler

--- a/src/Eto.Mac/Forms/NativeFormHandler.cs
+++ b/src/Eto.Mac/Forms/NativeFormHandler.cs
@@ -1,18 +1,11 @@
 using System;
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/Forms/NotificationHandler.cs
+++ b/src/Eto.Mac/Forms/NotificationHandler.cs
@@ -4,34 +4,17 @@ using Eto.Drawing;
 using System.Collections.Generic;
 using System.Linq;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/NotificationHandler.cs
+++ b/src/Eto.Mac/Forms/NotificationHandler.cs
@@ -11,12 +11,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class NotificationHandler : WidgetHandler<NSUserNotification, Notification, Notification.ICallback>, Notification.IHandler

--- a/src/Eto.Mac/Forms/OpenFileDialog.cs
+++ b/src/Eto.Mac/Forms/OpenFileDialog.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class OpenFileDialogHandler : MacFileDialog<NSOpenPanel, OpenFileDialog>, OpenFileDialog.IHandler

--- a/src/Eto.Mac/Forms/OpenFileDialog.cs
+++ b/src/Eto.Mac/Forms/OpenFileDialog.cs
@@ -2,34 +2,17 @@ using System.Linq;
 using Eto.Forms;
 using System.Collections.Generic;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/OpenWithDialogHandler.cs
+++ b/src/Eto.Mac/Forms/OpenWithDialogHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class OpenWithDialogHandler : WidgetHandler<NSOpenPanel, OpenWithDialog, OpenWithDialog.ICallback>, OpenWithDialog.IHandler

--- a/src/Eto.Mac/Forms/OpenWithDialogHandler.cs
+++ b/src/Eto.Mac/Forms/OpenWithDialogHandler.cs
@@ -2,34 +2,17 @@
 using System.Diagnostics;
 using Eto.Forms;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/PixelLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/PixelLayoutHandler.cs
@@ -5,34 +5,17 @@ using System.Collections.Generic;
 using System.Linq;
 using Eto.Mac.Forms.Controls;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/PixelLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/PixelLayoutHandler.cs
@@ -12,12 +12,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class PixelLayoutHandler : MacContainer<NSView, PixelLayout, PixelLayout.ICallback>, PixelLayout.IHandler

--- a/src/Eto.Mac/Forms/Printing/PrintDialogHandler.cs
+++ b/src/Eto.Mac/Forms/Printing/PrintDialogHandler.cs
@@ -1,18 +1,11 @@
 using System;
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Printing
 {

--- a/src/Eto.Mac/Forms/Printing/PrintDocumentHandler.cs
+++ b/src/Eto.Mac/Forms/Printing/PrintDocumentHandler.cs
@@ -2,32 +2,17 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 using Eto.Mac.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.Printing

--- a/src/Eto.Mac/Forms/Printing/PrintDocumentHandler.cs
+++ b/src/Eto.Mac/Forms/Printing/PrintDocumentHandler.cs
@@ -9,12 +9,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.Printing
 {
 	public class PrintDocumentHandler : WidgetHandler<PrintDocumentHandler.PrintView, PrintDocument, PrintDocument.ICallback>, PrintDocument.IHandler

--- a/src/Eto.Mac/Forms/Printing/PrintSettingsHandler.cs
+++ b/src/Eto.Mac/Forms/Printing/PrintSettingsHandler.cs
@@ -1,18 +1,11 @@
 using System;
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.Printing
 {

--- a/src/Eto.Mac/Forms/SaveFileDialogHandler.cs
+++ b/src/Eto.Mac/Forms/SaveFileDialogHandler.cs
@@ -1,18 +1,11 @@
 using System;
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/Forms/ScreenHandler.cs
+++ b/src/Eto.Mac/Forms/ScreenHandler.cs
@@ -1,19 +1,12 @@
 using System;
 using Eto.Forms;
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/Forms/ScreensHandler.cs
+++ b/src/Eto.Mac/Forms/ScreensHandler.cs
@@ -1,18 +1,11 @@
 using Eto.Forms;
 using System.Collections.Generic;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Mac/Forms/SelectFolderDialogHandler.cs
@@ -1,18 +1,11 @@
 using System;
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/Forms/TableLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/TableLayoutHandler.cs
@@ -10,12 +10,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 #if IOS
 using UIKit;
 using CoreGraphics;

--- a/src/Eto.Mac/Forms/TableLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/TableLayoutHandler.cs
@@ -3,34 +3,17 @@ using Eto.Forms;
 using System.Linq;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 #if IOS
@@ -44,11 +27,7 @@ using BaseMacContainer = Eto.iOS.Forms.IosLayout<UIKit.UIView, Eto.Forms.TableLa
 #elif OSX
 using Eto.Mac.Forms.Controls;
 
-#if XAMMAC2
 using BaseMacContainer = Eto.Mac.Forms.MacContainer<AppKit.NSView, Eto.Forms.TableLayout, Eto.Forms.TableLayout.ICallback>;
-#else
-using BaseMacContainer = Eto.Mac.Forms.MacContainer<MonoMac.AppKit.NSView, Eto.Forms.TableLayout, Eto.Forms.TableLayout.ICallback>;
-#endif
 
 #endif
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/ToolBar/ButtonToolItemHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/ButtonToolItemHandler.cs
@@ -1,18 +1,11 @@
 using System;
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.ToolBar
 {

--- a/src/Eto.Mac/Forms/ToolBar/CheckToolItemHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/CheckToolItemHandler.cs
@@ -1,18 +1,11 @@
 using System;
 using Eto.Forms;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.ToolBar
 {

--- a/src/Eto.Mac/Forms/ToolBar/RadioToolItemHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/RadioToolItemHandler.cs
@@ -1,19 +1,12 @@
 using System;
 using Eto.Forms;
 using System.Linq;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms.ToolBar
 {

--- a/src/Eto.Mac/Forms/ToolBar/SeparatorToolItemHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/SeparatorToolItemHandler.cs
@@ -9,12 +9,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.ToolBar
 {
 	public class SeparatorToolItemHandler : ToolItemHandler<NSToolbarItem, SeparatorToolItem>, SeparatorToolItem.IHandler, IToolBarBaseItemHandler

--- a/src/Eto.Mac/Forms/ToolBar/SeparatorToolItemHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/SeparatorToolItemHandler.cs
@@ -2,32 +2,17 @@ using Eto.Forms;
 using System;
 using Eto.Drawing;
 using Eto.Mac.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.ToolBar

--- a/src/Eto.Mac/Forms/ToolBar/ToolBarHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/ToolBarHandler.cs
@@ -4,32 +4,16 @@ using System.Linq;
 using System.Collections.Generic;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.ToolBar

--- a/src/Eto.Mac/Forms/ToolBar/ToolBarHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/ToolBarHandler.cs
@@ -10,12 +10,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.ToolBar
 {
 	public class ToolBarHandler : WidgetHandler<NSToolbar, Eto.Forms.ToolBar>, Eto.Forms.ToolBar.IHandler

--- a/src/Eto.Mac/Forms/ToolBar/ToolItemHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/ToolItemHandler.cs
@@ -2,32 +2,17 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 using Eto.Mac.Forms.Actions;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms.ToolBar

--- a/src/Eto.Mac/Forms/ToolBar/ToolItemHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/ToolItemHandler.cs
@@ -9,12 +9,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms.ToolBar
 {
 	public interface IToolBarBaseItemHandler

--- a/src/Eto.Mac/Forms/TrayIndicatorHandler.cs
+++ b/src/Eto.Mac/Forms/TrayIndicatorHandler.cs
@@ -2,34 +2,17 @@
 using Eto.Forms;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.Forms

--- a/src/Eto.Mac/Forms/TrayIndicatorHandler.cs
+++ b/src/Eto.Mac/Forms/TrayIndicatorHandler.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.Forms
 {
 	public class TrayIndicatorHandler : WidgetHandler<NSStatusItem, TrayIndicator, TrayIndicator.ICallback>, TrayIndicator.IHandler

--- a/src/Eto.Mac/Forms/UITimerHandler.cs
+++ b/src/Eto.Mac/Forms/UITimerHandler.cs
@@ -3,19 +3,11 @@ using Eto.Forms;
 #if IOS
 using Foundation;
 #else
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 #endif
 
 #if IOS

--- a/src/Eto.Mac/Forms/iosCompatibility.cs
+++ b/src/Eto.Mac/Forms/iosCompatibility.cs
@@ -1,16 +1,8 @@
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Forms
 {

--- a/src/Eto.Mac/IO/SystemIconsHandler.cs
+++ b/src/Eto.Mac/IO/SystemIconsHandler.cs
@@ -11,12 +11,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac.IO
 {
 	public class SystemIconsHandler : SystemIcons.IHandler

--- a/src/Eto.Mac/IO/SystemIconsHandler.cs
+++ b/src/Eto.Mac/IO/SystemIconsHandler.cs
@@ -4,34 +4,17 @@ using System.IO;
 using Eto.Mac.Drawing;
 using System;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac.IO

--- a/src/Eto.Mac/KeyMap.cs
+++ b/src/Eto.Mac/KeyMap.cs
@@ -9,12 +9,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac
 {
 	public static class KeyMap

--- a/src/Eto.Mac/KeyMap.cs
+++ b/src/Eto.Mac/KeyMap.cs
@@ -2,34 +2,17 @@
 using Eto.Forms;
 using System.Diagnostics;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac

--- a/src/Eto.Mac/Mac64Extensions.cs
+++ b/src/Eto.Mac/Mac64Extensions.cs
@@ -6,31 +6,17 @@ using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#elif XAMMAC2
+#else
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
 #endif
 #endif
 

--- a/src/Eto.Mac/Mac64Extensions.cs
+++ b/src/Eto.Mac/Mac64Extensions.cs
@@ -13,11 +13,6 @@ using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
 #endif
 
 #if IOS

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -15,12 +15,6 @@ using CoreAnimation;
 using CoreImage;
 using ImageIO;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac
 {
 	public static partial class MacConversions

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -7,7 +7,6 @@ using Eto.Mac.Forms.Printing;
 using System.Linq;
 using Eto.Mac.Forms.Menu;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
@@ -15,28 +14,11 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 using ImageIO;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
-using MonoMac.ImageIO;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac

--- a/src/Eto.Mac/MacConversions.ns.cs
+++ b/src/Eto.Mac/MacConversions.ns.cs
@@ -1,17 +1,10 @@
 using System;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac
 {

--- a/src/Eto.Mac/MacExtensions.cs
+++ b/src/Eto.Mac/MacExtensions.cs
@@ -8,12 +8,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac
 {
 	/// <summary>

--- a/src/Eto.Mac/MacExtensions.cs
+++ b/src/Eto.Mac/MacExtensions.cs
@@ -1,33 +1,17 @@
 using System;
 using System.Runtime.InteropServices;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac

--- a/src/Eto.Mac/MacHelpers.cs
+++ b/src/Eto.Mac/MacHelpers.cs
@@ -5,15 +5,9 @@ using Eto.Mac.Forms;
 using Eto.Mac.Forms.Controls;
 using Eto.Drawing;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using ObjCRuntime;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.ObjCRuntime;
-#endif
 
 namespace Eto.Forms
 {

--- a/src/Eto.Mac/MacVersion.cs
+++ b/src/Eto.Mac/MacVersion.cs
@@ -1,12 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
-#if XAMMAC2
 using Foundation;
 using ObjCRuntime;
-#else
-using MonoMac.Foundation;
-using MonoMac.ObjCRuntime;
-#endif
 
 namespace Eto.Mac
 {

--- a/src/Eto.Mac/Messaging.cs
+++ b/src/Eto.Mac/Messaging.cs
@@ -12,11 +12,6 @@ using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
 #endif
 
 #if IOS

--- a/src/Eto.Mac/Messaging.cs
+++ b/src/Eto.Mac/Messaging.cs
@@ -6,31 +6,16 @@ using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#elif XAMMAC2
+#else
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
 #endif
 #endif
 

--- a/src/Eto.Mac/NSImageExtensions.cs
+++ b/src/Eto.Mac/NSImageExtensions.cs
@@ -8,12 +8,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac
 {
 	public static class NSImageExtensions

--- a/src/Eto.Mac/NSImageExtensions.cs
+++ b/src/Eto.Mac/NSImageExtensions.cs
@@ -1,33 +1,17 @@
 using System;
 using Eto.Drawing;
-#if XAMMAC2
+
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac

--- a/src/Eto.Mac/ObjCExtensions.cs
+++ b/src/Eto.Mac/ObjCExtensions.cs
@@ -1,17 +1,12 @@
 using System;
 using System.Runtime.InteropServices;
-#if XAMMAC2
+
+#if OSX
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#elif OSX
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
 #elif IOS
 using ObjCRuntime;
 using Eto.iOS;

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -24,12 +24,6 @@ using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
 
-#if Mac64
-using nfloat = System.Double;
-using nint = System.Int64;
-using nuint = System.UInt64;
-#endif
-
 namespace Eto.Mac
 {
 

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -17,34 +17,17 @@ using Eto.Mac.Forms.ToolBar;
 using Eto.Shared.Forms;
 using Eto.Forms.ThemedControls;
 
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
 using CoreImage;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-using MonoMac.CoreImage;
+
 #if Mac64
 using nfloat = System.Double;
 using nint = System.Int64;
 using nuint = System.UInt64;
-#else
-using nfloat = System.Single;
-using nint = System.Int32;
-using nuint = System.UInt32;
-#endif
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
 #endif
 
 namespace Eto.Mac

--- a/src/Eto.Mac/Threading/ThreadHandler.cs
+++ b/src/Eto.Mac/Threading/ThreadHandler.cs
@@ -2,25 +2,17 @@ using System;
 using Eto.Threading;
 
 #if OSX
-#if XAMMAC2
 using AppKit;
 using Foundation;
 using CoreGraphics;
 using ObjCRuntime;
 using CoreAnimation;
-#else
-using MonoMac.AppKit;
-using MonoMac.Foundation;
-using MonoMac.CoreGraphics;
-using MonoMac.ObjCRuntime;
-using MonoMac.CoreAnimation;
-#endif
 
 namespace Eto.Mac.Threading
 #elif IOS
 
-using MonoTouch.Foundation;
-using MonoTouch.ObjCRuntime;
+using Foundation;
+using ObjCRuntime;
 
 namespace Eto.iOS.Threading
 #endif

--- a/src/Shared/PlatformDetect.cs
+++ b/src/Shared/PlatformDetect.cs
@@ -5,10 +5,8 @@ using System.Runtime.InteropServices;
 
 namespace Eto
 {
-	#if XAMMAC2
+	#if OSX
 	[Foundation.Preserve(AllMembers = true)]
-	#elif OSX
-	[MonoMac.Foundation.Preserve(AllMembers = true)]
 	#endif
 	static class PlatformDetect
 	{

--- a/test/Eto.Test.Mac/Startup.cs
+++ b/test/Eto.Test.Mac/Startup.cs
@@ -6,11 +6,7 @@ using Eto.Drawing;
 using Eto.Mac.Forms.ToolBar;
 using Eto.Forms;
 
-#if XAMMAC2
 using AppKit;
-#else
-using MonoMac.AppKit;
-#endif
 
 namespace Eto.Test.Mac
 {

--- a/test/Eto.Test.Mac/UnitTests/ButtonTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/ButtonTests.cs
@@ -6,18 +6,9 @@ using Eto.Test.UnitTests;
 using NUnit.Framework;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
-#if XAMMAC2
+
 using AppKit;
 using CoreGraphics;
-#else
-using MonoMac.AppKit;
-using MonoMac.CoreGraphics;
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
-#endif
 
 namespace Eto.Test.Mac.UnitTests
 {

--- a/test/Eto.Test.Mac/UnitTests/CheckBoxTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/CheckBoxTests.cs
@@ -4,18 +4,9 @@ using Eto.Forms;
 using Eto.Mac.Forms.Controls;
 using Eto.Test.UnitTests;
 using NUnit.Framework;
-#if XAMMAC2
+
 using AppKit;
 using CoreGraphics;
-#else
-using MonoMac.AppKit;
-using MonoMac.CoreGraphics;
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
-#endif
 
 namespace Eto.Test.Mac.UnitTests
 {

--- a/test/Eto.Test.Mac/UnitTests/NativeParentWindowTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/NativeParentWindowTests.cs
@@ -4,18 +4,8 @@ using NUnit.Framework;
 using Eto.Forms;
 using System.Threading;
 
-#if XAMMAC2
 using AppKit;
 using CoreGraphics;
-#else
-using MonoMac.AppKit;
-using MonoMac.CoreGraphics;
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
-#endif
 
 namespace Eto.Test.Mac.UnitTests
 {

--- a/test/Eto.Test.Mac/UnitTests/RadioButtonTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/RadioButtonTests.cs
@@ -4,18 +4,9 @@ using Eto.Forms;
 using Eto.Mac.Forms.Controls;
 using Eto.Test.UnitTests;
 using NUnit.Framework;
-#if XAMMAC2
+
 using AppKit;
 using CoreGraphics;
-#else
-using MonoMac.AppKit;
-using MonoMac.CoreGraphics;
-#if SDCOMPAT
-using CGSize = System.Drawing.SizeF;
-using CGRect = System.Drawing.RectangleF;
-using CGPoint = System.Drawing.PointF;
-#endif
-#endif
 
 namespace Eto.Test.Mac.UnitTests
 {


### PR DESCRIPTION
For better compatibility with Xamarin.Mac

Not sure if I'll merge this just yet.. mostly just a test and to see if others are interested in such a change (please chime in either way).

This gets rid of the "MonoMac" prefix of the namespaces for better code compatibility with Xamarin.Mac, with much fewer `#if` blocks in the code.

This will, however, break any existing code/binaries that relies on the existing MonoMac namespaces, such as Eto.OpenTK, Eto.HtmlRenderer, etc. so they'd need to be updated to work with this.