### PR TITLE
Cursor & Screen updates

### DIFF
--- a/src/Eto.Gtk/Forms/CursorHandler.cs
+++ b/src/Eto.Gtk/Forms/CursorHandler.cs
@@ -21,6 +21,11 @@ namespace Eto.GtkSharp.Forms
 
 		public void Create(Stream stream) => Create(new Gdk.Pixbuf(stream));
 
+		public void Create(Image image, PointF hotspot)
+		{
+			Control = new Gdk.Cursor(Gdk.Display.Default, image.ToGdk(), (int)hotspot.X, (int)hotspot.Y);
+		}
+
 		void Create(Gdk.Pixbuf pixbuf)
 		{
 			var hotspot = PointF.Empty;

--- a/src/Eto.Gtk/Forms/ScreenHandler.cs
+++ b/src/Eto.Gtk/Forms/ScreenHandler.cs
@@ -1,5 +1,7 @@
 using Eto.Forms;
 using Eto.Drawing;
+using Eto.GtkSharp.Drawing;
+using System;
 
 namespace Eto.GtkSharp.Forms
 {
@@ -47,6 +49,33 @@ namespace Eto.GtkSharp.Forms
 		public bool IsPrimary
 		{
 			get { return monitor == 0; }
+		}
+
+		public Image GetImage(RectangleF rect)
+		{
+			// hm, doesn't seem to work on ubuntu 18.04, but I can't find any other way to do this..
+			var rootWindowPtr = NativeMethods.gdk_get_default_root_window();
+			if (rootWindowPtr == IntPtr.Zero)
+				return null;
+
+			var bounds = Bounds;
+			rect.Location += bounds.Location;
+			var rectInt = Rectangle.Ceiling(rect);
+
+#if GTK2
+			var drawable = new Gdk.Window(rootWindowPtr);
+			var pb = Gdk.Pixbuf.FromDrawable(drawable, drawable.Colormap, rectInt.X, rectInt.Y, 0, 0, rectInt.Width, rectInt.Height);
+#else
+			var pbptr = NativeMethods.gdk_pixbuf_get_from_window(rootWindowPtr, rectInt.X, rectInt.Y, rectInt.Width, rectInt.Height);
+
+			if (pbptr == IntPtr.Zero)
+				return null;
+
+			var pb = new Gdk.Pixbuf(pbptr);
+
+#endif
+			return new Bitmap(new BitmapHandler(pb));
+
 		}
 	}
 }

--- a/src/Eto.Gtk/NativeMethods.cs
+++ b/src/Eto.Gtk/NativeMethods.cs
@@ -171,6 +171,12 @@ namespace Eto.GtkSharp
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
+
+			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gdk_get_default_root_window();
+
+			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
 		}
 
 		static class NMLinux
@@ -329,6 +335,12 @@ namespace Eto.GtkSharp
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
+
+			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gdk_get_default_root_window();
+
+			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
 		}
 
 		static class NMMac
@@ -487,6 +499,12 @@ namespace Eto.GtkSharp
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
+
+			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gdk_get_default_root_window();
+
+			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
 		}
 
 		public static string GetString(IntPtr handle)
@@ -981,6 +999,26 @@ namespace Eto.GtkSharp
 				return NMMac.gdk_cairo_get_clip_rectangle(context, rect);
 			else
 				return NMWindows.gdk_cairo_get_clip_rectangle(context, rect);
+		}
+
+		public static IntPtr gdk_get_default_root_window()
+		{
+			if (EtoEnvironment.Platform.IsLinux)
+				return NMLinux.gdk_get_default_root_window();
+			else if (EtoEnvironment.Platform.IsMac)
+				return NMMac.gdk_get_default_root_window();
+			else
+				return NMWindows.gdk_get_default_root_window();
+		}
+
+		public static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height)
+		{
+			if (EtoEnvironment.Platform.IsLinux)
+				return NMLinux.gdk_pixbuf_get_from_window(window, x, y, width, height);
+			else if (EtoEnvironment.Platform.IsMac)
+				return NMMac.gdk_pixbuf_get_from_window(window, x, y, width, height);
+			else
+				return NMWindows.gdk_pixbuf_get_from_window(window, x, y, width, height);
 		}
 	}
 }

