### PR TITLE
Wpf: Fix memory leaks when using a CustomCell

### DIFF
--- a/src/Eto/Forms/Binding/ObjectBinding.cs
+++ b/src/Eto/Forms/Binding/ObjectBinding.cs
@@ -144,18 +144,6 @@ namespace Eto.Forms
 		{
 			this.dataItem = dataItem;
 			InnerBinding = innerBinding;
-			InnerBinding.Changed += HandleInnerBindingChanged;
-			InnerBinding.Changing += HandleInnerBindingChanging;
-		}
-
-		void HandleInnerBindingChanging(object sender, BindingChangingEventArgs e)
-		{
-			OnChanging(e);
-		}
-
-		void HandleInnerBindingChanged(object sender, BindingChangedEventArgs e)
-		{
-			OnChanged(e);
 		}
 
 		/// <summary>
@@ -173,7 +161,12 @@ namespace Eto.Forms
 			}
 			set
 			{
+				var args = new BindingChangingEventArgs(DataValue);
+				OnChanging(args);
+				if (args.Cancel)
+					return;
 				InnerBinding.SetValue(DataItem, Equals(value, default(T)) ? SettingNullValue : value);
+				OnChanged(new BindingChangedEventArgs(DataValue));
 			}
 		}
 


### PR DESCRIPTION
Also fix leak when using a long lived inner binding for an ObjectBinding