### PR TITLE
Bump to 2.5.1-dev

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.5.0.{build}
+version: 2.5.1.{build}
 image: Visual Studio 2019
 install:
 - cmd: git submodule -q update --init

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,6 @@
 variables:
   build.increment: $[counter('buildnumber', 10000)]
-  build.version: 2.5.0-ci-$(build.increment)
+  build.version: 2.5.1-ci-$(Build.BuildNumber)
   build.configuration: Release
   build.arguments: /t:Package /p:Configuration=$(build.configuration) /p:BuildVersion=$(build.version) /p:Branch=$(Build.SourceBranch)
   build.dotnetversion: 3.1.100

--- a/build/Common.props
+++ b/build/Common.props
@@ -26,7 +26,7 @@
     <!-- global nuget/assembly properties -->
     
     <Version Condition="$(AssemblyVersion) == ''">2.5.0.0</Version>
-    <InformationalVersion Condition="$(InformationalVersion) == ''">2.5.0-dev</InformationalVersion>
+    <InformationalVersion Condition="$(InformationalVersion) == ''">2.5.1-dev</InformationalVersion>
     <Company>Picoe Software Solutions</Company>
     <Copyright>(c) 2010-2019 by Curtis Wensley, 2012-2014 by Vivek Jhaveri and contributors</Copyright>
     

--- a/src/Addins/Eto.Addin.MonoDevelop/Properties/Manifest.addin.xml
+++ b/src/Addins/Eto.Addin.MonoDevelop/Properties/Manifest.addin.xml
@@ -32,7 +32,7 @@
 	<Extension path="/MonoDevelop/Ide/Templates">
 		<Template
 			id="Eto.App.CSharp"
-			path="Packages/Eto.Forms.Templates.2.5.0-dev.nupkg"
+			path="Packages/Eto.Forms.Templates.2.5.1-dev.nupkg"
 			imageId="eto-project"
 			wizard="Eto.Addin.MonoDevelop.ProjectWizard"
 			category="multiplat/app/eto"
@@ -40,7 +40,7 @@
 			/>
 		<Template
 			id="Eto.App.FSharp"
-			path="Packages/Eto.Forms.Templates.2.5.0-dev.nupkg"
+			path="Packages/Eto.Forms.Templates.2.5.1-dev.nupkg"
 			imageId="eto-project"
 			wizard="Eto.Addin.MonoDevelop.ProjectWizard"
 			category="multiplat/app/eto"

--- a/src/Addins/Eto.Forms.Templates/Eto.Forms.Templates.csproj
+++ b/src/Addins/Eto.Forms.Templates/Eto.Forms.Templates.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<PackageType>Template</PackageType>
 		<PackageId>Eto.Forms.Templates</PackageId>
-		<PackageVersion>2.5.0-dev</PackageVersion>
+		<PackageVersion>2.5.1-dev</PackageVersion>
 		<Authors>Curtis Wensley</Authors>
 		<Description>Project and File templates for Eto.Forms</Description>
 		<Tags>cross-platform;gui;ui-framework;desktop;winforms;wpf;mac;osx;gtk;eto;eto.forms;dotnet-new</Tags>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.csproj
@@ -11,10 +11,10 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Windows" Version="2.5.0-dev" Condition="$(IncludeWinForms) == 'True'" />
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0-dev" />
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.0-dev" />
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.0-dev" />
+    <PackageReference Include="Eto.Platform.Windows" Version="2.5.1-dev" Condition="$(IncludeWinForms) == 'True'" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.1-dev" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.1-dev" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.1-dev" />
   </ItemGroup>
 	
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.0-dev" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.1-dev" />
   </ItemGroup>
 	
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Mac/EtoApp.1.Mac.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Mac/EtoApp.1.Mac.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.0-dev" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.1-dev" />
   </ItemGroup>
 	
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Windows" Version="2.5.0-dev" />
+    <PackageReference Include="Eto.Platform.Windows" Version="2.5.1-dev" />
   </ItemGroup>
 
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0-dev" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.1-dev" />
   </ItemGroup>
 
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Eto.Platform.XamMac2">
-      <Version>2.5.0-dev</Version>
+      <Version>2.5.1-dev</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/EtoApp.1.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/EtoApp.1.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.5.0-dev" />
-    <PackageReference Include="Eto.Serialization.Json" Version="2.5.0-dev" Condition="$(UseJeto) == 'True'" />
-    <PackageReference Include="Eto.Serialization.Xaml" Version="2.5.0-dev" Condition="$(UseXeto) == 'True'" />
+    <PackageReference Include="Eto.Forms" Version="2.5.1-dev" />
+    <PackageReference Include="Eto.Serialization.Json" Version="2.5.1-dev" Condition="$(UseJeto) == 'True'" />
+    <PackageReference Include="Eto.Serialization.Xaml" Version="2.5.1-dev" Condition="$(UseXeto) == 'True'" />
   </ItemGroup>
   
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.fsproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.0-dev" />
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0-dev" />
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.0-dev" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.1-dev" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.1-dev" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.1-dev" />
   </ItemGroup>
 
 

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.fsproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.0-dev" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.1-dev" />
   </ItemGroup>
 
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Mac/EtoApp.1.Mac.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Mac/EtoApp.1.Mac.fsproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.0-dev" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.1-dev" />
   </ItemGroup>
 
 

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.fsproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Windows" Version="2.5.0-dev" />
+    <PackageReference Include="Eto.Platform.Windows" Version="2.5.1-dev" />
   </ItemGroup>
 
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.fsproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.0-dev" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.1-dev" />
   </ItemGroup>
 
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.fsproj
@@ -84,7 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Eto.Platform.XamMac2">
-      <Version>2.5.0-dev</Version>
+      <Version>2.5.1-dev</Version>
     </PackageReference>
     <PackageReference Include="FSharp.Core">
       <Version>4.7.0</Version>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/EtoApp.1.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/EtoApp.1.fsproj
@@ -20,8 +20,8 @@
     </Compile>
     <EmbeddedResource Include="MainForm.xeto" Condition="$(UseXeto) == 'True'" />
     <EmbeddedResource Include="MainForm.jeto" Condition="$(UseJeto) == 'True'" />
-    <PackageReference Include="Eto.Forms" Version="2.5.0-dev" />
-    <PackageReference Include="Eto.Serialization.Json" Version="2.5.0-dev" Condition="$(UseJeto) == 'True'" />
-    <PackageReference Include="Eto.Serialization.Xaml" Version="2.5.0-dev" Condition="$(UseXeto) == 'True'" />
+    <PackageReference Include="Eto.Forms" Version="2.5.1-dev" />
+    <PackageReference Include="Eto.Serialization.Json" Version="2.5.1-dev" Condition="$(UseJeto) == 'True'" />
+    <PackageReference Include="Eto.Serialization.Xaml" Version="2.5.1-dev" Condition="$(UseXeto) == 'True'" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
- Use appveyor build number for CI builds as it's based on date.