### PR TITLE
Mac: Fix issues using the NSBitmapImageRep(NSData) constructor

### DIFF
--- a/src/Eto.Mac/Drawing/IconFrameHandler.cs
+++ b/src/Eto.Mac/Drawing/IconFrameHandler.cs
@@ -54,12 +54,26 @@ namespace Eto.Mac.Drawing
 				NSImageRep.RegisterImageRepClass(new Class(typeof(LazyImageRep)));
 			}
 
+			static readonly IntPtr s_selAlloc_Handle = Selector.GetHandle("alloc");
+			static readonly IntPtr s_bitmapImageRepClass = Class.GetHandle(typeof(NSBitmapImageRep));
+			static readonly IntPtr selInitWithData_Handle = Selector.GetHandle("initWithData:");
+
 			public NSBitmapImageRep Rep
 			{
 				get {
 					if (rep != null)
 						return rep;
-					rep = new NSBitmapImageRep(NSData.FromStream(Load()));
+
+					// fatal flaw in Xamarin.Mac/MonoMac here, so we can't use this constructor directly
+					// see https://github.com/xamarin/xamarin-macios/issues/9478
+					var data = NSData.FromStream(Load());
+					var ptr = Messaging.IntPtr_objc_msgSend(s_bitmapImageRepClass, s_selAlloc_Handle);
+					ptr = Messaging.IntPtr_objc_msgSend_IntPtr(ptr, selInitWithData_Handle, data.Handle);
+					rep = Runtime.GetNSObject<NSBitmapImageRep>(ptr);
+
+					// should be this:
+					//rep = new NSBitmapImageRep(NSData.FromStream(Load()));
+					
 					rep.Size = new CGSize(rep.PixelsWide, rep.PixelsHigh); // ignore dpi from image
 					return rep;
 				}


### PR DESCRIPTION
This constructor causes issues with objective-c objects created on other threads, such as invokes, etc.  This would only affected your application if you used `Icon.FromResource()`.

See this for more details: https://github.com/xamarin/xamarin-macios/issues/9478