### PR TITLE
Wpf: Fix crash with TreeGridView for editable cells

### DIFF
--- a/src/Eto.Wpf/CustomControls/TreeGridView/TreeToggleButton.cs
+++ b/src/Eto.Wpf/CustomControls/TreeGridView/TreeToggleButton.cs
@@ -15,7 +15,7 @@ namespace Eto.Wpf.CustomControls.TreeGridView
 	{
 		public const int LevelWidth = 16;
 		readonly TreeToggleButton button;
-		readonly FrameworkElement content;
+		FrameworkElement _content;
 
 		public TreeTogglePanel(FrameworkElement content, TreeController controller)
 		{
@@ -24,9 +24,19 @@ namespace Eto.Wpf.CustomControls.TreeGridView
 			SetDock(button, Dock.Left);
 			Children.Add(button);
 			Children.Add(content);
-			this.content = content;
+			_content = content;
 
 			DataContextChanged += OnDataContextChanged;
+		}
+
+		public void SetContent(FrameworkElement content)
+		{
+			if (ReferenceEquals(content, _content))
+				return;
+
+			Children.Remove(_content);
+			Children.Add(content);
+			_content = content;
 		}
 
 		private void OnDataContextChanged(object sender, DependencyPropertyChangedEventArgs e)
@@ -65,7 +75,7 @@ namespace Eto.Wpf.CustomControls.TreeGridView
 
 			while (hitTestResult != null && !ReferenceEquals(hitTestResult, panel))
 			{
-				if (ReferenceEquals(hitTestResult, panel.content))
+				if (ReferenceEquals(hitTestResult, panel._content))
 					return true;
 				hitTestResult = hitTestResult.GetVisualParent<DependencyObject>();
 			}
@@ -83,12 +93,6 @@ namespace Eto.Wpf.CustomControls.TreeGridView
 		{
 			DefaultStyleKeyProperty.OverrideMetadata (typeof (TreeToggleButton), new FrameworkPropertyMetadata (typeof (TreeToggleButton)));
 		}
-
-		public static FrameworkElement Create (FrameworkElement content, TreeController controller)
-		{
-			return new TreeTogglePanel(content, controller);
-		}
-
 
 		protected override void OnPreviewMouseLeftButtonUp(MouseButtonEventArgs e)
 		{

--- a/src/Eto.Wpf/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CellHandler.cs
@@ -7,7 +7,7 @@ namespace Eto.Wpf.Forms.Cells
 	public interface ICellContainerHandler
 	{
 		Grid Grid { get; }
-		sw.FrameworkElement SetupCell(ICellHandler cell, sw.FrameworkElement defaultContent);
+		sw.FrameworkElement SetupCell(ICellHandler handler, sw.FrameworkElement defaultContent, swc.DataGridCell cell);
 		void FormatCell(ICellHandler cell, sw.FrameworkElement element, swc.DataGridCell datacell, object dataItem);
 		void CellEdited(ICellHandler cell, sw.FrameworkElement element);
 	}
@@ -44,9 +44,9 @@ namespace Eto.Wpf.Forms.Cells
 			ContainerHandler.FormatCell(this, element, cell, dataItem);
 		}
 
-		public sw.FrameworkElement SetupCell(sw.FrameworkElement defaultContent)
+		public sw.FrameworkElement SetupCell(sw.FrameworkElement defaultContent, swc.DataGridCell cell)
 		{
-			return ContainerHandler != null ? ContainerHandler.SetupCell(this, defaultContent) : defaultContent;
+			return ContainerHandler != null ? ContainerHandler.SetupCell(this, defaultContent, cell) : defaultContent;
 		}
 
 		protected static T GetControl<T>(swc.DataGridCell cell)

--- a/src/Eto.Wpf/Forms/Cells/CheckBoxCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CheckBoxCellHandler.cs
@@ -37,7 +37,7 @@ namespace Eto.Wpf.Forms.Cells
 			{
 				var element = (swc.CheckBox)base.GenerateElement(cell, dataItem);
 				InitializeElement(element, cell, dataItem);
-				return Handler.SetupCell(element);
+				return Handler.SetupCell(element, cell);
 			}
 
 			void InitializeElement(swc.CheckBox element, swc.DataGridCell cell, object dataItem)
@@ -80,7 +80,7 @@ namespace Eto.Wpf.Forms.Cells
 			{
 				var element = (swc.CheckBox)base.GenerateEditingElement(cell, dataItem);
 				InitializeElement(element, cell, dataItem);
-				return Handler.SetupCell(element);
+				return Handler.SetupCell(element, cell);
 			}
 			protected override bool CommitCellEdit(sw.FrameworkElement editingElement)
 			{

--- a/src/Eto.Wpf/Forms/Cells/ComboBoxCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/ComboBoxCellHandler.cs
@@ -40,7 +40,7 @@ namespace Eto.Wpf.Forms.Cells
 			{
 				var element = (swc.ComboBox)base.GenerateElement(cell, dataItem);
 				Initialize(cell, element, dataItem);
-				return Handler.SetupCell(element);
+				return Handler.SetupCell(element, cell);
 			}
 
 			void Initialize(swc.DataGridCell cell, swc.ComboBox control, object dataItem)
@@ -72,7 +72,7 @@ namespace Eto.Wpf.Forms.Cells
 					};
 					SetControlEditInitialized(element, true);
 				}
