### PR TITLE
Update references and minor fixes

### DIFF
--- a/src/Addins/Eto.Addin.VisualStudio/Eto.Addin.VisualStudio.csproj
+++ b/src/Addins/Eto.Addin.VisualStudio/Eto.Addin.VisualStudio.csproj
@@ -301,8 +301,8 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Core" Version="4.3.1" />
-    <PackageReference Include="Portable.Xaml" Version="0.23.0" />
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.2.0" />
+    <PackageReference Include="Portable.Xaml" Version="0.24.0" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" />
     <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.202" ExcludeAssets="runtime" />
     <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.4.1057" />
   </ItemGroup>

--- a/src/Addins/Eto.Designer/DesignPanel.cs
+++ b/src/Addins/Eto.Designer/DesignPanel.cs
@@ -91,11 +91,19 @@ namespace Eto.Designer
 
 		void ControlCreatedInternal(Control control)
 		{
-			ControlCreating?.Invoke();
-			contentControl = control;
-			designSurface.Content = GetContent(control);
-			token = null;
-			ControlCreated?.Invoke();
+			try
+			{
+				ControlCreating?.Invoke();
+				contentControl = control;
+				designSurface.Content = GetContent(control);
+				token = null;
+				ControlCreated?.Invoke();
+			}
+			catch (Exception ex)
+			{
+				designSurface.Content = null;
+				ErrorInternal(ex);
+			}
 		}
 
 		void ErrorInternal(Exception ex)

--- a/src/Eto.Serialization.Xaml/Eto.Serialization.Xaml.csproj
+++ b/src/Eto.Serialization.Xaml/Eto.Serialization.Xaml.csproj
@@ -29,7 +29,7 @@ https://github.com/picoe/Eto/wiki
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Portable.Xaml" Version="0.23.0" />
+    <PackageReference Include="Portable.Xaml" Version="0.24.0" />
   </ItemGroup>
   
   <ItemGroup Condition="$(TargetFramework) == 'netstandard1.0'">

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -149,7 +149,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.2.0" PrivateAssets="all" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" PrivateAssets="all" />
     <PackageReference Include="Windows7APICodePack-Shell" Version="1.1.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Eto/Eto.csproj
+++ b/src/Eto/Eto.csproj
@@ -49,6 +49,6 @@ https://github.com/picoe/Eto/wiki
     <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
 </Project>

--- a/src/Eto/Eto.csproj
+++ b/src/Eto/Eto.csproj
@@ -40,7 +40,8 @@ https://github.com/picoe/Eto/wiki
     <Compile Include="..\Shared\EnumerableExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Update="Eto.Forms.targets" Pack="true" PackagePath="build" />
+    <None Remove="Eto.Forms.targets" />
+    <None Include="Eto.Forms.targets" Pack="true" PackagePath="build" />
     <None Update="$(BasePath)LICENSE.txt" CopyToOutputDirectory="PreserveNewest" /> 
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard1.0'">

--- a/src/Eto/Forms/Container.cs
+++ b/src/Eto/Forms/Container.cs
@@ -361,6 +361,10 @@ namespace Eto.Forms
 		/// <param name="previousChild">Previous child that the new child is replacing.</param>
 		protected void SetParent(Control child, Action assign = null, Control previousChild = null)
 		{
+			if (ReferenceEquals(child, this))
+			{
+				throw new InvalidOperationException("Cannot assign a control as a child of itself.");
+			}
 			if (Handler is IThemedControlHandler)
 			{
 				if (!ReferenceEquals(previousChild, null))
@@ -374,7 +378,7 @@ namespace Eto.Forms
 			{
 #if DEBUG
 				if (!ReferenceEquals(previousChild.VisualParent, this))
-					throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "The previous child control is not a child of this container. Ensure you only remove children that you own."));
+					throw new ArgumentException("The previous child control is not a child of this container. Ensure you only remove children that you own.");
 #endif
 
 				if (!ReferenceEquals(previousChild.VisualParent, null))

--- a/test/Eto.Test.Gtk/Eto.Test.Gtk2.csproj
+++ b/test/Eto.Test.Gtk/Eto.Test.Gtk2.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
   </ItemGroup>
   
 </Project>

--- a/test/Eto.Test.Gtk/Eto.Test.Gtk3.csproj
+++ b/test/Eto.Test.Gtk/Eto.Test.Gtk3.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
   </ItemGroup>
   
 </Project>

--- a/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
@@ -1,8 +1,8 @@
 <Project>
   
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props"/>
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
   
-  <Import Project="..\..\build\MSBuildTaskHelper.props" Condition="'$(MSBuildTaskHelpersImported)'!='true'"/>
+  <Import Project="..\..\build\MSBuildTaskHelper.props" Condition="'$(MSBuildTaskHelpersImported)'!='true'" />
   <Import Project="..\..\src\Eto.Mac\build\Mac.props" Condition="'$(ExcludeRestorePackageImports)' != 'true'" />
   
   <PropertyGroup>
@@ -24,13 +24,13 @@
     <ProjectReference Include="..\..\lib\monomac\src\MonoMac.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
   
-  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets"/>
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
   
   <Import Project="..\..\src\Eto.Mac\build\Mac.targets" Condition="'$(ExcludeRestorePackageImports)' != 'true'" />
   

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
@@ -41,7 +41,7 @@
     <ProjectReference Include="..\..\src\Eto.Mac\Eto.XamMac2.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="TestIcon.icns" />

--- a/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
+++ b/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
@@ -54,7 +54,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0">
+    <PackageReference Include="NUnit" Version="3.12.0">
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
+++ b/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
@@ -62,7 +62,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0">
+    <PackageReference Include="NUnit" Version="3.12.0">
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/test/Eto.Test/Eto.Test.csproj
+++ b/test/Eto.Test/Eto.Test.csproj
@@ -30,10 +30,10 @@
     <ProjectReference Include="..\..\src\Eto.Serialization.Json\Eto.Serialization.Json.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.11.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
-    <PackageReference Include="System.ComponentModel.Annotations" Version="4.5.0" />
+    <PackageReference Include="System.ComponentModel.Annotations" Version="4.7.0" />
   </ItemGroup>
   <ItemGroup>
     <None Remove="Sections\Serialization\Xaml\Test.xeto" />


### PR DESCRIPTION
- Portable.Xaml updated to 0.24.0
- Extended.Wpf.Toolkit updated to 3.6.0 (last commercial-friendly release)
- NUnit updated to 3.12
- Catch exceptions when setting designer content
- Prevent StackOverflow when assigning a control as a child of itself