### PR TITLE
Wpf/Gtk: Fix using only DragEnter to set effects

### DIFF
--- a/src/Eto.Gtk/Forms/DataObjectHandler.cs
+++ b/src/Eto.Gtk/Forms/DataObjectHandler.cs
@@ -150,11 +150,17 @@ namespace Eto.GtkSharp.Forms
 				?? GetSelectionData(type, selection =>
 				{
 					// using selection.Text doesn't always seem to work
-					var data = selection.Data;
-					if (data != null)
-						return Encoding.UTF8.GetString(data);
-					else
-						return null;
+					try 
+					{
+						var data = selection.Data;
+						if (data != null)
+							return Encoding.UTF8.GetString(data);
+					}
+					catch
+					{
+					}
+
+					return null;
 				});
 		}
 

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -472,7 +472,7 @@ namespace Eto.GtkSharp.Forms
 		/// </summary>
 		protected class GtkControlConnector : WeakConnector
 		{
-			bool isDragOver;
+			DragEffects? _dragEnterEffects;
 			protected DragEventArgs DragArgs { get; private set; }
 
 			new GtkControl<TControl, TWidget, TCallback> Handler { get { return (GtkControl<TControl, TWidget, TCallback>)base.Handler; } }
@@ -726,19 +726,26 @@ namespace Eto.GtkSharp.Forms
 				args.RetVal = true;
 			}
 
+
+
 			[GLib.ConnectBefore]
 			public virtual void HandleDragMotion(object o, Gtk.DragMotionArgs args)
 			{
 				DragArgs = GetDragEventArgs(args.Context, new PointF(args.X, args.Y), args.Time);
 
-				if (!isDragOver)
+				if (_dragEnterEffects == null)
+				{
 					Handler.Callback.OnDragEnter(Handler.Widget, DragArgs);
+					_dragEnterEffects = DragArgs.Effects;
+				}
 				else
+				{
+					DragArgs.Effects = _dragEnterEffects.Value;
 					Handler.Callback.OnDragOver(Handler.Widget, DragArgs);
+				}
 
 				Gdk.Drag.Status(args.Context, DragArgs.Effects.ToGdk(), args.Time);
 
-				isDragOver = true;
 				args.RetVal = true;
 			}
 
@@ -747,7 +754,7 @@ namespace Eto.GtkSharp.Forms
 				// use old args in case of a drop so we use the last motion args to determine position of drop for TreeGridView/GridView.
 				DragArgs = DragArgs ?? GetDragEventArgs(args.Context, Handler.PointFromScreen(Mouse.Position), args.Time);
 				Handler.Callback.OnDragLeave(Handler.Widget, DragArgs);
-				isDragOver = false;
+				_dragEnterEffects = null;
 				Eto.Forms.Application.Instance.AsyncInvoke(() => DragArgs = null);
 			}
 

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -512,6 +512,7 @@ namespace Eto.Wpf.Forms
 					break;
 				case Eto.Forms.Control.DragEnterEvent:
 					Control.DragEnter += Control_DragEnter;
+					HandleEvent(Eto.Forms.Control.DragOverEvent);
 					break;
 				case Eto.Forms.Control.DragLeaveEvent:
 					Control.DragLeave += Control_DragLeave;
@@ -622,17 +623,22 @@ namespace Eto.Wpf.Forms
 			if (e.Data.GetDataPresent(WpfFrameworkElement.CustomCursor_DataKey))
 				e.Data.SetDataEx(WpfFrameworkElement.CustomCursor_DataKey, false);
 			IsDragEntered = false;
+			if (dragEnterEffects != null)
+				args.Effects = dragEnterEffects.Value;
 			Callback.OnDragLeave(Widget, args);
 			Callback.OnDragDrop(Widget, args);
 			e.Effects = args.Effects.ToWpf();
 			e.Handled = true;
 		}
 
