### PR TITLE
Mac: TreeGridView fixes

### DIFF
--- a/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
@@ -114,6 +114,11 @@ namespace Eto.Mac.Forms.Cells
 			}
 		}
 
+		public override nfloat GetPreferredWidth(object value, CGSize cellSize, int row, object dataItem)
+		{
+			return -1; // TODO: Add ability for DrawableCell to provide a preferred width for a specific item.
+		}
+
 		public override Color GetBackgroundColor(NSView view)
 		{
 			return ((EtoCellView)view).BackgroundColor;

--- a/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
@@ -146,7 +146,10 @@ namespace Eto.Mac.Forms.Controls
 					var item = DataViewHandler.GetItem(i);
 					var val = GetObjectValue(item);
 					var cellWidth = cell.GetPreferredWidth(val, cellSize, i, item);
-					if (outlineView != null && Column == 0)
+					// -1 signifies that it doesn't support getting the preferred width
+					if (cellWidth == -1)
+						cellWidth = Control.Width;
+					else if (outlineView != null && Column == 0)
 					{
 						cellWidth += (float)((outlineView.LevelForRow((nint)i) + 1) * outlineView.IndentationPerLevel);
 					}

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -273,6 +273,20 @@ namespace Eto.Mac.Forms.Controls
 				}
 			}
 
+			public override void ColumnDidResize(NSNotification notification)
+			{
+				if (!Handler.IsAutoSizingColumns)
+				{
+					// when the user resizes the column, don't autosize anymore when data/scroll changes
+					var column = notification.UserInfo["NSTableColumn"] as NSTableColumn;
+					if (column != null)
+					{
+						var colHandler = Handler.GetColumn(column);
+						colHandler.AutoSize = false;
+					}
+				}
+			}
+
 			public override NSView GetView(NSOutlineView outlineView, NSTableColumn tableColumn, NSObject item)
 			{
 				if (tableColumn == null && Handler.ShowGroups)
@@ -620,7 +634,7 @@ namespace Eto.Mac.Forms.Controls
 			{
 				Delegate = new EtoOutlineDelegate { Handler = handler };
 				//HeaderView = null,
-				//AutoresizesOutlineColumn = true,
+				AutoresizesOutlineColumn = false;
 				//AllowsColumnResizing = false,
 				AllowsColumnReordering = false;
 				FocusRingType = NSFocusRingType.None;


### PR DESCRIPTION
- Disable autoresizing of outline column by default as it does not remember user-set sizes.  Fixes #1459
- Disable column autosizing when changed by the user (like it does for GridView)
- DrawableCell shouldn't autosize until it gets proper APIs for that.