### PR TITLE
Mac: Fix sizing of labels when initially shown on a PixelLayout

### DIFF
--- a/src/Eto.Mac/Forms/Controls/MacLabel.cs
+++ b/src/Eto.Mac/Forms/Controls/MacLabel.cs
@@ -148,6 +148,10 @@ namespace Eto.Mac.Forms.Controls
 
 		protected override SizeF GetNaturalSize(SizeF availableSize)
 		{
+			// set attributes if it hasn't been loaded yet, so we get the correct size.
+			if (!Widget.Loaded)
+				SetAttributes(true);
+
 			if (float.IsPositiveInfinity(availableSize.Width))
 			{
 				if (naturalSizeInfinity != null)
@@ -393,6 +397,7 @@ namespace Eto.Mac.Forms.Controls
 		{
 			base.OnLoad(e);
 			SetAttributes(true);
+			InvalidateMeasure();
 		}
 
 		public override void AttachEvent(string id)

--- a/test/Eto.Test/UnitTests/Forms/Layout/PixelLayoutTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Layout/PixelLayoutTests.cs
@@ -33,5 +33,20 @@ namespace Eto.Test.UnitTests.Forms.Layout
 				return layout;
 			});
 		}
+
+		[Test, ManualTest]
+		public void LabelsShouldGetCorrectSize()
+		{
+			ManualForm("Labels should end with a period", form => {
+				// note: this actually failed only when the form was the initial window, as it calculated its size before it was even shown.
+				form.ClientSize = new Size(200, 200);
+
+				var layout = new PixelLayout();
+				layout.Add(new Label { Text = "Hello world.", BackgroundColor = Colors.Yellow, TextColor = Colors.Black }, 50, 50);
+				layout.Add(new Label { Text = "Bonjour monde.", BackgroundColor = Colors.LightGreen, TextColor = Colors.Black }, 20, 20);
+				form.Content = layout;
+				return layout;
+			});
+		}
 	}
 }


### PR DESCRIPTION
This happened because, only when creating a form before running the app, a measure pass occurs on the form before it is shown/loaded.  For optimization, the Label only sets the attributed string after it is loaded caused the measure to incorrectly retain the value when measuring with the default string of "Field" for a label. 

Fixes #1747