### PR TITLE
Support LinearGradientBrush with a rectangle

### DIFF
--- a/src/Eto.Direct2D/Drawing/LinearGradientBrushHandler.cs
+++ b/src/Eto.Direct2D/Drawing/LinearGradientBrushHandler.cs
@@ -44,17 +44,8 @@ namespace Eto.Direct2D.Drawing
 
 		public object Create(RectangleF rectangle, Color startColor, Color endColor, float angle)
 		{
-			var matrix = new MatrixHandler();
-			var startPoint = rectangle.Location;
-			matrix.RotateAt(angle - 45, startPoint.X, startPoint.Y);
-			var endPoint = matrix.TransformPoint(rectangle.EndLocation);
-			return new LinearBrushData
-			{
-				StartColor = startColor,
-				EndColor = endColor,
-				StartPoint = startPoint,
-				EndPoint = endPoint
-			};
+			GradientHelper.GetLinearFromRectangle(rectangle, angle, out var startPoint, out var endPoint);
+			return Create(startColor, endColor, startPoint, endPoint);
 		}
 
 		public IMatrix GetTransform(LinearGradientBrush widget)

--- a/src/Eto.Direct2D/Eto.Direct2D.csproj
+++ b/src/Eto.Direct2D/Eto.Direct2D.csproj
@@ -46,6 +46,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
     <Compile Include="..\Eto.Mac\Drawing\SplineHelper.cs">
       <Link>Drawing\SplineHelper.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\GradientHelper.cs" />
     <Compile Include="..\Eto.WinForms\Win32.gdi.cs" Link="Win32.gdi.cs" />
   </ItemGroup>
   

--- a/src/Eto.Gtk/Drawing/LinearGradientBrushHandler.cs
+++ b/src/Eto.Gtk/Drawing/LinearGradientBrushHandler.cs
@@ -33,7 +33,8 @@ namespace Eto.GtkSharp.Drawing
 
 		public object Create(RectangleF rectangle, Color startColor, Color endColor, float angle)
 		{
-			throw new NotImplementedException();
+			GradientHelper.GetLinearFromRectangle(rectangle, angle, out var startPoint, out var endPoint);
+			return Create(startColor, endColor, startPoint, endPoint);
 		}
 
 		public IMatrix GetTransform(LinearGradientBrush widget)

--- a/src/Eto.Gtk/Eto.Gtk.csproj
+++ b/src/Eto.Gtk/Eto.Gtk.csproj
@@ -44,6 +44,9 @@ When building for the full framework, .NET Framework 4.6.1 or mono framework 5.1
     <Compile Include="..\Shared\BaseBitmapData.cs">
       <Link>Drawing\BaseBitmapData.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\GradientHelper.cs">
+      <Link>GradientHelper.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <None Update="NativeMethods.tt">

--- a/src/Eto.Gtk/Eto.Gtk2.csproj
+++ b/src/Eto.Gtk/Eto.Gtk2.csproj
@@ -69,6 +69,9 @@ On Linux, mono-complete 5.10 or higher and gtk-sharp2 packages are required.
     <Compile Include="..\Shared\BaseBitmapData.cs">
       <Link>Drawing\BaseBitmapData.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\GradientHelper.cs">
+      <Link>GradientHelper.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eto\Eto.csproj" />

--- a/src/Eto.Gtk/Eto.Gtk3.csproj
+++ b/src/Eto.Gtk/Eto.Gtk3.csproj
@@ -82,6 +82,9 @@ On Linux, mono framework 5.10 or higher and gtk-sharp3 are required.
     <Compile Include="..\Shared\BaseBitmapData.cs">
       <Link>Drawing\BaseBitmapData.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\GradientHelper.cs">
+      <Link>GradientHelper.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eto\Eto.csproj" />

--- a/src/Eto.Mac/Drawing/LinearGradientBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/LinearGradientBrushHandler.cs
@@ -144,13 +144,8 @@ namespace Eto.iOS.Drawing
 
 		public object Create(RectangleF rectangle, Color startColor, Color endColor, float angle)
 		{
-			return new BrushObject
-			{
-				StartColor = startColor.ToCG(),
-				EndColor = endColor.ToCG(),
-				StartPoint = rectangle.TopLeft,
-				EndPoint = rectangle.TopRight // TODO
-			};
+			GradientHelper.GetLinearFromRectangle(rectangle, angle, out var startPoint, out var endPoint);
+			return Create(startColor, endColor, startPoint, endPoint);
 		}
 
 		public IMatrix GetTransform(LinearGradientBrush widget)

--- a/src/Eto.WinForms/Drawing/LinearGradientBrushHandler.cs
+++ b/src/Eto.WinForms/Drawing/LinearGradientBrushHandler.cs
@@ -130,7 +130,8 @@ namespace Eto.WinForms.Drawing
 
 		public object Create(RectangleF rectangle, Color startColor, Color endColor, float angle)
 		{
-			return null;
+			GradientHelper.GetLinearFromRectangle(rectangle, angle, out var startPoint, out var endPoint);
+			return Create(startColor, endColor, startPoint, endPoint);
 		}
 
 		public IMatrix GetTransform(LinearGradientBrush widget)

