### PR TITLE
Initial work getting Grid.BeginEdit/CommitEdit/CancelEdit working on WPF

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -12,6 +12,9 @@
 			"group": {
 				"kind": "build",
 				"isDefault": true
+			},
+			"presentation": {
+				"clear": true
 			}
 		},
 		{
@@ -23,41 +26,59 @@
 			"type": "shell",
 			"problemMatcher": "$msCompile",
 			"group": "build",
+			"presentation": {
+				"clear": true
+			}
 		},
 		{
 			"label": "build-gtk",
 			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj",
 			"type": "shell",
 			"group": "build",
-			"problemMatcher": "$msCompile"
+			"problemMatcher": "$msCompile",
+			"presentation": {
+				"clear": true
+			}
 		},
 		{
 			"label": "build-mac64",
 			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.Mac64.csproj",
 			"type": "shell",
 			"group": "build",
-			"problemMatcher": "$msCompile"
+			"problemMatcher": "$msCompile",
+			"presentation": {
+				"clear": true
+			}
 		},
 		{
 			"label": "build-xammac2",
 			"command": "msbuild /restore ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj",
 			"type": "shell",
 			"group": "build",
-			"problemMatcher": "$msCompile"
+			"problemMatcher": "$msCompile",
+			"presentation": {
+				"clear": true
+			}
 		},
 		{
 			"label": "build-wpf",
 			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj",
 			"type": "shell",
 			"group": "build",
-			"problemMatcher": "$msCompile"
+			"problemMatcher": "$msCompile",
+			"presentation": {
+				"clear": true
+			}
 		},
 		{
 			"label": "build-winforms",
 			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj",
 			"type": "shell",
 			"group": "build",
-			"problemMatcher": "$msCompile"
+			"problemMatcher": "$msCompile",
+			"presentation": {
+				"clear": true
+			}
 		},
 		{
 			"label": "restore",
@@ -72,7 +93,10 @@
 			"windows": {
 				"command": "IF ('${input:confirm}' -ne 'Yes')  { exit 1 }; git clean -dxff ; git submodule foreach git clean -dxff ; git submodule update --init --recursive"
 			},
-			"problemMatcher": []
+			"problemMatcher": [],
+			"presentation": {
+				"clear": true
+			}
         },
 	],
 	"inputs": [

--- a/build/Build.proj
+++ b/build/Build.proj
@@ -154,7 +154,7 @@
   </ItemGroup>
 
   <!-- Build all source code -->
-  <Target Name="Build" DependsOnTargets="UpdateVersion">
+  <Target Name="Build" DependsOnTargets="UpdateVersion;PrintInfo">
 
     <PropertyGroup>
       <BuildProperties>Configuration=$(Configuration);Platform=$(OSPlatform)</BuildProperties>

--- a/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
@@ -60,6 +60,8 @@ namespace Eto.Mac.Forms.Controls
 		Grid Widget { get; }
 
 		bool SuppressUpdate { get; }
+
+		bool IsCancellingEdit { get; }
 	}
 
 	public interface IDataColumnHandler

--- a/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
@@ -3,10 +3,14 @@ using swc = System.Windows.Controls;
 using sw = System.Windows;
 using swd = System.Windows.Data;
 using swm = System.Windows.Media;
+using swi = System.Windows.Input;
 using Eto.Wpf.Drawing;
 using Eto.Drawing;
 using System.Collections.Generic;
 using System;
