### PR TITLE
Bind to struct properties

### DIFF
--- a/src/Eto.Mac/Forms/Controls/StepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/StepperHandler.cs
@@ -81,22 +81,13 @@ namespace Eto.Mac.Forms.Controls
 					Control.MaxValue = 0;
 					break;
 			}
-			SetStepperEnabled();
+			SetEnabled();
 		}
 
 		protected override bool ControlEnabled
 		{
 			get => base.ControlEnabled;
-			set
-			{
-				base.ControlEnabled = value;
-				SetStepperEnabled();
-			}
-		}
-
-		void SetStepperEnabled()
-		{
-			Control.Enabled = Enabled && ValidDirection != StepperValidDirections.None;
+			set => base.ControlEnabled = value && ValidDirection != StepperValidDirections.None;
 		}
 
 		StepperDirection? GetDirection()

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -960,7 +960,11 @@ namespace Eto.Mac.Forms
 			set => SetEnabled(ParentEnabled, value);
 		}
 
+		protected bool WantsEnabled => Widget.Properties.Get<bool?>(MacView.Enabled_Key) ?? true;
+
 		protected bool ParentEnabled => Widget.VisualParent?.Enabled != false;
+
+		public void SetEnabled() => SetEnabled(ParentEnabled);
 
 		public void SetEnabled(bool parentEnabled) => SetEnabled(parentEnabled, null);
 

--- a/src/Eto/Forms/Binding/DirectBinding.cs
+++ b/src/Eto/Forms/Binding/DirectBinding.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq.Expressions;
+using System.Reflection;
 
 namespace Eto.Forms
 {
@@ -156,15 +157,24 @@ namespace Eto.Forms
 		{
 			object childBindingReference = null;
 			EventHandler<EventArgs> eventHandler = null;
-			EventHandler<EventArgs> valueChanged = (sender, e) =>
+			void valueChanged(object sender, EventArgs e)
 			{
 				binding.RemoveValueChangedHandler(childBindingReference, eventHandler);
 				eventHandler?.Invoke(sender, e);
 				childBindingReference = binding.AddValueChangedHandler(DataValue, eventHandler);
-			};
+			}
+			void setValueStruct(TValue v)
+			{
+				object parentValue = DataValue;
+				binding.SetValue(parentValue, v);
+				DataValue = (T)parentValue;
+			}
+			void setValueObject(TValue v) => binding.SetValue(DataValue, v);
+			var isStruct = typeof(T).GetTypeInfo().IsValueType;
+
 			return new DelegateBinding<TValue>(
 				() => binding.GetValue(DataValue),
-				v => binding.SetValue(DataValue, v),
+				isStruct ? (Action<TValue>)setValueStruct : setValueObject,
 				addChangeEvent: ev =>
 				{
 					eventHandler = ev;

--- a/test/Eto.Test/UnitTests/Forms/Bindings/ChildBindingTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Bindings/ChildBindingTests.cs
@@ -1,0 +1,44 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Bindings
+{
+	[TestFixture]
+	public class ChildBindingTests : TestBase
+	{
+		class TestObject
+		{
+			public Color Color { get; set; }
+		}
+
+		[Test]
+		public void IndirectBindingStructPropertiesShouldWork()
+		{
+			// child binding via expression
+			var binding = Binding.Property((TestObject t) => t.Color.B);
+			var item = new TestObject
+			{
+				Color = Colors.White
+			};
+			binding.SetValue(item, 0.5f);
+			Assert.AreEqual(0.5f, item.Color.B, "Struct property value was not set");
+		}
+
+		[Test]
+		public void DirectBindingStructPropertiesShouldWork()
+		{
+			var item = new TestObject
+			{
+				Color = Colors.White
+			};
+			var colorBinding = Binding.Property((TestObject t) => t.Color);
+			var binding = new ObjectBinding<TestObject, Color>(item, colorBinding);
+
+			var childBinding = binding.Child(Binding.Property((Color c) => c.B));
+			childBinding.DataValue = 0.5f;
+			Assert.AreEqual(0.5f, item.Color.B, "Struct property value was not set");
+		}
+	}
+}


### PR DESCRIPTION
Binding to a property of a struct requires that the struct be set to the parent binding after it has been modified.

Also:
Mac: Stepper now re-enables correctly after disallowing both directions