### PR TITLE
Fix building/launching from VSCode

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -3,18 +3,17 @@
    "configurations": [
         {
             "name": "Eto.Test.Mac64",
-            "type": "mono",
+            "type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-mac64",
-			"useRuntime": false,
-            "program": "${workspaceFolder}/artifacts/test/Debug/net461/Eto.Test.Mac64.app/Contents/MacOS/Eto.Test.Mac64",
+            "program": "${workspaceFolder}/artifacts/test/Debug/netcoreapp3.1/Eto.Test.Mac64.app/Contents/MacOS/Eto.Test.Mac64",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
             "name": "Eto.Test.Gtk",
-            "type": "coreclr",
+			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-gtk",
             "program": "${workspaceFolder}/artifacts/test/Debug/netcoreapp3.1/Eto.Test.Gtk.dll",
@@ -24,22 +23,11 @@
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
-            "name": "Eto.Test.Gtk2",
-			"type": "clr",
-			"osx": {"type": "mono"},
-            "request": "launch",
-			"preLaunchTask": "build-gtk2",
-            "program": "${workspaceFolder}/artifacts/test/Debug/net461/Eto.Test.Gtk2.exe",
-            "args": [],
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart"
-        },
-        {
             "name": "Eto.Test.Wpf",
-			"type": "clr",
+			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-wpf",
-            "program": "${workspaceFolder}/artifacts/test/Debug/net461/Eto.Test.Wpf.exe",
+            "program": "${workspaceFolder}/artifacts/test/Debug/netcoreapp3.1/Eto.Test.Wpf.exe",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -8,6 +8,7 @@
 			"type": "process",
 			"args": [
 				"/t:Build",
+				"/v:Minimal",
 				"/p:Configuration=${input:configuration}",
 				"${workspaceFolder}/build/Build.proj"
 			],
@@ -23,20 +24,10 @@
 			"type": "process",
 			"args": [
 				"build",
+				"/v:Minimal",
 				"/p:Configuration=Debug",
+				"/p:TargetFramework=netcoreapp3.1",
 				"${workspaceFolder}/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj"
-			],
-			"group": "build",
-			"problemMatcher": "$msCompile"
-		},
-		{
-			"label": "build-gtk2",
-			"command": "msbuild",
-			"windows": { "command": "build/msbuild.cmd" },
-			"type": "process",
-			"args": [
-				"/p:Configuration=Debug",
-				"${workspaceFolder}/test/Eto.Test.Gtk2/Eto.Test.Gtk2.csproj"
 			],
 			"group": "build",
 			"problemMatcher": "$msCompile"
@@ -44,10 +35,11 @@
 		{
 			"label": "build-mac64",
 			"command": "msbuild",
-			"windows": { "command": "build/msbuild.cmd" },
 			"type": "process",
 			"args": [
+				"/v:Minimal",
 				"/p:Configuration=Debug",
+				"/p:TargetFramework=netcoreapp3.1",
 				"${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.Mac64.csproj"
 			],
 			"group": "build",
@@ -55,11 +47,13 @@
 		},
 		{
 			"label": "build-wpf",
-			"command": "msbuild",
-			"windows": { "command": "build/msbuild.cmd" },
+			"command": "dotnet",
 			"type": "process",
 			"args": [
+				"build",
+				"/v:Minimal",
 				"/p:Configuration=Debug",
+				"/p:TargetFramework=netcoreapp3.1",
 				"${workspaceFolder}/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj"
 			],
 			"group": "build",
@@ -67,10 +61,11 @@
 		},
 		{
 			"label": "restore",
-			"command": "nuget",
+			"command": "dotnet",
 			"type": "process",
 			"args": [
 				"restore",
+				"/v:Minimal",
 				"${workspaceFolder}/src/Eto.sln"
 			],
 			"problemMatcher": "$msCompile"

--- a/build/msbuild.cmd
+++ b/build/msbuild.cmd
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 set vswhere=%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe
-set version=15.0
+set version=16.0
 
 for /f "usebackq tokens=*" %%i in (`"%vswhere%" -version %version% -requires Microsoft.Component.MSBuild -find MSBuild\**\Bin\MSBuild.exe`) do (
   "%%i" %*

--- a/src/Eto.Gtk/Eto.Gtk.csproj
+++ b/src/Eto.Gtk/Eto.Gtk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace>Eto.GtkSharp</RootNamespace>
     <DefineConstants>$(DefineConstants);GTK3;GTKCORE</DefineConstants>

--- a/src/Eto.Gtk/Eto.Gtk2.csproj
+++ b/src/Eto.Gtk/Eto.Gtk2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace>Eto.GtkSharp</RootNamespace>
     <DefineConstants>$(DefineConstants);CAIRO;GTK2</DefineConstants>

--- a/src/Eto.Gtk/Eto.Gtk3.csproj
+++ b/src/Eto.Gtk/Eto.Gtk3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFrameworks>net45</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace>Eto.GtkSharp</RootNamespace>
     <DefineConstants>$(DefineConstants);CAIRO;GTK3</DefineConstants>

--- a/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj
+++ b/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
     <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <DefineConstants>$(DefineConstants);CAIRO;GTK3</DefineConstants>
     <TreatWarningsAsErrors Condition="$(Configuration) == 'Release'">true</TreatWarningsAsErrors>

--- a/test/Eto.Test.Gtk/Eto.Test.Gtk2.csproj
+++ b/test/Eto.Test.Gtk/Eto.Test.Gtk2.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>net461</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <DefineConstants>$(DefineConstants);GTK2</DefineConstants>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>

--- a/test/Eto.Test.Gtk/Eto.Test.Gtk3.csproj
+++ b/test/Eto.Test.Gtk/Eto.Test.Gtk3.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net461</TargetFramework>
+    <TargetFrameworks>net461</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <DefineConstants>$(DefineConstants);GTK3</DefineConstants>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>


### PR DESCRIPTION
- Eto.Test.Gtk builds for .NET Core and .NET Framework again, and specify the target framework when building instead
- Fix build error(s) due to mixing `<TargetFramework>` and `<TargetFrameworks>`.
- Use minimal build output
- Support launching/debugging Eto.Test.Mac64 and Eto.Test.Wpf using .NET Core.
- Build everything except Mac64 using dotnet command