### PR TITLE
Mac Fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,7 +6,7 @@
             "type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-mac64",
-            "program": "${workspaceFolder}/artifacts/test/Debug/netcoreapp3.1/Eto.Test.Mac64.app/Contents/MacOS/Eto.Test.Mac64",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/netcoreapp3.1/Eto.Test.Mac64.app/Contents/MacOS/Eto.Test.Mac64",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
@@ -16,7 +16,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-gtk",
-            "program": "${workspaceFolder}/artifacts/test/Debug/netcoreapp3.1/Eto.Test.Gtk.dll",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/netcoreapp3.1/Eto.Test.Gtk.dll",
             "args": [],
             "console": "internalConsole",
             "stopAtEntry": false,
@@ -27,7 +27,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-wpf",
-            "program": "${workspaceFolder}/artifacts/test/Debug/netcoreapp3.1/Eto.Test.Wpf.exe",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/netcoreapp3.1/Eto.Test.Wpf.exe",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
@@ -37,7 +37,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-winforms",
-            "program": "${workspaceFolder}/artifacts/test/Debug/netcoreapp3.1/Eto.Test.WinForms.exe",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}e/netcoreapp3.1/Eto.Test.WinForms.exe",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,10 @@
 		"**/*.user": true,
 		"**/packages": true
 	},
-	"vssolution.trackActiveItem": true
+	"vssolution.trackActiveItem": true,
+	"var": {
+		"configuration" : "Debug",
+		"buildProperties" : "/v:Minimal /p:GenerateFullPaths=True /consoleLoggerParameters:NoSummary"
+	}
+
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,15 +3,11 @@
 	"tasks": [
 		{
 			"label": "build",
-			"command": "msbuild",
-			"windows": { "command": "build/msbuild.cmd" },
-			"type": "process",
-			"args": [
-				"/t:Build",
-				"/v:Minimal",
-				"/p:Configuration=${input:configuration}",
-				"${workspaceFolder}/build/Build.proj"
-			],
+			"command": "msbuild /t:Build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/build/Build.proj",
+			"windows": {
+				"command": "build/msbuild.cmd /t:Build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/build/Build.proj"
+			},
+			"type": "shell",
 			"problemMatcher": "$msCompile",
 			"group": {
 				"kind": "build",
@@ -20,81 +16,43 @@
 		},
 		{
 			"label": "build-gtk",
-			"command": "dotnet",
-			"type": "process",
-			"args": [
-				"build",
-				"/v:Minimal",
-				"/p:Configuration=Debug",
-				"/p:TargetFramework=netcoreapp3.1",
-				"${workspaceFolder}/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj"
-			],
+			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj",
+			"type": "shell",
 			"group": "build",
 			"problemMatcher": "$msCompile"
 		},
 		{
 			"label": "build-mac64",
-			"command": "msbuild",
-			"type": "process",
-			"args": [
-				"/v:Minimal",
-				"/p:Configuration=Debug",
-				"/p:TargetFramework=netcoreapp3.1",
-				"${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.Mac64.csproj"
-			],
+			"command": "msbuild ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.Mac64.csproj",
+			"type": "shell",
 			"group": "build",
 			"problemMatcher": "$msCompile"
 		},
 		{
 			"label": "build-wpf",
-			"command": "dotnet",
-			"type": "process",
-			"args": [
-				"build",
-				"/v:Minimal",
-				"/p:Configuration=Debug",
-				"/p:TargetFramework=netcoreapp3.1",
-				"${workspaceFolder}/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj"
-			],
+			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj",
+			"type": "shell",
 			"group": "build",
 			"problemMatcher": "$msCompile"
 		},
 		{
 			"label": "build-winforms",
-			"command": "dotnet",
-			"type": "process",
-			"args": [
-				"build",
-				"/v:Minimal",
-				"/p:Configuration=Debug",
-				"/p:TargetFramework=netcoreapp3.1",
-				"${workspaceFolder}/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj"
-			],
+			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj",
+			"type": "shell",
 			"group": "build",
 			"problemMatcher": "$msCompile"
 		},
 		{
 			"label": "restore",
-			"command": "dotnet",
-			"type": "process",
-			"args": [
-				"restore",
-				"/v:Minimal",
-				"${workspaceFolder}/src/Eto.sln"
-			],
+			"command": "dotnet restore /v:Minimal ${workspaceFolder}/src/Eto.sln",
+			"type": "shell",
 			"problemMatcher": "$msCompile"
-		}
-	],
-	"inputs": [
+		},
 		{
-			"id": "configuration",
-			"type": "pickString",
-			"default": "Debug",
-			"description": "Build Configuration",
-			"options": [
-				"Debug",
-				"Release"
-			]
+			"label": "echo value of configuration",
+			"type": "shell",
+			"command": "echo \"Current value of configuration is '${input:configuration}'.\"",
+			"problemMatcher": []
 		}
 	]
 }

