### PR TITLE
Make sliders use floating point values

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/SliderHandler.cs
@@ -5,9 +5,9 @@ namespace Eto.GtkSharp.Forms.Controls
 {
 	public class SliderHandler : GtkControl<Gtk.EventBox, Slider, Slider.ICallback>, Slider.IHandler
 	{
-		int min;
-		int max = 100;
-		int tick = 1;
+		double min;
+		double max = 100;
+		double tick = 1;
 		Gtk.Scale scale;
 
 		public SliderHandler()
@@ -64,7 +64,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
-		public int MaxValue
+		public double MaxValue
 		{
 			get { return max; }
 			set
@@ -74,7 +74,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
-		public int MinValue
+		public double MinValue
 		{
 			get { return min; }
 			set
@@ -84,15 +84,15 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
-		public int Value
+		public double Value
 		{
-			get { return (int)scale.Value; }
+			get { return scale.Value; }
 			set { scale.Value = value; }
 		}
 
 		public bool SnapToTick { get; set; }
 
-		public int TickFrequency
+		public double TickFrequency
 		{
 			get
 			{

--- a/src/Eto.Mac/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SliderHandler.cs
@@ -125,7 +125,7 @@ namespace Eto.Mac.Forms.Controls
 			}
 			set
 			{ 
-				Control.TickMarksCount = value > 0 ? ((MaxValue - MinValue) / value) + 1 : 0;
+				Control.TickMarksCount = (long)(value > 0 ? ((MaxValue - MinValue) / value) + 1 : 0);
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SliderHandler.cs
@@ -83,7 +83,7 @@ namespace Eto.Mac.Forms.Controls
 
 		public double MaxValue
 		{
-			get { return (int)Control.MaxValue; }
+			get { return Control.MaxValue; }
 			set
 			{ 
 				var old = TickFrequency;
@@ -94,7 +94,7 @@ namespace Eto.Mac.Forms.Controls
 
 		public double MinValue
 		{
-			get { return (int)Control.MinValue; }
+			get { return Control.MinValue; }
 			set
 			{
 				var old = TickFrequency;

--- a/src/Eto.Mac/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SliderHandler.cs
@@ -125,7 +125,7 @@ namespace Eto.Mac.Forms.Controls
 			}
 			set
 			{ 
-				Control.TickMarksCount = (long)(value > 0 ? ((MaxValue - MinValue) / value) + 1 : 0);
+				Control.TickMarksCount = (nint)(value > 0 ? ((MaxValue - MinValue) / value) + 1 : 0);
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SliderHandler.cs
@@ -81,7 +81,7 @@ namespace Eto.Mac.Forms.Controls
 			return Orientation == Orientation.Horizontal ? new Size(80, 30) : new Size(30, 80);
 		}
 
-		public int MaxValue
+		public double MaxValue
 		{
 			get { return (int)Control.MaxValue; }
 			set
@@ -92,7 +92,7 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		public int MinValue
+		public double MinValue
 		{
 			get { return (int)Control.MinValue; }
 			set
@@ -103,10 +103,10 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		public int Value
+		public double Value
 		{
-			get { return Control.IntValue; }
-			set { Control.IntValue = value; }
+			get { return Control.DoubleValue; }
+			set { Control.DoubleValue = value; }
 		}
 
 		public bool SnapToTick
@@ -115,12 +115,12 @@ namespace Eto.Mac.Forms.Controls
 			set { Control.AllowsTickMarkValuesOnly = value; }
 		}
 
-		public int TickFrequency
+		public double TickFrequency
 		{
 			get
 			{ 
 				if (Control.TickMarksCount > 1)
-					return (int)((MaxValue - MinValue) / (Control.TickMarksCount - 1));
+					return (MaxValue - MinValue) / (Control.TickMarksCount - 1);
 				return 0;
 			}
 			set

--- a/src/Eto.WinForms/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/SliderHandler.cs
@@ -57,32 +57,32 @@ namespace Eto.WinForms.Forms.Controls
 			}
 		}
 
-		public int MaxValue
+		public double MaxValue
 		{
-			get { return Control.Maximum; }
-			set { Control.Maximum = value; }
+			get { return (double)Control.Maximum; }
+			set { Control.Maximum = (int)value; }
 		}
 
-		public int MinValue
+		public double MinValue
 		{
-			get { return Control.Minimum; }
-			set { Control.Minimum = value; }
+			get { return (double)Control.Minimum; }
+			set { Control.Minimum = (int)value; }
 		}
 
-		public int Value
+		public double Value
 		{
-			get { return Control.Value; }
-			set { Control.Value = value; }
+			get { return (double)Control.Value; }
+			set { Control.Value = (int)value; }
 		}
 
 		public bool SnapToTick { get; set; }
 
-		public int TickFrequency
+		public double TickFrequency
 		{
-			get { return Control.TickFrequency; }
+			get { return (double)Control.TickFrequency; }
 			set
 			{
-				Control.TickFrequency = value;
+				Control.TickFrequency = (int)value;
 			}
 		}
 

--- a/src/Eto.WinRT/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.WinRT/Forms/Controls/SliderHandler.cs
@@ -29,21 +29,21 @@ namespace Eto.WinRT.Forms.Controls
 
 		public override bool UseKeyPreview { get { return true; } }
 
-		public int MaxValue
+		public double MaxValue
 		{
-			get { return (int)Control.Maximum; }
+			get { return Control.Maximum; }
 			set { Control.Maximum = value; }
 		}
 
-		public int MinValue
+		public double MinValue
 		{
-			get { return (int)Control.Minimum; }
+			get { return Control.Minimum; }
 			set { Control.Minimum = value; }
 		}
 
-		public int Value
+		public double Value
 		{
-			get { return (int)Control.Value; }
+			get { return Control.Value; }
 			set { Control.Value = value; }
 		}
 
@@ -53,9 +53,9 @@ namespace Eto.WinRT.Forms.Controls
             set { Control.SnapsTo = SliderSnapsTo.Ticks; }
         }
 
-		public int TickFrequency
+		public double TickFrequency
 		{
-			get { return (int)Control.TickFrequency; }
+			get { return Control.TickFrequency; }
 			set { Control.TickFrequency = value; }
 		}
 

--- a/src/Eto.Wpf/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/SliderHandler.cs
@@ -43,21 +43,21 @@ namespace Eto.Wpf.Forms.Controls
 
 		public override bool UseKeyPreview { get { return true; } }
 
-		public int MaxValue
+		public double MaxValue
 		{
-			get { return (int)Control.Maximum; }
+			get { return Control.Maximum; }
 			set { Control.Maximum = value; }
 		}
 
-		public int MinValue
+		public double MinValue
 		{
-			get { return (int)Control.Minimum; }
+			get { return Control.Minimum; }
 			set { Control.Minimum = value; }
 		}
 
-		public int Value
+		public double Value
 		{
-			get { return (int)Control.Value; }
+			get { return Control.Value; }
 			set { Control.Value = value; }
 		}
 
@@ -67,9 +67,9 @@ namespace Eto.Wpf.Forms.Controls
             set { Control.IsSnapToTickEnabled = value; }
         }
 
-		public int TickFrequency
+		public double TickFrequency
 		{
-			get { return (int)Control.TickFrequency; }
+			get { return Control.TickFrequency; }
 			set { Control.TickFrequency = value; }
 		}
 

--- a/src/Eto.iOS/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.iOS/Forms/Controls/SliderHandler.cs
@@ -43,25 +43,25 @@ namespace Eto.iOS.Forms.Controls
 			TickFrequency = 1;
 		}
 
-		public int MaxValue
+		public double MaxValue
 		{
-			get { return (int)Control.MaxValue; }
+			get { return Control.MaxValue; }
 			set { Control.MaxValue = value; }
 		}
 
-		public int MinValue
+		public double MinValue
 		{
-			get { return (int)Control.MinValue; }
+			get { return Control.MinValue; }
 			set { Control.MinValue = value; }
 		}
 
-		public int Value
+		public double Value
 		{
-			get { return (int)Control.Value; }
+			get { return Control.Value; }
 			set { Control.Value = value; }
 		}
 
-		public int TickFrequency { get; set; }
+		public double TickFrequency { get; set; }
 
 		public bool SnapToTick
 		{

--- a/src/Eto/Forms/Controls/Slider.cs
+++ b/src/Eto/Forms/Controls/Slider.cs
@@ -32,7 +32,7 @@ namespace Eto.Forms
 		/// This is for visual representation only, unless the <see cref="SnapToTick"/> is set to true.
 		/// </remarks>
 		/// <value>The tick frequency.</value>
-		public int TickFrequency
+		public double TickFrequency
 		{
 			get { return Handler.TickFrequency; }
 			set { Handler.TickFrequency = value; }
@@ -57,7 +57,7 @@ namespace Eto.Forms
 		/// Gets or sets the maximum value that can be set by the user.
 		/// </summary>
 		/// <value>The maximum value.</value>
-		public int MaxValue
+		public double MaxValue
 		{
 			get { return Handler.MaxValue; }
 			set { Handler.MaxValue = value; }
@@ -67,7 +67,7 @@ namespace Eto.Forms
 		/// Gets or sets the minimum value that can be set by the user.
 		/// </summary>
 		/// <value>The minimum value.</value>
-		public int MinValue
+		public double MinValue
 		{
 			get { return Handler.MinValue; }
 			set { Handler.MinValue = value; }
@@ -77,7 +77,7 @@ namespace Eto.Forms
 		/// Gets or sets the current slider value.
 		/// </summary>
 		/// <value>The value.</value>
-		public int Value
+		public double Value
 		{
 			get { return Handler.Value; }
 			set { Handler.Value = value; }
@@ -139,19 +139,19 @@ namespace Eto.Forms
 			/// Gets or sets the maximum value that can be set by the user.
 			/// </summary>
 			/// <value>The maximum value.</value>
-			int MaxValue { get; set; }
+			double MaxValue { get; set; }
 
 			/// <summary>
 			/// Gets or sets the minimum value that can be set by the user.
 			/// </summary>
 			/// <value>The minimum value.</value>
-			int MinValue { get; set; }
+			double MinValue { get; set; }
 
 			/// <summary>
 			/// Gets or sets the current slider value.
 			/// </summary>
 			/// <value>The value.</value>
-			int Value { get; set; }
+			double Value { get; set; }
 
 			/// <summary>
 			/// Gets or sets the hint for numeric value between each visual tick.
@@ -160,7 +160,7 @@ namespace Eto.Forms
 			/// This is for visual representation only, unless the <see cref="SnapToTick"/> is set to true.
 			/// </remarks>
 			/// <value>The tick frequency.</value>
-			int TickFrequency { get; set; }
+			double TickFrequency { get; set; }
 
 			/// <summary>
 			/// Gets or sets a value indicating whether the slider will snap to each tick.


### PR DESCRIPTION
This change makes the Slider control use floating point values for all platforms. It appears that only WinForms is the only platform that doesn't support floating point values on sliders (because its so primitive), which has been accommodated for. 

Closes #1772 

## Affected, tested, and functioning as expected
- [x] Gtk
- [ ] Gtk2
- [ ] Gtk3
- [ ] Mac
- [ ] WPF
- [ ] WinForms
- [ ] WinRT
- [ ] iOS

