### PR TITLE
Don't fire CellClick when clicking on a TreeGridView expander

### DIFF
--- a/build/Common.Build.props
+++ b/build/Common.Build.props
@@ -23,6 +23,13 @@
     <!-- Ignore errors/warnings about semver 2.0 when packing CI builds -->
     <NoWarn>$(NoWarn);NU5105</NoWarn>
   </PropertyGroup>
-  
+
+  <!-- support t4 templates in projects -->
+  <ItemGroup>
+    <DotNetCliToolReference Include="dotnet-t4-project-tool" Version="2.0.5"/>
+    <TextTemplate Include="**\*.tt" />
+    <AvailableItemName Include="TextTemplate" />
+  </ItemGroup>
+
   <Import Condition="Exists('$(BasePath)..\Eto.Common.props')" Project="$(BasePath)..\Eto.Common.props" />
 </Project>

--- a/build/Common.Build.targets
+++ b/build/Common.Build.targets
@@ -110,4 +110,20 @@
     </ItemGroup>
     
   </Target>
+
+  <ItemGroup>
+    <None Remove="**\*.tt" />
+  </ItemGroup>
+
+  <Target Name="Transform" BeforeTargets="BeforeBuild" Inputs="@(TextTemplate)" Outputs="%(TextTemplate.RelativeDir)%(TextTemplate.Filename).cs" Condition="$(MSBuildRuntimeType) == 'Core'">
+    <Message Text="Transforming T4 templates..." Importance="high" />
+    <ItemGroup>
+      <Compile Remove="%(TextTemplate.RelativeDir)%(TextTemplate.Filename).cs" />
+    </ItemGroup>
+    <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet t4 %(TextTemplate.Identity) --out %(TextTemplate.RelativeDir)%(TextTemplate.Filename).cs"/>
+    <ItemGroup>
+      <Compile Include="%(TextTemplate.RelativeDir)%(TextTemplate.Filename).cs" />
+    </ItemGroup>
+  </Target>
+
 </Project>

--- a/src/Eto.Gtk/Forms/EtoControls.cs
+++ b/src/Eto.Gtk/Forms/EtoControls.cs
@@ -1,10 +1,17 @@
 ﻿
+
+
+
+
+
+
 using System;
 using Eto;
 using Eto.Drawing;
 
 namespace Eto.GtkSharp.Forms
 {
+
     public partial class EtoFixed : Gtk.Fixed
     {
         WeakReference _handler;
@@ -90,7 +97,8 @@ namespace Eto.GtkSharp.Forms
 
     }
     
-    public partial class EtoEventBox : Gtk.EventBox
+
+    public partial class EtoEventBox  : Gtk.EventBox 
     {
         WeakReference _handler;
         public IGtkControl Handler
@@ -175,4 +183,5 @@ namespace Eto.GtkSharp.Forms
 
     }
     
+
 }

--- a/src/Eto.Gtk/NativeMethods.cs
+++ b/src/Eto.Gtk/NativeMethods.cs
@@ -1,4 +1,11 @@
-﻿﻿
+﻿
+
+
+
+
+
+
+
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -15,6 +22,7 @@ namespace Eto.GtkSharp
 		const string ver = "3";
 #endif
 
