### PR TITLE
Fix TextStepper.HasFocus

### DIFF
--- a/src/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/src/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -169,8 +169,7 @@ namespace Eto.Forms
 		/// <summary>
 		/// Gets a value indicating whether this instance has the keyboard input focus.
 		/// </summary>
-		/// <value>true</value>
-		/// <c>false</c>
+		/// <value><c>true</c> if this instance has focus; otherwise, <c>false</c>.</value>
 		public virtual bool HasFocus
 		{
 			get { return Control.HasFocus; }

--- a/src/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
@@ -253,6 +253,12 @@ namespace Eto.Forms.ThemedControls
 		}
 
 		/// <summary>
+		/// Gets a value indicating whether this instance has the keyboard input focus.
+		/// </summary>
+		/// <value><c>true</c> if this instance has focus; otherwise, <c>false</c>.</value>
+		public override bool HasFocus => base.HasFocus || TextBox.HasFocus || Stepper.HasFocus;
+
+		/// <summary>
 		/// Attaches the specified event to the platform-specific control
 		/// </summary>
 		/// <remarks>Implementors should override this method to handle any events that the widget


### PR DESCRIPTION
We need to test if the textbox and/or stepper has focus.