+		DragEffects? dragEnterEffects;
+
 		protected virtual void HandleDragEnter(sw.DragEventArgs e, DragEventArgs args)
 		{
 			var lastCursor = MouseHandler.s_CursorSetCount;
 			Callback.OnDragEnter(Widget, args);
 			e.Effects = args.Effects.ToWpf();
+			dragEnterEffects = args.Effects;
 			e.Handled = true;
 
 			if (lastCursor != MouseHandler.s_CursorSetCount)
@@ -643,6 +649,7 @@ namespace Eto.Wpf.Forms
 		{
 			if (e.Data.GetDataPresent(WpfFrameworkElement.CustomCursor_DataKey))
 				e.Data.SetDataEx(WpfFrameworkElement.CustomCursor_DataKey, false);
+			dragEnterEffects = null;
 			Callback.OnDragLeave(Widget, args);
 			if (sw.DropTargetHelper.IsSupported(e.Data))
 			{
@@ -654,6 +661,8 @@ namespace Eto.Wpf.Forms
 		protected virtual void HandleDragOver(sw.DragEventArgs e, DragEventArgs args)
 		{
 			var lastCursor = MouseHandler.s_CursorSetCount;
+			if (dragEnterEffects != null)
+				args.Effects = dragEnterEffects.Value;
 			Callback.OnDragOver(Widget, args);
 			e.Effects = args.Effects.ToWpf();
 

--- a/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
@@ -11,6 +11,7 @@ namespace Eto.Test.Sections.Behaviors
 	[Section("Behaviors", "Drag and Drop")]
 	public class DragDropSection : Panel
 	{
+		EnumDropDown<DragEffects?> dragEnterEffect;
 		EnumDropDown<DragEffects?> dragOverEffect;
 		CheckBox showDragOverEvents;
 		CheckBox useDragImage;
@@ -30,13 +31,14 @@ namespace Eto.Test.Sections.Behaviors
 			innerTextBox = new TextBox { PlaceholderText = "Inner", ToolTip = "Highlighted text to insert into description" };
 			var textBox = new TextBox { Text = "Some text" };
 			allowedEffectDropDown = new EnumDropDown<DragEffects> { SelectedValue = DragEffects.All };
-			dragOverEffect = new EnumDropDown<DragEffects?> { SelectedValue = DragEffects.Copy };
+			dragEnterEffect = new EnumDropDown<DragEffects?> { SelectedValue = DragEffects.Copy };
+			dragOverEffect = new EnumDropDown<DragEffects?> { SelectedValue = null };
 			writeDataCheckBox = new CheckBox { Text = "Write data to log" };
 			useDragImage = new CheckBox { Text = "Use custom drag image" };
 			imageOffset = new PointEntry { Value = new Point(80, 80) };
 			imageOffset.Bind(c => c.Enabled, useDragImage, c => c.Checked);
 
-			var htmlTextArea = new TextArea();
+			var htmlTextArea = new TextArea { Height = 24 };
 			var selectFilesButton = new Button { Text = "Select Files" };
 			Uri[] fileUris = null;
 			selectFilesButton.Click += (sender, e) =>
@@ -245,6 +247,7 @@ namespace Eto.Test.Sections.Behaviors
 			layout.AddRow("DropDescription", descriptionTextBox);
 			layout.AddRow(new Panel(), innerTextBox);
 			layout.EndVertical();
+			layout.AddSeparateRow("DragEnter Effect", dragEnterEffect, null);
 			layout.AddSeparateRow("DragOver Effect", dragOverEffect, null);
 			layout.AddSeparateRow(useDragImage);
 			layout.AddSeparateRow("Image offset:", imageOffset);
@@ -379,8 +382,8 @@ namespace Eto.Test.Sections.Behaviors
 			{
 				Log.Write(sender, $"DragEnter: {WriteDragInfo(sender, e)}");
 
-				if (dragOverEffect.SelectedValue != null)
-					e.Effects = dragOverEffect.SelectedValue.Value;
+				if (dragEnterEffect.SelectedValue != null)
+					e.Effects = dragEnterEffect.SelectedValue.Value;
 				if (!string.IsNullOrEmpty(descriptionTextBox.Text) && e.SupportsDropDescription)
 					e.SetDropDescription(descriptionTextBox.Text, innerTextBox.Text);
 				WriteData(e.Data);
@@ -388,8 +391,8 @@ namespace Eto.Test.Sections.Behaviors
 			control.DragLeave += (sender, e) =>
 			{
 				Log.Write(sender, $"DragLeave: {WriteDragInfo(sender, e)}");
-				if (dragOverEffect.SelectedValue != null)
-					e.Effects = dragOverEffect.SelectedValue.Value;
+				if (dragEnterEffect.SelectedValue != null)
+					e.Effects = dragEnterEffect.SelectedValue.Value;
 
 				WriteData(e.Data);
 			};


### PR DESCRIPTION
This makes it so you can set the effects for the drop in DragEnter if you only need to detect it once, _or_ DragOver if it depends on the location within the control.

Fixes #1691