+
 		static class NMWindows
 		{
 #if GTK2
@@ -29,168 +37,228 @@ namespace Eto.GtkSharp
 			const string libpango = "libpango-" + plat + ver + ext;
 			const string libwebkit = "libwebkit2gtk-4.0.so.37";
 
+
 			[DllImport(libgobject, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void g_signal_stop_emission_by_name(IntPtr instance, string name);
+
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_new();
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_uri(IntPtr web_view, string uri);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_uri(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_html(IntPtr web_view, string content, string base_uri);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_title(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_reload(IntPtr web_view);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_stop_loading(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_back(IntPtr web_view);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_back(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_forward(IntPtr web_view);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_forward(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_run_javascript(IntPtr web_view, string script, IntPtr cancellable, Delegate callback, IntPtr user_data);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_run_javascript_finish(IntPtr web_view, IntPtr result, IntPtr error);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_global_context(IntPtr js_result);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_value(IntPtr js_result);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr JSValueToStringCopy(IntPtr context, IntPtr value, IntPtr idk);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static int JSStringGetMaximumUTF8CStringSize(IntPtr js_str_value);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringGetUTF8CString(IntPtr js_str_value, IntPtr str_value, int str_length);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringRelease(IntPtr js_str_value);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_navigation_policy_decision_get_request(IntPtr decision);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_uri_request_get_uri(IntPtr request);
 
+
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_clipboard_wait_for_targets(IntPtr cp, out IntPtr atoms, out int number);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_entry_set_placeholder_text(IntPtr entry, string text);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_print_settings_get_page_ranges(IntPtr handle, out int num_ranges);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_color_chooser_dialog_new(string title, IntPtr parent);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_get_rgba(IntPtr chooser, out RGBA color);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_rgba(IntPtr chooser, double[] color);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_use_alpha(IntPtr chooser, bool use_alpha);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_color_chooser_get_use_alpha(IntPtr chooser);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_dialog_new(string title, IntPtr parent);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_get_font(IntPtr fontchooser);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_font_chooser_set_font(IntPtr fontchooser, string fontname);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr g_file_new_for_path(string path);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_app_chooser_dialog_new(IntPtr parrent, int flags, IntPtr file);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_application_prefers_app_menu(IntPtr application);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_header_bar_new();
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_window_set_titlebar(IntPtr window, IntPtr widget);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_start(IntPtr bar, IntPtr child);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_end(IntPtr bar, IntPtr child);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_set_show_close_button(IntPtr bar, bool setting);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_selection_data_get_uris(IntPtr raw);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_selection_data_set_uris(IntPtr raw, IntPtr[] uris);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_print_unix_dialog_get_embed_page_setup(IntPtr raw);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_button_get_event_window(IntPtr button);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_major_version();
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_minor_version();
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_micro_version();
 
+
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
+
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_get_default_root_window();
 
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
 
+
+
 			[DllImport(libpango, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool pango_font_has_char(IntPtr font, int wc);
+
 		}
+
 
 		static class NMLinux
 		{
@@ -206,168 +274,228 @@ namespace Eto.GtkSharp
 			const string libpango = "libpango-" + plat + ver + ext;
 			const string libwebkit = "libwebkit2gtk-4.0.so.37";
 
+
 			[DllImport(libgobject, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void g_signal_stop_emission_by_name(IntPtr instance, string name);
+
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_new();
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_uri(IntPtr web_view, string uri);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_uri(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_html(IntPtr web_view, string content, string base_uri);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_title(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_reload(IntPtr web_view);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_stop_loading(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_back(IntPtr web_view);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_back(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_forward(IntPtr web_view);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_forward(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_run_javascript(IntPtr web_view, string script, IntPtr cancellable, Delegate callback, IntPtr user_data);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_run_javascript_finish(IntPtr web_view, IntPtr result, IntPtr error);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_global_context(IntPtr js_result);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_value(IntPtr js_result);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr JSValueToStringCopy(IntPtr context, IntPtr value, IntPtr idk);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static int JSStringGetMaximumUTF8CStringSize(IntPtr js_str_value);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringGetUTF8CString(IntPtr js_str_value, IntPtr str_value, int str_length);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringRelease(IntPtr js_str_value);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_navigation_policy_decision_get_request(IntPtr decision);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_uri_request_get_uri(IntPtr request);
 
+
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_clipboard_wait_for_targets(IntPtr cp, out IntPtr atoms, out int number);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_entry_set_placeholder_text(IntPtr entry, string text);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_print_settings_get_page_ranges(IntPtr handle, out int num_ranges);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_color_chooser_dialog_new(string title, IntPtr parent);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_get_rgba(IntPtr chooser, out RGBA color);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_rgba(IntPtr chooser, double[] color);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_use_alpha(IntPtr chooser, bool use_alpha);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_color_chooser_get_use_alpha(IntPtr chooser);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_dialog_new(string title, IntPtr parent);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_get_font(IntPtr fontchooser);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_font_chooser_set_font(IntPtr fontchooser, string fontname);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr g_file_new_for_path(string path);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_app_chooser_dialog_new(IntPtr parrent, int flags, IntPtr file);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_application_prefers_app_menu(IntPtr application);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_header_bar_new();
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_window_set_titlebar(IntPtr window, IntPtr widget);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_start(IntPtr bar, IntPtr child);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_end(IntPtr bar, IntPtr child);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_set_show_close_button(IntPtr bar, bool setting);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_selection_data_get_uris(IntPtr raw);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_selection_data_set_uris(IntPtr raw, IntPtr[] uris);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_print_unix_dialog_get_embed_page_setup(IntPtr raw);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_button_get_event_window(IntPtr button);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_major_version();
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_minor_version();
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_micro_version();
 
+
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
+
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_get_default_root_window();
 
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
 
+
+
 			[DllImport(libpango, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool pango_font_has_char(IntPtr font, int wc);
+
 		}
+
 
 		static class NMMac
 		{
@@ -383,168 +511,228 @@ namespace Eto.GtkSharp
 			const string libpango = "libpango-" + plat + ver + ext;
 			const string libwebkit = "libwebkit2gtk-4.0.so.37";
 
+
 			[DllImport(libgobject, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void g_signal_stop_emission_by_name(IntPtr instance, string name);
+
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_new();
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_uri(IntPtr web_view, string uri);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_uri(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_html(IntPtr web_view, string content, string base_uri);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_title(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_reload(IntPtr web_view);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_stop_loading(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_back(IntPtr web_view);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_back(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_forward(IntPtr web_view);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_forward(IntPtr web_view);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_run_javascript(IntPtr web_view, string script, IntPtr cancellable, Delegate callback, IntPtr user_data);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_run_javascript_finish(IntPtr web_view, IntPtr result, IntPtr error);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_global_context(IntPtr js_result);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_value(IntPtr js_result);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr JSValueToStringCopy(IntPtr context, IntPtr value, IntPtr idk);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static int JSStringGetMaximumUTF8CStringSize(IntPtr js_str_value);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringGetUTF8CString(IntPtr js_str_value, IntPtr str_value, int str_length);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringRelease(IntPtr js_str_value);
 
+
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_navigation_policy_decision_get_request(IntPtr decision);
+
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_uri_request_get_uri(IntPtr request);
 
+
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_clipboard_wait_for_targets(IntPtr cp, out IntPtr atoms, out int number);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_entry_set_placeholder_text(IntPtr entry, string text);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_print_settings_get_page_ranges(IntPtr handle, out int num_ranges);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_color_chooser_dialog_new(string title, IntPtr parent);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_get_rgba(IntPtr chooser, out RGBA color);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_rgba(IntPtr chooser, double[] color);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_use_alpha(IntPtr chooser, bool use_alpha);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_color_chooser_get_use_alpha(IntPtr chooser);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_dialog_new(string title, IntPtr parent);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_get_font(IntPtr fontchooser);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_font_chooser_set_font(IntPtr fontchooser, string fontname);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr g_file_new_for_path(string path);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_app_chooser_dialog_new(IntPtr parrent, int flags, IntPtr file);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_application_prefers_app_menu(IntPtr application);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_header_bar_new();
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_window_set_titlebar(IntPtr window, IntPtr widget);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_start(IntPtr bar, IntPtr child);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_end(IntPtr bar, IntPtr child);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_set_show_close_button(IntPtr bar, bool setting);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_selection_data_get_uris(IntPtr raw);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_selection_data_set_uris(IntPtr raw, IntPtr[] uris);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_print_unix_dialog_get_embed_page_setup(IntPtr raw);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_button_get_event_window(IntPtr button);
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_major_version();
 
+
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_minor_version();
+
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_micro_version();
 
+
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
+
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_get_default_root_window();
 
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
 
+
+
 			[DllImport(libpango, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool pango_font_has_char(IntPtr font, int wc);
+
 		}
+
 
 		public static string GetString(IntPtr handle)
 		{
@@ -560,8 +748,10 @@ namespace Eto.GtkSharp
 			return Encoding.UTF8.GetString(bytes);
 		}
 
+
 		public static void g_signal_stop_emission_by_name(IntPtr instance, string name)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.g_signal_stop_emission_by_name(instance, name);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -570,8 +760,10 @@ namespace Eto.GtkSharp
 				NMWindows.g_signal_stop_emission_by_name(instance, name);
 		}
 
+
 		public static bool gtk_clipboard_wait_for_targets(IntPtr cp, out IntPtr atoms, out int number)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_clipboard_wait_for_targets(cp, out atoms, out number);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -580,8 +772,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_clipboard_wait_for_targets(cp, out atoms, out number);
 		}
 
+
 		public static void gtk_entry_set_placeholder_text(IntPtr entry, string text)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_entry_set_placeholder_text(entry, text);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -590,8 +784,10 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_entry_set_placeholder_text(entry, text);
 		}
 
+
 		public static IntPtr gtk_print_settings_get_page_ranges(IntPtr handle, out int num_ranges)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_print_settings_get_page_ranges(handle, out num_ranges);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -600,8 +796,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_print_settings_get_page_ranges(handle, out num_ranges);
 		}
 
+
 		public static IntPtr gtk_color_chooser_dialog_new(string title, IntPtr parent)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_color_chooser_dialog_new(title, parent);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -610,8 +808,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_color_chooser_dialog_new(title, parent);
 		}
 
+
 		public static void gtk_color_chooser_get_rgba(IntPtr chooser, out RGBA color)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_color_chooser_get_rgba(chooser, out color);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -620,8 +820,10 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_color_chooser_get_rgba(chooser, out color);
 		}
 
+
 		public static void gtk_color_chooser_set_rgba(IntPtr chooser, double[] color)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_color_chooser_set_rgba(chooser, color);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -630,8 +832,10 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_color_chooser_set_rgba(chooser, color);
 		}
 
+
 		public static void gtk_color_chooser_set_use_alpha(IntPtr chooser, bool use_alpha)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_color_chooser_set_use_alpha(chooser, use_alpha);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -640,8 +844,10 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_color_chooser_set_use_alpha(chooser, use_alpha);
 		}
 
+
 		public static bool gtk_color_chooser_get_use_alpha(IntPtr chooser)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_color_chooser_get_use_alpha(chooser);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -650,8 +856,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_color_chooser_get_use_alpha(chooser);
 		}
 
+
 		public static IntPtr gtk_font_chooser_dialog_new(string title, IntPtr parent)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_font_chooser_dialog_new(title, parent);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -660,8 +868,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_font_chooser_dialog_new(title, parent);
 		}
 
+
 		public static string gtk_font_chooser_get_font(IntPtr fontchooser)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return GetString(NMLinux.gtk_font_chooser_get_font(fontchooser));
 			else if (EtoEnvironment.Platform.IsMac)
@@ -670,8 +880,10 @@ namespace Eto.GtkSharp
 				return GetString(NMWindows.gtk_font_chooser_get_font(fontchooser));
 		}
 
+
 		public static void gtk_font_chooser_set_font(IntPtr fontchooser, string fontname)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_font_chooser_set_font(fontchooser, fontname);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -680,8 +892,10 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_font_chooser_set_font(fontchooser, fontname);
 		}
 
+
 		public static IntPtr g_file_new_for_path(string path)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.g_file_new_for_path(path);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -690,8 +904,10 @@ namespace Eto.GtkSharp
 				return NMWindows.g_file_new_for_path(path);
 		}
 
+
 		public static IntPtr gtk_app_chooser_dialog_new(IntPtr parrent, int flags, IntPtr file)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_app_chooser_dialog_new(parrent, flags, file);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -700,8 +916,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_app_chooser_dialog_new(parrent, flags, file);
 		}
 
+
 		public static bool gtk_application_prefers_app_menu(IntPtr application)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_application_prefers_app_menu(application);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -710,8 +928,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_application_prefers_app_menu(application);
 		}
 
+
 		public static IntPtr gtk_header_bar_new()
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_header_bar_new();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -720,8 +940,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_header_bar_new();
 		}
 
+
 		public static void gtk_window_set_titlebar(IntPtr window, IntPtr widget)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_window_set_titlebar(window, widget);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -730,8 +952,10 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_window_set_titlebar(window, widget);
 		}
 
+
 		public static void gtk_header_bar_pack_start(IntPtr bar, IntPtr child)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_header_bar_pack_start(bar, child);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -740,8 +964,10 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_header_bar_pack_start(bar, child);
 		}
 
+
 		public static void gtk_header_bar_pack_end(IntPtr bar, IntPtr child)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_header_bar_pack_end(bar, child);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -750,8 +976,10 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_header_bar_pack_end(bar, child);
 		}
 
+
 		public static void gtk_header_bar_set_show_close_button(IntPtr bar, bool setting)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_header_bar_set_show_close_button(bar, setting);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -760,8 +988,10 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_header_bar_set_show_close_button(bar, setting);
 		}
 
+
 		public static IntPtr gtk_selection_data_get_uris(IntPtr raw)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_selection_data_get_uris(raw);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -770,8 +1000,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_selection_data_get_uris(raw);
 		}
 
+
 		public static bool gtk_selection_data_set_uris(IntPtr raw, IntPtr[] uris)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_selection_data_set_uris(raw, uris);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -780,8 +1012,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_selection_data_set_uris(raw, uris);
 		}
 
+
 		public static bool gtk_print_unix_dialog_get_embed_page_setup(IntPtr raw)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_print_unix_dialog_get_embed_page_setup(raw);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -790,8 +1024,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_print_unix_dialog_get_embed_page_setup(raw);
 		}
 
+
 		public static void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_print_unix_dialog_set_embed_page_setup(raw, embed);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -800,8 +1036,10 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_print_unix_dialog_set_embed_page_setup(raw, embed);
 		}
 
+
 		public static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_grid_get_child_at(raw, left, top);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -810,8 +1048,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_grid_get_child_at(raw, left, top);
 		}
 
+
 		public static IntPtr gtk_button_get_event_window(IntPtr button)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_button_get_event_window(button);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -820,8 +1060,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_button_get_event_window(button);
 		}
 
