### PR TITLE
Mac: Fix drag/drop changes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -17,7 +17,7 @@
             "type": "mono",
 			"request": "launch",
 			"preLaunchTask": "build-xammac2",
-			"program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/net461/Eto.Test.XamMac2.app/Contents/MacOS/Eto.Test.XamMac2",
+			"program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/net472/Eto.Test.XamMac2.app/Contents/MacOS/Eto.Test.XamMac2",
 			"useRuntime": false,
             "args": [],
             "console": "internalConsole",

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -646,6 +646,36 @@ namespace Eto.Mac.Forms.Controls
 			get { return Widget.Properties.Get(GridHandler.IsMouseDragging_Key, false); }
 			set { Widget.Properties.Set(GridHandler.IsMouseDragging_Key, value, false); }
 		}
+
+		static readonly object DragPasteboard_Key = new object();
+
+		protected NSPasteboard DragPasteboard
+		{
+			get { return Widget.Properties.Get<NSPasteboard>(DragPasteboard_Key); }
+			set { Widget.Properties.Set(DragPasteboard_Key, value); }
+		}
+
+		internal GridDragInfo DragInfo { get; set; }
+
+		public override void DoDragDrop(DataObject data, DragEffects allowedAction, Image image, PointF origin)
+		{
+			if (DragPasteboard != null)
+			{
+				var handler = data.Handler as IDataObjectHandler;
+				handler?.Apply(DragPasteboard);
+				SetupDragPasteboard(DragPasteboard);
+				DragInfo = new GridDragInfo
+				{
+					AllowedOperation = allowedAction.ToNS(),
+					DragImage = image.ToNS(),
+					ImageOffset = origin
+				};
+			}
+			else
+			{
+				base.DoDragDrop(data, allowedAction, image, origin);
+			}
+		}
 	}
 }
 

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -140,12 +140,10 @@ namespace Eto.Mac.Forms.Controls
 				SetDraggingSourceOperationMask(NSDragOperation.All, false);
 			}
 
-			internal GridDragInfo DragInfo { get; set; }
-
 			[Export("draggingSession:sourceOperationMaskForDraggingContext:")]
 			public NSDragOperation DraggingSessionSourceOperationMask(NSDraggingSession session, IntPtr context)
 			{
-				return DragInfo?.AllowedOperation ?? NSDragOperation.None;
+				return Handler?.DragInfo?.AllowedOperation ?? NSDragOperation.None;
 			}
 
 			public override void Layout()
@@ -161,6 +159,13 @@ namespace Eto.Mac.Forms.Controls
 #if XAMMAC2
 			public override NSImage DragImageForRowsWithIndexestableColumnseventoffset(NSIndexSet dragRows, NSTableColumn[] tableColumns, NSEvent dragEvent, ref CGPoint dragImageOffset)
 			{
+				var dragInfo = Handler?.DragInfo;
+				var img = dragInfo?.DragImage;
+				if (img != null)
+				{
+					dragImageOffset = dragInfo.GetDragImageOffset();
+					return img;
+				}
 				return base.DragImageForRowsWithIndexestableColumnseventoffset(dragRows, tableColumns, dragEvent, ref dragImageOffset);
 			}
 #else
@@ -170,10 +175,11 @@ namespace Eto.Mac.Forms.Controls
 			[Export("dragImageForRowsWithIndexes:tableColumns:event:offset:")]
 			public NSImage DragImageForRows(NSIndexSet dragRows, NSTableColumn[] tableColumns, NSEvent dragEvent, ref CGPoint dragImageOffset)
 			{
-				var img = DragInfo?.DragImage;
+				var dragInfo = Handler?.DragInfo;
+				var img = dragInfo?.DragImage;
 				if (img != null)
 				{
-					dragImageOffset = DragInfo.GetDragImageOffset();
+					dragImageOffset = dragInfo.GetDragImageOffset();
 					return img;
 				}
 
@@ -310,7 +316,7 @@ namespace Eto.Mac.Forms.Controls
 
 				if (h.IsMouseDragging)
 				{
-					h.Control.DragInfo = null;
+					h.DragInfo = null;
 					// give MouseMove event a chance to start the drag
 					h.DragPasteboard = pboard;
 
@@ -343,7 +349,7 @@ namespace Eto.Mac.Forms.Controls
 					h.Callback.OnMouseMove(h.Widget, args);
 					h.DragPasteboard = null;
 
-					return h.Control.DragInfo != null;
+					return h.DragInfo != null;
 				}
 
 				return false;
@@ -640,33 +646,6 @@ namespace Eto.Mac.Forms.Controls
 			column = (int)Control.GetColumn(nslocation);
 			row = (int)Control.GetRow(nslocation);
 			return row >= 0 ? GetItem(row) : null;
-		}
-
-		static readonly object DragPasteboard_Key = new object();
-
-		NSPasteboard DragPasteboard
-		{
-			get { return Widget.Properties.Get<NSPasteboard>(DragPasteboard_Key); }
-			set { Widget.Properties.Set(DragPasteboard_Key, value); }
-		}
-
-		public override void DoDragDrop(DataObject data, DragEffects allowedAction, Image image, PointF origin)
-		{
-			if (DragPasteboard != null)
-			{
-				var handler = data.Handler as IDataObjectHandler;
-				handler?.Apply(DragPasteboard);
-				Control.DragInfo = new GridDragInfo
-				{
-					AllowedOperation = allowedAction.ToNS(),
-					DragImage = image.ToNS(),
-					ImageOffset = origin
-				};
-			}
-			else
-			{
-				base.DoDragDrop(data, allowedAction, image, origin);
-			}
 		}
 
 		public GridViewDragInfo GetDragInfo(DragEventArgs args) => args.ControlObject as GridViewDragInfo;

