### PR TITLE
Wpf: Fix Clipboard/DataObject tests

### DIFF
--- a/src/Eto.Wpf/Forms/DataObjectHandler.cs
+++ b/src/Eto.Wpf/Forms/DataObjectHandler.cs
@@ -95,7 +95,7 @@ namespace Eto.Wpf.Forms
 			set
 			{
 				if (IsExtended)
-					Control.SetDataEx(sw.DataFormats.Text, value);
+					Control.SetDataEx(sw.DataFormats.UnicodeText, value);
 				else
 					Control.SetText(value);
 				Update();
@@ -106,7 +106,7 @@ namespace Eto.Wpf.Forms
 
 		public virtual string Html
 		{
-			get { return Control.ContainsText(sw.TextDataFormat.Html) ? Control.GetText(sw.TextDataFormat.Html) : null; }
+			get { return ContainsHtml ? Control.GetText(sw.TextDataFormat.Html) : null; }
 			set
 			{
 				if (IsExtended)
@@ -127,7 +127,12 @@ namespace Eto.Wpf.Forms
 			get
 			{
 				if (InnerContainsImage)
-					return InnerGetImage().ToEto();
+				{
+					// clipboard returns true but the image returned is null sometimes.. hrmph.
+					var img = InnerGetImage().ToEto();
+					if (img != null)
+						return img;
+				}
 				if (Contains(sw.DataFormats.Dib) && InnerGetData(sw.DataFormats.Dib) is Stream stream)
 					return Win32.FromDIB(stream);
 				return null;

--- a/src/Eto.Wpf/WpfConversions.cs
+++ b/src/Eto.Wpf/WpfConversions.cs
@@ -358,6 +358,8 @@ namespace Eto.Wpf
 
 		public static Bitmap ToEto(this swmi.BitmapSource bitmap)
 		{
+			if (bitmap == null)
+				return null;
 			return new Bitmap(new BitmapHandler(bitmap));
 		}
 


### PR DESCRIPTION
- Text property now sets UnicodeText when using the extended mode, similar to how SetText() works.
- Getting Image no longer crashes
#1110