### PR TITLE
Wpf: Use virtualization for DropDown when there are > 200 items

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -12,6 +12,18 @@
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
+			// requires mono extension from https://github.com/cwensley/vscode-mono-debug/releases
+            "name": "Eto.Test.XamMac2",
+            "type": "mono",
+			"request": "launch",
+			"preLaunchTask": "build-xammac2",
+			"program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/net461/Eto.Test.XamMac2.app/Contents/MacOS/Eto.Test.XamMac2",
+			"useRuntime": false,
+            "args": [],
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
             "name": "Eto.Test.Gtk",
 			"type": "coreclr",
 			"request": "launch",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,14 @@
 		},
 		{
 			"label": "build-mac64",
-			"command": "msbuild ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.Mac64.csproj",
+			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.Mac64.csproj",
+			"type": "shell",
+			"group": "build",
+			"problemMatcher": "$msCompile"
+		},
+		{
+			"label": "build-xammac2",
+			"command": "msbuild /restore ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj",
 			"type": "shell",
 			"group": "build",
 			"problemMatcher": "$msCompile"
@@ -48,11 +55,27 @@
 			"type": "shell",
 			"problemMatcher": "$msCompile"
 		},
-		{
-			"label": "echo value of configuration",
+        {
+            "label": "Git clean + submodule init (DANGEROUS!)",
 			"type": "shell",
-			"command": "echo \"Current value of configuration is '${input:configuration}'.\"",
+			"osx": {
+				"command": "[ '${input:confirm}' = 'Yes' ] && git clean -dxff && git submodule foreach git clean -dxff && git submodule update --init --recursive"
+			},
+			"windows": {
+				"command": "IF ('${input:confirm}' -ne 'Yes')  { exit 1 }; git clean -dxff ; git submodule foreach git clean -dxff ; git submodule update --init --recursive"
+			},
 			"problemMatcher": []
+        },
+	],
+	"inputs": [
+		{
+			"type": "pickString",
+			"id": "confirm",
+			"description": "Confirm?",
+			"options": [
+				"No",
+				"Yes"
+			]
 		}
 	]
 }