+
 		public static uint gtk_get_major_version()
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_get_major_version();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -830,8 +1072,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_get_major_version();
 		}
 
+
 		public static uint gtk_get_minor_version()
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_get_minor_version();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -840,8 +1084,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_get_minor_version();
 		}
 
+
 		public static uint gtk_get_micro_version()
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_get_micro_version();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -850,8 +1096,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_get_micro_version();
 		}
 
+
 		public static IntPtr webkit_web_view_new()
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_web_view_new();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -860,8 +1108,10 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_web_view_new();
 		}
 
+
 		public static void webkit_web_view_load_uri(IntPtr web_view, string uri)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_load_uri(web_view, uri);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -870,8 +1120,10 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_load_uri(web_view, uri);
 		}
 
+
 		public static string webkit_web_view_get_uri(IntPtr web_view)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return GetString(NMLinux.webkit_web_view_get_uri(web_view));
 			else if (EtoEnvironment.Platform.IsMac)
@@ -880,8 +1132,10 @@ namespace Eto.GtkSharp
 				return GetString(NMWindows.webkit_web_view_get_uri(web_view));
 		}
 
+
 		public static void webkit_web_view_load_html(IntPtr web_view, string content, string base_uri)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_load_html(web_view, content, base_uri);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -890,8 +1144,10 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_load_html(web_view, content, base_uri);
 		}
 
