### PR TITLE
Wpf: TreeGridView tweaks

### DIFF
--- a/src/Eto.Wpf/CustomControls/TreeGridView/TreeToggleButton.cs
+++ b/src/Eto.Wpf/CustomControls/TreeGridView/TreeToggleButton.cs
@@ -6,16 +6,64 @@ using System.Windows.Controls;
 using Eto.CustomControls;
 using swc = System.Windows.Controls;
 using swcp = System.Windows.Controls.Primitives;
+using swm = System.Windows.Media;
+using System.Windows.Input;
 
 namespace Eto.Wpf.CustomControls.TreeGridView
 {
-	public class TreeToggleButton : swcp.ToggleButton
+	public class TreeTogglePanel : DockPanel
 	{
 		public const int LevelWidth = 16;
+		readonly TreeToggleButton button;
+		readonly FrameworkElement content;
 
+		public TreeTogglePanel(FrameworkElement content, TreeController controller)
+		{
+			Background = swm.Brushes.Transparent; // needed?
+			button = new TreeToggleButton { Controller = controller, Width = 16 };
+			SetDock(button, Dock.Left);
+			Children.Add(button);
+			Children.Add(content);
+			this.content = content;
+
+			DataContextChanged += OnDataContextChanged;
+		}
+
+		private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
+		{
+			if (DataContext is ITreeGridItem item)
+			{
+				button.Item = item;
+				var index = button.Controller.IndexOf(item);
+				button.IsChecked = button.Controller.IsExpanded(index);
+				button.Visibility = item != null && item.Expandable ? Visibility.Visible : Visibility.Hidden;
+				button.Margin = new Thickness(button.Controller.LevelAtRow(index) * LevelWidth, 0, 0, 0);
+			}
+		}
+
+		public static bool? IsOverContent(DependencyObject hitTestResult)
+		{
+			if (hitTestResult is TreeTogglePanel)
+				return false;
+			var panel = hitTestResult.GetVisualParent<TreeTogglePanel>();
+			if (panel == null)
+				return null;
+
+			while (hitTestResult != null && !ReferenceEquals(hitTestResult, panel))
+			{
+				if (ReferenceEquals(hitTestResult, panel.content))
+					return true;
+				hitTestResult = hitTestResult.GetVisualParent<DependencyObject>();
+			}
+			return false;
+		}
+	}
+
+	public class TreeToggleButton : swcp.ToggleButton
+	{
 		public TreeController Controller { get; set; }
 
-		public ITreeGridItem Item { get; private set; }
+		public ITreeGridItem Item { get; set; }
 
 		static TreeToggleButton ()
 		{
@@ -24,42 +72,49 @@ namespace Eto.Wpf.CustomControls.TreeGridView
 
 		public static FrameworkElement Create (FrameworkElement content, TreeController controller)
 		{
-			var dock = new DockPanel();
-			var button = new TreeToggleButton { Controller = controller, Width = 16 };
-			DockPanel.SetDock(button, Dock.Left);
-			dock.Children.Add (button);
-			dock.DataContextChanged += (sender, e) => button.Configure(dock.DataContext as ITreeGridItem);
-			dock.Children.Add (content);
-			return dock;
+			return new TreeTogglePanel(content, controller);
 		}
 
-		protected override void OnPreviewMouseLeftButtonDown (System.Windows.Input.MouseButtonEventArgs e)
+
+		protected override void OnPreviewMouseLeftButtonUp(MouseButtonEventArgs e)
 		{
-			base.OnPreviewMouseLeftButtonDown (e);
-			
-			var index = Controller.IndexOf ((ITreeGridItem)DataContext);
-			if (index >= 0) {
-				Dispatcher.BeginInvoke (new Action (delegate {
-					if (IsChecked ?? false) {
-						if (Controller.CollapseRow (index)) {
-							IsChecked = false;
-						}
-					}
-					else if (Controller.ExpandRow (index)) {
-						IsChecked = true;
-					}
-				}));
+			base.OnPreviewMouseLeftButtonUp(e);
+
+			// only activate if the mouse wasn't moved outside the toggle button area
+			var position = e.GetPosition(this);
+			var size = this.GetSize();
+			if (position.X >= 0 && position.Y >= 0 && position.X < size.Width && position.Y < size.Height)
+			{
+				Dispatcher.BeginInvoke(new Action(ToggleExpandCollapse));
+				e.Handled = true;
 			}
+		}
+		protected override void OnPreviewMouseLeftButtonDown(MouseButtonEventArgs e)
+		{
+			base.OnPreviewMouseLeftButtonDown(e);
 			e.Handled = true;
 		}
 
-		public void Configure (ITreeGridItem item)
+		void ToggleExpandCollapse()
 		{
-			Item = item;
-			var index = Controller.IndexOf (item);
-			IsChecked = Controller.IsExpanded (index);
-			Visibility = item != null && item.Expandable ? Visibility.Visible : Visibility.Hidden;
-			Margin = new Thickness (Controller.LevelAtRow (index) * LevelWidth, 0, 0, 0);
+			if (DataContext is ITreeGridItem item)
+			{
+				var index = Controller.IndexOf(item);
+				if (index >= 0)
+				{
+					if (IsChecked ?? false)
+					{
+						if (Controller.CollapseRow(index))
+						{
+							IsChecked = false;
+						}
+					}
+					else if (Controller.ExpandRow(index))
+					{
+						IsChecked = true;
+					}
+				}
+			}
 		}
 	}
 }

--- a/src/Eto.Wpf/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CellHandler.cs
@@ -16,8 +16,8 @@ namespace Eto.Wpf.Forms.Cells
 	{
 		ICellContainerHandler ContainerHandler { get; set; }
 		swc.DataGridColumn Control { get; }
-		bool OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell);
-		bool OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell);
+		void OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell);
+		void OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell);
 	}
 
 	static class CellProperties