--- a/src/Eto.Mac/Forms/DataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/DataObjectHandler.cs
@@ -71,14 +71,6 @@ namespace Eto.Mac.Forms
 	{
 		nint _changeCount;
 
-		static string TranslateType(string type)
-		{
-			// register custom types with a UTType.Item base type so it gets picked up by the drag/drop infrastructure 
-			if (!UTType.IsDynamic(type) && !UTType.IsDeclared(type))
-				type = UTType.CreatePreferredIdentifier(UTType.TagClassNSPboardType, type, UTType.Item);
-			return type;
-		}
-
 		void ClearIfNeeded()
 		{
 			if (Control.ChangeCount != _changeCount)
@@ -88,7 +80,6 @@ namespace Eto.Mac.Forms
 		public void SetData(byte[] value, string type)
 		{
 			ClearIfNeeded();
-			type = TranslateType(type);
 			Control.SetDataForType(NSData.FromArray(value), type);
 		}
 
@@ -108,7 +99,6 @@ namespace Eto.Mac.Forms
 		public void SetString(string value, string type)
 		{
 			ClearIfNeeded();
-			type = TranslateType(type);
 			Control.SetStringForType(value, type);
 		}
 
@@ -155,7 +145,6 @@ namespace Eto.Mac.Forms
 
 		public byte[] GetData(string type)
 		{
-			type = TranslateType(type);
 			var availableType = Control.GetAvailableTypeFromArray(new string[] { type });
 
 			if (availableType != null)
@@ -172,7 +161,6 @@ namespace Eto.Mac.Forms
 
 		public string GetString(string type)
 		{
-			type = TranslateType(type);
 			return Control.GetStringForType(type);
 		}
 
@@ -242,13 +230,11 @@ namespace Eto.Mac.Forms
 
 		public bool Contains(string type)
 		{
-			type = TranslateType(type);
 			return Control.GetAvailableTypeFromArray(new[] { type }) != null;
 		}
 
 		public bool TryGetObject(string type, out object value)
 		{
-			type = TranslateType(type);
 			if (type == NSPasteboard.NSPasteboardTypeColor)
 			{
 				value = NSColor.FromPasteboard(Control)?.ToEto();
@@ -260,7 +246,6 @@ namespace Eto.Mac.Forms
 
 		public bool TrySetObject(object value, string type)
 		{
-			type = TranslateType(type);
 			if (value is Color color && type == NSPasteboard.NSPasteboardTypeColor)
 			{
 				Control.WriteObjects(new[] { color.ToNSUI() });

--- a/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
@@ -39,15 +39,6 @@ namespace Eto.Mac.Forms
 	{
 		const string UrlKey = "ba330802-0ac2-4ee0-a22f-0e67316ac339";
 
-		static string TranslateType(string type)
-		{
-			// register custom types with a UTType.Item base type so it gets picked up by the drag/drop infrastructure 
-			if (!UTType.IsDynamic(type) && !UTType.IsDeclared(type))
-				type = UTType.CreatePreferredIdentifier(UTType.TagClassNSPboardType, type, UTType.Item);
-			return type;
-		}
-
-
 		public abstract class BaseItem
 		{
 			public abstract void Apply(NSPasteboard pasteboard, string type);
@@ -194,7 +185,7 @@ namespace Eto.Mac.Forms
 		{
 			foreach (var item in Control)
 			{
-				item.Value?.Apply(pasteboard, TranslateType(item.Key));
+				item.Value?.Apply(pasteboard, item.Key);
 			}
 		}
 
@@ -215,7 +206,7 @@ namespace Eto.Mac.Forms
 				{
 					if (pasteboardItem == null)
 						pasteboardItem = new NSPasteboardItem();
-					item.Value.Apply(pasteboardItem, TranslateType(item.Key));
+					item.Value?.Apply(pasteboardItem, item.Key);
 				}
 			}
 			if (pasteboardItem != null)


### PR DESCRIPTION
- Revert translating all custom types to dynamic types, it is not necessary
- Fix using drag image from GridView
- Add custom UTType.Item based type for all drag operations so they get picked up by other eto controls
- Combine/refactor GridView/TreeGridView implementations