### PR TITLE
Wpf: Fix issue with TextBox.TextChanged when using IME

### DIFF
--- a/src/Eto/Forms/Controls/MaskedTextBox.cs
+++ b/src/Eto/Forms/Controls/MaskedTextBox.cs
@@ -177,6 +177,7 @@ namespace Eto.Forms
 		static readonly object SupportsInsertKey = new object();
 		static readonly object OverwriteModeKey = new object();
 		static readonly object ShowPlaceholderWhenEmptyKey = new object();
+		static readonly object IsUpdatingTextKey = new object();
 
 		/// <summary>
 		/// Gets a cached value indicating the current platform supports getting the insert mode state.
@@ -186,7 +187,7 @@ namespace Eto.Forms
 			get
 			{
 				// cache whether the platform supports the insert key for Keyboard.IsKeyLocked
-				return Platform.Instance.GetSharedProperty<bool>(SupportsInsertKey, () => Keyboard.SupportedLockKeys.Contains(Keys.Insert));
+				return Platform.Instance.GetSharedProperty(SupportsInsertKey, () => Keyboard.SupportedLockKeys.Contains(Keys.Insert));
 			}
 		}
 
@@ -195,7 +196,7 @@ namespace Eto.Forms
 		/// </summary>
 		static bool ManualOverwriteMode
 		{
-			get { return Platform.Instance.GetSharedProperty<bool>(OverwriteModeKey, () => false); }
+			get { return Platform.Instance.GetSharedProperty(OverwriteModeKey, () => false); }
 			set { Platform.Instance.SetSharedProperty(OverwriteModeKey, value); }
 		}
 
@@ -256,7 +257,7 @@ namespace Eto.Forms
 			{ 
 				if (ShowPromptOnFocus != value)
 				{
-					Properties[ShowPromptOnFocusKey] = value; 
+					Properties[ShowPromptOnFocusKey] = value;
 					UpdateText();
 				}
 			}
@@ -275,25 +276,33 @@ namespace Eto.Forms
 			{ 
 				if (ShowPlaceholderWhenEmpty != value)
 				{
-					Properties[ShowPlaceholderWhenEmptyKey] = value; 
+					Properties[ShowPlaceholderWhenEmptyKey] = value;
 					UpdateText();
 				}
 			}
 		}
 
+		int IsUpdatingText
+		{
+			get => Properties.Get<int>(IsUpdatingTextKey);
+			set => Properties.Set(IsUpdatingTextKey, value);
+		}
+
+
 		/// <summary>
-		/// Initializes a new instance of the <see cref="Eto.Forms.MaskedTextBox"/> class.
+		/// Initializes a new instance of the <see cref="MaskedTextBox"/> class.
 		/// </summary>
 		public MaskedTextBox()
 		{
 			HandleEvent(TextChangingEvent);
+			HandleEvent(TextChangedEvent);
 			HandleEvent(KeyDownEvent);
 			HandleEvent(GotFocusEvent);
 			HandleEvent(LostFocusEvent);
 		}
 
 		/// <summary>
-		/// Initializes a new instance of the <see cref="Eto.Forms.MaskedTextBox"/> class with the specified masked text provider.
+		/// Initializes a new instance of the <see cref="MaskedTextBox"/> class with the specified masked text provider.
 		/// </summary>
 		/// <param name="provider">Masked text provider to specify the format of the mask.</param>
 		public MaskedTextBox(IMaskedTextProvider provider)
@@ -318,6 +327,7 @@ namespace Eto.Forms
 		{
 			if (provider == null)
 				return;
+			IsUpdatingText++;
 			var hasFocus = HasFocus;
 			if (!hasFocus && ShowPlaceholderWhenEmpty && provider.IsEmpty && !string.IsNullOrEmpty(PlaceholderText))
 				base.Text = null;
@@ -325,6 +335,7 @@ namespace Eto.Forms
 				base.Text = provider.DisplayText;
 			else
 				base.Text = provider.Text;
+			IsUpdatingText--;
 		}
 
 		/// <summary>
@@ -357,6 +368,22 @@ namespace Eto.Forms
 			base.OnLostFocus(e);
 			if (ShowPromptOnFocus || ShowPlaceholderWhenEmpty)
 				UpdateText();
+		}
+
+		/// <summary>
+		/// Raises the <see cref="TextControl.TextChanged"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments.</param>
+		protected override void OnTextChanged(EventArgs e)
+		{
+			// handle undo/redo and drag/drop which doesn't always get a TextChanging event.
+			if (IsUpdatingText == 0 && provider != null)
+			{
+				provider.Text = base.Text;
+				UpdateText();
+			}
+
+			base.OnTextChanged(e);
 		}
 
 		/// <summary>
@@ -485,10 +512,7 @@ namespace Eto.Forms
 		/// Gets a value indicating whether the mask is completed.
 		/// </summary>
 		/// <value><c>true</c> if mask completed; otherwise, <c>false</c>.</value>
-		public bool MaskCompleted
-		{
-			get { return provider != null && provider.MaskCompleted; }
-		}
+		public bool MaskCompleted => provider?.MaskCompleted == true;
 	}
 }
 

--- a/test/Eto.Test/Sections/Controls/TextBoxSection.cs
+++ b/test/Eto.Test/Sections/Controls/TextBoxSection.cs
@@ -61,8 +61,16 @@ namespace Eto.Test.Sections.Controls
 		void LogEvents(TextBox control)
 		{
 			control.TextChanging += (sender, e) => Log.Write(control, $"TextChanging, Range: {e.Range}, Text: {e.Text}");
-			control.TextChanged += (sender, e) => Log.Write(control, "TextChanged, Text: {0}", control.Text);
+			control.TextChanged += (sender, e) => Log.Write(control, $"TextChanged, Text: {control.Text}, Selection: {control.Selection}");
 			control.TextInput += (sender, e) => Log.Write(control, "TextInput: {0}", e.Text);
+			control.KeyDown += (sender, e) =>
+			{
+				if (e.KeyData == (Keys.Slash | Keys.Shift))
+				{
+					e.Handled = true;
+					Log.Write(control, $"Selection: {control.Selection}");
+				}
+			};
 		}
 	}
 }


### PR DESCRIPTION
- TextBox.Text will only change and TextBox.TextChanged will only fire after the IME composition is completed, instead of during composition.
- MaskedTextBox/MaskedTextStepper better handle drag/drop and other events that do might not trigger a TextChanging event.

The TextChanging event was firing _after_ the text actually changed because during IME composition it sets the Text and fires the TextChanged event for each composition keystroke.  In some IME's using the numeric keyboard also triggered the TextChanging event even though there was no composition happening.  Now, the TextChanging only triggers after the composition is completed.