### PR TITLE
Mac: Fix using custom types for Drag/Drop

### DIFF
--- a/test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
@@ -32,6 +32,12 @@ namespace Eto.Test.Sections.Behaviors
 				clipboard.Image = TestIcons.TestImage;
 				Update();
 			};
+			var copyCustomButton = new Button { Text = "Copy Custom" };
+			copyCustomButton.Click += (sender, e) =>
+			{
+				clipboard.SetString("my value", "my.custom.type");
+				Update();
+			};
 
 			var pasteTextButton = new Button { Text = "Paste" };
 			pasteTextButton.Click += (sender, e) => Update();
@@ -54,7 +60,7 @@ namespace Eto.Test.Sections.Behaviors
 						Orientation = Orientation.Horizontal, 
 						Spacing = 5,
 						Padding = new Padding(10),
-						Items = { copyTextButton, copyHtmlButton, copyImageButton, pasteTextButton, clearButton }
+						Items = { copyTextButton, copyHtmlButton, copyImageButton, copyCustomButton, pasteTextButton, clearButton }
 					},
 					new StackLayoutItem(pasteData, expand: true)
 				}

--- a/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
@@ -69,6 +69,7 @@ namespace Eto.Test.Sections.Behaviors
 					data.Html = htmlTextArea.Text;
 				if (includeImageCheck.Checked == true)
 					data.Image = TestIcons.Logo;
+
 				return data;
 			}
 
@@ -107,7 +108,7 @@ namespace Eto.Test.Sections.Behaviors
 						return;
 					var data = CreateDataObject();
 					var selected = treeSource.SelectedItems.OfType<TreeGridItem>().Select(r => (string)r.Values[0]);
-					data.SetString(string.Join(";", selected), "my-tree-data");
+					data.SetString(string.Join(";", selected), "my.tree.data");
 
 					DoDragDrop(treeSource, data);
 					e.Handled = true;
@@ -127,7 +128,7 @@ namespace Eto.Test.Sections.Behaviors
 						return;
 					var data = CreateDataObject();
 					var selected = gridSource.SelectedItems.OfType<GridItem>().Select(r => (string)r.Values[0]);
-					data.SetString(string.Join(";", selected), "my-grid-data");
+					data.SetString(string.Join(";", selected), "my.grid.data");
 
 					DoDragDrop(gridSource, data);
 					e.Handled = true;


### PR DESCRIPTION
If you created a DataObject with _only_ a custom data type set, it wouldn't allow you to drag to any other control if it "looked" like a UTI type like "my.custom.type".  This ensures the custom type is registered properly and has a base type of UTType.Item, which is what we listen for when setting `AllowDrop = true`.