### PR TITLE
Wpf: Fix detection for when the application is terminating

### DIFF
--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -205,10 +205,13 @@ namespace Eto.Wpf.Forms
 						var args = new CancelEventArgs { Cancel = e.Cancel };
 						Callback.OnClosing(Widget, args);
 						var willShutDown =
-							sw.Application.Current.Windows.Count == 1
+							(
+								sw.Application.Current.ShutdownMode == sw.ShutdownMode.OnLastWindowClose
+								&& sw.Application.Current.Windows.Count == 1
+							)
 							|| (
-								sw.Application.Current.MainWindow == Control
-								&& sw.Application.Current.ShutdownMode == sw.ShutdownMode.OnMainWindowClose
+								sw.Application.Current.ShutdownMode == sw.ShutdownMode.OnMainWindowClose
+								&& sw.Application.Current.MainWindow == Control
 							);
 
 						if (!args.Cancel && willShutDown)


### PR DESCRIPTION
Don't just assume the application will terminate when the last window closes, we need to check the current shutdown mode for that as well..