### PR TITLE
Wpf: Fix setting byte[] data for DataObject

### DIFF
--- a/src/Eto.Wpf/CustomControls/DragDropLib.Swf.cs
+++ b/src/Eto.Wpf/CustomControls/DragDropLib.Swf.cs
@@ -217,24 +217,32 @@ namespace System.Windows.Forms
 			{
 				formatETC.tymed = tymed;
 
-				// Set data on an empty DataObject instance
-				DataObject conv = new DataObject();
-				conv.SetData(format, true, data);
-
-				// Now retrieve the data, using the COM interface.
-				// This will perform a managed to unmanaged conversion for us.
-				ComTypes.STGMEDIUM medium;
-				((ComTypes.IDataObject)conv).GetData(ref formatETC, out medium);
-				try
+				if (data is byte[] bytes)
 				{
-					// Now set the data on our data object
-					((ComTypes.IDataObject)dataObject).SetData(ref formatETC, ref medium, true);
+					// don't convert byte array as it adds extra data
+					ComTypes.ComDataObjectExtensions.SetByteData((ComTypes.IDataObject)dataObject, format, bytes);
 				}
-				catch
+				else
 				{
-					// On exceptions, release the medium
-					ReleaseStgMedium(ref medium);
-					throw;
+					// Set data on an empty DataObject instance
+					DataObject conv = new DataObject();
+					conv.SetData(format, true, data);
+
+					// Now retrieve the data, using the COM interface.
+					// This will perform a managed to unmanaged conversion for us.
+					ComTypes.STGMEDIUM medium;
+					((ComTypes.IDataObject)conv).GetData(ref formatETC, out medium);
+					try
+					{
+						// Now set the data on our data object
+						((ComTypes.IDataObject)dataObject).SetData(ref formatETC, ref medium, true);
+					}
+					catch
+					{
+						// On exceptions, release the medium
+						ReleaseStgMedium(ref medium);
+						throw;
+					}
 				}
 			}
 			else

--- a/src/Eto.Wpf/CustomControls/DragDropLib.Wpf.cs
+++ b/src/Eto.Wpf/CustomControls/DragDropLib.Wpf.cs
@@ -1044,24 +1044,32 @@ namespace System.Windows
 			{
 				formatETC.tymed = tymed;
 
-				// Set data on an empty DataObject instance
-				DataObject conv = new DataObject();
-				conv.SetData(format, data, true);
-
-				// Now retrieve the data, using the COM interface.
-				// This will perform a managed to unmanaged conversion for us.
-				ComTypes.STGMEDIUM medium;
-				((ComTypes.IDataObject)conv).GetData(ref formatETC, out medium);
-				try
+				if (data is byte[] bytes)
 				{
-					// Now set the data on our data object
-					((ComTypes.IDataObject)dataObject).SetData(ref formatETC, ref medium, true);
+					// don't convert byte array as it adds extra data
+					ComTypes.ComDataObjectExtensions.SetByteData((ComTypes.IDataObject)dataObject, format, bytes);
 				}
-				catch
+				else
 				{
-					// On exceptions, release the medium
-					ReleaseStgMedium(ref medium);
-					throw;
+					// Set data on an empty DataObject instance
+					DataObject conv = new DataObject();
+					conv.SetData(format, data, true);
+
+					// Now retrieve the data, using the COM interface.
+					// This will perform a managed to unmanaged conversion for us.
+					ComTypes.STGMEDIUM medium;
+					((ComTypes.IDataObject)conv).GetData(ref formatETC, out medium);
+					try
+					{
+						// Now set the data on our data object
+						((ComTypes.IDataObject)dataObject).SetData(ref formatETC, ref medium, true);
+					}
+					catch
+					{
+						// On exceptions, release the medium
+						ReleaseStgMedium(ref medium);
+						throw;
+					}
 				}
 			}
 			else


### PR DESCRIPTION
When loading the byte[] data from native applications it would include additional data, probably due to using serialization.  So, when setting a byte[] array we explicitly just set the data directly now.