+
 		public static string webkit_web_view_get_title(IntPtr web_view)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return GetString(NMLinux.webkit_web_view_get_title(web_view));
 			else if (EtoEnvironment.Platform.IsMac)
@@ -900,8 +1156,10 @@ namespace Eto.GtkSharp
 				return GetString(NMWindows.webkit_web_view_get_title(web_view));
 		}
 
+
 		public static void webkit_web_view_reload(IntPtr web_view)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_reload(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -910,8 +1168,10 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_reload(web_view);
 		}
 
+
 		public static void webkit_web_view_stop_loading(IntPtr web_view)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_stop_loading(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -920,8 +1180,10 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_stop_loading(web_view);
 		}
 
+
 		public static bool webkit_web_view_can_go_back(IntPtr web_view)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_web_view_can_go_back(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -930,8 +1192,10 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_web_view_can_go_back(web_view);
 		}
 
+
 		public static void webkit_web_view_go_back(IntPtr web_view)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_go_back(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -940,8 +1204,10 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_go_back(web_view);
 		}
 
+
 		public static bool webkit_web_view_can_go_forward(IntPtr web_view)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_web_view_can_go_forward(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -950,8 +1216,10 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_web_view_can_go_forward(web_view);
 		}
 
+
 		public static void webkit_web_view_go_forward(IntPtr web_view)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_go_forward(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -960,8 +1228,10 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_go_forward(web_view);
 		}
 
