### PR TITLE
Fix for PropertyGrid that on GTK didn't show expandable item

### DIFF
--- a/src/Eto/Forms/ThemedControls/ThemedPropertyGridHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedPropertyGridHandler.cs
@@ -680,7 +680,7 @@ namespace Eto.Forms.ThemedControls
                 for (int i = 0; i < properties.Count; i++)
                 {
 					var descriptor = EtoTypeDescriptor.Get(properties[i]);
-					if (descriptor == null)
+					if (descriptor != null)
 						descriptors.Add(descriptor);
                 }
 


### PR DESCRIPTION
I had an issue with PropertyGrid control and searched what is wrong with my code. Then I have discovered that problem is here.