+using System.Windows;
+using System.Windows.Input;
+using Eto.Wpf.Forms.Controls;
 
 namespace Eto.Wpf.Forms.Cells
 {
@@ -21,18 +25,46 @@ namespace Eto.Wpf.Forms.Cells
 
 		public class WpfCellEventArgs : CellEventArgs
 		{
-			public WpfCellEventArgs(Grid grid, CustomCell cell, int row, object item, CellStates cellState)
-				: base(grid, cell, row, item, cellState)
+			swc.DataGridColumn _gridColumn;
+			int? _column;
+			public WpfCellEventArgs(Grid grid, CustomCell cell, int row, swc.DataGridColumn column, object item, CellStates cellState, Control control = null)
+				: base(grid, cell, row, -1, item, cellState, control)
 			{
+				_gridColumn = column;
+			}
+
+			public override int Column => _column ?? (_column = GetColumnIndex()).Value;
+
+			int GetColumnIndex()
+			{
+				if (_gridColumn != null && Grid.ControlObject is swc.DataGrid grid)
+				{
+					return grid.Columns.IndexOf(_gridColumn);
+				}
+				return -1;
 			}
 
 			public void SetSelected(swc.DataGridCell cell)
 			{
-				var row = cell.GetVisualParent<swc.DataGrid>();
+				var grid = cell.GetVisualParent<swc.DataGrid>();
 				var selected = cell.IsSelected;
 				IsSelected = selected;
-				var focused = row?.IsKeyboardFocusWithin == true;
-				CellTextColor = selected && focused ? SystemColors.HighlightText : SystemColors.ControlText;
+				var focused = grid?.IsKeyboardFocusWithin == true;
+				CellTextColor = selected ? Eto.Drawing.SystemColors.HighlightText : Eto.Drawing.SystemColors.ControlText;
+			}
+			public void SetRow(sw.FrameworkElement element)
+			{
+				SetRow(element.GetVisualParent<swc.DataGridRow>()?.GetIndex() ?? -1);
+			}
+
+			public void SetRow(int row)
+			{
+				Row = row;
+			}
+
+			public void SetIsEditing(bool isEditing)
+			{
+				IsEditing = isEditing;
 			}
 
 			public void SetDataContext(object dataContext)
@@ -84,6 +116,9 @@ namespace Eto.Wpf.Forms.Cells
 					control.Unloaded += HandleControlUnloaded;
 					control.Loaded += HandleControlLoaded;
 					control.DataContextChanged += HandleControlDataContextChanged;
+					control.PreviewMouseDown += HandlePreviewMouseDown;
+					control.IsKeyboardFocusWithinChanged += HandleIsKeyboardFocusWithinChanged;
+
 					if (!Equals(cell.GetValue(dpSelectedHookedUp), true))
 					{
 						cell.SetValue(dpSelectedHookedUp, true);
@@ -100,6 +135,44 @@ namespace Eto.Wpf.Forms.Cells
 				return control;
 			}
 
+			private void HandlePreviewMouseDown(object sender, MouseButtonEventArgs e)
+			{
+				var ctl = sender as sw.FrameworkElement;
+				var cell = ctl?.GetVisualParent<swc.DataGridCell>();
+				if (!cell.IsKeyboardFocusWithin)
+				{
+					cell.IsEditing = true;
+					//var row = cell.GetVisualParent<swc.DataGridRow>();
+					//if (row != null)
+					//	row.IsSelected = true;
+					//var ee = new MouseButtonEventArgs(e.MouseDevice, e.Timestamp, e.ChangedButton, e.StylusDevice);
+					//ee.RoutedEvent = sw.FrameworkElement.MouseDownEvent;
+					//cell.RaiseEvent(ee);
+					//e.Handled = true;
+				}
+			}
+
+			void HandleIsKeyboardFocusWithinChanged(object sender, DependencyPropertyChangedEventArgs e)
+			{
+				var h = Handler;
+				var ctl = sender as sw.FrameworkElement;
+				var cell = ctl?.GetVisualParent<swc.DataGridCell>();
+				var isEditing = ctl.IsKeyboardFocusWithin || cell.IsEditing;
+				var args = GetEditArgs(cell, ctl);
+				if (args?.IsEditing != isEditing)
+				{
+					args.SetIsEditing(isEditing);
+					//cell.IsEditing = isEditing;
+					if (isEditing)
+					{
+						h.Callback.OnBeginEdit(h.Widget, args);
+					}
+					else {
+						h.Callback.OnCommitEdit(h.Widget, args);
+						h.ContainerHandler.CellEdited(h, ctl);
+					}
+				}
+			}
 			static void HandleRowFocusChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
 			{
 				var grid = sender as swc.DataGrid;
@@ -127,8 +200,9 @@ namespace Eto.Wpf.Forms.Cells
 				var handler = col?.Handler;
 				if (handler == null)
 					return;
-				var args = new WpfCellEventArgs(handler.ContainerHandler?.Grid, handler.Widget, -1, ctl.DataContext, CellStates.None);
+				var args = new WpfCellEventArgs(handler.ContainerHandler?.Grid, handler.Widget, -1, cell.Column, ctl.DataContext, CellStates.None);
 				args.SetSelected(cell);
+				args.SetRow(cell);
 				var id = handler.Callback.OnGetIdentifier(handler.Widget, args);
 				var child = ctl.Control;
 				if (id != ctl.Identifier || child == null)
@@ -230,6 +304,82 @@ namespace Eto.Wpf.Forms.Cells
 			protected override sw.FrameworkElement GenerateEditingElement(swc.DataGridCell cell, object dataItem)
 			{
 				return Handler.SetupCell(Create(cell));
+			}
+
+			protected override object PrepareCellForEdit(sw.FrameworkElement editingElement, sw.RoutedEventArgs editingEventArgs)
+			{
+				var obj = base.PrepareCellForEdit(editingElement, editingEventArgs);
+				var handler = Handler;
+				var cell = editingElement?.GetParent<swc.DataGridCell>();
+				var args = GetEditArgs(cell, editingElement);
+				if (handler != null && args != null)
+				{
+					args.SetIsEditing(true);
+					handler.Callback.OnBeginEdit(handler.Widget, args);
+				}
+				if (args?.Handled != true && !cell.IsKeyboardFocusWithin)
+				{
+					// default implementation is to focus the cell's control
+					editingElement.Focus();
+					editingElement.MoveFocus(new swi.TraversalRequest(swi.FocusNavigationDirection.First));
+				}
+				return obj;
+			}
+
+			WpfCellEventArgs GetEditArgs(swc.DataGridCell cell, FrameworkElement editingElement)
+			{
+				var handler = Handler;
+				if (handler == null)
+					return null;
+				var ctl = editingElement as EtoBorder;
+				var args = ctl.Control.Properties.Get<WpfCellEventArgs>(CellEventArgs_Key);
+				if (args == null)
+				{
+					args = new WpfCellEventArgs(handler.ContainerHandler?.Grid, handler.Widget, -1, cell.Column, ctl.DataContext, CellStates.None, ctl.Control);
+					ctl.Control.Properties.Set(CellEventArgs_Key, args);
+				}
+				args.Handled = false;
+				return args;
+			}
+
+			protected override bool CommitCellEdit(sw.FrameworkElement editingElement)
+			{
+				var result = base.CommitCellEdit(editingElement);
+				var handler = Handler;
+				var cell = editingElement?.GetParent<swc.DataGridCell>();
+				var args = GetEditArgs(cell, editingElement);
+				if (handler != null && args != null)
+				{
+					args.SetIsEditing(false);
+					cell.IsEditing = false;
+					handler.Callback.OnCommitEdit(handler.Widget, args);
+				}
+				if (args?.Handled != true && editingElement.IsKeyboardFocusWithin)
+				{
+					// default implementation is to move focus back to the grid
+					var grid = editingElement.GetVisualParent<swc.DataGrid>();
+					grid?.Focus();
+				}
+				handler?.ContainerHandler.CellEdited(handler, editingElement);
+
+				return true;
+			}
+
+			protected override void CancelCellEdit(sw.FrameworkElement editingElement, object uneditedValue)
+			{
+				var handler = Handler;
+				var cell = editingElement?.GetParent<swc.DataGridCell>();
+				var args = GetEditArgs(cell, editingElement);
+				if (handler != null && args != null)
+				{
+					args.SetIsEditing(false);
+					cell.IsEditing = false;
+					handler.Callback.OnCancelEdit(handler.Widget, args);
+				}
+				if (args?.Handled != true && editingElement.IsKeyboardFocusWithin)
+				{
+					editingElement.GetVisualParent<swc.DataGrid>()?.Focus();
+				}
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -581,10 +581,15 @@ namespace Eto.Wpf.Forms.Controls
 
 		public void BeginEdit(int row, int column)
 		{
-			Control.UnselectAll();
+			CommitEdit();
 			//sometimes couldn't focus to cell, so use ScrollIntoView
 			Control.ScrollIntoView(Control.Items[row]);
-			//set current cell
+			//set current cell and select its row.
+			if (!SelectedRows.Contains(row))
+			{
+				Control.UnselectAll();
+				Control.SelectedIndex = row;
+			}
 			Control.CurrentCell = new swc.DataGridCellInfo(Control.Items[row], Control.Columns[column]);	
 			Control.Focus();
 			Control.BeginEdit();

--- a/src/Eto/Forms/Cells/CustomCell.cs
+++ b/src/Eto/Forms/Cells/CustomCell.cs
@@ -79,7 +79,7 @@ namespace Eto.Forms
 		/// Gets or sets the row for the cell.
 		/// </summary>
 		/// <value>The cell's row.</value>
-		public int Row
+		public virtual int Row
 		{
 			get { return row; }
 			protected set
@@ -93,6 +93,18 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Gets the column index for the cell.
+		/// </summary>
+		/// <value>The cell's column index.</value>
+		public virtual int Column { get; }
+
+		/// <summary>
+		/// Gets the column for the cell.
+		/// </summary>
+		/// <value>The cell's column.</value>
+		public GridColumn GridColumn => Column >= 0 ? Grid?.Columns[Column] : null;
+
+		/// <summary>
 		/// Gets the cell that triggered this event
 		/// </summary>
 		public Cell Cell { get; }
@@ -101,6 +113,21 @@ namespace Eto.Forms
 		/// Gets the grid that this event was triggered from
 		/// </summary>
 		public Grid Grid { get; }
+
+		/// <summary>
+		/// Gets the custom control associated with the cell (if any)
+		/// </summary>
+		/// <value>Instance of the control for the cell</value>
+		public Control Control { get; protected set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating that the default behavior should not be executed for the event, if supported.
+		/// </summary>
+		/// <remarks>
+		/// Note that not all events can be handled.
+		/// </remarks>
+		/// <value>True if the event is user-handled, false to use system behavior.</value>
+		public bool Handled { get; set; }
 
 		Color cellTextColor = SystemColors.ControlText;
         
@@ -141,13 +168,31 @@ namespace Eto.Forms
 		/// <param name="row">Row for the cell.</param>
 		/// <param name="item">Item the cell is displaying.</param>
 		/// <param name="cellState">State of the cell.</param>
+		[Obsolete("Use constructor with column number and control")]
 		public CellEventArgs(Grid grid, Cell cell, int row, object item, CellStates cellState)
+			: this(null, null, row, -1, item, cellState, null)
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.CellEventArgs"/> class.
+		/// </summary>
+		/// <param name="grid">Grid the event is triggered for.</param>
+		/// <param name="cell">Cell the event is triggered for.</param>
+		/// <param name="row">Row for the cell.</param>
+		/// <param name="column">Column for the cell.</param>
+		/// <param name="item">Item the cell is displaying.</param>
+		/// <param name="cellState">State of the cell.</param>
+		/// <param name="control">Control object for the cell (if any)</param>
+		public CellEventArgs(Grid grid, Cell cell, int row, int column, object item, CellStates cellState, Control control)
 		{
 			Grid = grid;
 			Cell = cell;
+			Column = column;
 			Row = row;
 			Item = item;
 			CellState = cellState;
+			Control = control;
 		}
 
 		/// <summary>
@@ -359,6 +404,37 @@ namespace Eto.Forms
 				control.DataContext = args.Item;
 		}
 
+		/// <summary>
+		/// Event to handle when the cell should begin editing.
+		/// </summary>
+		public event EventHandler<CellEventArgs> BeginEdit;
+		/// <summary>
+		/// Event to handle when the cell should cancel editing.
+		/// </summary>
+		public event EventHandler<CellEventArgs> CancelEdit;
+		/// <summary>
+		/// Event to handle when the cell should commit editing.
+		/// </summary>
+		public event EventHandler<CellEventArgs> CommitEdit;
+
+		/// <summary>
+		/// Triggers the <see cref="BeginEdit"/> event.
+		/// </summary>
+		/// <param name="e">Cell event arguments</param>
+		protected virtual void OnBeginEdit(CellEventArgs e) => BeginEdit?.Invoke(this, e);
+
+		/// <summary>
+		/// Triggers the <see cref="CancelEdit"/> event.
+		/// </summary>
+		/// <param name="e">Cell event arguments</param>
+		protected virtual void OnCancelEdit(CellEventArgs e) => CancelEdit?.Invoke(this, e);
+
+		/// <summary>
+		/// Triggers the <see cref="CommitEdit"/> event.
+		/// </summary>
+		/// <param name="e">Cell event arguments</param>
+		protected virtual void OnCommitEdit(CellEventArgs e) => CommitEdit?.Invoke(this, e);
+
 		static readonly object PaintEvent = new object();
 
 		/// <summary>
@@ -415,6 +491,21 @@ namespace Eto.Forms
 			/// Raises the paint event.
 			/// </summary>
 			void OnPaint(CustomCell widget, CellPaintEventArgs args);
+
+			/// <summary>
+			/// Raises the BeginEdit event.
+			/// </summary>
+			void OnBeginEdit(CustomCell widget, CellEventArgs args);
+
+			/// <summary>
+			/// Raises the CancelEdit event.
+			/// </summary>
+			void OnCancelEdit(CustomCell widget, CellEventArgs args);
+
+			/// <summary>
+			/// Raises the CommitEdit event.
+			/// </summary>
+			void OnCommitEdit(CustomCell widget, CellEventArgs args);
 		}
 
 		/// <summary>
@@ -466,6 +557,33 @@ namespace Eto.Forms
 				using (widget.Platform.Context)
 					widget.OnPaint(args);
 			}
+
+			/// <summary>
+			/// Raises the BeginEdit event.
+			/// </summary>
+			public void OnBeginEdit(CustomCell widget, CellEventArgs args)
+			{
+				using (widget.Platform.Context)
+					widget.OnBeginEdit(args);
+			}
+
+			/// <summary>
+			/// Raises the CancelEdit event.
+			/// </summary>
+			public void OnCancelEdit(CustomCell widget, CellEventArgs args)
+			{
+				using (widget.Platform.Context)
+					widget.OnCancelEdit(args);
+			}
+
+			/// <summary>
+			/// Raises the CommitEdit event.
+			/// </summary>
+			public void OnCommitEdit(CustomCell widget, CellEventArgs args)
+			{
+				using (widget.Platform.Context)
+					widget.OnCommitEdit(args);
+			}
 		}
 
 		static readonly object callback = new Callback();
@@ -474,10 +592,7 @@ namespace Eto.Forms
 		/// Gets an instance of an object used to perform callbacks to the widget from handler implementations
 		/// </summary>
 		/// <returns>The callback.</returns>
-		protected override object GetCallback()
-		{
-			return callback;
-		}
+		protected override object GetCallback() => callback;
 	}
 }
 

--- a/src/Shared/MutableCellEventArgs.cs
+++ b/src/Shared/MutableCellEventArgs.cs
@@ -6,8 +6,8 @@ namespace Eto.Shared
 {
 	public class MutableCellEventArgs : CellEventArgs
 	{
-		public MutableCellEventArgs(Grid grid, Cell cell, int row, object item, CellStates cellState)
-			: base(grid, cell, row, item, cellState)
+		public MutableCellEventArgs(Grid grid, Cell cell, int row, int column, object item, CellStates cellState, Control control)
+			: base(grid, cell, row, column, item, cellState, control)
 		{
 		}
 
@@ -29,6 +29,11 @@ namespace Eto.Shared
 		public void SetItem(object item)
 		{
 			Item = item;
+		}
+
+		public void SetControl(Control control)
+		{
+			Control = control;
 		}
 	}
 	

--- a/test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -455,12 +455,12 @@ namespace Eto.Test.Sections.Controls
 
 		protected virtual void LogEvents(GridView control)
 		{
-			control.CellEditing += (sender, e) => Log.Write(control, $"BeginCellEdit, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
-			control.CellEdited += (sender, e) => Log.Write(control, $"EndCellEdit, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
-			control.SelectionChanged += (sender, e) => Log.Write(control, $"Selection Changed, Rows: {SelectedRowsString(control)}");
-			control.ColumnHeaderClick += (sender, e) => Log.Write(control, $"Column Header Clicked: {e.Column.HeaderText}");
-			control.CellClick += (sender, e) => Log.Write(control, $"Cell Clicked, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
-			control.CellDoubleClick += (sender, e) => Log.Write(control, $"Cell Double Clicked, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
+			control.CellEditing += (sender, e) => Log.Write(control, $"CellEditing, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
+			control.CellEdited += (sender, e) => Log.Write(control, $"CellEdited, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
+			control.SelectionChanged += (sender, e) => Log.Write(control, $"SelectionChanged, Rows: {SelectedRowsString(control)}");
+			control.ColumnHeaderClick += (sender, e) => Log.Write(control, $"ColumnHeaderClick: {e.Column.HeaderText}");
+			control.CellClick += (sender, e) => Log.Write(control, $"CellClick, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
+			control.CellDoubleClick += (sender, e) => Log.Write(control, $"CellDoubleClick, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
 
 			control.MouseDown += (sender, e) => Log.Write(control, $"MouseDown, Buttons: {e.Buttons}, Location: {e.Location}");
 			control.MouseDoubleClick += (sender, e) => Log.Write(control, $"MouseDoubleClick, Buttons: {e.Buttons}, Location: {e.Location}");

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
@@ -12,9 +12,137 @@ using System.Threading;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {
-	[TestFixture]
-	public class GridViewTests : TestBase
+	public abstract class GridTests<T> : TestBase
+		where T: Grid, new()
 	{
+		class GridTestItem : TreeGridItem
+		{
+			public string Text { get; set; }
+		}
+
+		[Test, ManualTest]
+		public void BeginEditShoudWorkOnCustomCells()
+		{
+			ManualForm("The custom cell should go in edit mode when clicking the BeginEdit button", form =>
+			{
+				var grid = new T();
+				grid.ShowHeader = true;
+				grid.AllowMultipleSelection = true;
+
+				string CellInfo(GridViewCellEventArgs e) => $"Row: {e.Row}, Column: {e.Column}";
+				string CellEditInfo(CellEventArgs e) => $"Row: {e.Row}";
+				void AddLogging(CustomCell cell)
+				{
+					cell.BeginEdit += (sender, e) => Log.Write(sender, $"BeginEdit {CellEditInfo(e)}, Grid.IsEditing: {grid.IsEditing}");
+					cell.CommitEdit += (sender, e) => Log.Write(sender, $"CommitEdit {CellEditInfo(e)}, Grid.IsEditing: {grid.IsEditing}");
+					cell.CancelEdit += (sender, e) => Log.Write(sender, $"CancelEdit {CellEditInfo(e)}, Grid.IsEditing: {grid.IsEditing}");
+
+					if (!CustomCell.SupportsControlView)
+					{
+						cell.GetPreferredWidth = args => 100;
+						cell.Paint += (sender, e) => {
+							e.Graphics.DrawText(SystemFonts.Default(), Brushes.Black, e.ClipRectangle, "Cell", alignment: FormattedTextAlignment.Center);
+						};
+					}
+
+				}
+
+				grid.CellEditing += (sender, e) => Log.Write(sender, $"CellEditing {CellInfo(e)}, Grid.IsEditing: {grid.IsEditing}");
+				grid.CellEdited += (sender, e) => Log.Write(sender, $"CellEdited {CellInfo(e)}, Grid.IsEditing: {grid.IsEditing}");
+				var customCell = new CustomCell();
+				customCell.CreateCell = args =>
+				{
+					var textBox = new TextBox { ShowBorder = false, BackgroundColor = Colors.Transparent };
+
+					if (!Platform.Instance.IsMac)
+					{
+						textBox.GotFocus += (sender, e) => textBox.BackgroundColor = SystemColors.ControlBackground;
+						textBox.LostFocus += (sender, e) => textBox.BackgroundColor = Colors.Transparent;
+
+						// ugly, there should be a better way to do this..
+						var colorBinding = textBox.Bind(c => c.TextColor, args, Binding.Property((CellEventArgs a) => a.CellTextColor).Convert(c => args.IsEditing ? SystemColors.ControlText : c));
+						args.PropertyChanged += (sender, e) => {
+							if (e.PropertyName == nameof(CellEventArgs.IsEditing))
+								colorBinding.Update();
+						};
+					}
+					else
+					{
+						// macOS handles colors more automaticcally for a TextBox
+					}
+
+					textBox.TextBinding.BindDataContext((GridTestItem i) => i.Text);
+
+					return textBox;
+				};
+				AddLogging(customCell);
+				grid.Columns.Add(new GridColumn { DataCell = customCell, Editable = true, HeaderText = "CustomTextBox" });
+
+				var customCell2 = new CustomCell();
+				customCell2.CreateCell = args =>
+				{
+					var dropDown = new DropDown { Items = { "Item 1", "Item 2", "Item 3" }};
+
+					return dropDown;
+				};
+				AddLogging(customCell2);
+				grid.Columns.Add(new GridColumn { DataCell = customCell2, Editable = true, HeaderText = "CustomDropDown" });
+
+				var customCell3 = new CustomCell();
+				customCell3.CreateCell = args =>
+				{
+					var checkBox = new CheckBox();
+
+					return checkBox;
+				};
+				AddLogging(customCell3);
+				grid.Columns.Add(new GridColumn { DataCell = customCell3, Editable = true, HeaderText = "CustomCheckBox" });
+
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(nameof(GridTestItem.Text)), HeaderText = "TextBoxCell", Editable = true });
+
+				var list = new List<GridTestItem>();
+				list.Add(new GridTestItem { Text = "Item 1" });
+				list.Add(new GridTestItem { Text = "Item 2" });
+				list.Add(new GridTestItem { Text = "Item 3" });
+				SetDataStore(grid, list);
+
+				// using MouseDown so the buttons don't get focus
+				var beginEditButton = new Button { Text = "BeginEdit" };
+				beginEditButton.MouseDown += (sender, e) => {
+					grid.BeginEdit(1, 0);
+					e.Handled = true;
+				};
+
+				var commitEditButton = new Button { Text = "CommitEdit" };
+				commitEditButton.MouseDown += (sender, e) => {
+					grid.CommitEdit();
+					e.Handled = true;
+				};
+
+				var cancelEditButton = new Button { Text = "CancelEdit" };
+				cancelEditButton.MouseDown += (sender, e) => {
+					grid.CancelEdit();
+					e.Handled = true;
+				};
+
+				return new TableLayout(
+					TableLayout.Horizontal(4, beginEditButton, commitEditButton, cancelEditButton, null),
+					grid
+					);
+			});
+		}
+
+		protected abstract void SetDataStore(T grid, IEnumerable<object> dataStore);
+	}
+
+	[TestFixture]
+	public class GridViewTests : GridTests<GridView>
+	{
+		protected override void SetDataStore(GridView grid, IEnumerable<object> dataStore)
+		{
+			grid.DataStore = dataStore;
+		}
+
 		[Test, ManualTest]
 		public void CellClickShouldHaveMouseInformation()
 		{


### PR DESCRIPTION
When creating a CustomCell, Grid.BeginEdit/CommitEdit/CancelEdit does not work on WPF, but they sort of do on macOS.  There should be some automatic functionality or a way to hook into these events with the CustomCell so you can provide a more consistent way to programatically begin editing.

Note that this is WIP, and doesn't currently work.