+
 		public static void webkit_web_view_run_javascript(IntPtr web_view, string script, IntPtr cancellable, Delegate callback, IntPtr user_data)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_run_javascript(web_view, script, cancellable, callback, user_data);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -970,8 +1240,10 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_run_javascript(web_view, script, cancellable, callback, user_data);
 		}
 
+
 		public static IntPtr webkit_web_view_run_javascript_finish(IntPtr web_view, IntPtr result, IntPtr error)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_web_view_run_javascript_finish(web_view, result, error);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -980,8 +1252,10 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_web_view_run_javascript_finish(web_view, result, error);
 		}
 
+
 		public static IntPtr webkit_javascript_result_get_global_context(IntPtr js_result)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_javascript_result_get_global_context(js_result);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -990,8 +1264,10 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_javascript_result_get_global_context(js_result);
 		}
 
+
 		public static IntPtr webkit_javascript_result_get_value(IntPtr js_result)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_javascript_result_get_value(js_result);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1000,8 +1276,10 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_javascript_result_get_value(js_result);
 		}
 
+
 		public static IntPtr JSValueToStringCopy(IntPtr context, IntPtr value, IntPtr idk)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.JSValueToStringCopy(context, value, idk);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1010,8 +1288,10 @@ namespace Eto.GtkSharp
 				return NMWindows.JSValueToStringCopy(context, value, idk);
 		}
 
