### PR TITLE
Mac: Fix crash when resizing icons

### DIFF
--- a/src/Eto.Mac/Drawing/IconFrameHandler.cs
+++ b/src/Eto.Mac/Drawing/IconFrameHandler.cs
@@ -160,7 +160,15 @@ namespace Eto.Mac.Drawing
 			[Export("copyWithZone:")]
 			public NSObject CopyWithZone(IntPtr zone)
 			{
-				return new LazyImageRep { rep = rep?.Copy() as NSBitmapImageRep, Load = Load };
+				var obj = new LazyImageRep {
+					rep = rep?.Copy() as NSBitmapImageRep,
+					pixelsHigh = pixelsHigh,
+					pixelsWide = pixelsWide,
+					size = size,
+					Load = Load
+				};
+				obj.DangerousRetain();
+				return obj;
 			}
 		}
 

--- a/test/Eto.Test.Mac/UnitTests/IconTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/IconTests.cs
@@ -1,0 +1,52 @@
+using System;
+using System.Linq;
+using Eto.Drawing;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+using Eto.Mac;
+#if XAMMAC2
+using AppKit;
+using CoreGraphics;
+#else
+using MonoMac.AppKit;
+using MonoMac.CoreGraphics;
+#endif
+
+namespace Eto.Test.Mac64.UnitTests
+{
+	[TestFixture]
+	public class IconTests : TestBase
+	{
+		[Test]
+		public void BitmapToIconShouldNotChangeBitmapSize()
+		{
+			var bmp = TestIcons.LogoBitmap;
+			var bitmapNSImage = bmp.ControlObject as NSImage;
+			var bitmapRep = bitmapNSImage.Representations()[0] as NSBitmapImageRep;
+
+			var oldSize = bmp.Size;
+
+			var newSize = new Size(32, 32);
+			// initial sanity check
+			Assert.AreEqual(oldSize, bitmapRep.Size.ToEtoSize(), "#1");
+
+			var icon = bmp.WithSize(newSize);
+
+			var iconNSImage = icon.ControlObject as NSImage;
+			var iconRep = iconNSImage.Representations()[0] as NSBitmapImageRep;
+
+			Assert.AreEqual(bmp.Size, oldSize, "#2.1");
+			Assert.AreEqual(newSize, icon.Size, "#2.2");
+			Assert.AreEqual(bmp.Size, icon.Frames.First().PixelSize, "#2.3");
+
+			// rep in icon needs the new size
+			Assert.AreEqual(newSize, iconRep.Size.ToEtoSize(), "#2.4");
+
+			// rep in bitmap should have the old size still..
+			Assert.AreEqual(oldSize, bitmapRep.Size.ToEtoSize(), "#3");
+
+			icon.Dispose();
+			bmp.Dispose();
+		}
+	}
+}

--- a/test/Eto.Test/UnitTests/Drawing/IconTests.cs
+++ b/test/Eto.Test/UnitTests/Drawing/IconTests.cs
@@ -108,6 +108,19 @@ namespace Eto.Test.UnitTests.Drawing
 				Assert.AreEqual(height, frame.Size.Height, $"Frame #{i} with scale {frame.Scale} does not match icon height");
 			}
 		}
+
+		[Test]
+		public void BitmapToIconShouldNotChangeBitmapSize()
+		{
+			var bmp = TestIcons.LogoBitmap;
+			var oldSize = bmp.Size;
+
+			var icon = bmp.WithSize(32, 32);
+
+			Assert.AreEqual(bmp.Size, oldSize, "#1");
+			Assert.AreEqual(new Size(32, 32), icon.Size, "#2");
+			Assert.AreEqual(bmp.Size, icon.Frames.First().PixelSize, "#3");
+		}
 	}
 }
 


### PR DESCRIPTION
- need to retain when returning an object from CopyWithZone