### PR TITLE
Wpf: GridView/TreeGridView fixes

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
@@ -9,6 +9,7 @@ namespace Eto.Wpf.Forms.Controls
 	{
 		Grid Widget { get; }
 		bool Loaded { get; }
+		bool DisableAutoScrollToSelection { get; }
 		sw.FrameworkElement SetupCell (IGridColumnHandler column, sw.FrameworkElement defaultContent);
 		void FormatCell (IGridColumnHandler column, ICellHandler cell, sw.FrameworkElement element, swc.DataGridCell gridcell, object dataItem);
 		void CellEdited(int row, swc.DataGridColumn dataGridColumn, object dataItem);

--- a/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -198,8 +198,10 @@ namespace Eto.Wpf.Forms.Controls
 
 		void ITreeHandler.PostResetTree()
 		{
+			DisableAutoScrollToSelection = true;
 			RestoreFocus();
 			SkipSelectionChanged = false;
+			DisableAutoScrollToSelection = false;
 		}
 
 		public void ReloadData()


### PR DESCRIPTION
- Don't scroll to selection when expanding/collapsing rows. Fixes #1479
- Fix interacting with cells in edit mode. Fixes #1601
- Commit editing when clicking to the right or bottom of grid rows