### PR TITLE
Fix PixelFormat.Format32bppRgb

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -32,5 +32,15 @@
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
         },
+        {
+            "name": "Eto.Test.WinForms",
+			"type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "build-winforms",
+            "program": "${workspaceFolder}/artifacts/test/Debug/netcoreapp3.1/Eto.Test.WinForms.exe",
+            "args": [],
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
+        }
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -60,6 +60,20 @@
 			"problemMatcher": "$msCompile"
 		},
 		{
+			"label": "build-winforms",
+			"command": "dotnet",
+			"type": "process",
+			"args": [
+				"build",
+				"/v:Minimal",
+				"/p:Configuration=Debug",
+				"/p:TargetFramework=netcoreapp3.1",
+				"${workspaceFolder}/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj"
+			],
+			"group": "build",
+			"problemMatcher": "$msCompile"
+		},
+		{
 			"label": "restore",
 			"command": "dotnet",
 			"type": "process",

--- a/src/Eto.Gtk/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Gtk/Drawing/GraphicsHandler.cs
@@ -119,6 +119,7 @@ namespace Eto.GtkSharp.Drawing
 			surface = handler.Surface;
 			if (surface == null)
 			{
+				handler.FixupAlpha();
 				var format = handler.Alpha ? Cairo.Format.Argb32 : Cairo.Format.Rgb24;
 				surface = new Cairo.ImageSurface(format, image.Size.Width, image.Size.Height);
 				Control = new Cairo.Context(surface);
@@ -553,12 +554,16 @@ namespace Eto.GtkSharp.Drawing
 #if !GTK2
 		public static bool GetClipRectangle(Cairo.Context cr, ref Gdk.Rectangle rect)
 		{
+#if GTKCORE
+			return Gdk.CairoHelper.GetClipRectangle(cr, out rect);
+#else
 			IntPtr intPtr = Marshaller.StructureToPtrAlloc(rect);
 			bool flag = NativeMethods.gdk_cairo_get_clip_rectangle((cr != null) ? cr.Handle : IntPtr.Zero, intPtr);
 			bool result = flag;
 			rect = (Gdk.Rectangle)Marshal.PtrToStructure(intPtr, typeof(Gdk.Rectangle));
 			Marshal.FreeHGlobal(intPtr);
 			return result;
+#endif
 		}
 #endif
 

--- a/src/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
@@ -13,8 +13,15 @@ namespace Eto.GtkSharp.Forms.Controls
 		public NumericStepperHandler()
 		{
 			Control = new Gtk.SpinButton(double.MinValue, double.MaxValue, 1);
-			Control.WidthChars = 0;
+			Control.WidthChars = 5; // default to show 5 characters
 			Value = 0;
+		}
+
+		protected override void SetSize(Size size)
+		{
+			// if a width is set, we allow it to shrink as small as possible..
+			Control.WidthChars = size.Width > 0 ? 0 : 5;
+			base.SetSize(size);
 		}
 
 		static readonly object SuppressValueChanged_Key = new object();

--- a/src/Eto.Gtk/Forms/GtkPanel.cs
+++ b/src/Eto.Gtk/Forms/GtkPanel.cs
@@ -83,6 +83,7 @@ namespace Eto.GtkSharp.Forms
 			{
 				Widget.Properties.Set(GtkPanel.MinimumSize_Key, value);
 				ContainerControl.QueueResize();
+				SetSize(UserPreferredSize);
 			}
 		}
 

--- a/src/Eto.Wpf/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Wpf/Drawing/GraphicsHandler.cs
@@ -350,7 +350,7 @@ namespace Eto.Wpf.Drawing
 			}
 		}
 
-		bool Close()
+		unsafe bool Close()
 		{
 			CloseGroup();
 			if (image != null)
@@ -360,7 +360,23 @@ namespace Eto.Wpf.Drawing
 				var bmp = image.ToWpf();
 				var newbmp = new swmi.RenderTargetBitmap(bmp.PixelWidth, bmp.PixelHeight, bmp.DpiX, bmp.DpiY, swm.PixelFormats.Pbgra32);
 				newbmp.RenderWithCollect(visual);
-				handler.SetBitmap(newbmp);
+				if (!bmp.Format.HasAlpha())
+				{
+					// convert to non-alpha, as RenderTargetBitmap does not support anything other than Pbgra32
+					var wb = new swmi.WriteableBitmap(bmp.PixelWidth, bmp.PixelWidth, bmp.DpiX, bmp.DpiY, swm.PixelFormats.Bgr32, null);
+					var rect = new sw.Int32Rect(0, 0, bmp.PixelWidth, bmp.PixelHeight);
+					var pixels = new byte[bmp.PixelHeight * wb.BackBufferStride];
+					newbmp.CopyPixels(rect, pixels, wb.BackBufferStride, 0);
+					fixed (byte* ptr = pixels)
+					{
+						wb.WritePixels(rect, (IntPtr)ptr, pixels.Length, wb.BackBufferStride, 0, 0);
+					}
+					handler.SetBitmap(wb);
+				}
+				else
+				{
+					handler.SetBitmap(newbmp);
+				}
 				return true;
 			}
 			return false;

