### PR TITLE
NumericMaskedText* fixes and improvements

### DIFF
--- a/src/Eto/Forms/Controls/MaskedTextBox.cs
+++ b/src/Eto/Forms/Controls/MaskedTextBox.cs
@@ -74,11 +74,38 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Gets or sets the culture for the <see cref="NumericMaskedTextProvider.DecimalCharacter"/> and <see cref="NumericMaskedTextProvider.SignCharacters"/> formatting characters.
+		/// </summary>
+		public CultureInfo Culture
+		{
+			get => Provider.Culture;
+			set
+			{
+				Provider.Culture = value;
+				UpdateText();
+			}
+		}
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="Eto.Forms.NumericMaskedTextBox{T}"/> class.
 		/// </summary>
 		public NumericMaskedTextBox()
 			: base(new NumericMaskedTextProvider<T>())
 		{
+		}
+
+		/// <inheritdoc/>
+		protected override void OnKeyDown(KeyEventArgs e)
+		{
+			base.OnKeyDown(e);
+			if (e.KeyData == Keys.Decimal)
+			{
+				var pos = CaretIndex;
+				Provider.Insert(Provider.DecimalCharacter, ref pos);
+				UpdateText();
+				CaretIndex = pos;
+				e.Handled = true;
+			}
 		}
 	}
 

--- a/src/Eto/Forms/Controls/MaskedTextStepper.cs
+++ b/src/Eto/Forms/Controls/MaskedTextStepper.cs
@@ -1,7 +1,8 @@
 using System;
 using System.Linq;
 using System.ComponentModel;
-
+using System.Globalization;
+using System.Text;
 
 namespace Eto.Forms
 {
@@ -48,11 +49,38 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Gets or sets the culture for the <see cref="NumericMaskedTextProvider.DecimalCharacter"/> and <see cref="NumericMaskedTextProvider.SignCharacters"/> formatting characters.
+		/// </summary>
+		public CultureInfo Culture
+		{
+			get => Provider.Culture;
+			set
+			{
+				Provider.Culture = value;
+				UpdateText();
+			}
+		}
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="Forms.NumericMaskedTextStepper{T}"/> class.
 		/// </summary>
 		public NumericMaskedTextStepper()
 			: base(new NumericMaskedTextProvider<T>())
 		{
+		}
+
+		/// <inheritdoc/>
+		protected override void OnKeyDown(KeyEventArgs e)
+		{
+			base.OnKeyDown(e);
+			if (e.KeyData == Keys.Decimal)
+			{
+				var pos = CaretIndex;
+				Provider.Insert(Provider.DecimalCharacter, ref pos);
+				UpdateText();
+				CaretIndex = pos;
+				e.Handled = true;
+			}
 		}
 	}
 

--- a/src/Eto/Forms/Controls/TextChangingEventArgs.cs
+++ b/src/Eto/Forms/Controls/TextChangingEventArgs.cs
@@ -135,7 +135,10 @@ namespace Eto.Forms
 			var r = Range;
 			if (r.Length() < 0 || newText == null)
 				return string.Empty;
-			return newText.Substring(r.Start, newText.Length - (OldText.Length - r.End - 1) - r.Start);
+			var length = newText.Length - (OldText.Length - r.End - 1) - r.Start;
+			if (length <= 0)
+				return string.Empty;
+			return newText.Substring(r.Start, length);
 		}
 	}
 }

--- a/src/Eto/Forms/MaskedTextProvider/NumericMaskedTextProvider.cs
+++ b/src/Eto/Forms/MaskedTextProvider/NumericMaskedTextProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Text;
 using System.Linq;
 using System.Globalization;
 using System.ComponentModel;
@@ -24,21 +23,27 @@ namespace Eto.Forms
 			public Func<object, string> ToText;
 		}
 
+		// do all conversions with invariant culture
+		static CultureInfo Inv => CultureInfo.InvariantCulture;
+
 		// use dictionary instead of reflection for Xamarin.Mac linking
