### PR TITLE
Gtk fixes

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk2.cs
+++ b/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk2.cs
@@ -111,7 +111,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			get { return label.Text.ToEtoMnemonic(); }
 			set
 			{
-				label.Text = value;
+				label.TextWithMnemonic = value.ToPlatformMnemonic();
 				SetImagePosition();
 			}
 		}

--- a/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk3.cs
+++ b/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk3.cs
@@ -59,7 +59,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			get { return label.Text.ToEtoMnemonic(); }
 			set
 			{
-				label.Text = value.ToPlatformMnemonic();
+				label.TextWithMnemonic = value.ToPlatformMnemonic();
 				SetImagePosition();
 			}
 		}

--- a/src/Eto.Gtk/Forms/Controls/DocumentControlHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DocumentControlHandler.cs
@@ -19,6 +19,14 @@ namespace Eto.GtkSharp.Forms.Controls
 			Control.Scrollable = true;
 		}
 
+		static readonly object HideTabsWithSinglePage_Key = new object();
+
+		public bool HideTabsWithSinglePage
+		{
+			get => Widget.Properties.Get<bool>(HideTabsWithSinglePage_Key);
+			set => Widget.Properties.Set(HideTabsWithSinglePage_Key, value);
+		}
+
 		protected override void Initialize()
 		{
 			base.Initialize();
@@ -120,7 +128,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 
 			Control.SetTabReorderable(pageHandler.ContainerControl, allowReorder && Enabled);
-			Control.ShowTabs = Control.NPages > 1;
+			SetShowTabs();
 		}
 
 		public override bool Enabled
@@ -136,10 +144,18 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
+		void SetShowTabs()
+		{
+			if (HideTabsWithSinglePage)
+			{
+				Control.ShowTabs = Control.NPages > 1;
+			}
+		}
+
 		internal void ClosePage(Gtk.Widget control, DocumentPage page)
 		{
 			Control.RemovePage(Control.PageNum(control));
-			Control.ShowTabs = Control.NPages > 1;
+			SetShowTabs();
 
 			if (Widget.Loaded)
 				Callback.OnPageClosed(Widget, new DocumentPageEventArgs(page));
@@ -153,7 +169,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			if (Widget.Loaded && Control.NPages == 0)
 				Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
 
-			Control.ShowTabs = Control.NPages > 1;
+			SetShowTabs();
 		}
 
 		public DocumentPage GetPage(int index)

--- a/src/Eto.Gtk/Forms/Controls/WebKit2WebViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/WebKit2WebViewHandler.cs
@@ -164,13 +164,15 @@ namespace Eto.GtkSharp.Forms.Controls
 			jsrunning = true;
 			jsreturn = "";
 
-			NativeMethods.webkit_web_view_run_javascript(Control.Handle, "function EtOrEtFuN() {" + script + " } EtOrEtFuN();", IntPtr.Zero, (Action<IntPtr, IntPtr, IntPtr>)FinishScriptExecution, IntPtr.Zero);
+			NativeMethods.webkit_web_view_run_javascript(Control.Handle, "function EtOrEtFuN() {" + script + " } EtOrEtFuN();", IntPtr.Zero, (FinishScriptExecutionDelegate)FinishScriptExecution, IntPtr.Zero);
 
 			while (jsrunning)
 				Gtk.Application.RunIteration();
 
 			return jsreturn;
 		}
+
+		delegate void FinishScriptExecutionDelegate(IntPtr webview, IntPtr result, IntPtr error);
 
 		private void FinishScriptExecution(IntPtr webview, IntPtr result, IntPtr error)
 		{


### PR DESCRIPTION
A few fun fixes for Gtk.

- Gtk: Fix Button.Text regression with ampersands. Fixes #1739
- Gtk: Always show tabs on DocumentControl by default. Fixes #1608
- Gtk: Fix WebView.ExecuteScript when running in .NET Core. Fixes #1738