### PR TITLE
Mac: DataObject.GetData() should not crash when data is zero

### DIFF
--- a/src/Eto.Mac/Forms/DataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/DataObjectHandler.cs
@@ -150,7 +150,7 @@ namespace Eto.Mac.Forms
 			if (availableType != null)
 			{
 				var data = Control.GetDataForType(availableType);
-				if (data == null)
+				if (data == null || data.Bytes == IntPtr.Zero)
 					return null;
 				var bytes = new byte[data.Length];
 				Marshal.Copy(data.Bytes, bytes, 0, (int)data.Length);

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1242,7 +1242,8 @@ namespace Eto.Mac.Forms
 			if (s_etoDragItemType == null)
 				s_etoDragItemType = UTType.CreatePreferredIdentifier(UTType.TagClassNSPboardType, "eto.dragitem", UTType.Item);
 
-			pasteboard.SetStringForType(string.Empty, s_etoDragItemType);
+			// don't send an empty string, some code can't handle null data.
+			pasteboard.SetStringForType(".", s_etoDragItemType);
 		}
 
 		public virtual void DoDragDrop(DataObject data, DragEffects allowedAction, Image image, PointF origin)


### PR DESCRIPTION
Also make the eto.dragitem data non-empty so other code doesn't have to handle it either.