### PR TITLE
Mac: Fix using ImageTextCell on macOS 10.9

### DIFF
--- a/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
@@ -174,8 +174,7 @@ namespace Eto.Mac.Forms.Cells
 				Selectable = false,
 				DrawsBackground = false,
 				Bezeled = false,
-				Bordered = false,
-				UsesSingleLineMode = false
+				Bordered = false
 			};
 
 			public EtoLabelFieldCell TextCell => (EtoLabelFieldCell)TextField.Cell;


### PR DESCRIPTION
No need to set UsesSingleLineMode on the EtoCellTextField as it is already being set on the NSCell which is supported in 10.6.

Fixes #1623