### PR TITLE
Child binding fixes

### DIFF
--- a/src/Eto/Forms/Binding/IndirectChildBinding.cs
+++ b/src/Eto/Forms/Binding/IndirectChildBinding.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Reflection;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// An indirect binding class to provide a way to bind to a child object of a value.
+	/// </summary>
+	/// <typeparam name="TParent">Property type from the parent object</typeparam>
+	/// <typeparam name="TChild">Property type from the child object</typeparam>
+	class IndirectChildBinding<TParent, TChild> : IndirectBinding<TChild>
+	{
+		IndirectBinding<TParent> _parent;
+		IndirectBinding<TChild> _child;
+
+		/// <summary>
+		/// Initializes a new instance of the ChildBinding class
+		/// </summary>
+		/// <param name="parent">Binding from the parent to get the child</param>
+		/// <param name="child">Binding for the child to get the actual value</param>
+		public IndirectChildBinding(IndirectBinding<TParent> parent, IndirectBinding<TChild> child)
+		{
+			_parent = parent ?? throw new ArgumentNullException(nameof(parent));
+			_child = child ?? throw new ArgumentNullException(nameof(child));
+		}
+
+		class BindingReference
+		{
+			public IndirectChildBinding<TParent, TChild> owner;
+			public object parentReference;
+			public object childReference;
+			public EventHandler<EventArgs> handler;
+			public object dataItem;
+
+			public void ValueChanged(object sender, EventArgs e)
+			{
+				// remove binding from old child
+				owner._child.RemoveValueChangedHandler(childReference, handler);
+
+				// get new child and add binding 
+				var newChild = owner._parent.GetValue(dataItem);
+				childReference = owner._child.AddValueChangedHandler(newChild, handler);
+
+				// now, fire the change event
+				handler(sender, e);
+			}
+		}
+
+		/// <inheritdoc/>
+		public override object AddValueChangedHandler(object dataItem, EventHandler<EventArgs> handler)
+		{
+			var reference = new BindingReference();
+			reference.owner = this;
+			reference.dataItem = dataItem;
+			reference.handler = handler;
+			var childItem = _parent.GetValue(dataItem);
+			reference.parentReference = _parent.AddValueChangedHandler(dataItem, reference.ValueChanged);
+			reference.childReference = _child.AddValueChangedHandler(childItem, handler);
+			return reference;
+		}
+
+		/// <inheritdoc/>
+		public override void RemoveValueChangedHandler(object bindingReference, EventHandler<EventArgs> handler)
+		{
+			if (bindingReference is BindingReference reference)
+			{
+				_parent.RemoveValueChangedHandler(reference.parentReference, reference.ValueChanged);
+				_child.RemoveValueChangedHandler(reference.childReference, handler);
+			}
+		}
+
+		/// <inheritdoc/>
+		protected override TChild InternalGetValue(object dataItem)
+		{
+			var childItem = _parent.GetValue(dataItem);
+			return _child.GetValue(childItem);
+		}
+
+		bool? _isStruct;
+		bool IsStruct => _isStruct ?? (_isStruct = typeof(TParent).GetTypeInfo().IsValueType).Value;
+
+		/// <inheritdoc/>
+		protected override void InternalSetValue(object dataItem, TChild value)
+		{
+			if (IsStruct)
+			{
+				// box value to object so it is passed by reference
+				object childItem = _parent.GetValue(dataItem);
+				// set the child value
+				_child.SetValue(childItem, value);
+				// set value back since it is a struct
+				_parent.SetValue(dataItem, (TParent)childItem);
+			}
+			else
+			{
+				var childItem = _parent.GetValue(dataItem);
+				_child.SetValue(childItem, value);
+			}
+		}
+	}
+}

--- a/src/Eto/Forms/Binding/ObjectBinding.cs
+++ b/src/Eto/Forms/Binding/ObjectBinding.cs
@@ -65,6 +65,7 @@ namespace Eto.Forms
 	public class ObjectBinding<T, TValue> : DirectBinding<TValue>
 	{
 		object dataValueChangedReference;
+		bool dataValueChangedHandled;
 		T dataItem;
 
 		/// <summary>
@@ -80,12 +81,12 @@ namespace Eto.Forms
 			get { return dataItem; }
 			set
 			{
-				var updateEvent = dataValueChangedReference != null;
-				if (updateEvent)
+				var hasValueChanged = dataValueChangedHandled;
+				if (hasValueChanged)
 					RemoveEvent(DataValueChangedEvent);
 				dataItem = value;
 				OnDataValueChanged(EventArgs.Empty);
-				if (updateEvent)
+				if (hasValueChanged)
 					HandleEvent(DataValueChangedEvent);
 			}
 		}