+
 		public static int JSStringGetMaximumUTF8CStringSize(IntPtr js_str_value)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.JSStringGetMaximumUTF8CStringSize(js_str_value);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1020,8 +1300,10 @@ namespace Eto.GtkSharp
 				return NMWindows.JSStringGetMaximumUTF8CStringSize(js_str_value);
 		}
 
+
 		public static void JSStringGetUTF8CString(IntPtr js_str_value, IntPtr str_value, int str_length)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.JSStringGetUTF8CString(js_str_value, str_value, str_length);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1030,8 +1312,10 @@ namespace Eto.GtkSharp
 				NMWindows.JSStringGetUTF8CString(js_str_value, str_value, str_length);
 		}
 
+
 		public static void JSStringRelease(IntPtr js_str_value)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.JSStringRelease(js_str_value);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1040,8 +1324,10 @@ namespace Eto.GtkSharp
 				NMWindows.JSStringRelease(js_str_value);
 		}
 
+
 		public static IntPtr webkit_navigation_policy_decision_get_request(IntPtr decision)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_navigation_policy_decision_get_request(decision);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1050,8 +1336,10 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_navigation_policy_decision_get_request(decision);
 		}
 
+
 		public static string webkit_uri_request_get_uri(IntPtr request)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return GetString(NMLinux.webkit_uri_request_get_uri(request));
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1060,8 +1348,10 @@ namespace Eto.GtkSharp
 				return GetString(NMWindows.webkit_uri_request_get_uri(request));
 		}
 
