### PR TITLE
Update build.yml to trigger on a published release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,8 +5,8 @@ on:
     branches: [ develop ]
   pull_request:
     branches: [ develop ]
-  create:
-    tags: [ '*' ]
+  release:
+    type: [ published ]
 
 env:
   DotNetVersion: "3.1.301"
@@ -116,26 +116,21 @@ jobs:
         name: log
         path: artifacts/log/**/*
 
-  create-release:
+  update-release:
     needs: [ build-windows, build-mac ]
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
 
-      - name: Create release
-        id: create_release
-        uses: actions/create-release@v1
+      - name: Get release
+        id: get_release
+        uses: bruceadams/get-release@v1.2.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ steps.get_version.outputs.VERSION }}
-          draft: true
-          prerelease: false
-
+        
       - name: Download extension artifacts
         uses: actions/download-artifact@v2
         with:
@@ -146,7 +141,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: Eto.Addin.VisualStudio-${{ steps.get_version.outputs.VERSION }}.vsix
           asset_name: Eto.Addin.VisualStudio-${{ steps.get_version.outputs.VERSION }}.vsix
           asset_content_type: application/octet-stream
@@ -156,7 +151,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          upload_url: ${{ steps.get_release.outputs.upload_url }}
           asset_path: Eto.Addin.MonoDevelop-${{ steps.get_version.outputs.VERSION }}.mpack
           asset_name: Eto.Addin.MonoDevelop-${{ steps.get_version.outputs.VERSION }}.mpack
           asset_content_type: application/octet-stream
@@ -164,7 +159,7 @@ jobs:
   publish:
     needs: [ build-windows, build-mac ]
     runs-on: ubuntu-latest
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || startsWith(github.ref, 'refs/tags/')
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.ref, 'refs/tags/'))
     steps:
       - name: Download nuget artifacts
         uses: actions/download-artifact@v2
@@ -175,5 +170,5 @@ jobs:
         run: dotnet nuget push '*.nupkg' --skip-duplicate -s https://www.myget.org/F/eto/api/v2/package -k ${{secrets.MYGET_API_KEY}}
 
       - name: Push packages to nuget.org
-        if: startsWith(github.ref, 'refs/tags/')
+        if: (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.ref, 'refs/tags/'))
         run: dotnet nuget push '*.nupkg' --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ develop ]
   release:
-    type: [ published ]
+    types: [ published ]
 
 env:
   DotNetVersion: "3.1.301"


### PR DESCRIPTION
This way I can publish from GitHub directly instead of creating a tag manually.