### PR TITLE
Fix issue compiling when referencing libraries that use Eto.Platform.Mac64

### DIFF
--- a/build/Common.Build.props
+++ b/build/Common.Build.props
@@ -19,6 +19,9 @@
     
     <!-- GtkSharp package likes to install things during package restore, we don't want that -->
     <SkipGtkInstall>True</SkipGtkInstall>
+
+    <!-- Ignore errors/warnings about semver 2.0 when packing CI builds -->
+    <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
   
   <Import Condition="Exists('$(BasePath)..\Eto.Common.props')" Project="$(BasePath)..\Eto.Common.props" />

--- a/src/Eto.Mac/build/BundleDotNetCore.targets
+++ b/src/Eto.Mac/build/BundleDotNetCore.targets
@@ -37,6 +37,7 @@
       <MacTempBuildPath>$(IntermediateOutputPath)macbuild\</MacTempBuildPath>
       
       <MacBuildProperties>MacIsBuildingBundle=True</MacBuildProperties>
+      <MacBuildProperties>$(MacBuildProperties);MacBundlingProject=$(MSBuildProjectFullPath)</MacBuildProperties>
       <MacBuildProperties>$(MacBuildProperties);TargetFramework=$(TargetFramework)</MacBuildProperties>
       <MacBuildProperties Condition="$(PublishSingleFile) == '' AND $(Configuration) == 'Release'">$(MacBuildProperties);PublishSingleFile=True</MacBuildProperties>
       <MacBuildProperties Condition="$(PublishTrimmed) == '' AND $(Configuration) == 'Release'">$(MacBuildProperties);PublishTrimmed=True</MacBuildProperties>

--- a/src/Eto.Mac/build/Mac.props
+++ b/src/Eto.Mac/build/Mac.props
@@ -8,7 +8,7 @@
   </PropertyGroup>
   
   <!-- for .NET Core publishing -->
-  <PropertyGroup Condition="$(MacIsBuildingBundle) == 'True' AND $(MacOutputPath) != ''">
+  <PropertyGroup Condition="$(MacIsBuildingBundle) == 'True' AND $(MacOutputPath) != '' AND $(MacBundlingProject) == $(MSBuildProjectFullPath)">
     <BaseOutputAppPath>$(MacOutputPath)</BaseOutputAppPath>
     <BaseOutputAppPath Condition="$(MacAppendRuntimeIdentifierToOutputPath) == 'True'">$(BaseOutputAppPath)$(RuntimeIdentifier)\</BaseOutputAppPath>
     <OutputPath>$(MacTempBuildPath)bin\</OutputPath>


### PR DESCRIPTION
When compiling projects that reference a library that uses Eto.Platform.Mac64 it would give an error saying it could not find the referenced library since the nuget targets files were changing the outputpath of that referenced library instead of just the one it wants to package/publish into an .app folder.  To fix it, we only fix up the outputpath for the same project that is compiling.

Fixes #1599