--- a/src/Eto.Wpf/Drawing/LinearGradientBrushHandler.cs
+++ b/src/Eto.Wpf/Drawing/LinearGradientBrushHandler.cs
@@ -25,15 +25,8 @@ namespace Eto.Wpf.Drawing
 
 		public object Create(RectangleF rectangle, Color startColor, Color endColor, float angle)
 		{
-			var matrix = swm.Matrix.Identity;
-			var startPoint = rectangle.Location.ToWpf();
-			matrix.RotateAtPrepend(angle - 45, startPoint.X, startPoint.Y);
-			var endPoint = matrix.Transform(rectangle.EndLocation.ToWpf());
-			return new FrozenBrushWrapper(new swm.LinearGradientBrush(startColor.ToWpf(), endColor.ToWpf(), startPoint, endPoint)
-			{
-				MappingMode = swm.BrushMappingMode.Absolute,
-				SpreadMethod = swm.GradientSpreadMethod.Pad
-			});
+			GradientHelper.GetLinearFromRectangle(rectangle, angle, out var startPoint, out var endPoint);
+			return Create(startColor, endColor, startPoint, endPoint);
 		}
 
 		public IMatrix GetTransform(LinearGradientBrush widget)

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -103,6 +103,9 @@ You do not need to use any of the classes of this assembly (unless customizing t
     <Compile Include="..\Shared\Conversions.cs">
       <Link>Conversions.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\GradientHelper.cs">
+      <Link>GradientHelper.cs</Link>
+    </Compile>
     <Compile Include="..\Shared\FixedMaskedTextProviderHandler.cs">
       <Link>Forms\FixedMaskedTextProviderHandler.cs</Link>
     </Compile>

--- a/src/Eto/Drawing/LinearGradientBrush.cs
+++ b/src/Eto/Drawing/LinearGradientBrush.cs
@@ -75,7 +75,7 @@ namespace Eto.Drawing
 		public LinearGradientBrush(Color startColor, Color endColor, PointF startPoint, PointF endPoint)
 		{
 			handler = Platform.Instance.LinearGradientBrushHandler;
-			ControlObject = handler.Create (startColor, endColor, startPoint, endPoint);
+			ControlObject = handler.Create(startColor, endColor, startPoint, endPoint);
 		}
 
 		/// <summary>
@@ -84,11 +84,11 @@ namespace Eto.Drawing
 		/// <param name="rectangle">Rectangle to define the area of the gradient</param>
 		/// <param name="startColor">Start color for the gradient</param>
 		/// <param name="endColor">End color for the gradient</param>
-		/// <param name="angle">Angle of the gradient</param>
+		/// <param name="angle">Angle of the gradient, in degrees</param>
 		public LinearGradientBrush(RectangleF rectangle, Color startColor, Color endColor, float angle)
 		{
 			handler = Platform.Instance.LinearGradientBrushHandler;
-			ControlObject = handler.Create (rectangle, startColor, endColor, angle);
+			ControlObject = handler.Create(rectangle, startColor, endColor, angle);
 		}
 
 		/// <summary>
@@ -97,8 +97,8 @@ namespace Eto.Drawing
 		/// <value>The transform to apply to the gradient</value>
 		public IMatrix Transform
 		{
-			get { return handler.GetTransform (this); }
-			set { handler.SetTransform (this, value); }
+			get { return handler.GetTransform(this); }
+			set { handler.SetTransform(this, value); }
 		}
 
 		/// <summary>
@@ -107,8 +107,8 @@ namespace Eto.Drawing
 		/// <value>The wrap mode for the gradient</value>
 		public GradientWrapMode Wrap
 		{
-			get { return handler.GetGradientWrap (this); }
-			set { handler.SetGradientWrap (this, value); }
+			get { return handler.GetGradientWrap(this); }
+			set { handler.SetGradientWrap(this, value); }
 		}
 
 		#region Handler
@@ -128,7 +128,7 @@ namespace Eto.Drawing
 			/// <param name="startPoint">Start point.</param>
 			/// <param name="endPoint">End point.</param>
 			/// <returns>ControlObject for the brush</returns>
-			object Create (Color startColor, Color endColor, PointF startPoint, PointF endPoint);
+			object Create(Color startColor, Color endColor, PointF startPoint, PointF endPoint);
 
 			/// <summary>
 			/// Create the specified rectangle, startColor, endColor and angle.
@@ -138,35 +138,35 @@ namespace Eto.Drawing
 			/// <param name="endColor">End color.</param>
 			/// <param name="angle">Angle.</param>
 			/// <returns>ControlObject for the brush</returns>
-			object Create (RectangleF rectangle, Color startColor, Color endColor, float angle);
+			object Create(RectangleF rectangle, Color startColor, Color endColor, float angle);
 
 			/// <summary>
 			/// Gets the transform for the specified brush
 			/// </summary>
 			/// <returns>The current transform for the specified brush</returns>
 			/// <param name="widget">Brush to get the transform</param>
-			IMatrix GetTransform (LinearGradientBrush widget);
+			IMatrix GetTransform(LinearGradientBrush widget);
 
 			/// <summary>
 			/// Sets the transform for the specified brush
 			/// </summary>
 			/// <param name="widget">Brush to set the transform</param>
 			/// <param name="transform">Transform to set to the brush</param>
-			void SetTransform (LinearGradientBrush widget, IMatrix transform);
+			void SetTransform(LinearGradientBrush widget, IMatrix transform);
 
 			/// <summary>
 			/// Gets the gradient wrap mode
 			/// </summary>
 			/// <returns>The gradient wrap mode for the brush</returns>
 			/// <param name="widget">Brush to get the gradient wrap mode</param>
-			GradientWrapMode GetGradientWrap (LinearGradientBrush widget);
+			GradientWrapMode GetGradientWrap(LinearGradientBrush widget);
 
 			/// <summary>
 			/// Sets the gradient wrap mode
 			/// </summary>
 			/// <param name="widget">Brush to set the wrap mode</param>
 			/// <param name="gradientWrap">Gradient wrap mode to set</param>
-			void SetGradientWrap (LinearGradientBrush widget, GradientWrapMode gradientWrap);
+			void SetGradientWrap(LinearGradientBrush widget, GradientWrapMode gradientWrap);
 		}
 
 		#endregion

