### PR TITLE
Hotfix for Application.Instance.Open(url) not working in .net core

### DIFF
--- a/src/Eto.Gtk/Forms/ApplicationHandler.cs
+++ b/src/Eto.Gtk/Forms/ApplicationHandler.cs
@@ -222,8 +222,7 @@ namespace Eto.GtkSharp.Forms
 
 		public void Open(string url)
 		{
-			var info = new ProcessStartInfo(url);
-			Process.Start(info);
+			Process.Start(new ProcessStartInfo("https://www.google.com") { UseShellExecute = true });
 		}
 
 		public Keys CommonModifier { get { return Keys.Control; } }

--- a/src/Eto.Gtk/Forms/ApplicationHandler.cs
+++ b/src/Eto.Gtk/Forms/ApplicationHandler.cs
@@ -222,7 +222,7 @@ namespace Eto.GtkSharp.Forms
 
 		public void Open(string url)
 		{
-			Process.Start(new ProcessStartInfo("https://www.google.com") { UseShellExecute = true });
+			Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
 		}
 
 		public Keys CommonModifier { get { return Keys.Control; } }

--- a/src/Eto.WinForms/Forms/ApplicationHandler.cs
+++ b/src/Eto.WinForms/Forms/ApplicationHandler.cs
@@ -216,8 +216,7 @@ namespace Eto.WinForms.Forms
 
 		public void Open(string url)
 		{
-			var info = new ProcessStartInfo(url);
-			Process.Start(info);
+		    Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
 		}
 
 		public override void AttachEvent(string id)

--- a/src/Eto.Wpf/Forms/ApplicationHandler.cs
+++ b/src/Eto.Wpf/Forms/ApplicationHandler.cs
@@ -210,7 +210,7 @@ namespace Eto.Wpf.Forms
 
 		public void Open(string url)
 		{
-			Process.Start(url);
+			Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
 		}
 
 		public void Run()


### PR DESCRIPTION
This is a small hotfix for `Application.Instance.Open()` not working when fed a URL on WPF, WinForms, and GTK with .net core.

The bug results from a breaking change in .NET Core, where `UseShellExecute` is `false` by default, as opposed to `true` on .net framework ([source](https://github.com/dotnet/core/issues/4109#issuecomment-573307566)). This pull request explicitly sets it to true, ensuring that it'll work no matter the framework.

