### PR TITLE
Mac fixes and auto-load platform assemblies when subclassed

### DIFF
--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -580,8 +580,14 @@ namespace Eto.Mac.Forms
 			set
 			{
 				var oldFrame = Control.Frame;
-				var newFrame = oldFrame.SetSize(value);
-				newFrame.Y = (nfloat)Math.Max(0, oldFrame.Y - (value.Height - oldFrame.Height));
+				var newFrame = oldFrame;
+				if (value.Width >= 0)
+					newFrame.Width = value.Width;
+				if (value.Height > 0)
+				{
+					newFrame.Height = value.Height;
+					newFrame.Y = (nfloat)Math.Max(0, oldFrame.Y - (value.Height - oldFrame.Height));
+				}
 				Control.SetFrame(newFrame, true);
 				UserPreferredSize = value;
 				SetAutoSize();

--- a/src/Eto.Mac/build/BundleDotNetCore.targets
+++ b/src/Eto.Mac/build/BundleDotNetCore.targets
@@ -63,7 +63,7 @@
   <Target Name="MacBuildAppBundleWithoutRuntime" AfterTargets="AfterBuild" Condition="$(MacBundleDotNet) != 'True' AND $(MacIsBuildingBundle) == 'True'" DependsOnTargets="MacInitializeBundle;MacCollectExecutableFiles">
 
     <!-- copy executable files -->
-    <Copy SourceFiles="@(MacExecutableFiles)" DestinationFiles="$(LauncherPath)%(MacExecutableFiles.TargetPath)" />
+    <Copy SourceFiles="@(MacExecutableFiles)" DestinationFiles="@(MacExecutableFiles->'$(LauncherPath)%(TargetPath)')" />
 
     <!-- finish building the bundle -->
     <CallTarget Targets="MacFinishBundle" />

--- a/src/Eto.Mac/build/BundleMono.targets
+++ b/src/Eto.Mac/build/BundleMono.targets
@@ -165,7 +165,7 @@
     </ItemGroup>
 
     <!-- copy executable files -->
-    <Copy SourceFiles="@(MacExecutableFiles)" DestinationFiles="$(OutputMonoBundlePath)%(MacExecutableFiles.TargetPath)" />
+    <Copy SourceFiles="@(MacExecutableFiles)" DestinationFiles="@(MacExecutableFiles->'$(OutputMonoBundlePath)%(TargetPath)')" />
   </Target>
   
   


### PR DESCRIPTION
- Mac: Fix setting width/height of window after it is loaded.  This was a regression from earlier versions.
- Mac: Fix .app bundle errors when using msbuild on mono
- Auto-load handler type assembly if not found in platform, which fixes auto-loading subclasses when they are in a different assembly as the type with the handler