### PR TITLE
Fix opening links on recent mono versions

### DIFF
--- a/src/Eto.Gtk/Forms/ApplicationHandler.cs
+++ b/src/Eto.Gtk/Forms/ApplicationHandler.cs
@@ -222,7 +222,16 @@ namespace Eto.GtkSharp.Forms
 
 		public void Open(string url)
 		{
-			Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+			try
+			{
+				Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
+			}
+			catch
+			{
+				// Use fallback for recent mono versions that do not support UseShellExecute.
+				url = Uri.EscapeUriString(url);
+				Process.Start("xdg-open", url);
+			}
 		}
 
 		public Keys CommonModifier { get { return Keys.Control; } }


### PR DESCRIPTION
Fixes #1700 and #1697, at least for Gtk. The EscapeUri call is for URLs conatining special characters such as spaces, which works with UseShellExecute, but not _directly_ with `xdg-open`.