--- a/src/Eto.Wpf/WpfConversions.cs
+++ b/src/Eto.Wpf/WpfConversions.cs
@@ -915,5 +915,14 @@ namespace Eto.Wpf
 		}
 
 		public static swi.Cursor ToWpf(this Cursor cursor) => cursor?.ControlObject as swi.Cursor;
+
+		public static bool HasAlpha(this swm.PixelFormat format)
+		{
+			return format == swm.PixelFormats.Pbgra32
+				|| format == swm.PixelFormats.Prgba128Float
+				|| format == swm.PixelFormats.Prgba64
+				|| format == swm.PixelFormats.Rgba64
+				|| format == swm.PixelFormats.Rgba64;
+		}
 	}
 }

--- a/test/Eto.Test/Sections/Drawing/BitmapSection.cs
+++ b/test/Eto.Test/Sections/Drawing/BitmapSection.cs
@@ -84,17 +84,20 @@ namespace Eto.Test.Sections.Drawing
 			return new DrawableImageView { Image = image };
 		}
 
-		void DrawTest(Bitmap image)
+		void DrawTest(Bitmap image, bool clearAlpha)
 		{
 			// should always ensure .Dispose() is called when you are done with a Graphics or BitmapData object.
+
+			Color Fix(Color color) => clearAlpha ? new Color(color, 0) : color;
 
 			// Test setting pixels directly
 			using (var bd = image.Lock())
 			{
+				var color = Fix(Colors.Green);
 				var sz = image.Size / 5;
 				for (int x = sz.Width; x < sz.Width * 2; x++)
 					for (int y = sz.Height; y < sz.Height * 2; y++)
-						bd.SetPixel(x, y, Colors.Green);
+						bd.SetPixel(x, y, color);
 			}
 
 			// Test using Graphics object
@@ -108,39 +111,40 @@ namespace Eto.Test.Sections.Drawing
 			using (var bd = image.Lock())
 			{
 				var sz = image.Size / 5;
+				var color = Fix(Colors.Red);
 				for (int x = sz.Width * 3; x < sz.Width * 4; x++)
 					for (int y = sz.Height * 3; y < sz.Height * 4; y++)
-						bd.SetPixel(x, y, Colors.Red);
+						bd.SetPixel(x, y, color);
 			}
 
 		}
 
 		Control CreateCustom24()
 		{
-			var size = new Size(100, 100) * (int)Screen.PrimaryScreen.LogicalPixelSize;
+			var size = Size.Round(new SizeF(100, 100) * Screen.PrimaryScreen.LogicalPixelSize);
 			var image = new Bitmap(size, PixelFormat.Format24bppRgb);
 
-			DrawTest(image);
+			DrawTest(image, true);
 
 			return new DrawableImageView { Image = new Icon(Screen.PrimaryScreen.LogicalPixelSize, image) };
 		}
 
 		Control CreateCustom32()
 		{
-			var size = new Size(100, 100) * (int)Screen.PrimaryScreen.LogicalPixelSize;
+			var size = Size.Round(new SizeF(100, 100) * Screen.PrimaryScreen.LogicalPixelSize);
 			var image = new Bitmap(size, PixelFormat.Format32bppRgb);
 
-			DrawTest(image);
+			DrawTest(image, true);
 
 			return new DrawableImageView { Image = new Icon(Screen.PrimaryScreen.LogicalPixelSize, image) };
 		}
 
 		Control CreateCustom32Alpha()
 		{
-			var size = new Size(100, 100) * (int)Screen.PrimaryScreen.LogicalPixelSize;
+			var size = Size.Round(new SizeF(100, 100) * Screen.PrimaryScreen.LogicalPixelSize);
 			var image = new Bitmap(size, PixelFormat.Format32bppRgba);
 
-			DrawTest(image);
+			DrawTest(image, false);
 			return new DrawableImageView { Image = new Icon(Screen.PrimaryScreen.LogicalPixelSize, image) };
 		}
 
@@ -180,7 +184,7 @@ namespace Eto.Test.Sections.Drawing
 		{
 			var image64 = TestIcons.Textures;
 
-			var size = new Size(105, 105) * (int)Screen.PrimaryScreen.LogicalPixelSize;
+			var size = Size.Round(new SizeF(105, 105) * Screen.PrimaryScreen.LogicalPixelSize);
 			var bitmap = new Bitmap(size, PixelFormat.Format32bppRgba);
 			using (var g = new Graphics(bitmap))
 			{


### PR DESCRIPTION
This fixes issues when using non-alpha pixel format when creating a bitmap and using Lock() or a Graphics object to draw to it.

Other changes included:
- Gtk3: MinimumSize should now work
- Gtk3: NumericStepper should show some characters by default if no width is set
- WinForms is added to VSCode launch/tasks

Fixes #1458