### PR TITLE
Remove obsolete System.Xml reference for RoslyCodeTaskFactory

### DIFF
--- a/src/Eto.Mac/build/Mac.targets
+++ b/src/Eto.Mac/build/Mac.targets
@@ -65,6 +65,13 @@
     <RemoveDir Directories="$(OutputAppPath)"/>
   </Target>
 
+  <PropertyGroup Condition="'$(MSBuildTaskFactoryType)'=='CodeTaskFactory'">
+      <_UpdatePListReference>System.Xml</_UpdatePListReference>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(MSBuildTaskFactoryType)'!='CodeTaskFactory'">
+      <_UpdatePListReference>netstandard</_UpdatePListReference>
+  </PropertyGroup>
+
   <!-- Task to update the plist file with new values -->
   <UsingTask TaskName="UpdatePList" TaskFactory="$(MSBuildTaskFactoryType)"  AssemblyFile="$(MSBuildTasksAssemblyFile)">
     <ParameterGroup>
@@ -76,7 +83,7 @@
       <IconFile ParameterType="System.String" Output="true" />
     </ParameterGroup>
     <Task>
-      <Reference Include="System.Xml" />
+      <Reference Include="$(_UpdatePListReference)"/>
       <Code Type="Class" Language="cs"><![CDATA[
     using System;
     using System.IO;


### PR DESCRIPTION
The `UpdatePList` task used in `Eto.Platform.Mac64.targets` uses a MSBuild `CodeTaskFactory`. Depending on whether we're on .NET Core or Full Framework we use either the `CodeTaskFactory` or `RoslynCodeTaskFactory` as indicated by our `$(MSBuildTaskFactoryType)` property.

The Code fragment in `Mac.targets` uses an XML Writer to generate a plist file for the Mac app bundle. On .NET Framework you'd reference `System.Xml` and load it from the GAC and this is what the previous version of `Mac.targets` does.

On .NET Core, `System.Xml` does not exist (and neither does the GAC). So the Xml types need to be referenced from somewhere else, namely the .NET Standard.

This PR creates a conditional MSBuild property `_UpdatePListReference` (following the MSBuild naming convention of internal properties being prefixed with `_`) that is evaluated either to `System.Xml` (on Full Framework) or `netstandard` (on .NET Core).

**Effectively, this makes it possible to use .NET Core compilers to produce Mac App bundles.**