### PR TITLE
[Gtk] Fix drop down being partially visible with its height

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DropDownHandler.cs
@@ -113,7 +113,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				else
 				{
 					text.Ellipsize = Pango.EllipsizeMode.End;
-					text.Width = 0;
+					text.Width = 1;
 				}
 
 				base.Size = value;


### PR DESCRIPTION
Seems like Gtk does not like width to be 0.