### PR TITLE
Fix build for VS on Windows

### DIFF
--- a/src/Eto.Mac/Eto.XamMac2.csproj
+++ b/src/Eto.Mac/Eto.XamMac2.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <TargetFrameworks>net45;xamarinmac20</TargetFrameworks>
+    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks Condition="$(HasXamarinMac) == 'True'">$(TargetFrameworks);xamarinmac20</TargetFrameworks>
     <RootNamespace>Eto.Mac</RootNamespace>
     <DefineConstants>$(DefineConstants);OSX;DESKTOP;XAMMAC;XAMMAC2;UNIFIED</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
@@ -3,7 +3,8 @@
   <PropertyGroup>
     <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net461;xamarinmac20</TargetFrameworks>
+    <TargetFrameworks>net461</TargetFrameworks>
+    <TargetFrameworks Condition="$(HasXamarinMac) == 'True'">$(TargetFrameworks);xamarinmac20</TargetFrameworks>
     <RootNamespace>Eto.Test.Mac</RootNamespace>
     <DefineConstants>$(DefineConstants);XAMMAC2</DefineConstants>
     <LanguageTargets Condition="$(HasXamarinMac) == 'True'">$(XamarinMacTargetsPath)Xamarin.Mac.CSharp.targets</LanguageTargets>


### PR DESCRIPTION
- Only use xamarinmac20 framework if it is available
- Fix monomac build when building in VS on Windows
Fixes #1554