### PR TITLE
Apply handler styles after they are fully initialized

### DIFF
--- a/src/Eto/WidgetHandler.cs
+++ b/src/Eto/WidgetHandler.cs
@@ -124,12 +124,13 @@ namespace Eto
 		/// </remarks>
 		protected virtual void Initialize()
 		{
-			Style.Provider?.ApplyDefault(this);
 		}
 
 		void Widget.IHandler.Initialize()
 		{
 			Initialize();
+			// apply styles after the handler is fully initialized.
+			Style.Provider?.ApplyDefault(this);
 		}
 
 		/// <summary>


### PR DESCRIPTION
- some handlers create the control during Initialize() which would make it impossible to style
- the style should override any defaults set in Initialize()