--- a/src/Eto.Core.sln
+++ b/src/Eto.Core.sln
@@ -3,25 +3,25 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
 MinimumVisualStudioVersion = 15.0.26124.0
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto", "Eto\Eto.csproj", "{FE25EE53-3993-4463-AB8E-CCDCE5E3BDC2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto", "Eto\Eto.csproj", "{FE25EE53-3993-4463-AB8E-CCDCE5E3BDC2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Serialization.Json", "Eto.Serialization.Json\Eto.Serialization.Json.csproj", "{503A9238-E2D0-4849-8B62-4CEFB799A252}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Serialization.Json", "Eto.Serialization.Json\Eto.Serialization.Json.csproj", "{503A9238-E2D0-4849-8B62-4CEFB799A252}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Serialization.Xaml", "Eto.Serialization.Xaml\Eto.Serialization.Xaml.csproj", "{5830F6AC-68BE-4444-9160-0739F36BD761}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Serialization.Xaml", "Eto.Serialization.Xaml\Eto.Serialization.Xaml.csproj", "{5830F6AC-68BE-4444-9160-0739F36BD761}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test", "..\test\Eto.Test\Eto.Test.csproj", "{509D49DE-8BDD-43D2-B5D9-EDD390FDA8F3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test", "..\test\Eto.Test\Eto.Test.csproj", "{509D49DE-8BDD-43D2-B5D9-EDD390FDA8F3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Gtk", "Eto.Gtk\Eto.Gtk.csproj", "{0C792DAE-8855-44CF-87F9-CE7385E3F141}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Gtk", "Eto.Gtk\Eto.Gtk.csproj", "{0C792DAE-8855-44CF-87F9-CE7385E3F141}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.Gtk", "..\test\Eto.Test.Gtk\Eto.Test.Gtk.csproj", "{9122333E-56EF-4A18-BBC4-0100589EA49C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.Gtk", "..\test\Eto.Test.Gtk\Eto.Test.Gtk.csproj", "{9122333E-56EF-4A18-BBC4-0100589EA49C}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.WinForms", "Eto.WinForms\Eto.WinForms.csproj", "{675E4CC9-41B2-45A6-925D-4E21DD23FAFB}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.WinForms", "Eto.WinForms\Eto.WinForms.csproj", "{675E4CC9-41B2-45A6-925D-4E21DD23FAFB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.WinForms", "..\test\Eto.Test.WinForms\Eto.Test.WinForms.csproj", "{BC4CAE43-F35A-47FD-9284-1D76502A4F2B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.WinForms", "..\test\Eto.Test.WinForms\Eto.Test.WinForms.csproj", "{BC4CAE43-F35A-47FD-9284-1D76502A4F2B}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Wpf", "Eto.Wpf\Eto.Wpf.csproj", "{4BF1720D-10C5-468E-A419-95EE76BF3C98}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Wpf", "Eto.Wpf\Eto.Wpf.csproj", "{4BF1720D-10C5-468E-A419-95EE76BF3C98}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.Wpf", "..\test\Eto.Test.Wpf\Eto.Test.Wpf.csproj", "{AE451719-9FDC-4C53-A34A-2788D564A1E3}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.Wpf", "..\test\Eto.Test.Wpf\Eto.Test.Wpf.csproj", "{AE451719-9FDC-4C53-A34A-2788D564A1E3}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Eto.Gtk/Eto.Gtk.csproj
+++ b/src/Eto.Gtk/Eto.Gtk.csproj
@@ -24,6 +24,7 @@ When building for the full framework, .NET Framework 4.6.1 or mono framework 5.1
 
   <ItemGroup>
     <PackageReference Include="GtkSharp" Version="3.22.25.74" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eto\Eto.csproj" />

--- a/src/Eto.Mac/Forms/Controls/ExpanderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ExpanderHandler.cs
@@ -62,7 +62,7 @@ namespace Eto.Mac.Forms.Controls
 		public bool EnableAnimation
 		{
 			get { return Widget.Properties.Get<bool>(EnableAnimation_Key, true); }
-			set { Widget.Properties.Set(EnableAnimation_Key, value); }
+			set { Widget.Properties.Set(EnableAnimation_Key, value, true); }
 		}
 
 		static readonly object AnimationDuration_Key = new object();

--- a/src/Eto.WinForms/Eto.WinForms.csproj
+++ b/src/Eto.WinForms/Eto.WinForms.csproj
@@ -111,6 +111,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
 
   <ItemGroup>
     <PackageReference Include="Windows7APICodePack-Shell" Version="1.1.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -154,7 +154,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
   <ItemGroup>
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" PrivateAssets="all" />
     <PackageReference Include="Windows7APICodePack-Shell" Version="1.1.0" PrivateAssets="all" />
-	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />

--- a/src/Eto.sln
+++ b/src/Eto.sln
@@ -3,31 +3,31 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 16
 VisualStudioVersion = 16.0.29613.14
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.Wpf", "..\test\Eto.Test.Wpf\Eto.Test.Wpf.csproj", "{DD0C2B40-CA55-11E3-9C1A-0800200C9A66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.Wpf", "..\test\Eto.Test.Wpf\Eto.Test.Wpf.csproj", "{DD0C2B40-CA55-11E3-9C1A-0800200C9A66}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.Mac64", "..\test\Eto.Test.Mac\Eto.Test.Mac64.csproj", "{B5BC1D10-24ED-441C-A4D6-1F3AB9FF3689}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.Mac64", "..\test\Eto.Test.Mac\Eto.Test.Mac64.csproj", "{B5BC1D10-24ED-441C-A4D6-1F3AB9FF3689}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.Gtk", "..\test\Eto.Test.Gtk\Eto.Test.Gtk.csproj", "{063AF7E7-18BD-488F-85BF-53B6E3D75685}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.Gtk", "..\test\Eto.Test.Gtk\Eto.Test.Gtk.csproj", "{063AF7E7-18BD-488F-85BF-53B6E3D75685}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto", "Eto\Eto.csproj", "{35EF0A4E-2A1A-492C-8BED-106774EA09F2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto", "Eto\Eto.csproj", "{35EF0A4E-2A1A-492C-8BED-106774EA09F2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Serialization.Json", "Eto.Serialization.Json\Eto.Serialization.Json.csproj", "{3F8178EF-0710-43F7-92E2-130B9BE2212D}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Serialization.Json", "Eto.Serialization.Json\Eto.Serialization.Json.csproj", "{3F8178EF-0710-43F7-92E2-130B9BE2212D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.WinForms", "Eto.WinForms\Eto.WinForms.csproj", "{9F51798A-354C-47A1-9207-4BB7D7FC7FC4}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.WinForms", "Eto.WinForms\Eto.WinForms.csproj", "{9F51798A-354C-47A1-9207-4BB7D7FC7FC4}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Gtk2", "Eto.Gtk\Eto.Gtk2.csproj", "{80915A80-CA54-11E3-9C1A-0800200C9A66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Gtk2", "Eto.Gtk\Eto.Gtk2.csproj", "{80915A80-CA54-11E3-9C1A-0800200C9A66}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Wpf", "Eto.Wpf\Eto.Wpf.csproj", "{63137FA0-CA55-11E3-9C1A-0800200C9A66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Wpf", "Eto.Wpf\Eto.Wpf.csproj", "{63137FA0-CA55-11E3-9C1A-0800200C9A66}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Gtk3", "Eto.Gtk\Eto.Gtk3.csproj", "{543B2F90-CA56-11E3-9C1A-0800200C9A66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Gtk3", "Eto.Gtk\Eto.Gtk3.csproj", "{543B2F90-CA56-11E3-9C1A-0800200C9A66}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{E121B009-AB4B-4585-B3FB-D70E3DF8D3CC}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test", "..\test\Eto.Test\Eto.Test.csproj", "{EB9C0A22-6644-46E4-948C-F7C95E1F8CE1}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test", "..\test\Eto.Test\Eto.Test.csproj", "{EB9C0A22-6644-46E4-948C-F7C95E1F8CE1}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Mac64", "Eto.Mac\Eto.Mac64.csproj", "{55DAB390-1CFC-11E4-8C21-0800200C9A66}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Mac64", "Eto.Mac\Eto.Mac64.csproj", "{55DAB390-1CFC-11E4-8C21-0800200C9A66}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Serialization.Xaml", "Eto.Serialization.Xaml\Eto.Serialization.Xaml.csproj", "{E381E8CA-0DE1-4792-88F9-AC1529E911DF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Serialization.Xaml", "Eto.Serialization.Xaml\Eto.Serialization.Xaml.csproj", "{E381E8CA-0DE1-4792-88F9-AC1529E911DF}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{95227DFB-FD41-4709-BB54-3EA94C89C9C1}"
 	ProjectSection(SolutionItems) = preProject
@@ -44,31 +44,31 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{95227DFB
 		..\build\Utilities.targets = ..\build\Utilities.targets
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Gtk", "Eto.Gtk\Eto.Gtk.csproj", "{659873CA-9949-4353-B0AA-E0589D045584}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Gtk", "Eto.Gtk\Eto.Gtk.csproj", "{659873CA-9949-4353-B0AA-E0589D045584}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Direct2D", "Eto.Direct2D\Eto.Direct2D.csproj", "{3511ADDE-7CA8-4F7F-9721-AB48D3913760}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Direct2D", "Eto.Direct2D\Eto.Direct2D.csproj", "{3511ADDE-7CA8-4F7F-9721-AB48D3913760}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.Gtk2", "..\test\Eto.Test.Gtk\Eto.Test.Gtk2.csproj", "{E3832AF1-FCBA-4575-8FB1-7168949150D8}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.Gtk2", "..\test\Eto.Test.Gtk\Eto.Test.Gtk2.csproj", "{E3832AF1-FCBA-4575-8FB1-7168949150D8}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.Gtk3", "..\test\Eto.Test.Gtk\Eto.Test.Gtk3.csproj", "{B45F3211-6C33-43B9-A492-1495FB149636}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.Gtk3", "..\test\Eto.Test.Gtk\Eto.Test.Gtk3.csproj", "{B45F3211-6C33-43B9-A492-1495FB149636}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.XamMac2", "..\test\Eto.Test.Mac\Eto.Test.XamMac2.csproj", "{96C9D209-238D-4EBF-8391-F632A14921AD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.XamMac2", "..\test\Eto.Test.Mac\Eto.Test.XamMac2.csproj", "{96C9D209-238D-4EBF-8391-F632A14921AD}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.XamMac2", "Eto.Mac\Eto.XamMac2.csproj", "{6A38350E-51D6-4C13-ADD8-B9C6DC8A4358}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.XamMac2", "Eto.Mac\Eto.XamMac2.csproj", "{6A38350E-51D6-4C13-ADD8-B9C6DC8A4358}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Forms.Sample", "Eto.Forms.Sample\Eto.Forms.Sample.csproj", "{D34D3F47-2E1B-4A36-87D0-C77969C7EA90}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Forms.Sample", "Eto.Forms.Sample\Eto.Forms.Sample.csproj", "{D34D3F47-2E1B-4A36-87D0-C77969C7EA90}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.Direct2D", "..\test\Eto.Test.Direct2D\Eto.Test.Direct2D.csproj", "{7EBEA53F-6CDC-4DB8-8042-1B048C3502CF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.Direct2D", "..\test\Eto.Test.Direct2D\Eto.Test.Direct2D.csproj", "{7EBEA53F-6CDC-4DB8-8042-1B048C3502CF}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.WinForms", "..\test\Eto.Test.WinForms\Eto.Test.WinForms.csproj", "{CF18B0BB-2C60-437F-8AA3-711ABAE11A91}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.WinForms", "..\test\Eto.Test.WinForms\Eto.Test.WinForms.csproj", "{CF18B0BB-2C60-437F-8AA3-711ABAE11A91}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MonoMac", "..\lib\monomac\src\MonoMac.csproj", "{4C76B511-0849-4E5A-BF4B-C3365E103259}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MonoMac", "..\lib\monomac\src\MonoMac.csproj", "{4C76B511-0849-4E5A-BF4B-C3365E103259}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "monomac", "monomac", "{9A93A30F-7627-4F92-ACC4-226BDAD712FB}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "core", "..\lib\monomac\src\core.csproj", "{CEB897E2-8040-44F5-B41E-DBA9144FEDB2}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "core", "..\lib\monomac\src\core.csproj", "{CEB897E2-8040-44F5-B41E-DBA9144FEDB2}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "generator", "..\lib\monomac\src\generator.csproj", "{5A16F4FA-C960-46A2-875E-C6CE556F0C36}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "generator", "..\lib\monomac\src\generator.csproj", "{5A16F4FA-C960-46A2-875E-C6CE556F0C36}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj
+++ b/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj
@@ -19,4 +19,7 @@
     <ProjectReference Include="..\..\src\Eto\Eto.csproj" />
     <ProjectReference Include="..\Eto.Test\Eto.Test.csproj" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
+++ b/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
@@ -54,8 +54,8 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0">
-    </PackageReference>
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />

--- a/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
+++ b/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
@@ -63,7 +63,7 @@
   
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
-	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
+	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />


### PR DESCRIPTION
- Mac: Fix setting ExpanderHandler.EnableAnimation. Fixes #1709
- Update monomac to allow setting null for Dialog.DefaultButton. Fixes #1718

Also: 
- Allow building windows projects with dotnet
- launch and .sln updates for vscode