### PR TITLE
Wpf: Don't escape file paths for DataObject.Uris

### DIFF
--- a/src/Eto.Wpf/Forms/DataObjectHandler.cs
+++ b/src/Eto.Wpf/Forms/DataObjectHandler.cs
@@ -201,7 +201,7 @@ namespace Eto.Wpf.Forms
 
 					// file uris
 					var files = new StringCollection();
-					files.AddRange(coll.Where(r => r.IsFile).Select(r => r.AbsolutePath).ToArray());
+					files.AddRange(coll.Where(r => r.IsFile).Select(r => r.LocalPath).ToArray());
 					if (files.Count > 0)
 					{
 						if (IsExtended)

--- a/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
@@ -369,7 +369,7 @@ namespace Eto.Test.Sections.Behaviors
 				sb.Append($"\n\tTypes: {string.Join(", ", data.Types)}");
 			var uris = data.Uris;
 			if (uris != null)
-				sb.Append($"\n\tUris: {string.Join(", ", uris.Select(r => r.AbsoluteUri))})");
+				sb.Append($"\n\tUris: {string.Join(", ", uris.Select(r => r.IsFile ? r.LocalPath : r.AbsoluteUri))})");
 			return sb.ToString();
 		}
 


### PR DESCRIPTION
Use LocalPath instead for files.  This makes it work the same when dragging from Explorer for both files on drives or UNC paths.

Fixes #1400