### PR TITLE
Wpf: Only set initial splitter position the first time Loaded is called.

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/SplitterHandler.cs
@@ -70,7 +70,7 @@ namespace Eto.Wpf.Forms.Controls
 			style.Setters.Add(new sw.Setter(sw.FrameworkElement.HorizontalAlignmentProperty, sw.HorizontalAlignment.Stretch));
 
 			UpdateOrientation();
-			Control.Loaded += (sender, e) => SetInitialPosition();
+			Control.Loaded += Control_Loaded;
 			Control.SizeChanged += (sender, e) => ResetMinMax();
 
 			panel1VisibilityNotifier = new PropertyChangeNotifier(sw.UIElement.VisibilityProperty);
@@ -78,6 +78,13 @@ namespace Eto.Wpf.Forms.Controls
 
 			panel2VisibilityNotifier = new PropertyChangeNotifier(sw.UIElement.VisibilityProperty);
 			panel2VisibilityNotifier.ValueChanged += HandlePanel2IsVisibleChanged;
+		}
+
+		private void Control_Loaded(object sender, sw.RoutedEventArgs e)
+		{
+			// only set on initial load, subsequent loads should keep the last position
+			Control.Loaded -= Control_Loaded;
+			SetInitialPosition();
 		}
 
 		public override void AttachEvent(string id)

--- a/src/Eto/Forms/Application.cs
+++ b/src/Eto/Forms/Application.cs
@@ -240,9 +240,6 @@ namespace Eto.Forms
 		public Application(Platform platform)
 			: this(InitializePlatform(platform))
 		{
-			if (!Platform.AllowReinitialize && Instance != null)
-				throw new InvalidOperationException("The Eto.Forms Application is already created.");
-
 			Instance = this;
 		}
 
@@ -258,6 +255,10 @@ namespace Eto.Forms
 		static InitHelper InitializePlatform(Platform platform)
 		{
 			Platform.Initialize(platform);
+
+			if (!Platform.AllowReinitialize && Instance != null)
+				throw new InvalidOperationException("The Eto.Forms Application is already created.");
+
 			return null;
 		}
 
@@ -352,7 +353,6 @@ namespace Eto.Forms
 		{
 			Handler.AsyncInvoke(action);
 		}
-
 
 		/// <summary>
 		/// Invokes the specified function on the UI thread asynchronously and return the result in a Task.

--- a/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
@@ -7,7 +7,7 @@ namespace Eto.Test.UnitTests.Forms
 	[TestFixture]
 	public class ApplicationTests : TestBase
 	{
-		[Test]
+		[Test, InvokeOnUI]
 		public void ReinitializingWithNewPlatformShouldThrowException()
 		{
 			Assert.Throws<InvalidOperationException>(() =>
@@ -16,7 +16,7 @@ namespace Eto.Test.UnitTests.Forms
 			});
 		}
 
-		[Test]
+		[Test, InvokeOnUI]
 		public void ReinitializingWithCurrentPlatformShouldThrowException()
 		{
 			Assert.Throws<InvalidOperationException>(() =>

--- a/test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
@@ -374,5 +374,30 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			}, -1);
 			Assert.IsTrue(success, message);
 		}
+
+		[Test]
+		public void SplitterInTabControlShouldKeepPosition()
+		{
+			ManualForm("Move the splitter then switch tabs and then back again. The splitter should be at the same position as you left it", form =>
+			{
+				var splitter = new Splitter
+				{
+					FixedPanel = SplitterFixedPanel.Panel1,
+					Orientation = Orientation.Vertical,
+					Panel1 = new Panel { Content = "Panel1" },
+					Panel2 = new Panel { Content = "Panel2" }
+				};
+				var tabs = new TabControl
+				{
+					Size = new Size(300, 300),
+					Pages =
+					{
+						new TabPage { Text = "Tab with splitter", Content = splitter },
+						new TabPage { Text = "Tab 2", Content = "Some content" }
+					}
+				};
+				return tabs;
+			});
+		}
 	}
 }

--- a/test/Eto.Test/UnitTests/PlatformTests.cs
+++ b/test/Eto.Test/UnitTests/PlatformTests.cs
@@ -6,7 +6,7 @@ namespace Eto.Test.UnitTests
 	[TestFixture]
 	public class PlatformTests : TestBase
 	{
-		[Test]
+		[Test, InvokeOnUI]
 		public void ReinitializingPlatformShouldThrowException()
 		{
 			Assert.Throws<InvalidOperationException>(() =>
@@ -15,7 +15,7 @@ namespace Eto.Test.UnitTests
 			});
 		}
 
-		[Test]
+		[Test, InvokeOnUI]
 		public void ReinitializingPlatformWithCurrentInstanceShouldNotThrowException()
 		{
 			Platform.Initialize(Platform.Instance);


### PR DESCRIPTION
- This fixes an issue when the Splitter is placed in a TabControl where it loads/unloads controls when switching tabs.
- Fix async unit tests when running in Wpf and WinForms
- Fix issue with ApplicationTests where it would put the application in a bad state so it wouldn't open new windows.