--- a/src/Shared/GradientHelper.cs
+++ b/src/Shared/GradientHelper.cs
@@ -37,6 +37,39 @@ namespace Eto
 			return scale;
 		}
 
+		public static void GetLinearFromRectangle(RectangleF rectangle, float angle, out PointF min, out PointF max)
+		{
+			PointF startPoint;
+			PointF endPoint;
+			if (angle >= 0 && angle < 90)
+			{
+				startPoint = rectangle.TopLeft;
+				endPoint = rectangle.TopRight;
+			}
+			else if (angle >= 90 && angle < 180)
+			{
+				startPoint = rectangle.TopRight;
+				endPoint = rectangle.BottomRight;
+				angle -= 90;
+			}
+			else if (angle >= 180 && angle < 270)
+			{
+				startPoint = rectangle.BottomRight;
+				endPoint = rectangle.BottomLeft;
+				angle -= 180;
+			}
+			else
+			{
+				startPoint = rectangle.BottomLeft;
+				endPoint = rectangle.TopLeft;
+				angle -= 270;
+			}
+			var matrix = Matrix.Create();
+			matrix.RotateAt(angle, startPoint);
+			endPoint = matrix.TransformPoint(endPoint);
+			GradientHelper.GetLinearMinMax(startPoint, endPoint, rectangle, out min, out max);
+		}
+
 		public static void GetLinearMinMax(PointF startPoint, PointF endPoint, RectangleF rect, out PointF min, out PointF max, bool includeStartEnd = false)
 		{
 			var points = new List<PointF>

--- a/test/Eto.Test/UnitTests/Drawing/BrushTests.cs
+++ b/test/Eto.Test/UnitTests/Drawing/BrushTests.cs
@@ -54,5 +54,35 @@ namespace Eto.Test.UnitTests.Drawing
 			});
 		}
 
+		[Test]
+		public void LinearGradientBrushShouldFillWithRectangleAndAngle()
+		{
+			var bmp = new Bitmap(30, 30, PixelFormat.Format32bppRgba);
+			using (var g = new Graphics(bmp))
+			{
+				var brush = new LinearGradientBrush(
+					new Rectangle(0, 0, 100, 100),
+					Colors.Blue,
+					Colors.Green,
+					0);
+				GraphicsPath path = new GraphicsPath();
+				path.AddLines(new PointF(0, 0), new PointF(100, 100), new PointF(0, 100));
+				path.CloseFigure();
+				g.FillPath(brush, path);
+			}
+
+			// start out mostly blue
+			var startPixel = bmp.GetPixel(1, 2);
+			Assert.LessOrEqual(startPixel.Rb, 10, "#1.1");
+			Assert.LessOrEqual(startPixel.Gb, 10, "#1.2");
+			Assert.GreaterOrEqual(startPixel.Bb, 10, "#1.3");
+
+			// end mostly green
+			var endPixel = bmp.GetPixel(98, 99);
+			Assert.LessOrEqual(endPixel.Rb, 10, "#2.1");
+			Assert.GreaterOrEqual(endPixel.Gb, 80, "#2.2");
+			Assert.LessOrEqual(endPixel.Bb, 10, "#2.3");
+		}
+
 	}
 }


### PR DESCRIPTION
Creating a LinearGradientBrush with a Rectangle never worked on _any_ platform.  This implements the correct behaviour for all platforms.

Fixes #1645