### PR TITLE
Wpf: Fix huge performance penalty using Graphics on many Bitmaps

### DIFF
--- a/src/Eto.Wpf/WpfExtensions.cs
+++ b/src/Eto.Wpf/WpfExtensions.cs
@@ -330,7 +330,11 @@ namespace Eto.Wpf
 			// fix memory leak with RenderTargetBitmap.  See http://stackoverflow.com/questions/14786490/wpf-memory-leak-using-rendertargetbitmap
 			// Reproducible with the 
 			// GC.Collect alone seems to fix the issue.  Adding GC.WaitForPendingFinalizers may impact performance.
-			GC.Collect();
+			
+			// Note: this may no longer be an issue with the latest version of .NET after some testing, however
+			// we keep it here to keep memory in check, but instead make it non-blocking so it doesn't cause a huge
+			// performance penalty creating many Bitmaps with a Graphics object.
+			GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, false);
 		}
 
 

--- a/test/Eto.Test.Wpf/UnitTests/BitmapTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/BitmapTests.cs
@@ -1,0 +1,31 @@
+using System;
+using System.Diagnostics;
+using Eto.Drawing;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+
+namespace Eto.Test.Wpf.UnitTests
+{
+	[TestFixture]
+	public class BitmapTests : TestBase
+	{
+		[Test, Timeout(1000)]
+		public void CreatingManySmallBitmapsShouldBeFast()
+		{
+			var sw = new Stopwatch();
+			sw.Start();
+			for (int i = 0; i < 100; i++)
+			{
+				var bmp = new Bitmap(20, 20, PixelFormat.Format32bppRgba);
+
+				using (var g = new Graphics(bmp))
+				{
+					g.Clear(Colors.Blue);
+				}
+			}
+			sw.Stop();
+			Console.WriteLine($"Total time: {sw.Elapsed}");
+		}
+
+	}
+}


### PR DESCRIPTION
When trying to create many bitmaps using the Graphics object it can be very slow due to the GC.Collect() required to eliminate memory leaks.  This change makes the GC.Collect non-blocking so that it goes muuuuuch faster.