### PR TITLE
Add PixelOffsetMode.Aligned for aligned drawing with sharp lines

### DIFF
--- a/src/Eto.Gtk/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Gtk/Drawing/GraphicsHandler.cs
@@ -64,7 +64,12 @@ namespace Eto.GtkSharp.Drawing
 
 		void SetOffset(bool fill)
 		{
-			var requiresOffset = !fill && PixelOffsetMode == PixelOffsetMode.None;
+			var currentMode = PixelOffsetMode;
+			var requiresOffset =
+				(
+					currentMode == PixelOffsetMode.Aligned
+					|| (!fill && currentMode == PixelOffsetMode.None)
+				);
 			if (requiresOffset != isOffset)
 			{
 				ReverseAll();
@@ -379,7 +384,7 @@ namespace Eto.GtkSharp.Drawing
 		{
 			var oldAA = AntiAlias;
 			AntiAlias = true;
-			SetOffset(true);
+			SetOffset(false);
 			using (var layout = CreateLayout())
 			{
 				font.Apply(layout);
@@ -397,7 +402,7 @@ namespace Eto.GtkSharp.Drawing
 		{
 			var oldAA = AntiAlias;
 			AntiAlias = true;
-			SetOffset(true);
+			SetOffset(false);
 			using (var layout = CreateLayout())
 			{
 				var handler = (FormattedTextHandler)formattedText.Handler;

--- a/src/Eto.Mac/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Mac/Drawing/GraphicsHandler.cs
@@ -101,7 +101,12 @@ namespace Eto.iOS.Drawing
 
 		void SetOffset(bool fill)
 		{
-			var requiresOffset = !fill && PixelOffsetMode == PixelOffsetMode.None;
+			var currentMode = PixelOffsetMode;
+			var requiresOffset =
+				(
+					currentMode == PixelOffsetMode.Aligned
+					|| (!fill && currentMode == PixelOffsetMode.None)
+				);
 			if (requiresOffset != isOffset)
 			{
 				RewindAll();
@@ -472,7 +477,7 @@ namespace Eto.iOS.Drawing
 
 		public void DrawArc(Pen pen, float x, float y, float width, float height, float startAngle, float sweepAngle)
 		{
-			SetOffset(true);
+			SetOffset(false);
 			StartDrawing();
 
 			var rect = new CGRect(x, y, width, height);
@@ -605,7 +610,7 @@ namespace Eto.iOS.Drawing
 
 		public void DrawText(FormattedText formattedText, PointF location)
 		{
-			SetOffset(true);
+			SetOffset(false);
 			StartDrawing();
 			if (formattedText.Handler is FormattedTextHandler handler)
 				handler.DrawText(this, location);

--- a/src/Eto.WinForms/Drawing/GraphicsHandler.cs
+++ b/src/Eto.WinForms/Drawing/GraphicsHandler.cs
@@ -40,11 +40,11 @@ namespace Eto.WinForms.Drawing
 		static GraphicsHandler()
 		{
 			DefaultTextFormat = swf.TextFormatFlags.Left
-			                    | swf.TextFormatFlags.NoPadding
-			                    | swf.TextFormatFlags.NoClipping
-			                    | swf.TextFormatFlags.PreserveGraphicsClipping
-			                    | swf.TextFormatFlags.PreserveGraphicsTranslateTransform
-			                    | swf.TextFormatFlags.NoPrefix;
+								| swf.TextFormatFlags.NoPadding
+								| swf.TextFormatFlags.NoClipping
+								| swf.TextFormatFlags.PreserveGraphicsClipping
+								| swf.TextFormatFlags.PreserveGraphicsTranslateTransform
+								| swf.TextFormatFlags.NoPrefix;
 
 			// Set the StringFormat
 			DefaultStringFormat = new sd.StringFormat(sd.StringFormat.GenericTypographic);
@@ -113,14 +113,27 @@ namespace Eto.WinForms.Drawing
 		public PixelOffsetMode PixelOffsetMode
 		{
 			get { return Widget.Properties.Get<PixelOffsetMode>(PixelOffsetMode_Key); }
-			set { Widget.Properties.Set(PixelOffsetMode_Key, value); }
+			set
+			{
+				if (Widget.Properties.TrySet(PixelOffsetMode_Key, value))
+				{
+					if (value == PixelOffsetMode.Aligned)
+						Control.PixelOffsetMode = sdd.PixelOffsetMode.None;
+				}
+			}
 		}
 
 		void SetOffset(bool fill)
 		{
-			var mode = sdd.PixelOffsetMode.Half;
-			if (!fill && PixelOffsetMode == PixelOffsetMode.None)
+			var currentMode = PixelOffsetMode;
+			if (currentMode == PixelOffsetMode.Aligned)
+				return;
+
+			sdd.PixelOffsetMode mode;
+			if (!fill && currentMode == PixelOffsetMode.None)
 				mode = sdd.PixelOffsetMode.None;
+			else
+				mode = sdd.PixelOffsetMode.Half;
 			Control.PixelOffsetMode = mode;
 		}
 
@@ -154,7 +167,7 @@ namespace Eto.WinForms.Drawing
 		public void DrawLine(Pen pen, float startx, float starty, float endx, float endy)
 		{
 			SetOffset(false);
-            Control.DrawLine(pen.ToSD(new RectangleF(startx, starty, endx, endy)), startx, starty, endx, endy);
+			Control.DrawLine(pen.ToSD(new RectangleF(startx, starty, endx, endy)), startx, starty, endx, endy);
 		}
 
 		public void DrawLines(Pen pen, IEnumerable<PointF> points)

--- a/src/Eto.WinForms/WinConversions.cs
+++ b/src/Eto.WinForms/WinConversions.cs
@@ -279,6 +279,8 @@ namespace Eto.WinForms
 					return sd2.PixelOffsetMode.None;
 				case PixelOffsetMode.Half:
 					return sd2.PixelOffsetMode.Half;
+				case PixelOffsetMode.Aligned:
+					return sd2.PixelOffsetMode.None;
 				default:
 					throw new NotSupportedException();
 			}

--- a/src/Eto.Wpf/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Wpf/Drawing/GraphicsHandler.cs
@@ -44,7 +44,12 @@ namespace Eto.Wpf.Drawing
 
 		void SetOffset(bool fill)
 		{
-			var requiresOffset = !fill && PixelOffsetMode == PixelOffsetMode.None;
+			var currentMode = PixelOffsetMode;
+			var requiresOffset =
+				(
+					currentMode == PixelOffsetMode.Aligned
+					|| (!fill && currentMode == PixelOffsetMode.None)
+				);
 			if (requiresOffset != isOffset)
 			{
 				RewindAll();
@@ -302,7 +307,7 @@ namespace Eto.Wpf.Drawing
 
 		public void DrawText(FormattedText formattedText, PointF location)
 		{
-			SetOffset(true);
+			SetOffset(false);
 			if (formattedText.Handler is FormattedTextHandler handler)
 			{
 				handler.DrawText(this, location);
@@ -311,7 +316,7 @@ namespace Eto.Wpf.Drawing
 
 		public void DrawText(Font font, Brush b, float x, float y, string text)
 		{
-			SetOffset(true);
+			SetOffset(false);
 			var fontHandler = font.Handler as FontHandler;
 			if (fontHandler != null)
 			{

--- a/src/Eto/Drawing/PixelOffsetMode.cs
+++ b/src/Eto/Drawing/PixelOffsetMode.cs
@@ -5,7 +5,7 @@ namespace Eto.Drawing
 	/// Enumeration of the pixel offset modes of a <see cref="Graphics"/>
 	/// </summary>
 	/// <remarks>
-	/// The pixel offset mode applies to all Draw* graphics operations such as 
+	/// The pixel offset mode applies to all Draw* and Fill* graphics operations such as 
 	/// <see cref="Graphics.DrawLine(Pen,PointF,PointF)"/>, <see cref="Graphics.DrawRectangle(Pen,RectangleF)"/>, etc.
 	/// </remarks>
 	/// <copyright>(c) 2014 by Curtis Wensley</copyright>
@@ -16,7 +16,8 @@ namespace Eto.Drawing
 		/// Specifies that pixels will not be offset and be relative to the center of each pixel.
 		/// </summary>
 		/// <remarks>
-		/// This simplifies drawing odd-width lines by aligning them to the pixel boundary.
+		/// This simplifies drawing odd-width lines and fills by aligning them to the pixel boundary.
+		/// Fills on this mode have crisp pixel-aligned boundaries, such as <see cref="Graphics.FillRectangle(Brush, RectangleF)" /> and variants.
 		/// </remarks>
 		None,
 		/// <summary>
@@ -30,6 +31,14 @@ namespace Eto.Drawing
 		/// Only Draw operations are offset with this mode, Fill operations will not be offset. (new in 2.1)
 		/// For example, filling a rectangle from 10, 10 to 20, 20 will not be antialiased and fall on (logical) pixel boundaries.
 		/// </remarks>
-		Half
+		Half,
+		/// <summary>
+		/// Similar to None, specifies that pixels will be relative to the center of each pixel, but only for line drawing.
+		/// </summary>
+		/// <remarks>
+		/// This simplifies drawing lines and fills with the same dimensions, as they will both be offset by 0.5 pixels.
+		/// Note that in this mode, any fills will not be aligned on a pixel boundary, such as <see cref="Graphics.FillRectangle(Brush, RectangleF)" /> or other variants.
+		/// </remarks>
+		Aligned
 	}
 }

--- a/test/Eto.Test/Sections/Drawing/PixelOffsetModeSection.cs
+++ b/test/Eto.Test/Sections/Drawing/PixelOffsetModeSection.cs
@@ -4,32 +4,27 @@ using Eto.Forms;
 namespace Eto.Test.Sections.Drawing
 {
 	[Section("Drawing", "PixelOffsetMode")]
-	public class PixelOffsetSection : Scrollable
+	public class PixelOffsetModeSection : Scrollable
 	{
-		Size canvasSize = new Size(501, 221);
-
-		public PixelOffsetSection()
+		public PixelOffsetModeSection()
 		{
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
 
-			var drawable = new Drawable { Size = canvasSize };
-			drawable.Paint += (sender, pe) =>
-			{
-				pe.Graphics.FillRectangle(Brushes.Black, pe.ClipRectangle);
-				pe.Graphics.PixelOffsetMode = PixelOffsetMode.None;
-				Draw(pe.Graphics);
-			};
-			layout.AddRow(new Label { Text = "None (Default)" }, drawable);
+			var pixelLayoutMode = new EnumDropDown<PixelOffsetMode> { SelectedValue = PixelOffsetMode.None };
 
-			drawable = new Drawable { Size = canvasSize };
+			var drawable = new Drawable { Size = new Size(600, 250) };
 			drawable.Paint += (sender, pe) =>
 			{
 				pe.Graphics.FillRectangle(Brushes.Black, pe.ClipRectangle);
-				pe.Graphics.PixelOffsetMode = PixelOffsetMode.Half;
+				pe.Graphics.PixelOffsetMode = pixelLayoutMode.SelectedValue;
 				Draw(pe.Graphics);
 			};
-			layout.AddRow(new Label { Text = "Half" }, drawable);
-			layout.Add(null);
+
+			pixelLayoutMode.SelectedValueChanged += (sender, e) => drawable.Invalidate();
+
+			layout.AddCentered(pixelLayoutMode);
+
+			layout.Add(drawable);
 
 			Content = layout;
 		}

--- a/test/Eto.Test/Sections/Drawing/TransformSection.cs
+++ b/test/Eto.Test/Sections/Drawing/TransformSection.cs
@@ -121,7 +121,7 @@ namespace Eto.Test.Sections.Drawing
 				m.Scale(0.4f);
 				m.Rotate(90);
 				g.MultiplyTransform(m);
-				PixelOffsetSection.Draw(g);
+				PixelOffsetModeSection.Draw(g);
 				g.RestoreTransform();
 			}
 		}
@@ -189,7 +189,7 @@ namespace Eto.Test.Sections.Drawing
 			g.TranslateTransform(480, 20);
 			g.ScaleTransform(0.4f);
 			g.RotateTransform(90);
-			PixelOffsetSection.Draw(g);
+			PixelOffsetModeSection.Draw(g);
 			g.RestoreTransform();
 		}
 

--- a/test/Eto.Test/UnitTests/Drawing/GraphicsOffsetModeTests.cs
+++ b/test/Eto.Test/UnitTests/Drawing/GraphicsOffsetModeTests.cs
@@ -1,0 +1,248 @@
+using System;
+using System.IO;
+using Eto.Forms;
+using Eto.Drawing;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Drawing
+{
+	[TestFixture]
+	public class GraphicsOffsetModeTests : TestBase
+	{
+		string folder;
+
+		static PixelOffsetMode defaultMode = PixelOffsetMode.Aligned;
+
+		public GraphicsOffsetModeTests()
+		{
+			folder = Path.Combine(EtoEnvironment.GetFolderPath(EtoSpecialFolder.Documents), "TestShapeDrawing", Platform.Instance.ID);
+			if (!Directory.Exists(folder))
+			{
+				Directory.CreateDirectory(folder);
+			}
+		}
+
+		[ManualTest, Test]
+		public void TestEdgeInconsistency()
+		{
+			int Distance(Color a, Color b)
+			{
+				var d = 0f;
+				d += Math.Abs(a.R - b.R);
+				d += Math.Abs(a.G - b.G);
+				d += Math.Abs(a.B - b.B);
+				return (int)(255 * d / 3);
+			}
+
+			using (var small = Chequer(20, Colors.White, Colors.White))
+			{
+				using (var sg = new Graphics(small))
+				{
+					sg.PixelOffsetMode = defaultMode;
+					sg.DrawEllipse(Colors.Black, new RectangleF(1, 1, 17, 17));
+				}
+
+				var map = small.Clone();
+				for (int x = 0; x < map.Width; x++)
+					for (int y = 0; y < map.Height; y++)
+					{
+						// We're only mirroring along the vertical axis.
+						var a = small.GetPixel(x, y);
+						var b = small.GetPixel(small.Width - x - 1, y);
+						var d = Distance(a, b);
+
+						if (d > 24)
+							map.SetPixel(x, y, Colors.Purple);
+						else if (d > 12)
+							map.SetPixel(x, y, Colors.Red);
+						else if (d > 6)
+							map.SetPixel(x, y, Colors.Orange);
+						else if (d > 1)
+							map.SetPixel(x, y, Colors.Gold);
+						else
+							map.SetPixel(x, y, Colors.White);
+					}
+
+				using (var large = Enlarge(small, 400))
+				using (var largeMap = Enlarge(map, 400))
+				{
+					var stacked = Stack(large, largeMap);
+					DisplayImage(stacked);
+				}
+			}
+		}
+
+		[Test]
+		public void TestEdgeFillMisalignment()
+		{
+			using (var small = Chequer(20))
+			{
+				using (var graphics = new Graphics(small))
+				{
+					graphics.PixelOffsetMode = defaultMode;
+					graphics.FillEllipse(Colors.Crimson, new RectangleF(1, 1, 17, 17));
+					graphics.DrawEllipse(Colors.Black, new RectangleF(1, 1, 17, 17));
+				}
+
+				var pure = small.Clone();
+				for (int x = 0; x < pure.Width; x++)
+					for (int y = 0; y < pure.Height; y++)
+					{
+						var c = pure.GetPixel(x, y);
+						var hsl = new ColorHSL(c);
+						if (hsl.S > 0f)
+						{
+							hsl.S = 1;
+							pure.SetPixel(x, y, hsl);
+						}
+					}
+
+				using (var large = Enlarge(small, 400))
+				using (var largePure = Enlarge(pure, 400))
+				{
+					var stacked = Stack(large, largePure);
+					DisplayImage(stacked);
+				}
+
+				pure.Dispose();
+			}
+		}
+
+		[Test]
+		public void TestPlugIcon()
+		{
+			var polygon = new PointF[]
+			{
+		new PointF(7.5f, 4.5f),
+		new PointF(14.5f, 11.5f),
+		new PointF(10.5f, 15.5f),
+		new PointF(6.5f, 15.5f),
+		new PointF(3.5f, 12.5f),
+		new PointF(3.5f, 8.5f),
+			};
+
+			var linesA = new float[4][];
+			linesA[0] = new float[] { 5.5f, 13.5f, 2.5f, 16.5f };
+			linesA[1] = new float[] { 9.5f, 5.5f, 13.5f, 1.5f };
+			linesA[2] = new float[] { 15.5f, 11.5f, 7.5f, 3.5f };
+			linesA[3] = new float[] { 13.5f, 9.5f, 17.5f, 5.5f };
+
+			var linesB = new float[2][];
+			linesB[0] = new float[] { 8, 8, 11, 11 };
+			linesB[1] = new float[] { 6, 10, 9, 13 };
+
+			using (var small = Chequer(20, Colors.White, Colors.White))
+			{
+				using (var graphics = new Graphics(small))
+				{
+					graphics.PixelOffsetMode = defaultMode;
+					graphics.FillPolygon(Colors.DimGray, polygon);
+
+					using (var edge = new Pen(Colors.DimGray, 2))
+						foreach (var line in linesA)
+							graphics.DrawLine(edge, line[0], line[1], line[2], line[3]);
+
+					using (var edge = new Pen(Colors.LightGrey, 1))
+						foreach (var line in linesB)
+							graphics.DrawLine(edge, line[0], line[1], line[2], line[3]);
+				}
+
+				using (var large = Enlarge(small, 400))
+				{
+					// Multiply all coordinates by 800/20.
+					var factor = large.Width / small.Width;
+					for (int i = 0; i < polygon.Length; i++)
+						polygon[i] *= factor;
+
+					for (int i = 0; i < linesA.Length; i++)
+						for (int j = 0; j < linesA[i].Length; j++)
+							linesA[i][j] *= factor;
+
+					for (int i = 0; i < linesB.Length; i++)
+						for (int j = 0; j < linesB[i].Length; j++)
+							linesB[i][j] *= factor;
+
+					DrawPixelGrid(large, factor);
+					using (var graphics = new Graphics(large))
+					{
+						//graphics.PixelOffsetMode = PixelOffsetMode.Half;
+						graphics.DrawPolygon(Colors.Red, polygon);
+						foreach (var line in linesA)
+							graphics.DrawLine(Colors.Red, line[0], line[1], line[2], line[3]);
+						foreach (var line in linesB)
+							graphics.DrawLine(Colors.Red, line[0], line[1], line[2], line[3]);
+					}
+
+					DisplayImage(large);
+				}
+			}
+		}
+
+		void DisplayImage(Bitmap image)
+		{
+			ManualForm("Inspect image", form => 
+			{
+				form.WindowState = WindowState.Maximized;
+				return TableLayout.AutoSized(new ImageView { Image = image }, centered: true);
+			});
+
+		}
+
+		private static Bitmap Chequer(int size, Color? a = null, Color? b = null)
+		{
+			var ca = a ?? Colors.White;
+			var cb = b ?? Colors.LightGrey;
+
+			var image = new Bitmap(size, size, PixelFormat.Format32bppRgba);
+			for (int x = 0; x < image.Width; x++)
+				for (int y = 0; y < image.Height; y++)
+					if ((x + y) % 2 == 0)
+						image.SetPixel(x, y, ca);
+					else
+						image.SetPixel(x, y, cb);
+
+			return image;
+		}
+		private static Bitmap Enlarge(Bitmap image, int newSize)
+		{
+			var bitmap = new Bitmap(newSize, newSize, PixelFormat.Format32bppRgba);
+			using (var graphics = new Graphics(bitmap))
+			{
+				//graphics.PixelOffsetMode = PixelOffsetMode.Half;
+				graphics.Clear(Colors.DeepPink);
+				graphics.AntiAlias = false;
+				graphics.ImageInterpolation = ImageInterpolation.None;
+				graphics.DrawImage(image, 0, 0, newSize, newSize);
+			}
+
+			return bitmap;
+		}
+		private static Bitmap Stack(Bitmap a, Bitmap b)
+		{
+			var bitmap = new Bitmap(a.Width + b.Width, Math.Max(a.Height, b.Height), PixelFormat.Format32bppRgba);
+			using (var graphics = new Graphics(bitmap))
+			{
+				//graphics.PixelOffsetMode = PixelOffsetMode.Half;
+				graphics.AntiAlias = false;
+				graphics.ImageInterpolation = ImageInterpolation.None;
+				graphics.DrawImage(a, 0, 0, a.Width, a.Height);
+				graphics.DrawImage(b, a.Width, 0, b.Width, b.Height);
+			}
+
+			return bitmap;
+		}
+		private static void DrawPixelGrid(Bitmap image, int pixelSize, Color? colour = null)
+		{
+			var c = colour ?? new Color(0, 0, 0, 0.3f);
+
+			using (var graphics = new Graphics(image))
+			{
+				//graphics.PixelOffsetMode = PixelOffsetMode.Half;
+				for (int x = 0; x < image.Width; x += pixelSize)
+					graphics.DrawLine(c, x, 0, x, image.Height);
+				for (int y = 0; y < image.Height; y += pixelSize)
+					graphics.DrawLine(c, 0, y, image.Width, y);
+			}
+		}
+	}
+}


### PR DESCRIPTION
In Eto's PixelOffsetMode.None, both Graphics.FillRect(Colors.Blue, 10, 10, 10, 10) and Graphics.DrawRect(Colors.Blue, 10, 10, 10, 10) would draw a sharp-edged rectangle with no antialiasing (sans transforms). In System.Drawing's PixelOffsetMode.None, fills are antialiased unless you offset the rectangle by 0.5 pixels. Unfortunately, if you want to use the same rectangles for both the draws and fills you would have to do extra calculations to account for this such as shrinking the rectangle by one pixel for line drawing. PixelOffsetMode.Half was the usual way to deal with this, however line draws will no longer fall on pixel boundaries unless you offset them by 0.5 pixels yourself.

So, a new mode has been added named PixelOffsetMode.Aligned that makes line draws fall on pixel boundaries, and fills with the same dimensions align with them. So, you can now choose Half when you want fills to be crisp with whole numbers, Aligned if you want lines to be crisp with whole numbers, or None if you want both fills and lines to be crisp with whole numbers.