-				return Handler.SetupCell(element);
+				return Handler.SetupCell(element, cell);
 			}
 
 			protected override bool CommitCellEdit(sw.FrameworkElement editingElement)

--- a/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
@@ -129,7 +129,7 @@ namespace Eto.Wpf.Forms.Cells
 			{
 				var ctl = sender as sw.FrameworkElement;
 				var cell = ctl?.GetVisualParent<swc.DataGridCell>();
-				if (!cell.IsKeyboardFocusWithin)
+				if (!cell.IsKeyboardFocusWithin && !cell.Column.IsReadOnly)
 				{
 					cell.IsEditing = true;
 					//var row = cell.GetVisualParent<swc.DataGridRow>();
@@ -302,12 +302,13 @@ namespace Eto.Wpf.Forms.Cells
 
 			protected override sw.FrameworkElement GenerateElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell));
+				return Handler.SetupCell(Create(cell), cell);
 			}
 
 			protected override sw.FrameworkElement GenerateEditingElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell));
+
+				return Handler.SetupCell(Create(cell), cell);
 			}
 
 			protected override object PrepareCellForEdit(sw.FrameworkElement editingElement, sw.RoutedEventArgs editingEventArgs)
@@ -334,10 +335,10 @@ namespace Eto.Wpf.Forms.Cells
 			{
 				if (handler == null)
 					return null;
-				var wpfctl = editingElement as EtoBorder;
+				var wpfctl = editingElement as EtoBorder ?? GetControl<EtoBorder>(cell);
 				var etoctl = wpfctl?.Control;
 				var args = etoctl?.Properties.Get<WpfCellEventArgs>(CellEventArgs_Key);
-				if (args == null)
+				if (args == null && wpfctl != null)
 				{
 					args = new WpfCellEventArgs(handler.ContainerHandler?.Grid, handler.Widget, -1, cell.Column, wpfctl.IsLoaded ? wpfctl.DataContext : null, CellStates.None, etoctl);
 					etoctl?.Properties.Set(CellEventArgs_Key, args);

--- a/src/Eto.Wpf/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/DrawableCellHandler.cs
@@ -68,12 +68,12 @@ namespace Eto.Wpf.Forms.Cells
 
 			protected override sw.FrameworkElement GenerateElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell));
+				return Handler.SetupCell(Create(cell), cell);
 			}
 
 			protected override sw.FrameworkElement GenerateEditingElement(swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell(Create(cell));
+				return Handler.SetupCell(Create(cell), cell);
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/ImageTextCellHandler.cs
@@ -122,13 +122,13 @@ namespace Eto.Wpf.Forms.Cells
 				return image;
 			}
 
-			sw.FrameworkElement SetupCell(sw.FrameworkElement element)
+			sw.FrameworkElement SetupCell(sw.FrameworkElement element, swc.DataGridCell cell)
 			{
 				element.HorizontalAlignment = sw.HorizontalAlignment.Stretch;
 				var container = new swc.DockPanel();
 				container.Children.Add(CreateImage());
 				container.Children.Add(element);
-				return Handler.SetupCell(container);
+				return Handler.SetupCell(container, cell);
 			}
 
 			swd.Binding CreateBinding(string property)
@@ -154,7 +154,7 @@ namespace Eto.Wpf.Forms.Cells
 					control.Text = Handler.GetTextValue(control.DataContext);
 					Handler.FormatCell(control, cell, control.DataContext);
 				};
-				return SetupCell(element);
+				return SetupCell(element, cell);
 			}
 
 			protected override object PrepareCellForEdit(sw.FrameworkElement editingElement, sw.RoutedEventArgs editingEventArgs)
@@ -203,7 +203,7 @@ namespace Eto.Wpf.Forms.Cells
 					control.Text = Handler.GetTextValue(control.DataContext);
 					Handler.FormatCell(control, cell, control.DataContext);
 				};
-				return SetupCell(element);
+				return SetupCell(element, cell);
 			}
 
 

--- a/src/Eto.Wpf/Forms/Cells/ImageViewCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/ImageViewCellHandler.cs
@@ -59,7 +59,7 @@ namespace Eto.Wpf.Forms.Cells
 
 			protected override sw.FrameworkElement GenerateElement (swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell (Image(cell));
+				return Handler.SetupCell (Image(cell), cell);
 			}
 
 			protected override object PrepareCellForEdit (sw.FrameworkElement editingElement, sw.RoutedEventArgs editingEventArgs)