-		Dictionary<Type, Info> numericTypes = new Dictionary<Type, Info>
+		static readonly Dictionary<Type, Info> numericTypes = new Dictionary<Type, Info>
 		{
-			{ typeof(decimal), new Info { Parse = s => { decimal d; return decimal.TryParse(s, out d) ? (object)d : null; }, AllowSign = true, AllowDecimal = true } },
-			{ typeof(double), new Info { Parse = s => { double d; return double.TryParse(s, out d) ? (object)d : null; }, ToText = v => ((double?)v)?.ToString("F99").TrimEnd('0', '.'), AllowSign = true, AllowDecimal = true } },
-			{ typeof(float), new Info { Parse = s => { float d; return float.TryParse(s, out d) ? (object)d : null; }, ToText = v => ((float?)v)?.ToString("F99").TrimEnd('0', '.'), AllowSign = true, AllowDecimal = true } },
-			{ typeof(int), new Info { Parse = s => { int d; return int.TryParse(s, out d) ? (object)d : null; }, AllowSign = true } },
-			{ typeof(uint), new Info { Parse = s => { uint d; return uint.TryParse(s, out d) ? (object)d : null; } } },
-			{ typeof(long), new Info { Parse = s => { long d; return long.TryParse(s, out d) ? (object)d : null; }, AllowSign = true } },
-			{ typeof(ulong), new Info { Parse = s => { ulong d; return ulong.TryParse(s, out d) ? (object)d : null; } } },
-			{ typeof(short), new Info { Parse = s => { short d; return short.TryParse(s, out d) ? (object)d : null; }, AllowSign = true } },
-			{ typeof(ushort), new Info { Parse = s => { ushort d; return ushort.TryParse(s, out d) ? (object)d : null; } } },
-			{ typeof(byte), new Info { Parse = s => { byte d; return byte.TryParse(s, out d) ? (object)d : null; } } },
-			{ typeof(sbyte), new Info { Parse = s => { sbyte d; return sbyte.TryParse(s, out d) ? (object)d : null; }, AllowSign = true } }
+			{ typeof(decimal), new Info { Parse = s => decimal.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, AllowSign = true, AllowDecimal = true } },
+			{ typeof(double), new Info { Parse = s => double.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, ToText = DoubleToText, AllowSign = true, AllowDecimal = true } },
+			{ typeof(float), new Info { Parse = s => float.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, ToText = FloatToText, AllowSign = true, AllowDecimal = true } },
+			{ typeof(int), new Info { Parse = s => int.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, AllowSign = true } },
+			{ typeof(uint), new Info { Parse = s => uint.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null } },
+			{ typeof(long), new Info { Parse = s => long.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, AllowSign = true } },
+			{ typeof(ulong), new Info { Parse = s => ulong.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null } },
+			{ typeof(short), new Info { Parse = s => short.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, AllowSign = true } },
+			{ typeof(ushort), new Info { Parse = s => ushort.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null } },
+			{ typeof(byte), new Info { Parse = s => byte.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null } },
+			{ typeof(sbyte), new Info { Parse = s => sbyte.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, AllowSign = true } }
 		};
+
+		static string DoubleToText(object v) => ((double)v).ToString("F99", Inv).TrimEnd('0').TrimEnd('.');
+		static string FloatToText(object v) => ((float)v).ToString("F99", Inv).TrimEnd('0').TrimEnd('.');
 
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Eto.Forms.NumericMaskedTextProvider{T}"/> class.
@@ -47,21 +52,21 @@ namespace Eto.Forms
 		{
 			var type = typeof(T);
 			var underlyingType = Nullable.GetUnderlyingType(type) ?? type;
-			Info info;
-			if (numericTypes.TryGetValue(underlyingType, out info))
+			if (numericTypes.TryGetValue(underlyingType, out Info info))
 			{
 				AllowSign = info.AllowSign;
 				AllowDecimal = info.AllowDecimal;
 				parse = text =>
 				{
 					var val = info.Parse(text);
-					return val == null ? default(T) : (T)val;
+					return val == null ? default : (T)val;
 				};
+
 				if (info.ToText != null)
 					toString = val => info.ToText(val);
 				else
-					toString = val => val.ToString();
-				Validate = text => info.Parse(text) != null;
+					toString = val => Convert.ToString(val, CultureInfo.InvariantCulture);
+				Validate = text => info.Parse(text.Replace(DecimalCharacter, '.')) != null;
 			}
 			else
 			{
@@ -69,7 +74,7 @@ namespace Eto.Forms
 				AllowSign = Convert.ToBoolean(underlyingType.GetRuntimeField("MinValue").GetValue(null));
 				AllowDecimal = underlyingType == typeof(decimal) || underlyingType == typeof(double) || underlyingType == typeof(float);
 
-				var tryParseMethod = underlyingType.GetRuntimeMethod("TryParse", new [] { typeof(string), underlyingType.MakeByRefType() });
+				var tryParseMethod = underlyingType.GetRuntimeMethod("TryParse", new[] { typeof(string), underlyingType.MakeByRefType() });
 				if (tryParseMethod == null || tryParseMethod.ReturnType != typeof(bool))
 					throw new ArgumentException(string.Format("Type of T ({0}) must implement a static bool TryParse(string, out T) method", typeof(T)));
 
@@ -80,13 +85,13 @@ namespace Eto.Forms
 					{
 						return (T)parameters[1];
 					}
-					return default(T);
+					return default;
 				};
 				toString = val => val.ToString();
 
 				Validate = text =>
 				{
-					var parameters = new object[] { text, null };
+					var parameters = new object[] { text.Replace(DecimalCharacter, '.'), null };
 					return (bool)tryParseMethod.Invoke(null, parameters);
 				};
 			}