@@ -184,11 +185,14 @@ namespace Eto.Forms
 			switch (id)
 			{
 				case DataValueChangedEvent:
-					if (dataValueChangedReference == null)
+					if (!dataValueChangedHandled)
+					{
 						dataValueChangedReference = InnerBinding.AddValueChangedHandler(
 							DataItem,
 							new EventHandler<EventArgs>(HandleChangedEvent)
 						);
+						dataValueChangedHandled = true;
+					}
 					break;
 				default:
 					base.HandleEvent(id);
@@ -204,13 +208,14 @@ namespace Eto.Forms
 			switch (id)
 			{
 				case DataValueChangedEvent:
-					if (dataValueChangedReference != null)
+					if (dataValueChangedHandled)
 					{
 						InnerBinding.RemoveValueChangedHandler(
 							dataValueChangedReference,
 							new EventHandler<EventArgs>(HandleChangedEvent)
 						);
 						dataValueChangedReference = null;
+						dataValueChangedHandled = false;
 					}
 					break;
 				default:

--- a/src/Eto/Forms/Controls/MaskedTextBox.cs
+++ b/src/Eto/Forms/Controls/MaskedTextBox.cs
@@ -29,6 +29,25 @@ namespace Eto.Forms
 	}
 
 	/// <summary>
+	/// Mode for when prompt characters are shown in a control.
+	/// </summary>
+	public enum ShowPromptMode
+	{
+		/// <summary>
+		/// Always show the prompt characters.
+		/// </summary>
+		Always,
+		/// <summary>
+		/// Only show the prompt characters when the control has focus.
+		/// </summary>
+		OnFocus,
+		/// <summary>
+		/// Never show the prompt characters
+		/// </summary>
+		Never
+	}
+
+	/// <summary>
 	/// Masked text box with a variable length numeric mask.
 	/// </summary>
 	/// <remarks>
@@ -204,7 +223,7 @@ namespace Eto.Forms
 	{
 		IMaskedTextProvider provider;
 		static readonly object InsertKeyModeKey = new object();
-		static readonly object ShowPromptOnFocusKey = new object();
+		static readonly object ShowPromptModeKey = new object();
 		static readonly object SupportsInsertKey = new object();
 		static readonly object OverwriteModeKey = new object();
 		static readonly object ShowPlaceholderWhenEmptyKey = new object();
@@ -281,14 +300,23 @@ namespace Eto.Forms
 		/// Gets or sets a value indicating that the prompt characters should only be shown when the control has focus.
 		/// </summary>
 		/// <value><c>true</c> if to show the prompt only when focussed; otherwise, <c>false</c>.</value>
+		[Obsolete("Since 2.5.1, Use ShowPromptMode instead")]
 		public bool ShowPromptOnFocus
 		{
-			get { return Properties.Get<bool>(ShowPromptOnFocusKey); }
+			get => ShowPromptMode == ShowPromptMode.OnFocus;
+			set => ShowPromptMode = value ? ShowPromptMode.OnFocus : ShowPromptMode.Always;
+		}
+
+		/// <summary>
+		/// Gets or sets the mode for when the input prompts should be shown
+		/// </summary>
+		public ShowPromptMode ShowPromptMode
+		{
+			get => Properties.Get<ShowPromptMode>(ShowPromptModeKey);
 			set
 			{ 
-				if (ShowPromptOnFocus != value)
+				if (Properties.TrySet(ShowPromptModeKey, value))
 				{
-					Properties[ShowPromptOnFocusKey] = value;
 					UpdateText();
 				}
 			}
@@ -362,7 +390,7 @@ namespace Eto.Forms
 			var hasFocus = HasFocus;
 			if (!hasFocus && ShowPlaceholderWhenEmpty && provider.IsEmpty && !string.IsNullOrEmpty(PlaceholderText))
 				base.Text = null;
-			else if (hasFocus || !ShowPromptOnFocus)
+			else if ((hasFocus && ShowPromptMode == ShowPromptMode.OnFocus) || ShowPromptMode == ShowPromptMode.Always)
 				base.Text = provider.DisplayText;
 			else
 				base.Text = provider.Text;
@@ -386,7 +414,7 @@ namespace Eto.Forms
 		protected override void OnGotFocus(EventArgs e)
 		{
 			base.OnGotFocus(e);
-			if (ShowPromptOnFocus || ShowPlaceholderWhenEmpty)
+			if (ShowPromptMode == ShowPromptMode.OnFocus || ShowPlaceholderWhenEmpty)
 				UpdateText();
 		}
 
@@ -397,7 +425,7 @@ namespace Eto.Forms
 		protected override void OnLostFocus(EventArgs e)
 		{
 			base.OnLostFocus(e);
-			if (ShowPromptOnFocus || ShowPlaceholderWhenEmpty)
+			if (ShowPromptMode == ShowPromptMode.OnFocus || ShowPlaceholderWhenEmpty)
 				UpdateText();
 		}
 

--- a/src/Eto/Forms/Controls/MaskedTextStepper.cs
+++ b/src/Eto/Forms/Controls/MaskedTextStepper.cs
@@ -179,7 +179,7 @@ namespace Eto.Forms
 	{
 		IMaskedTextProvider provider;
 		static readonly object InsertKeyModeKey = new object();
-		static readonly object ShowPromptOnFocusKey = new object();
+		static readonly object ShowPromptModeKey = new object();
 		static readonly object SupportsInsertKey = new object();
 		static readonly object OverwriteModeKey = new object();
 		static readonly object ShowPlaceholderWhenEmptyKey = new object();
@@ -256,14 +256,23 @@ namespace Eto.Forms
 		/// Gets or sets a value indicating that the prompt characters should only be shown when the control has focus.
 		/// </summary>
 		/// <value><c>true</c> if to show the prompt only when focussed; otherwise, <c>false</c>.</value>
+		[Obsolete("Since 2.5.1, Use ShowPromptMode instead")]
 		public bool ShowPromptOnFocus
 		{
-			get { return Properties.Get<bool>(ShowPromptOnFocusKey); }
+			get => ShowPromptMode == ShowPromptMode.OnFocus;
+			set => ShowPromptMode = value ? ShowPromptMode.OnFocus : ShowPromptMode.Always;
+		}
+
+		/// <summary>
+		/// Gets or sets the mode for when the input prompts should be shown
+		/// </summary>
+		public ShowPromptMode ShowPromptMode
+		{
+			get => Properties.Get<ShowPromptMode>(ShowPromptModeKey);
 			set
-			{
-				if (ShowPromptOnFocus != value)
+			{ 
+				if (Properties.TrySet(ShowPromptModeKey, value))
 				{
-					Properties[ShowPromptOnFocusKey] = value;
 					UpdateText();
 				}
 			}
@@ -337,7 +346,7 @@ namespace Eto.Forms
 			var hasFocus = HasFocus;
 			if (!hasFocus && ShowPlaceholderWhenEmpty && provider.IsEmpty && !string.IsNullOrEmpty(PlaceholderText))
 				base.Text = null;
-			else if (hasFocus || !ShowPromptOnFocus)
+			else if ((hasFocus && ShowPromptMode == ShowPromptMode.OnFocus) || ShowPromptMode == ShowPromptMode.Always)
 				base.Text = provider.DisplayText;
 			else
 				base.Text = provider.Text;
@@ -361,7 +370,7 @@ namespace Eto.Forms
 		protected override void OnGotFocus(EventArgs e)
 		{
 			base.OnGotFocus(e);
-			if (ShowPromptOnFocus || ShowPlaceholderWhenEmpty)
+			if (ShowPromptMode == ShowPromptMode.OnFocus || ShowPlaceholderWhenEmpty)
 				UpdateText();
 		}
 
@@ -372,7 +381,7 @@ namespace Eto.Forms
 		protected override void OnLostFocus(EventArgs e)
 		{
 			base.OnLostFocus(e);
-			if (ShowPromptOnFocus || ShowPlaceholderWhenEmpty)
+			if (ShowPromptMode == ShowPromptMode.OnFocus || ShowPlaceholderWhenEmpty)
 				UpdateText();
 		}
 

--- a/test/Eto.Test/Sections/UnitTestPanel.cs
+++ b/test/Eto.Test/Sections/UnitTestPanel.cs
@@ -1130,6 +1130,7 @@ namespace Eto.Test.Sections
 			stopButton.Click += (s, e) => runner?.StopTests();
 
 			search = new SearchBox();
+			search.Text = TestApplication.Settings.LastUnitTestFilter;
 			search.PlaceholderText = "Filter(s)";
 			search.Focus();
 			search.KeyDown += (sender, e) =>
@@ -1140,7 +1141,11 @@ namespace Eto.Test.Sections
 					e.Handled = true;
 				}
 			};
-			search.TextChanged += (sender, e) => timer.Start();
+			search.TextChanged += (sender, e) =>
+			{
+				TestApplication.Settings.LastUnitTestFilter = search.Text;
+				timer.Start();
+			};
 
 
 			tree = new TreeGridView { ShowHeader = false, Size = new Size(400, -1) };

--- a/test/Eto.Test/Settings.cs
+++ b/test/Eto.Test/Settings.cs
@@ -4,42 +4,44 @@ using System.IO;
 
 namespace Eto.Test
 {
-    public class Settings
-    {
-        static string AppSettingsFolder => EtoEnvironment.GetFolderPath(EtoSpecialFolder.ApplicationSettings);
-        static string SettingsFile => Path.Combine(AppSettingsFolder, "mainform.json");
+	public class Settings
+	{
+		static string AppSettingsFolder => EtoEnvironment.GetFolderPath(EtoSpecialFolder.ApplicationSettings);
+		static string SettingsFile => Path.Combine(AppSettingsFolder, "mainform.json");
 
-        public string InitialSection { get; set; }
+		public string InitialSection { get; set; }
 
-        public bool SaveInitialSection { get; set; }
+		public bool SaveInitialSection { get; set; }
 
-        public static Settings Load()
-        {
-            try
-            {
-                if (File.Exists(SettingsFile))
-                    return Newtonsoft.Json.JsonConvert.DeserializeObject<Settings>(File.ReadAllText(SettingsFile)) ?? new Settings();
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"Error reading settings: {ex}");
-            }
-            return new Settings();
-        }
+		public string LastUnitTestFilter { get; set; }
 
-        public void Save()
-        {
-            try
-            {
-                var str = Newtonsoft.Json.JsonConvert.SerializeObject(this);
-                File.WriteAllText(SettingsFile, str);
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"Error writing settings: {ex}");
-            }
+		public static Settings Load()
+		{
+			try
+			{
+				if (File.Exists(SettingsFile))
+					return Newtonsoft.Json.JsonConvert.DeserializeObject<Settings>(File.ReadAllText(SettingsFile)) ?? new Settings();
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Error reading settings: {ex}");
+			}
+			return new Settings();
+		}
 
-        }
-    }
+		public void Save()
+		{
+			try
+			{
+				var str = Newtonsoft.Json.JsonConvert.SerializeObject(this);
+				File.WriteAllText(SettingsFile, str);
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Error writing settings: {ex}");
+			}
+
+		}
+	}
 }
 

--- a/test/Eto.Test/UnitTests/Forms/Bindings/ChildBindingTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Bindings/ChildBindingTests.cs
@@ -10,7 +10,35 @@ namespace Eto.Test.UnitTests.Forms.Bindings
 	{
 		class TestObject
 		{
-			public Color Color { get; set; }
+			Color _color;
+			TestObject _child;
+			public Color Color
+			{
+				get => _color;
+				set
+				{
+					if (_color != value)
+					{
+						_color = value;
+						ColorChanged?.Invoke(this, EventArgs.Empty);
+					}
+				}
+			}
+
+			public event EventHandler<EventArgs> ColorChanged;
+
+			public TestObject Child
+			{
+				get => _child;
+				set {
+					if (_child != value)
+					{
+						_child = value;
+						ChildChanged?.Invoke(this, EventArgs.Empty);
+					}
+				}
+			}
+			public event EventHandler<EventArgs> ChildChanged;
 		}
 
 		[Test]
@@ -39,6 +67,110 @@ namespace Eto.Test.UnitTests.Forms.Bindings
 			var childBinding = binding.Child(Binding.Property((Color c) => c.B));
 			childBinding.DataValue = 0.5f;
 			Assert.AreEqual(0.5f, item.Color.B, "Struct property value was not set");
+		}
+
+		[Test]
+		public void AddingMultipleChangeHandlersForIndirectBindingsShouldWork()
+		{
+			var item = new TestObject { Color = Colors.Blue, Child = new TestObject { Color = Colors.Blue } };
+			var binding = Binding.Property((TestObject t) => t.Child);
+			var childBinding = binding.Child(c => c.Color);
+
+			int valueChange1Count = 0;
+			int valueChange2Count = 0;
+			void ValueChanged1(object sender, EventArgs e) => valueChange1Count++;
+			void ValueChanged2(object sender, EventArgs e) => valueChange2Count++;
+
+			var changed1 = childBinding.AddValueChangedHandler(item, ValueChanged1);
+			var changed2 = childBinding.AddValueChangedHandler(item, ValueChanged2);
+
+			item.Child.Color = Colors.Green;
+
+			Assert.AreEqual(1, valueChange1Count, "#1.1");
+			Assert.AreEqual(1, valueChange2Count, "#1.2");
+
+			// setting the child to something else should re-wire all the value changed bindings to the new instance
+			// .. and trigger the value changed
+			item.Child = new TestObject { Color = Colors.Blue };
+
+			Assert.AreEqual(2, valueChange1Count, "#2.1");
+			Assert.AreEqual(2, valueChange2Count, "#2.2");
+
+			// remove the first handler and ensure the second one is still active
+			childBinding.RemoveValueChangedHandler(changed1, ValueChanged1);
+
+			item.Child.Color = Colors.Yellow;
+
+			// only hooked up to the second handler
+			Assert.AreEqual(2, valueChange1Count, "#3.1");
+			Assert.AreEqual(3, valueChange2Count, "#3.2");
+
+			item.Child = new TestObject { Color = Colors.White };
+
+			Assert.AreEqual(2, valueChange1Count, "#4.1");
+			Assert.AreEqual(4, valueChange2Count, "#4.2");
+
+			childBinding.RemoveValueChangedHandler(changed2, ValueChanged2);
+
+			item.Child.Color = Colors.Tomato;
+			item.Child = new TestObject { Color = Colors.Wheat };
+
+			// no changes as nothing should be hooked up
+			Assert.AreEqual(2, valueChange1Count, "#5.1");
+			Assert.AreEqual(4, valueChange2Count, "#5.2");
+
+		}
+
+		[Test]
+		public void AddingMultipleChangeHandlersForDirectBindingsShouldWork()
+		{
+			var item = new TestObject { Color = Colors.Blue, Child = new TestObject { Color = Colors.Blue } };
+			var binding = Binding.Property(item, t => t.Child);
+			var childBinding = binding.Child(c => c.Color);
+
+			int valueChange1Count = 0;
+			int valueChange2Count = 0;
+			void ValueChanged1(object sender, EventArgs e) => valueChange1Count++;
+			void ValueChanged2(object sender, EventArgs e) => valueChange2Count++;
+
+			childBinding.DataValueChanged += ValueChanged1;
+			childBinding.DataValueChanged += ValueChanged2;
+
+			item.Child.Color = Colors.Green;
+
+			Assert.AreEqual(1, valueChange1Count, "#1.1");
+			Assert.AreEqual(1, valueChange2Count, "#1.2");
+
+			// setting the child to something else should re-wire all the value changed bindings to the new instance
+			// .. and trigger the value changed
+			item.Child = new TestObject { Color = Colors.Blue };
+
+			Assert.AreEqual(2, valueChange1Count, "#2.1");
+			Assert.AreEqual(2, valueChange2Count, "#2.2");
+
+			// remove the first handler and ensure the second one is still active
+			childBinding.DataValueChanged -= ValueChanged1;
+
+			item.Child.Color = Colors.Yellow;
+
+			// only hooked up to the second handler
+			Assert.AreEqual(2, valueChange1Count, "#3.1");
+			Assert.AreEqual(3, valueChange2Count, "#3.2");
+
+			item.Child = new TestObject { Color = Colors.White };
+
+			Assert.AreEqual(2, valueChange1Count, "#4.1");
+			Assert.AreEqual(4, valueChange2Count, "#4.2");
+
+			childBinding.DataValueChanged -= ValueChanged2;
+
+			item.Child.Color = Colors.Tomato;
+			item.Child = new TestObject { Color = Colors.Wheat };
+
+			// no changes as nothing should be hooked up
+			Assert.AreEqual(2, valueChange1Count, "#5.1");
+			Assert.AreEqual(4, valueChange2Count, "#5.2");
+
 		}
 	}
 }


### PR DESCRIPTION
When using `IndirectBinding.Child<T>`, it would only work if the binding is used in one spot.  This enables you to reuse the same indirect binding for different controls.

Also in this PR:
- Add MaskedTextBox/MaskedTextStepper.ShowPromptMode
- Remember unit test filter between sessions