--- a/build/Xamarin.Mac.targets
+++ b/build/Xamarin.Mac.targets
@@ -1,0 +1,82 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <!-- Xamarin.Mac support for sdk style projects
+
+    Set UseXamarinMac or UseXamarinMacBinding to True and import this at the end of your .csproj
+  -->
+  <PropertyGroup>
+    <XamarinMacPath>\Library\Frameworks\Xamarin.Mac.framework\Versions\Current\</XamarinMacPath>
+    <XamarinMacLibPath>$(XamarinMacPath)lib\mono\</XamarinMacLibPath>
+    <XamarinMacTargetsPath>$(XamarinMacPath)lib\msbuild\</XamarinMacTargetsPath>
+    <HasXamarinMac Condition="!Exists('$(XamarinMacTargetsPath)Xamarin.Mac.CSharp.targets')">False</HasXamarinMac>
+    <HasXamarinMac Condition="$(HasXamarinMac) == ''">True</HasXamarinMac> <!-- VS for Mac needs this, Exists isn't evaluated -->
+
+    <EnableDefaultImageAssets Condition="$(EnableDefaultImageAssets) == ''">True</EnableDefaultImageAssets>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(UseXamarinMac) == 'True' OR $(UseXamarinMacBinding) == 'True'">
+    <ProjectTypeGuids Condition="$(UseXamarinMacBinding) != 'True'">{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectTypeGuids Condition="$(UseXamarinMacBinding) == 'True'">{810C163F-4746-4721-8B8E-88A3673A62EA};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+
+    <UseXamarinMac>True</UseXamarinMac>
+    <IsXamarinMacMobile Condition="$(TargetFramework.StartsWith('xamarinmac')) == 'True'">True</IsXamarinMacMobile>
+    <DefineConstants>$(DefineConstants);XAMMAC;XAMMAC2;UNIFIED</DefineConstants>
+
+    <LanguageTargets Condition="$(HasXamarinMac) == 'True' AND $(UseXamarinMacBinding) != 'True'">$(XamarinMacTargetsPath)Xamarin.Mac.CSharp.targets</LanguageTargets>
+    <LanguageTargets Condition="$(HasXamarinMac) == 'True' AND $(UseXamarinMacBinding) == 'True'">$(XamarinMacTargetsPath)Xamarin.Mac.ObjcBinding.CSharp.targets</LanguageTargets>
+
+    <TargetFrameworkIdentifier Condition="$(IsXamarinMacMobile) == 'True'">Xamarin.Mac</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion Condition="$(IsXamarinMacMobile) == 'True'">v2.0</TargetFrameworkVersion>
+
+    <MacBuildBundle>False</MacBuildBundle>
+    <UseSGen Condition="$(UseSGen) == ''">True</UseSGen>
+    <AOTMode Condition="$(AOTMode) == ''">None</AOTMode>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="$(UseXamarinMac) == 'True' AND $(TargetFramework.StartsWith('xamarinmac')) != 'True'">
+    <UseXamMacFullFramework>true</UseXamMacFullFramework>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(UseXamarinMac) == 'True'">
+    <ProjectReference Update="@(ProjectReference)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(UseXamarinMac) == 'True' AND $(DisableImplicitFrameworkReferences) != 'True'">
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.Mac" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(UseXamarinMac) == 'True'">
+    <AvailableItemName Include="ObjcBindingApiDefinition" />
+    <AvailableItemName Include="ObjcBindingCoreSource" />
+    <AvailableItemName Include="NativeReference" />
+    <AvailableItemName Include="ImageAsset" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(UseXamarinMac) == 'True'">
+    <!-- Doesn't actually work for some reason.. -->
+    <!--ImageAsset Include="Assets.xcassets\**\*" Condition="$(EnableDefaultImageAssets) == 'True'" /-->
+  </ItemGroup>
+
+  <ItemGroup Condition="$(UseXamarinMac) == 'True' AND $(EnableDefaultCompileItems) != 'False'">
+    <Compile Remove="@(ObjcBindingApiDefinition)" />
+    <Compile Remove="@(ObjcBindingCoreSource)" />
+  </ItemGroup>
+
+  <ItemGroup Condition="$(UseXamarinMac) == 'True' AND $(EnableDefaultNoneItems) != 'False'">
+    <None Remove="@(ImageAsset)" />
+
+    <!-- Xamarin.Mac looks for the logical name, but implicit entries don't have it -->
+    <None Include="Info.plist" LogicalName="Info.plist" Condition="$(OutputType) == 'Exe'" />
+  </ItemGroup>
+
+  <Target Name="_XamarinMacRemoveImplicitReference" BeforeTargets="BeforeBuild" Condition="$(UseXamarinMac) == 'True'">
+    <ItemGroup>
+      <!-- System.Drawing doesn't exist even when targetting full framework -->
+      <Reference Remove="System.Drawing" Condition="$(DisableImplicitFrameworkReferences) != 'True'" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Eto.Mac/Eto.Mac64.csproj
+++ b/src/Eto.Mac/Eto.Mac64.csproj
@@ -47,6 +47,10 @@ You do not need to use any of the classes of this assembly (unless customizing t
   </ItemGroup>
   
   <ItemGroup>
+	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Eto\Eto.csproj" />
     <ProjectReference Include="..\..\lib\monomac\src\MonoMac.csproj" PrivateAssets="all" Pack="True" />
   </ItemGroup>

--- a/src/Eto.Mac/Eto.XamMac2.csproj
+++ b/src/Eto.Mac/Eto.XamMac2.csproj
@@ -1,18 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <UseXamarinMac>True</UseXamarinMac>
     <TargetFrameworks>net45</TargetFrameworks>
     <TargetFrameworks Condition="$(HasXamarinMac) == 'True'">$(TargetFrameworks);xamarinmac20</TargetFrameworks>
     <RootNamespace>Eto.Mac</RootNamespace>
-    <DefineConstants>$(DefineConstants);OSX;DESKTOP;XAMMAC;XAMMAC2;UNIFIED</DefineConstants>
+    <DefineConstants>$(DefineConstants);OSX;DESKTOP</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefaultItemExcludes>build\*</DefaultItemExcludes>
-    <LanguageTargets Condition="$(HasXamarinMac) == 'True'">$(XamarinMacTargetsPath)Xamarin.Mac.CSharp.targets</LanguageTargets>
-    <UseSGen>false</UseSGen>
-    <AOTMode>None</AOTMode>
-    <DisableImplicitFrameworkReferences>True</DisableImplicitFrameworkReferences>
-    <UseXamMacFullFramework Condition="$(TargetFramework) == 'net45'">true</UseXamMacFullFramework>
   </PropertyGroup>
   
   <PropertyGroup>
@@ -33,16 +28,6 @@ You do not need to use any of the classes of this assembly (unless customizing t
     </PackageDescription>
   </PropertyGroup>
   
-  <PropertyGroup Condition="$(TargetFramework) == 'xamarinmac20'">
-    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
-  </PropertyGroup>
-  
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Xamarin.Mac" />
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Shared\PlatformDetect.cs">
       <Link>PlatformDetect.cs</Link>
@@ -72,4 +57,6 @@ You do not need to use any of the classes of this assembly (unless customizing t
     <None Include="..\..\build\MSBuildTaskHelper.props" Pack="True" PackagePath="build" />
   </ItemGroup>
   
+  <Import Project="..\..\build\Xamarin.Mac.targets" />
+
 </Project>

--- a/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
@@ -10,11 +10,15 @@ using System.Collections.Generic;
 using Eto.Drawing;
 using System.Globalization;
 using Eto.Wpf.Drawing;
+using System.Linq;
+using System.Collections.Specialized;
 
 namespace Eto.Wpf.Forms.Controls
 {
 	public class DropDownHandler : DropDownHandler<EtoComboBox, DropDown, DropDown.ICallback>
 	{
+		internal static readonly object AllowVirtualization_Key = new object();
+		internal static readonly object VirtualizationThreshold_Key = new object();
 	}
 
 	public class EtoComboBox : swc.ComboBox, IEtoWpfControl
@@ -24,6 +28,12 @@ namespace Eto.Wpf.Forms.Controls
 		public EtoComboBox()
 		{
 			Loaded += ComboBoxEx_Loaded;
+		}
+
+		public bool IsVirtualizing
+		{
+			get => swc.VirtualizingPanel.GetIsVirtualizing(this);
+			set => swc.VirtualizingPanel.SetIsVirtualizing(this, value);
 		}
 
 		public override void OnApplyTemplate()
@@ -37,6 +47,8 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
+		public swc.Primitives.Popup Popup => GetTemplateChild("PART_Popup") as swc.Primitives.Popup;
+
 		public swc.ScrollViewer ContentHost
 		{
 			get
@@ -48,10 +60,7 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
-		public swc.TextBox TextBox
-		{
-			get { return GetTemplateChild("PART_EditableTextBox") as swc.TextBox; }
-		}
+		public swc.TextBox TextBox => GetTemplateChild("PART_EditableTextBox") as swc.TextBox;
 
 		public IWpfFrameworkElement Handler { get; set; }
 
@@ -83,12 +92,16 @@ namespace Eto.Wpf.Forms.Controls
 			var popup = GetTemplateChild("PART_Popup") as swc.Primitives.Popup;
 			if (popup == null)
 				return size;
+
 			popup.Child.Measure(WpfConversions.PositiveInfinitySize); // force generating containers
+
 			if (ItemContainerGenerator.Status != swc.Primitives.GeneratorStatus.ContainersGenerated)
 				return size;
+
 			double maxWidth = 0;
-			foreach (var item in Items)
+			for (int i = 0; i < Items.Count; i++)
 			{
+				var item = Items[i];
 				var comboBoxItem = (swc.ComboBoxItem)ItemContainerGenerator.ContainerFromItem(item);
 				if (comboBoxItem == null)
 					continue;
@@ -97,10 +110,11 @@ namespace Eto.Wpf.Forms.Controls
 			}
 
 			var toggle = GetTemplateChild("toggleButton") as sw.UIElement;
-			maxWidth += toggle != null ? toggle.DesiredSize.Width : 20;
+			maxWidth += toggle?.DesiredSize.Width ?? 20;
 			size.Width = Math.Max(maxWidth, size.Width);
 			if (!double.IsNaN(constraint.Width))
 				size.Width = Math.Min(size.Width, constraint.Width);
+
 			return size;
 		}
 
@@ -135,19 +149,72 @@ namespace Eto.Wpf.Forms.Controls
 
 		public override bool UseKeyPreview { get { return true; } }
 
+		/// <summary>
+		/// Gets or sets a valuie indication virtualation will be automatically enabled/disabled based on <see cref="VirtualizationThreshold" />.
+		/// </summary>
+		public bool AllowVirtualization
+		{
+			get => Widget.Properties.Get<bool>(DropDownHandler.AllowVirtualization_Key, true);
+			set
+			{
+				if (Widget.Properties.TrySet(DropDownHandler.AllowVirtualization_Key, value, true))
+					SetVirtualization();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the minimum number of items before virtualization is enabled.
+		/// </summary>
+		/// <value>Threshold of items required when virtualization is enabled</value>
+		public int VirtualizationThreshold
+		{
+			get => Widget.Properties.Get<int>(DropDownHandler.VirtualizationThreshold_Key, 200);
+			set
+			{
+				if (Widget.Properties.TrySet(DropDownHandler.VirtualizationThreshold_Key, value, 200))
+				{
+					SetVirtualization();
+				}
+			}
+		}
 
 		public IEnumerable<object> DataStore
 		{
 			get { return store; }
 			set
 			{
+				if (store is INotifyCollectionChanged notifyChanged)
+				{
+					notifyChanged.CollectionChanged -= Store_CollectionChanged;
+				}
+
 				var oldSelectedIndex = SelectedIndex;
 				store = value;
+
+				if (store is INotifyCollectionChanged notifyChanged2)
+				{
+					notifyChanged2.CollectionChanged += Store_CollectionChanged;
+				}
+
+				SetVirtualization();
+
 				Control.ItemsSource = store;
 				// WPF only triggers a slection change when the item instance has changed
 				if (oldSelectedIndex != SelectedIndex && SelectedIndex >= 0)
 					Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
 			}
+		}
+
+		private void Store_CollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (AllowVirtualization)
+				SetVirtualization();	
+		}
+
+		private void SetVirtualization()
+		{
+			// Use virtualization for large lists
+			Control.IsVirtualizing = AllowVirtualization && store?.Count() >= VirtualizationThreshold;
 		}
 
 		public int SelectedIndex

--- a/src/Eto.Wpf/themes/generic.xaml
+++ b/src/Eto.Wpf/themes/generic.xaml
@@ -1,6 +1,7 @@
 <ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:r="clr-namespace:Eto.Wpf.CustomControls.TreeGridView"
+    xmlns:efc="clr-namespace:Eto.Wpf.Forms.Controls"
     xmlns:s="clr-namespace:System;assembly=mscorlib">
 
     <ResourceDictionary.MergedDictionaries>
@@ -80,6 +81,18 @@
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
             </Trigger>
         </Style.Triggers>
+    </Style>
+
+    <Style TargetType="{x:Type efc:EtoComboBox}">
+        <Style.Setters>
+            <Setter Property="ItemsPanel">
+                <Setter.Value>
+                    <ItemsPanelTemplate>
+                        <VirtualizingStackPanel />
+                    </ItemsPanelTemplate>
+                </Setter.Value>
+            </Setter>
+        </Style.Setters>
     </Style>
 
 </ResourceDictionary>

--- a/src/Eto.sln
+++ b/src/Eto.sln
@@ -52,9 +52,9 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.Gtk2", "..\test\Et
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.Gtk3", "..\test\Eto.Test.Gtk\Eto.Test.Gtk3.csproj", "{B45F3211-6C33-43B9-A492-1495FB149636}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Test.XamMac2", "..\test\Eto.Test.Mac\Eto.Test.XamMac2.csproj", "{96C9D209-238D-4EBF-8391-F632A14921AD}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.Test.XamMac2", "..\test\Eto.Test.Mac\Eto.Test.XamMac2.csproj", "{96C9D209-238D-4EBF-8391-F632A14921AD}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.XamMac2", "Eto.Mac\Eto.XamMac2.csproj", "{6A38350E-51D6-4C13-ADD8-B9C6DC8A4358}"
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Eto.XamMac2", "Eto.Mac\Eto.XamMac2.csproj", "{6A38350E-51D6-4C13-ADD8-B9C6DC8A4358}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Forms.Sample", "Eto.Forms.Sample\Eto.Forms.Sample.csproj", "{D34D3F47-2E1B-4A36-87D0-C77969C7EA90}"
 EndProject

--- a/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
@@ -21,6 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="3.12.0" />
+	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
@@ -1,38 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+	  <UseXamarinMac>True</UseXamarinMac>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net461</TargetFrameworks>
     <TargetFrameworks Condition="$(HasXamarinMac) == 'True'">$(TargetFrameworks);xamarinmac20</TargetFrameworks>
     <RootNamespace>Eto.Test.Mac</RootNamespace>
-    <DefineConstants>$(DefineConstants);XAMMAC2</DefineConstants>
-    <LanguageTargets Condition="$(HasXamarinMac) == 'True'">$(XamarinMacTargetsPath)Xamarin.Mac.CSharp.targets</LanguageTargets>
     <EnableDefaultNoneItems>False</EnableDefaultNoneItems>
     <EnableDefaultContentItems>False</EnableDefaultContentItems>
-    <UseSGen>True</UseSGen>
-    <AOTMode>None</AOTMode>
     <CodeSigningKey>Mac Developer</CodeSigningKey>
     <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
-    <DisableImplicitFrameworkReferences>True</DisableImplicitFrameworkReferences>
     <MonoBundlingExtraArgs>--nowarn:2006 --nowarn:5220</MonoBundlingExtraArgs>
   </PropertyGroup>
   
   <PropertyGroup Condition="$(TargetFramework) == 'xamarinmac20'">
-    <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
-    <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <LinkMode Condition="$(Configuration) == 'Release'">Platform</LinkMode>
-    <UseXamMacFullFramework>false</UseXamMacFullFramework>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework) != 'xamarinmac20'">
-    <UseXamMacFullFramework>true</UseXamMacFullFramework>
-  </PropertyGroup>
-  
-  <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="Xamarin.Mac" />
-  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\Eto.Test\Eto.Test.csproj" />
@@ -63,4 +46,7 @@
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
+
+  <Import Project="..\..\build\Xamarin.Mac.targets" />
+
 </Project>

--- a/test/Eto.Test/Sections/Controls/DropDownSection.cs
+++ b/test/Eto.Test/Sections/Controls/DropDownSection.cs
@@ -23,6 +23,12 @@ namespace Eto.Test.Sections.Controls
 			layout.AddRow("EnumDropDown<Key>", TableLayout.AutoSized(EnumCombo()));
 
 			layout.AddRow("FormatItem", TableLayout.AutoSized(DropDownWithFonts()));
+			
+			// TODO: get this working on Gtk as it is unusably slow and WinForms is a wee slow.
+			if (!Platform.IsGtk)
+			{
+			layout.AddRow("LotsOfItems", TableLayout.AutoSized(LotsOfItems()));
+			}
 
 			layout.Add(null, null, true);
 
@@ -179,6 +185,14 @@ namespace Eto.Test.Sections.Controls
 			control.Width = 100;
 			LogEvents(control);
 			control.SelectedKey = ((int)Keys.E).ToString();
+			return control;
+		}
+
+		Control LotsOfItems()
+		{
+			var control = new DropDown();
+			LogEvents(control);
+			control.DataStore = Enumerable.Range(0, 5000).Select(r => $"Item {r}").ToList();
 			return control;
 		}
 


### PR DESCRIPTION
This is done otherwise it can cause a huge lag when determining the size of the drop down when loaded or changed.

Also included:
- Enable building Eto.Mac64 with dotnet
- Move sdk-style csproj config for XamMac2 projects to shared targets file.  I may look into including this with the Eto.Platform.XamMac2 nuget package.