@@ -65,7 +65,12 @@ namespace Eto.Wpf.Forms.Cells
 			return null;
 		}
 
-		public virtual bool OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell) => false;
-		public virtual bool OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell) => false;
+		public virtual void OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
+		{
+		}
+
+		public virtual void OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
+		{
+		}
 	}
 }

--- a/src/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
@@ -7,6 +7,7 @@ using swm = System.Windows.Media;
 using Eto.Wpf.Drawing;
 using Eto.Drawing;
 using System.ComponentModel;
+using System.Linq;
 
 namespace Eto.Wpf.Forms.Cells
 {
@@ -228,25 +229,25 @@ namespace Eto.Wpf.Forms.Cells
 
 		public AutoSelectMode AutoSelectMode { get; set; } = AutoSelectMode.OnFocus;
 
-		public override bool OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
+		public override void OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
 		{
-			if (cell?.IsEditing == true && hitTestResult is swc.Image)
+			if (cell?.IsEditing == true && !hitTestResult.GetVisualParents().TakeWhile(r => !(r is swc.DataGridCell)).OfType<swc.TextBox>().Any())
 			{
-				// commit editing when clicking on the image
+				// commit editing when clicking on anything other than the text box
 				ContainerHandler?.Grid.CommitEdit();
-				return true;
+				args.Handled = true;
 			}
 
-			return base.OnMouseDown(args, hitTestResult, cell);
+			base.OnMouseDown(args, hitTestResult, cell);
 		}
-		public override bool OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
+		public override void OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
 		{
-			if (cell?.IsEditing == false && !Control.IsReadOnly && hitTestResult is swc.Image)
+			if (cell?.IsEditing == false && !Control.IsReadOnly && !hitTestResult.GetVisualParents().TakeWhile(r => !(r is swc.DataGridCell)).OfType<swc.TextBlock>().Any())
 			{
-				// prevent default behaviour of editing if we click on the image
-				return true;
+				// prevent default behaviour of editing unless we click on the text
+				args.Handled = true;
 			}
-			return base.OnMouseUp(args, hitTestResult, cell);
+			base.OnMouseUp(args, hitTestResult, cell);
 		}
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
@@ -131,14 +131,14 @@ namespace Eto.Wpf.Forms.Controls
 
 		internal ICellHandler DataCellHandler => DataCell?.Handler as ICellHandler;
 
-		internal bool OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
+		internal void OnMouseDown(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
 		{
-			return DataCellHandler?.OnMouseDown(args, hitTestResult, cell) ?? false;
+			DataCellHandler?.OnMouseDown(args, hitTestResult, cell);
 		}
 
-		internal bool OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
+		internal void OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
 		{
-			return DataCellHandler?.OnMouseUp(args, hitTestResult, cell) ?? false;
+			DataCellHandler?.OnMouseUp(args, hitTestResult, cell);
 		}
 
 		swc.DataGridColumn IGridColumnHandler.Control => Control;

--- a/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -3,6 +3,7 @@ using swc = System.Windows.Controls;
 using sw = System.Windows;
 using swd = System.Windows.Data;
 using swm = System.Windows.Media;
+using swi = System.Windows.Input;
 using Eto.Forms;
 using Eto.CustomControls;
 using Eto.Wpf.CustomControls.TreeGridView;
@@ -27,6 +28,63 @@ namespace Eto.Wpf.Forms.Controls
 			base.Initialize();
 			controller = new TreeController { Handler = this };
 			Control.Background = sw.SystemColors.WindowBrush;
+			Control.PreviewKeyDown += Control_PreviewKeyDown;
+		}
+
+		private void Control_PreviewKeyDown(object sender, sw.Input.KeyEventArgs e)
+		{
+			if (e.Handled || swi.Keyboard.Modifiers != swi.ModifierKeys.None)
+				return;
+
+			// handle expanding/collapsing via the keyboard
+			if (e.Key == swi.Key.Right)
+			{
+				var currentCell = Control.CurrentCell;
+				if (currentCell.Column != null 
+					&& Control.Columns.IndexOf(currentCell.Column) == 0
+					&& currentCell.Item is ITreeGridItem item
+					&& item.Expandable
+					&& !item.Expanded)
+				{
+					var index = controller.IndexOf(item);
+					if (index >= 0)
+					{
+						controller.ExpandRow(index);
+
+						e.Handled = true;
+					}
+				}
+			}
+			else if (e.Key == swi.Key.Left)
+			{
+				var currentCell = Control.CurrentCell;
+				if (currentCell.Column != null
+					&& Control.Columns.IndexOf(currentCell.Column) == 0
+					&& currentCell.Item is ITreeGridItem item)
+				{
+					if (!item.Expandable || !item.Expanded)
+					{
+						// select parent if not the top node
+						item = item.Parent;
+						if (item != null && !ReferenceEquals(item, DataStore))
+						{
+							Control.CurrentCell = new swc.DataGridCellInfo(item, currentCell.Column);
+							SelectedItem = item;
+							e.Handled = true;
+						}
+					}
+					else
+					{
+						var index = controller.IndexOf(item);
+						if (index >= 0)
+						{
+							controller.CollapseRow(index);
+
+							e.Handled = true;
+						}
+					}
+				}
+			}
 		}
 
 		public override void AttachEvent(string id)

--- a/src/Eto.Wpf/WpfExtensions.cs
+++ b/src/Eto.Wpf/WpfExtensions.cs
@@ -35,6 +35,16 @@ namespace Eto.Wpf
 			return null;
 		}
 
+		public static IEnumerable<sw.DependencyObject> GetVisualParents(this sw.DependencyObject control)
+		{
+			while (control != null)
+			{
+				yield return control;
+
+				control = control.GetVisualParent<sw.DependencyObject>();
+			}
+		}
+
 		public static T GetParent<T>(this sw.FrameworkElement control)
 			where T : class
 		{


### PR DESCRIPTION
- ImageTextCell only begins editing when clicking on text, not empty areas (e.g. when used as a first column in a TreeGridView)
- Keyboard left/right can now expand/collapse tree nodes
- Fixes Expand/Collapse button when the item is selected.
- Expand/Collapse button now is triggered on mouse up, and only activated if the mouse up is still over the button.
- CheckBoxCell now changes its value on first click instead of 3rd click.