### PR TITLE
Wpf/WinForms: FontDialog updates

### DIFF
--- a/src/Eto.WinForms/Forms/FontDialogHandler.cs
+++ b/src/Eto.WinForms/Forms/FontDialogHandler.cs
@@ -9,7 +9,7 @@ namespace Eto.WinForms.Forms
 {
 	public class FontDialogHandler : WidgetHandler<swf.FontDialog, FontDialog, FontDialog.ICallback>, FontDialog.IHandler
 	{
-		Font font;
+		Font _font;
 
 		public FontDialogHandler()
 		{
@@ -20,37 +20,48 @@ namespace Eto.WinForms.Forms
 			};
 		}
 
-		public override void AttachEvent (string id)
+		public override void AttachEvent(string id)
 		{
-			switch (id) {
-			case FontDialog.FontChangedEvent:
-				// handled in ShowDialog
-				break;
-			default:
-				base.AttachEvent (id);
-				break;
+			switch (id)
+			{
+				case FontDialog.FontChangedEvent:
+					Control.ShowApply = true;
+					Control.Apply += Control_Apply;
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
 			}
+		}
+
+		private void Control_Apply(object sender, EventArgs e)
+		{
+			_font = null;
+			Callback.OnFontChanged(Widget, EventArgs.Empty);
 		}
 
 		public Font Font
 		{
-			get {
-				if (font == null)
-					font = new Font(new FontHandler(Control.Font));
-				return font;
+			get
+			{
+				if (_font == null)
+					_font = Control.Font.ToEto();
+				return _font;
 			}
-			set {
-				font = value;
-				Control.Font = font.ToSD ();
+			set
+			{
+				_font = value;
+				Control.Font = _font.ToSD();
+				Callback.OnFontChanged(Widget, EventArgs.Empty);
 			}
 		}
 
-		public DialogResult ShowDialog (Window parent)
+		public DialogResult ShowDialog(Window parent)
 		{
 			var result = Control.ShowDialog();
 			if (result == swf.DialogResult.OK)
 			{
-				font = Control.Font.ToEto();
+				_font = null;
 				Callback.OnFontChanged(Widget, EventArgs.Empty);
 				return DialogResult.Ok;
 			}

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -151,6 +151,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
   <ItemGroup>
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" PrivateAssets="all" />
     <PackageReference Include="Windows7APICodePack-Shell" Version="1.1.0" PrivateAssets="all" />
+	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
   </ItemGroup>
 
   <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/src/Eto.Wpf/Forms/FontDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/FontDialogHandler.cs
@@ -1,15 +1,26 @@
 using Eto.Drawing;
 using Eto.Forms;
+using Eto.Wpf.CustomControls.FontDialog;
 using Eto.Wpf.Drawing;
 using System;
 
 using sw = System.Windows;
 namespace Eto.Wpf.Forms
 {
-	public class FontDialogHandler : WidgetHandler<CustomControls.FontDialog.FontChooser, FontDialog, FontDialog.ICallback>, FontDialog.IHandler
+	public class FontDialogHandler : WidgetHandler<FontChooser, FontDialog, FontDialog.ICallback>, FontDialog.IHandler
 	{
+		Font _font;
+		static readonly object DisableFontChanged_Key = new object();
+
+		int DisableFontChanged
+		{
+			get => Widget.Properties.Get<int>(DisableFontChanged_Key);
+			set => Widget.Properties.Set(DisableFontChanged_Key, value);
+		}
+
 		public FontDialogHandler()
 		{
+			Control = new FontChooser();
 		}
 
 		public override void AttachEvent(string id)
@@ -17,7 +28,11 @@ namespace Eto.Wpf.Forms
 			switch (id)
 			{
 				case FontDialog.FontChangedEvent:
-					// handled during showdialog
+					Widget.Properties.Set(FontChooser.SelectedFontFamilyProperty, PropertyChangeNotifier.Register(FontChooser.SelectedFontFamilyProperty, FontChanged, Control));
+					Widget.Properties.Set(FontChooser.SelectedFontSizeProperty, PropertyChangeNotifier.Register(FontChooser.SelectedFontSizeProperty, FontChanged, Control));
+					Widget.Properties.Set(FontChooser.SelectedFontStretchProperty, PropertyChangeNotifier.Register(FontChooser.SelectedFontStretchProperty, FontChanged, Control));
+					Widget.Properties.Set(FontChooser.SelectedFontStyleProperty, PropertyChangeNotifier.Register(FontChooser.SelectedFontStyleProperty, FontChanged, Control));
+					Widget.Properties.Set(FontChooser.SelectedFontWeightProperty, PropertyChangeNotifier.Register(FontChooser.SelectedFontWeightProperty, FontChanged, Control));
 					break;
 				default:
 					base.AttachEvent(id);
@@ -25,42 +40,79 @@ namespace Eto.Wpf.Forms
 			}
 		}
 
+		private void FontChanged(object sender, EventArgs e)
+		{
+			if (DisableFontChanged > 0)
+				return;
+
+			if (IsChanged(_font))
+			{
+				_font = null;
+				Callback.OnFontChanged(Widget, EventArgs.Empty);
+			}
+		}
+
 		public Font Font
 		{
-			get;
-			set;
+			get => _font ?? (_font = GetFont());
+			set
+			{
+				if (!ReferenceEquals(_font, value))
+				{
+					_font = value;
+					if (_font?.Handler is FontHandler fontHandler && IsChanged(_font))
+					{
+						DisableFontChanged++;
+						Control.SelectedFontFamily = fontHandler.WpfFamily;
+						Control.SelectedFontPointSize = fontHandler.Size;
+						Control.SelectedFontStyle = fontHandler.WpfFontStyle;
+						Control.SelectedFontWeight = fontHandler.WpfFontWeight;
+						Control.SelectedFontStretch = fontHandler.WpfFontStretch;
+						DisableFontChanged--;
+						Callback.OnFontChanged(Widget, EventArgs.Empty);
+					}
+				}
+			}
+		}
+
+		private bool IsChanged(Font font)
+		{
+			if (font?.Handler is FontHandler fontHandler)
+			{
+				return Control.SelectedFontFamily?.Source != fontHandler.WpfFamily?.Source
+				|| Control.SelectedFontPointSize != fontHandler.Size
+				|| Control.SelectedFontStyle != fontHandler.WpfFontStyle
+				|| Control.SelectedFontWeight != fontHandler.WpfFontWeight
+				|| Control.SelectedFontStretch != fontHandler.WpfFontStretch;
+			}
+			return true;
+		}
+
+		Font GetFont()
+		{
+			var fontHandler = new FontHandler(Control.SelectedFontFamily, Control.SelectedFontPointSize, Control.SelectedFontStyle, Control.SelectedFontWeight, Control.SelectedFontStretch);
+			return new Font(fontHandler);
 		}
 
 		public DialogResult ShowDialog(Window parent)
 		{
-			Control = new CustomControls.FontDialog.FontChooser();
-			
 			if (parent != null)
 			{
 				var owner = parent.ControlObject as sw.Window;
 				Control.Owner = owner;
 				Control.WindowStartupLocation = sw.WindowStartupLocation.CenterOwner;
 			}
+			var lastFont = Font;
 
-			if (Font?.Handler is FontHandler fontHandler)
-			{
-				Control.SelectedFontFamily = fontHandler.WpfFamily;
-				Control.SelectedFontPointSize = fontHandler.Size;
-				Control.SelectedFontStyle = fontHandler.WpfFontStyle;
-				Control.SelectedFontWeight = fontHandler.WpfFontWeight;
-				Control.SelectedFontStretch = fontHandler.WpfFontStretch;
-			}
 			var result = Control.ShowDialog();
 
-			if (result == true)
+			if (result != true)
 			{
-				fontHandler = new FontHandler(Control.SelectedFontFamily, Control.SelectedFontPointSize, Control.SelectedFontStyle, Control.SelectedFontWeight, Control.SelectedFontStretch);
-				Font = new Font(fontHandler);
-				Callback.OnFontChanged(Widget, EventArgs.Empty);
-				return DialogResult.Ok;
+				// restore to original font when cancelled.
+				Font = lastFont;
 			}
 
-			return DialogResult.Cancel;
+			return result == true ? DialogResult.Ok : DialogResult.Cancel;
 		}
 	}
 }


### PR DESCRIPTION
This makes it so the FontChanged event fires while changing the font, not only after the user clicks Ok.

On WinForms, it adds the Apply button so you can apply the selected font while the dialog is shown.