--- a/src/Eto.Gtk/NativeMethods.tt
+++ b/src/Eto.Gtk/NativeMethods.tt
@@ -71,7 +71,9 @@ var gtkmethods = new[]
 
 var gdkmethods = new[]
 {
-	"bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect)"
+	"bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect)",
+    "IntPtr gdk_get_default_root_window()",
+    "IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height)",
 };
 
 var methods = giomethods.Concat(gtkmethods).Concat(webkitmethods).Concat(gdkmethods).ToArray();

--- a/src/Eto.Mac/Drawing/BitmapHandler.cs
+++ b/src/Eto.Mac/Drawing/BitmapHandler.cs
@@ -310,21 +310,25 @@ namespace Eto.Mac.Drawing
 		{
 			if (rep == null)
 				rep = Control.BestRepresentationForDevice(null);
+			if (bmprep != null)
+				return;
+
+			if (rep is IconFrameHandler.LazyImageRep lazyRep)
+			{
+				bmprep = lazyRep.Rep;
+			}
+			else
+			{
+				bmprep = rep as NSBitmapImageRep ?? Control.BestRepresentationForDevice(null) as NSBitmapImageRep;
+			}
+
 			if (bmprep == null)
 			{
-				var lazyRep = rep as IconFrameHandler.LazyImageRep;
-				if (lazyRep != null)
-					bmprep = lazyRep.Rep;
-				else
-				{
-					bmprep = rep as NSBitmapImageRep;
-					if (bmprep == null)
-					{
-						rep = Control.BestRepresentationForDevice(null);
-						bmprep = rep as NSBitmapImageRep;
-					}
-				}
-			}				
+				Control.LockFocus();
+				bmprep = new NSBitmapImageRep(new CGRect(CGPoint.Empty, Control.Size));
+				//bmprep.Type.ColorSpaceName = Control.Representations()[0].ColorSpaceName;
+				Control.UnlockFocus();
+			}
 		}
 	}
 }

