### PR TITLE
Fix comparing colors when they are only off by a single byte value

### DIFF
--- a/src/Eto/Drawing/Color.cs
+++ b/src/Eto/Drawing/Color.cs
@@ -18,7 +18,7 @@ namespace Eto.Drawing
 		// static members for mapping color names from the Colors class
 		static Dictionary<string, Color> colormap;
 		static readonly object colormaplock = new object();
-		internal const float Epsilon = 1f / byte.MaxValue;
+		internal const float Epsilon = 1f / 256f;
 
 		/// <summary>
 		/// Gets or sets the alpha/opacity (0-1)


### PR DESCRIPTION
Whey say red is 255 vs 254, it would be equal.  An example of a case that doesn't work:

<img width="404" alt="Screen Shot 2020-08-28 at 12 50 24 PM" src="https://user-images.githubusercontent.com/367446/91609871-0c74c200-e92d-11ea-8d08-fbaaeaa91ad1.png">
