### PR TITLE
Fix replacing a handler after it has been used for the first time

### DIFF
--- a/src/Eto/Platform.cs
+++ b/src/Eto/Platform.cs
@@ -548,6 +548,8 @@ namespace Eto
 			if (handler != null)
 				instantiatorMap[handler.Type] = instantiator; // for backward compatibility, for now
 			instantiatorMap[type] = instantiator;
+			// clear handler map so it can pick up the new instantiator next time it is created
+			handlerMap.Clear();
 		}
 
 		/// <summary>


### PR DESCRIPTION
If you've created a control then used `Platform.Add<T>()` to change the handler used for that control, it would still use the old handler.