--- a/src/Eto.Mac/Drawing/IconHandler.cs
+++ b/src/Eto.Mac/Drawing/IconHandler.cs
@@ -79,20 +79,19 @@ namespace Eto.Mac.Drawing
 
 		public void Create(IEnumerable<IconFrame> frames)
 		{
-			this._frames = frames.ToList();
+			_frames = frames.ToList();
 			var curScale = Screen.PrimaryScreen.LogicalPixelSize;
-			var item = this._frames.FirstOrDefault(r => Math.Abs(r.Scale - curScale) < 0.0001) ?? this._frames.First();
+			var item = _frames.FirstOrDefault(r => Math.Abs(r.Scale - curScale) < 0.0001) ?? _frames.First();
 
 			var size = Size.Ceiling((SizeF)item.PixelSize / (float)item.Scale).ToNS();
 
-			Control = new NSImage();
-			Control.Size = size;
-			foreach (var frame in this._frames)
+			Control = new NSImage { Size = size };
+			foreach (var frame in _frames)
 			{
-				var rep = frame.Bitmap.ToNS().Representations().First();
+				var rep = (NSImageRep)frame.Bitmap.ToNS().Representations().First().Copy();
+				
 				rep.Size = (new SizeF(rep.PixelsWide, rep.PixelsHigh) / (float)frame.Scale).ToNS();
-				var mns = rep as IconFrameHandler.LazyImageRep;
-				if (mns != null)
+				if (rep is IconFrameHandler.LazyImageRep mns)
 				{
 					mns.Size = size;//(size.ToEto() * (float)r.Scale).ToNS();
 					var pixelSize = Size.Ceiling(size.ToEto() * (float)frame.Scale);

--- a/src/Eto.Mac/Forms/CursorHandler.cs
+++ b/src/Eto.Mac/Forms/CursorHandler.cs
@@ -81,7 +81,7 @@ namespace Eto.Mac.Forms
 			}
 		}
 
-		public void Create(Bitmap image, PointF hotspot)
+		public void Create(Image image, PointF hotspot)
 		{
 			var nsimage = image.ToNS();
 			Control = new NSCursor(nsimage, hotspot.ToNS());

--- a/src/Eto.WinForms/Forms/CursorHandler.cs
+++ b/src/Eto.WinForms/Forms/CursorHandler.cs
@@ -60,10 +60,20 @@ namespace Eto.WinForms.Forms
 		[DllImport("user32.dll", CharSet = CharSet.Ansi, BestFitMapping = false, ThrowOnUnmappableChar = true)]
 		private static extern IntPtr LoadCursorFromFile(String str);
 
-
-		public void Create(Bitmap image, PointF hotspot)
+		public void Create(Image image, PointF hotspot)
 		{
-			if (image.ToSD() is sd.Bitmap bmp)
+			if (image.ControlObject is sd.Icon ico)
+			{
+				IntPtr ptr = ico.Handle;
+				IconInfo tmp = new IconInfo();
+				GetIconInfo(ptr, ref tmp);
+				tmp.xHotspot = (int)hotspot.X;
+				tmp.yHotspot = (int)hotspot.Y;
+				tmp.fIcon = false;
+				ptr = CreateIconIndirect(ref tmp);
+				Control = new swf.Cursor(ptr);
+			}
+			else if (image.ToSD() is sd.Bitmap bmp)
 			{
 				IntPtr ptr = bmp.GetHicon();
 				IconInfo tmp = new IconInfo();

--- a/src/Eto.WinForms/Forms/ScreenHandler.cs
+++ b/src/Eto.WinForms/Forms/ScreenHandler.cs
@@ -3,49 +3,61 @@ using Eto.Forms;
 using sd = System.Drawing;
 using swf = System.Windows.Forms;
 using Eto.Drawing;
+using Eto.WinForms.Drawing;
+using System.Runtime.InteropServices;
 
 namespace Eto.WinForms.Forms
 {
 	public class ScreenHandler : WidgetHandler<swf.Screen, Screen>, Screen.IHandler
 	{
-		float scale;
+		float? scale;
 
-		public ScreenHandler (swf.Screen screen)
+		public ScreenHandler(swf.Screen screen)
 		{
-			this.Control = screen;
-			var form = new swf.Form ();
-			var graphics = form.CreateGraphics ();
-			scale = graphics.DpiY / 72f;
+			Control = screen;
 		}
 
-		public float RealScale
-		{
-			get { return scale; }
-		}
+		public float RealScale => scale ?? (scale = Control.GetLogicalPixelSize()) ?? 1;
 
-		public float Scale
-		{
-			get { return scale; }
-		}
+		public float Scale => 96f / 72f;
+		public RectangleF Bounds => Control.Bounds.ToEto();
 
-		public RectangleF Bounds
-		{
-			get { return Control.Bounds.ToEto (); }
-		}
+		public RectangleF WorkingArea => Control.WorkingArea.ToEto();
 
-		public RectangleF WorkingArea
-		{
-			get { return Control.WorkingArea.ToEto (); }
-		}
+		public int BitsPerPixel => Control.BitsPerPixel;
 
-		public int BitsPerPixel
-		{
-			get { return Control.BitsPerPixel; }
-		}
+		public bool IsPrimary => Control.Primary;
 
-		public bool IsPrimary
+		const int DESKTOPVERTRES = 0x75;
+		const int DESKTOPHORZRES = 0x76;
+
+		[DllImport("gdi32.dll")]
+		static extern int GetDeviceCaps(IntPtr hdc, int nIndex);
+
+		public Image GetImage(RectangleF rect)
 		{
-			get { return Control.Primary; }
+			var ss = Bounds.Size;
+
+			// get scale based on actual pixel size, we don't support high DPI on winforms (yet)
+			// and the CopyFromScreen API always requires actual pixel size.
+			using (var g = sd.Graphics.FromHwnd(IntPtr.Zero))
+			{
+				var hdc = g.GetHdc();
+
+				ss.Width = GetDeviceCaps(hdc, DESKTOPHORZRES);
+				ss.Height = GetDeviceCaps(hdc, DESKTOPVERTRES);
+
+				g.ReleaseHdc(hdc);
+			}
+
+			var realRect = Rectangle.Ceiling(rect * (float)(ss.Width / Bounds.Width));
+			var screenBmp = new sd.Bitmap(realRect.Width, realRect.Height, sd.Imaging.PixelFormat.Format32bppArgb);
+			using (var bmpGraphics = sd.Graphics.FromImage(screenBmp))
+			{
+				bmpGraphics.CopyFromScreen(realRect.X, realRect.Y, 0, 0, realRect.Size.ToSD());
+
+			}
+			return new Bitmap(new BitmapHandler(screenBmp));
 		}
 	}
 }

--- a/src/Eto.Wpf/Drawing/IconHandler.cs
+++ b/src/Eto.Wpf/Drawing/IconHandler.cs
@@ -19,7 +19,7 @@ namespace Eto.Wpf.Drawing
 
 	public class IconHandler : WidgetHandler<swmi.BitmapFrame, Icon>, Icon.IHandler, IWpfImage
 	{
-		List<IconFrame> frames;
+		List<IconFrame> _frames;
 		CachedBitmapFrame _cached;
 
 		public IconHandler()
@@ -31,12 +31,6 @@ namespace Eto.Wpf.Drawing
 			var rect = new sw.Int32Rect(0, 0, icon.Width, icon.Height);
 			var img = swi.Imaging.CreateBitmapSourceFromHIcon(icon.Handle, rect, swmi.BitmapSizeOptions.FromEmptyOptions());
 			Control = swmi.BitmapFrame.Create(img);
-			using (var ms = new MemoryStream())
-			{
-				icon.Save(ms);
-				ms.Position = 0;
-				SetFrames(ms);
-			}
 		}
 
 		public IconHandler(swmi.BitmapFrame control)
@@ -44,50 +38,30 @@ namespace Eto.Wpf.Drawing
 			this.Control = control;
 		}
 
-		public static void CopyStream(Stream input, Stream output)
-		{
-			var buffer = new byte[32768];
-			int read;
-			while ((read = input.Read(buffer, 0, buffer.Length)) > 0)
-			{
-				output.Write(buffer, 0, read);
-			}
-		}
-
-		public static MemoryStream CreateStream(Stream input)
-		{
-			var ms = new MemoryStream();
-			CopyStream(input, ms);
-			ms.Position = 0;
-			return ms;
-		}
-
 		public void Create(Stream stream)
 		{
-			var ms = CreateStream(stream);
-			Control = swmi.BitmapFrame.Create(ms);
-			ms.Position = 0;
-			SetFrames(ms);
+			Control = swmi.BitmapFrame.Create(stream);
 		}
 
 		public void Create(string fileName)
 		{
 			using (var stream = File.OpenRead(fileName))
 			{
-				var ms = CreateStream(stream);
-				Control = swmi.BitmapFrame.Create(ms);
-				ms.Position = 0;
-				SetFrames(ms);
+				Control = swmi.BitmapFrame.Create(stream);
 			}
 		}
 
-		void SetFrames(MemoryStream ms)
+		IEnumerable<IconFrame> GetFrames()
 		{
-			var icons = SplitIcon(Control, ms);
-			frames = new List<IconFrame>();
+			var icons = Control.Decoder?.Frames;
+			if (icons == null)
+			{
+				yield return IconFrame.FromControlObject(1f, new Bitmap(new BitmapHandler(Control)));
+				yield break;
+			}
 			foreach (var icon in icons)
 			{
-				frames.Add(IconFrame.FromControlObject(1f, new Bitmap(new BitmapHandler(icon))));
+				yield return IconFrame.FromControlObject(1f, new Bitmap(new BitmapHandler(icon)));
 			}
 		}
 		Size? size;
@@ -102,14 +76,14 @@ namespace Eto.Wpf.Drawing
 			}
 		}
 
-		public IEnumerable<IconFrame> Frames => frames;
+		public IEnumerable<IconFrame> Frames => _frames ?? (_frames = GetFrames().ToList());
 
 		IconFrame GetLargestIcon()
 		{
-			var curicon = frames[0];
-			foreach (var icon in frames)
+			IconFrame curicon = null;
+			foreach (var icon in Frames)
 			{
-				if (icon.PixelSize.Width > curicon.PixelSize.Width)
+				if (curicon == null || icon.PixelSize.Width > curicon.PixelSize.Width)
 					curicon = icon;
 			}
 			return curicon;
@@ -132,10 +106,11 @@ namespace Eto.Wpf.Drawing
 			return _cached.Get(wpfBitmap, scale, size.Width, size.Height, swm.BitmapScalingMode.Linear) ?? wpfBitmap;
 		}
 
+		/*
 		const int sICONDIR = 6;            // sizeof(ICONDIR) 
 		const int sICONDIRENTRY = 16;      // sizeof(ICONDIRENTRY)
 
-		public swmi.BitmapSource[] SplitIcon(swmi.BitmapFrame icon, MemoryStream input)
+		public IEnumerable<swmi.BitmapFrame> SplitIcon(swmi.BitmapFrame icon, MemoryStream input)
 		{
 			if (icon == null)
 			{
@@ -145,7 +120,7 @@ namespace Eto.Wpf.Drawing
 			// Get multiple .ico file image.
 			byte[] srcBuf = input.ToArray();
 
-			var splitIcons = new List<swmi.BitmapSource>();
+			var splitIcons = new List<swmi.BitmapFrame>();
 			int count = BitConverter.ToInt16(srcBuf, 4); // ICONDIR.idCount
 
 			for (int i = 0; i < count; i++)
@@ -182,12 +157,13 @@ namespace Eto.Wpf.Drawing
 
 			return splitIcons.ToArray();
 		}
+		*/
 
 		public void Create(IEnumerable<IconFrame> frames)
 		{
-			this.frames = new List<IconFrame>(frames);
+			_frames = new List<IconFrame>(frames);
 			var scale = 1;
-			var largest = this.frames.OrderBy(r => r.PixelSize.Width * r.PixelSize.Height).LastOrDefault(r => r.Scale == scale);
+			var largest = _frames.OrderBy(r => r.PixelSize.Width * r.PixelSize.Height).LastOrDefault(r => r.Scale == scale);
 			if (largest == null)
 				largest = GetLargestIcon();
 			size = Size.Ceiling((SizeF)largest.PixelSize / largest.Scale);

--- a/src/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ImageViewHandler.cs
@@ -30,8 +30,15 @@ namespace Eto.Wpf.Forms.Controls
 				Stretch = swm.Stretch.Uniform,
 				StretchDirection = swc.StretchDirection.Both
 			};
+			Control.Loaded += Control_Loaded;
 			Control.SizeChanged += Control_SizeChanged;
 			border = new swc.Border { Child = Control };
+		}
+
+		private void Control_Loaded(object sender, RoutedEventArgs e)
+		{
+			if (image is Icon)
+				SetSource();
 		}
 
 		void Control_SizeChanged(object sender, SizeChangedEventArgs e)