+
 		public static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gdk_cairo_get_clip_rectangle(context, rect);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1070,8 +1360,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gdk_cairo_get_clip_rectangle(context, rect);
 		}
 
+
 		public static IntPtr gdk_get_default_root_window()
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gdk_get_default_root_window();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1080,8 +1372,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gdk_get_default_root_window();
 		}
 
+
 		public static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gdk_pixbuf_get_from_window(window, x, y, width, height);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1090,8 +1384,10 @@ namespace Eto.GtkSharp
 				return NMWindows.gdk_pixbuf_get_from_window(window, x, y, width, height);
 		}
 
+
 		public static bool pango_font_has_char(IntPtr font, int wc)
 		{
+
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.pango_font_has_char(font, wc);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1099,5 +1395,6 @@ namespace Eto.GtkSharp
 			else
 				return NMWindows.pango_font_has_char(font, wc);
 		}
+
 	}
 }

--- a/src/Eto.Wpf/CustomControls/TreeGridView/TreeToggleButton.cs
+++ b/src/Eto.Wpf/CustomControls/TreeGridView/TreeToggleButton.cs
@@ -41,6 +41,20 @@ namespace Eto.Wpf.CustomControls.TreeGridView
 			}
 		}
 
+		public static bool IsOverExpander(DependencyObject hitTestResult)
+		{
+			while (hitTestResult != null)
+			{
+				if (hitTestResult is TreeToggleButton ttb)
+					return ttb.IsVisible;
+				if (hitTestResult is DataGridCell)
+					return false;
+				hitTestResult = hitTestResult.GetVisualParent<DependencyObject>();
+			}
+
+			return false;
+		}
+
 		public static bool? IsOverContent(DependencyObject hitTestResult)
 		{
 			if (hitTestResult is TreeTogglePanel)
@@ -55,7 +69,7 @@ namespace Eto.Wpf.CustomControls.TreeGridView
 					return true;
 				hitTestResult = hitTestResult.GetVisualParent<DependencyObject>();
 			}
-			return false;
+			return !ReferenceEquals(hitTestResult, panel);
 		}
 	}
 

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -180,7 +180,15 @@ namespace Eto.Wpf.Forms.Controls
 					// handled by each cell after value is set with the CellEdited method
 					break;
 				case Grid.CellClickEvent:
-					Control.PreviewMouseDown += (sender, e) => Callback.OnCellClick(Widget, CreateCellMouseArgs(e.OriginalSource, e));
+					Control.PreviewMouseDown += (sender, e) => {
+						var hitTestResult = swm.VisualTreeHelper.HitTest(Control, e.GetPosition(Control))?.VisualHit;
+						if (!TreeTogglePanel.IsOverExpander(hitTestResult))
+						{
+							var args = CreateCellMouseArgs(e.OriginalSource, e);
+							Callback.OnCellClick(Widget, args);
+							e.Handled = args.Handled;
+						}
+					};
 					break;
 				case Grid.CellDoubleClickEvent:
 					Control.MouseDoubleClick += (sender, e) => Callback.OnCellDoubleClick(Widget, CreateCellMouseArgs(e.OriginalSource, e));
@@ -353,7 +361,9 @@ namespace Eto.Wpf.Forms.Controls
 					if (cell != null)
 					{
 						var args = CreateCellMouseArgs(cell, e);
-						Callback.OnCellClick(Widget, args);
+						if (!TreeTogglePanel.IsOverExpander(hitTestResult))
+							Callback.OnCellClick(Widget, args);
+
 						if (!args.Handled)
 						{
 							if (!hadMultipleSelection && ReferenceEquals(info.Cell, cell))


### PR DESCRIPTION
This allows you to handle custom code when clicking on the cell without interfering with clicks to expand/collapse a node.

This brings WPF and GTK in line with how it works on macOS.