@@ -70,7 +70,7 @@ namespace Eto.Wpf.Forms.Cells
 
 			protected override sw.FrameworkElement GenerateEditingElement (swc.DataGridCell cell, object dataItem)
 			{
-				return Handler.SetupCell (Image (cell));
+				return Handler.SetupCell (Image (cell), cell);
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/Cells/ProgressCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/ProgressCellHandler.cs
@@ -69,12 +69,13 @@ namespace Eto.Wpf.Forms.Cells
 			protected override sw.FrameworkElement GenerateElement(swc.DataGridCell cell, object dataItem)
 			{
 				var element = GenerateProgressBar(cell, dataItem);
-				return Handler.SetupCell(element);
+				return Handler.SetupCell(element, cell);
 			}
 
 			protected override sw.FrameworkElement GenerateEditingElement(swc.DataGridCell cell, object dataItem)
 			{
-				return GenerateProgressBar(cell, dataItem);
+				var element = GenerateProgressBar(cell, dataItem);
+				return Handler.SetupCell(element, cell);
 			}
 
 			private swc.Grid GenerateProgressBar(swc.DataGridCell cell, object dataItem)

--- a/src/Eto.Wpf/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/TextBoxCellHandler.cs
@@ -105,7 +105,7 @@ namespace Eto.Wpf.Forms.Cells
 					control.Text = Handler.GetValue(control.DataContext);
 					Handler.FormatCell(control, cell, control.DataContext);
 				};
-				return Handler.SetupCell(element);
+				return Handler.SetupCell(element, cell);
 			}
 
 			protected override sw.FrameworkElement GenerateEditingElement(swc.DataGridCell cell, object dataItem)
@@ -130,7 +130,7 @@ namespace Eto.Wpf.Forms.Cells
 					control.Text = Handler.GetValue(control.DataContext);
 					Handler.FormatCell(control, cell, control.DataContext);
 				};
-				return Handler.SetupCell(element);
+				return Handler.SetupCell(element, cell);
 			}
 
 			protected override object PrepareCellForEdit(sw.FrameworkElement editingElement, sw.RoutedEventArgs editingEventArgs)

--- a/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
@@ -10,7 +10,7 @@ namespace Eto.Wpf.Forms.Controls
 		Grid Widget { get; }
 		bool Loaded { get; }
 		bool DisableAutoScrollToSelection { get; }
-		sw.FrameworkElement SetupCell (IGridColumnHandler column, sw.FrameworkElement defaultContent);
+		sw.FrameworkElement SetupCell (IGridColumnHandler column, sw.FrameworkElement defaultContent, swc.DataGridCell cell);
 		void FormatCell (IGridColumnHandler column, ICellHandler cell, sw.FrameworkElement element, swc.DataGridCell gridcell, object dataItem);
 		void CellEdited(int row, swc.DataGridColumn dataGridColumn, object dataItem);
 	}
@@ -119,9 +119,9 @@ namespace Eto.Wpf.Forms.Controls
 			GridHandler = gridHandler;
 		}
 
-		public sw.FrameworkElement SetupCell (ICellHandler cell, sw.FrameworkElement defaultContent)
+		public sw.FrameworkElement SetupCell (ICellHandler handler, sw.FrameworkElement defaultContent, swc.DataGridCell cell)
 		{
-			return GridHandler != null ? GridHandler.SetupCell(this, defaultContent) : defaultContent;
+			return GridHandler != null ? GridHandler.SetupCell(this, defaultContent, cell) : defaultContent;
 		}
 
 		public void FormatCell (ICellHandler cell, sw.FrameworkElement element, swc.DataGridCell gridcell, object dataItem)

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -609,7 +609,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		public bool CancelEdit() => Control.CancelEdit();
 
-		public virtual sw.FrameworkElement SetupCell(IGridColumnHandler column, sw.FrameworkElement defaultContent)
+		public virtual sw.FrameworkElement SetupCell(IGridColumnHandler column, sw.FrameworkElement defaultContent, swc.DataGridCell cell)
 		{
 			return defaultContent;
 		}

--- a/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -183,11 +183,21 @@ namespace Eto.Wpf.Forms.Controls
 
 		public IEnumerable<object> SelectedItems => Control.SelectedItems.OfType<object>();
 
-		public override sw.FrameworkElement SetupCell(IGridColumnHandler column, sw.FrameworkElement defaultContent)
+		public override sw.FrameworkElement SetupCell(IGridColumnHandler column, sw.FrameworkElement defaultContent, swc.DataGridCell cell)
 		{
-			if (object.ReferenceEquals(column, Columns.Collection[0].Handler))
-				return TreeToggleButton.Create(defaultContent, controller);
-			return defaultContent;
+			// only first column
+			if (!ReferenceEquals(column, Columns.Collection[0].Handler))
+				return defaultContent;
+
+			// already a toggle panel, reuse it and set new content (if needed)
+			if (cell.Content is TreeTogglePanel ttp)
+			{
+				ttp.SetContent(defaultContent);
+				return ttp;
+			}
+
+			// create a new toggle panel
+			return new TreeTogglePanel(defaultContent, controller);
 		}
 
 		void ITreeHandler.PreResetTree()


### PR DESCRIPTION
- Reuse the TreeTogglePanel when we can instead of always creating a new one
- Only put CustomCell in edit mode when clicked if GridColum.Editable = true