@@ -48,14 +55,23 @@ namespace Eto.Wpf.Forms.Controls
 		void SetSource()
 		{
 			var fittingSize = image?.Size;
-			if (Widget.Loaded)
+			if (Control.IsLoaded)
 			{
 				// use actual size of the control to get the correct image
 				var size = Size;
 				if (size.Width > 0 && size.Height > 0)
 					fittingSize = size;
 			}
-			Control.Source = image.ToWpf(ParentScale, fittingSize);
+			Image img = image;
+			if (image is Icon icon)
+			{
+				var frame = icon.GetFrame(ParentScale, fittingSize);
+				Control.Source = frame.Bitmap.ToWpf();
+			}
+			else
+			{
+				Control.Source = img.ToWpf(ParentScale, fittingSize);
+			}
 		}
 
 		public Image Image

--- a/src/Eto.Wpf/Forms/CursorHandler.cs
+++ b/src/Eto.Wpf/Forms/CursorHandler.cs
@@ -41,7 +41,18 @@ namespace Eto.Wpf.Forms
 			}
 		}
 
-		public void Create(Bitmap image, PointF hotspot)
+		public void Create(Image image, PointF hotspot)
+		{
+			if (image is Bitmap bitmap)
+				CreateBitmap(bitmap, hotspot);
+			else if (image is Icon icon)
+			{
+				var frame = icon.GetFrame(Screen.PrimaryScreen.LogicalPixelSize);
+				CreateBitmap(frame.Bitmap, hotspot * frame.Scale);
+			}
+		}
+
+		void CreateBitmap(Bitmap image, PointF hotspot)
 		{
 			using (var pngStream = new MemoryStream())
 			{

--- a/src/Eto.Wpf/Forms/ScreenHandler.cs
+++ b/src/Eto.Wpf/Forms/ScreenHandler.cs
@@ -6,6 +6,7 @@ using swm = System.Windows.Media;
 using swf = System.Windows.Forms;
 using Eto.Drawing;
 using System.Linq;
+using Eto.Wpf.Drawing;
 
 namespace Eto.Wpf.Forms
 {
@@ -45,6 +46,25 @@ namespace Eto.Wpf.Forms
 				realScale = Control.GetLogicalPixelSize();
 			}
 			return realScale ?? 1f;
+		}
+
+		public Image GetImage(RectangleF rect)
+		{
+			var realRect = Rectangle.Ceiling(rect * Widget.LogicalPixelSize);
+			using (var screenBmp = new sd.Bitmap(realRect.Width, realRect.Height, sd.Imaging.PixelFormat.Format32bppArgb))
+			{
+				using (var bmpGraphics = sd.Graphics.FromImage(screenBmp))
+				{
+					bmpGraphics.CopyFromScreen(realRect.X, realRect.Y, 0, 0, realRect.Size.ToSD());
+					var bitmapSource = sw.Interop.Imaging.CreateBitmapSourceFromHBitmap(
+						screenBmp.GetHbitmap(),
+						IntPtr.Zero,
+						sw.Int32Rect.Empty,
+						sw.Media.Imaging.BitmapSizeOptions.FromEmptyOptions());
+
+					return new Bitmap(new BitmapHandler(bitmapSource));
+				}
+			}
 		}
 
 		public float RealScale => GetRealScale() * Scale;

--- a/src/Eto/Forms/Cursor.cs
+++ b/src/Eto/Forms/Cursor.cs
@@ -147,6 +147,18 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Initializes a new instance of the Cursor with the specified <paramref name="image"/> and <paramref name="hotspot"/>. 
+		/// </summary>
+		/// <param name="image">Image for the cursor</param>
+		/// <param name="hotspot">Hotspot for where the cursor pointer is located on the image</param>
+		/// TODO: Combine with above using Image base class in 3.x
+		public Cursor(Icon image, PointF hotspot)
+		{
+			Handler.Create(image, hotspot);
+			Initialize();
+		}
+
+		/// <summary>
 		/// Initializes a new instance of the Cursor class with the specified <paramref name="handler"/>.
 		/// </summary>
 		/// <param name="handler">Handler to assign to this cursor for its implementation</param>
@@ -170,7 +182,7 @@ namespace Eto.Forms
 			/// </summary>
 			/// <param name="image">Image for the cursor</param>
 			/// <param name="hotspot">Hotspot for where the cursor pointer is located on the image</param>
-			void Create(Bitmap image, PointF hotspot);
+			void Create(Image image, PointF hotspot);
 			/// <summary>
 			/// Creates the cursor instance with the specified <paramref name="fileName"/>
 			/// </summary>

--- a/src/Eto/Forms/Screen.cs
+++ b/src/Eto/Forms/Screen.cs
@@ -172,6 +172,13 @@ namespace Eto.Forms
 		public float LogicalPixelSize { get { return RealScale / Scale; } }
 
 		/// <summary>
+		/// Gets a copy of a portion of the screen as an image
+		/// </summary>
+		/// <param name="rect">Rectangle to get the screen contents</param>
+		/// <returns>A new image (Icon or Bitmap) representing the specified rectangle</returns>
+		public Image GetImage(RectangleF rect) => Handler.GetImage(rect);
+
+		/// <summary>
 		/// Handler interface for the <see cref="Screen"/>.
 		/// </summary>
 		public new interface IHandler : Widget.IHandler
@@ -226,6 +233,13 @@ namespace Eto.Forms
 			/// </summary>
 			/// <value><c>true</c> if this is the primary screen; otherwise, <c>false</c>.</value>
 			bool IsPrimary { get; }
+
+			/// <summary>
+			/// Gets a copy of a portion of the screen as an image
+			/// </summary>
+			/// <param name="rect">Rectangle to get the screen contents</param>
+			/// <returns>A new image (Icon or Bitmap) representing the specified rectangle</returns>
+			Image GetImage(RectangleF rect);
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/ThemedControls/ThemedColorPickerHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedColorPickerHandler.cs
@@ -1,0 +1,133 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+
+namespace Eto.Forms.ThemedControls
+{
+	/// <summary>
+	/// Themed handler for the <see cref="ColorPicker"/> using a Drawable and the ColorDialog.
+	/// </summary>
+	/// <remarks>
+	/// This is useful if for example you have changed out the ColorDialog to a non-standard dialog and want to use that on
+	/// all platforms using a consistent interface.
+	/// </remarks>
+    public class ThemedColorPickerHandler : ThemedControlHandler<Control, ColorPicker, ColorPicker.ICallback>, ColorPicker.IHandler
+    {
+        static Color ActiveBackgroundColor = new Color(Colors.Gray, 0.8f);
+        static Color InactiveBackgroundColor = new Color(Colors.Gray, 0.2f);
+        static Color EnabledBorderColor = new Color(Colors.Gray, 0.6f);
+        static Color DisabledBorderColor = new Color(Colors.Gray, 0.3f);
+        static Color InnerColorBorder = new Color(Colors.Gray, 0.8f);
+
+        Color _color;
+        bool _isActive;
+
+		/// <summary>
+		/// Initializes a new instance of ThemedColorPickerHandler
+		/// </summary>
+        public ThemedColorPickerHandler()
+        {
+			var drawable = new Drawable { Size = new Size(44, 23) };
+			drawable.Paint += Drawable_Paint;
+            Control = drawable;
+            Control.MouseDown += Control_MouseDown;
+            Control.MouseUp += Control_MouseUp;
+            Control.EnabledChanged += Control_EnabledChanged;
+        }
+
+        private void Control_EnabledChanged(object sender, EventArgs e)
+        {
+            Invalidate(false);
+        }
+
+        private void Drawable_Paint(object sender, PaintEventArgs e)
+        {
+            var g = e.Graphics;
+            g.PixelOffsetMode = PixelOffsetMode.None;
+            var rect = new Rectangle(Size);
+
+            g.FillRectangle(_isActive ? ActiveBackgroundColor : InactiveBackgroundColor, rect);
+
+            var outlineRect = rect;
+            outlineRect.Size -= 1;
+            g.DrawRectangle(Enabled ? EnabledBorderColor : DisabledBorderColor, outlineRect);
+
+
+            var rectInner = rect;
+            var innerSpacing = Math.Max(0, Math.Min(6, (Math.Min(rect.Width, rect.Height) - 6) / 2));
+
+            rectInner.Inflate(-innerSpacing, -innerSpacing);
+
+            g.FillRectangle(Color, rectInner);
+
+            if (innerSpacing > 2)
+            {
+                // draw border around color
+                var rectInnerBorder = rectInner;
+                rectInnerBorder.Location -= 1;
+                rectInnerBorder.Size += 1;
+                g.DrawRectangle(InnerColorBorder, rectInnerBorder);
+            }
+
+        }
+
+        private void Control_MouseUp(object sender, MouseEventArgs e)
+        {
+            if (Enabled && e.Buttons == MouseButtons.Primary && new RectangleF(Size).Contains(e.Location))
+            {
+                e.Handled = true;
+
+                var dlg = new ColorDialog
+                {
+                    AllowAlpha = AllowAlpha,
+                    Color = Color
+                };
+                dlg.ColorChanged += (sender2, e2) =>
+                {
+                    Color = dlg.Color;
+                };
+
+                _isActive = true;
+                Invalidate(false);
+
+                var lastColor = Color;
+
+                var result = dlg.ShowDialog(Control);
+                if (result == DialogResult.Cancel || result == DialogResult.Abort)
+                    Color = lastColor;
+
+                _isActive = false;
+                Invalidate(false);
+            }
+        }
+
+        private void Control_MouseDown(object sender, MouseEventArgs e)
+        {
+            if (Enabled && e.Buttons == MouseButtons.Primary)
+            {
+                e.Handled = true;
+            }
+        }
+
+        /// <inheritdoc/>
+        public Color Color
+        {
+            get => _color;
+            set
+            {
+                if (_color != value)
+                {
+                    _color = value;
+                    Invalidate(false);
+                    Callback.OnColorChanged(Widget, EventArgs.Empty);
+                }
+            }
+        }
+
+		/// <inheritdoc/>
+        public bool AllowAlpha { get; set; }
+
+        /// <inheritdoc/>
+        public bool SupportsAllowAlpha => true;
+    }
+}


### PR DESCRIPTION
- Create a cursor from an Icon to support high dpi cursors
- Add Screen.GetImage() to get an image from a part of the screen
- Added ThemedColorPickerHandler for cases when you want to use your own ColorDialog implementation.

Wpf: Fix loading .ico files with PNG image parts
Mac: Fix GetPixel/Lock for images that don't currently have a NSBitmapImageRep
Mac: Prevent Bitmap.WithSize() from modifying the DPI of the original bitmap.