@@ -98,14 +103,15 @@ namespace Eto.Forms
 		/// <value>The value of the mask.</value>
 		public T Value
 		{
-			get
-			{
-				return parse(Text);
-			}
-			set
-			{
-				Text = toString(value);
-			}
+			get => parse(Text.Replace(DecimalCharacter, '.'));
+			set => Text = toString(value).Replace('.', DecimalCharacter);
+		}
+
+		internal override void SetCulture()
+		{
+			var value = Value;
+			base.SetCulture();
+			Value = value;
 		}
 	}
 
@@ -114,6 +120,8 @@ namespace Eto.Forms
 	/// </summary>
 	public class NumericMaskedTextProvider : VariableMaskedTextProvider
 	{
+		CultureInfo _culture = CultureInfo.CurrentCulture;
+
 		/// <summary>
 		/// Gets or sets a value indicating that the mask can optionally include a decimal, as specified by the <see cref="DecimalCharacter"/>.
 		/// </summary>
@@ -146,12 +154,46 @@ namespace Eto.Forms
 		public char DecimalCharacter { get; set; }
 
 		/// <summary>
+		/// Gets or sets the alternate decimal character that can be accepted.
+		/// </summary>
+		/// <remarks>
+		/// This is useful when the DecimalCharacter is localized but you still want to allow alternate characters
+		/// </remarks>
+		public char[] AltDecimalCharacters { get; set; }
+
+		/// <summary>
 		/// Initializes a new instance of the <see cref="Eto.Forms.NumericMaskedTextProvider"/> class.
 		/// </summary>
 		public NumericMaskedTextProvider()
 		{
-			DecimalCharacter = '.';
-			SignCharacters = new [] { '+', '-' };
+			SetCultureInternal();
+		}
+
+		/// <summary>
+		/// Gets or sets the culture of the <see cref="DecimalCharacter"/> and <see cref="SignCharacters"/> formatting characters.
+		/// </summary>
+		public CultureInfo Culture
+		{
+			get => _culture;
+			set
+			{
+				_culture = value ?? throw new ArgumentNullException(nameof(value));
+				SetCulture();
+			}
+		}
+
+		internal virtual void SetCulture() => SetCultureInternal();
+
+		void SetCultureInternal()
+		{
+			var format = _culture.NumberFormat;
+			// note: we do not support formats with multiple-characters
+			DecimalCharacter = format.NumberDecimalSeparator[0];
+			SignCharacters = new[] { format.PositiveSign[0], format.NegativeSign[0] };
+			if (DecimalCharacter != '.')
+				AltDecimalCharacters = new[] { '.' };
+			else
+				AltDecimalCharacters = null;
 		}
 
 		/// <summary>
@@ -171,34 +213,41 @@ namespace Eto.Forms
 		/// <returns><c>true</c> when the replacement was successful, or <c>false</c> if it failed.</returns>
 		public override bool Replace(char character, ref int position)
 		{
-			var allow = Allow(character, ref position);
+			var allow = Allow(ref character, ref position);
 			return allow && base.Replace(character, ref position);
 		}
 
-		bool Allow(char character, ref int position)
+		bool Allow(ref char character, ref int position)
 		{
 			bool allow = false;
-			if (!allow && AllowDecimal && character == DecimalCharacter)
+			if (!allow && AllowDecimal && (character == DecimalCharacter || AltDecimalCharacters?.Contains(character) == true))
 			{
-				var val = Text;
-				if (val.IndexOf(DecimalCharacter) == -1)
+				character = DecimalCharacter;
+				var decimalIndex = Text.IndexOf(DecimalCharacter);
+
+				if (decimalIndex >= 0)
 				{
-					allow = true;
-					if (position < val.Length && !char.IsDigit(val[position]))
-					{
-						// insert at correct location and move cursor
-						int idx;
-						for (idx = 0; idx < val.Length; idx++)
-						{
-							if (char.IsDigit(val[idx]))
-							{
-								break;
-							}
-						}
-						position = idx;
-						allow = true;
-					}
+					Builder.Remove(decimalIndex, 1);
+					if (position > decimalIndex)
+						position--;
 				}
+
+				allow = true;
+				if (position < Builder.Length && !char.IsDigit(Builder[position]))
+				{
+					// insert at correct location and move cursor
+					int idx;
+					for (idx = 0; idx < Builder.Length; idx++)
+					{
+						if (char.IsDigit(Builder[idx]))
+						{
+							break;
+						}
+					}
+					position = idx;
+					allow = true;
+				}
+				
 			}
 			if (!allow && AllowSign && SignCharacters.Contains(character))
 			{
@@ -228,7 +277,7 @@ namespace Eto.Forms
 		{
 			int pos = position;
 
-			var allow = Allow(character, ref position);
+			var allow = Allow(ref character, ref position);
 
 			var ret = allow && base.Insert(character, ref position);
 

--- a/test/Eto.Test/CultureDropDown.cs
+++ b/test/Eto.Test/CultureDropDown.cs
@@ -1,0 +1,22 @@
+using System;
+using System.Globalization;
+using System.Linq;
+using Eto.Forms;
+
+namespace Eto.Test
+{
+	public class CultureDropDown : DropDown
+	{
+		public CultureDropDown()
+		{
+			ItemTextBinding = Binding.Delegate((CultureInfo c) => c.ThreeLetterISOLanguageName == "IVL" ? "Invariant" : c.Name);
+			DataStore = CultureInfo.GetCultures(CultureTypes.AllCultures).OrderBy(r => r.Name);
+		}
+
+		public new CultureInfo SelectedValue
+		{
+			get => base.SelectedValue as CultureInfo;
+			set => base.SelectedValue = value;
+		}
+	}
+}

--- a/test/Eto.Test/Sections/Controls/MaskedTextBoxSection.cs
+++ b/test/Eto.Test/Sections/Controls/MaskedTextBoxSection.cs
@@ -3,47 +3,67 @@ using Eto.Forms;
 using System.Diagnostics;
 using Eto.Drawing;
 using System.Linq;
+using System.Globalization;
 
 namespace Eto.Test.Sections.Controls
 {
 	[Section("Controls", typeof(MaskedTextBox))]
-	public class MaskedTextBoxSection : StackLayout
+	public class MaskedTextBoxSection : DynamicLayout
 	{
+		static bool rememberValue;
+		static double lastValue;
+
 		public MaskedTextBoxSection()
 		{
-			Spacing = 5;
+			DefaultSpacing = new Size(5, 5);
 			Padding = new Padding(10);
 
 			var enabledCheckBox = new CheckBox { Text = "Enabled", Checked = true };
-			enabledCheckBox.CheckedChanged += (sender, e) =>
-			{
-				foreach (var child in Children.OfType<MaskedTextBox>())
-				{
-					child.Enabled = enabledCheckBox.Checked == true;
-				}
-			};
+			enabledCheckBox.CheckedChanged += (sender, e) => Set(m => m.Enabled = enabledCheckBox.Checked == true);
 
 			var readOnlyCheckBox = new CheckBox { Text = "ReadOnly", Checked = false };
-			readOnlyCheckBox.CheckedChanged += (sender, e) =>
-			{
-				foreach (var child in Children.OfType<MaskedTextBox>())
-				{
-					child.ReadOnly = readOnlyCheckBox.Checked == true;
-				}
-			};
+			readOnlyCheckBox.CheckedChanged += (sender, e) => Set(m => m.ReadOnly = readOnlyCheckBox.Checked == true);
 
-			var tb = new NumericMaskedTextBox<decimal> { Value = 123.456M };
+
+			var tb = new NumericMaskedTextBox<double> { Value = rememberValue ? lastValue : 123.456 };
+			tb.ValueChanged += (sender, e) => lastValue = tb.Value;
+
 			var l = new Label();
 			l.TextBinding.Bind(Binding.Property(tb, c => c.Value).Convert(r => "Value: " + Convert.ToString(r)));
 
-			Items.Add(enabledCheckBox);
-			Items.Add(readOnlyCheckBox);
-			Items.Add(new StackLayout { Orientation = Orientation.Horizontal, Spacing = 5, Items = { tb, l } });
-			Items.Add(new NumericMaskedTextBox<double> { Value = 0.000000123 });
-			Items.Add(new MaskedTextBox(new FixedMaskedTextProvider("(999) 000-0000")) { ShowPromptOnFocus = true, PlaceholderText = "(123) 456-7890" });
-			Items.Add(new MaskedTextBox<DateTime>(new FixedMaskedTextProvider<DateTime>("&&/90/0000") { ConvertToValue = DateTime.Parse }));
-			Items.Add(new MaskedTextBox(new FixedMaskedTextProvider(">L0L 0L0")));
-			Items.Add(new MaskedTextBox { InsertMode = InsertKeyMode.Toggle });
+			var cultureSelector = new CultureDropDown();
+			cultureSelector.SelectedValueBinding.Bind(tb, s => s.Culture);
+
+			var rememberCheckBox = new CheckBox { Text = "Remember Value", Checked = rememberValue };
+			rememberCheckBox.CheckedChanged += (sender, e) => rememberValue = rememberCheckBox.Checked == true;
+
+			AddAutoSized(enabledCheckBox);
+			AddAutoSized(readOnlyCheckBox);
+
+			BeginGroup("FixedMaskedTextProvider", padding: 10);
+			AddAutoSized(new MaskedTextBox(new FixedMaskedTextProvider("(999) 000-0000")) { ShowPromptOnFocus = true, PlaceholderText = "(123) 456-7890" });
+			AddAutoSized(new MaskedTextBox<DateTime>(new FixedMaskedTextProvider<DateTime>("&&/90/0000") { ConvertToValue = DateTime.Parse }));
+			AddAutoSized(new MaskedTextBox(new FixedMaskedTextProvider(">L0L 0L0")));
+			AddAutoSized(new MaskedTextBox { InsertMode = InsertKeyMode.Toggle });
+			EndGroup();
+
+			BeginGroup("NumericMaskedTextBox<double>", padding: 10);
+			AddSeparateRow(tb, l, rememberCheckBox, null);
+			AddSeparateRow("Culture:", cultureSelector, null);
+			BeginHorizontal();
+			EndHorizontal();
+			EndGroup();
+
+			AddSpace();
+		}
+
+		void Set(Action<MaskedTextBox> action)
+		{
+			foreach (var child in Children.OfType<MaskedTextBox>())
+			{
+				action(child);
+			}
+
 		}
 	}
 }

--- a/test/Eto.Test/Sections/Controls/NumericStepperSection.cs
+++ b/test/Eto.Test/Sections/Controls/NumericStepperSection.cs
@@ -57,10 +57,7 @@ namespace Eto.Test.Sections.Controls
 			formatString.TextBinding.Convert(c => string.IsNullOrEmpty(c)).Bind(decimalPlaces, d => d.Enabled);
 			formatString.TextBinding.Convert(c => string.IsNullOrEmpty(c)).Bind(maxDecimalPlaces, d => d.Enabled);
 
-			var cultureDropDown = new DropDown();
-			cultureDropDown.ItemTextBinding = Binding.Delegate((CultureInfo c) => c == CultureInfo.InvariantCulture ? "invariant" : c.ToString());
-			var cultures = typeof(CultureInfo).GetTypeInfo().GetDeclaredMethod("GetCultures")?.Invoke(null, new object[] { 7 /* AllCultures */}) as IEnumerable<CultureInfo>;
-			cultureDropDown.DataStore = cultures.OrderBy(r => r.ToString());
+			var cultureDropDown = new CultureDropDown();
 			cultureDropDown.SelectedValueBinding.Bind(numeric, c => c.CultureInfo);
 
 			var increment = new NumericStepper { MaximumDecimalPlaces = 15 };


### PR DESCRIPTION
- Use defaults from current culture
- Parse and format the number using invariant culture, then replace with currently selected decimal character.
- Add ability to set a specific culture
- When decimal key is pressed on the keyboard, insert decimal character regardless if it is the same character
- Allow fall back to invariant '.' character for decimal separator
- Allow decimal to be placed anywhere even if it already is in the string
- Fix crash getting TextChangingEventArgs.Text when deleting text
- Trim zeros then decimal when converting the value to text so it doesn't go past the decimal

Fixes #1468
Fixes #1568