### PR TITLE
Augmenteddrawloop

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
@@ -96,11 +96,10 @@ namespace Eto.GtkSharp.Forms.Controls
 				{
 					if (h.SelectedBackgroundColor != null)
 						graphics.Clear(h.SelectedBackgroundColor.Value);
-
+					
 					h.Callback.OnPaint(h.Widget, new PaintEventArgs(graphics, rect.ToEto()));
 				}
 			}
-
 #endif
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
@@ -1,3 +1,4 @@
+//#define old
 using Eto.Drawing;
 using Eto.Forms;
 using Eto.GtkSharp.Drawing;
@@ -91,14 +92,29 @@ namespace Eto.GtkSharp.Forms.Controls
 				if (!GraphicsHandler.GetClipRectangle(args.Cr, ref rect))
 					rect = new Gdk.Rectangle(Gdk.Point.Zero, allocation);
 
+#if old
 				using (var graphics = new Graphics(new GraphicsHandler(args.Cr, h.Control.CreatePangoContext(), false)))
 				{
 					if (h.SelectedBackgroundColor != null)
 						graphics.Clear(h.SelectedBackgroundColor.Value);
-					
-					h.Callback.OnPaint(h.Widget, new PaintEventArgs (graphics, rect.ToEto()));
+
+					h.Callback.OnPaint(h.Widget, new PaintEventArgs(graphics, rect.ToEto()));
 				}
+
+#else
+				using (var pango = h.Control.CreatePangoContext())
+				{
+					using (var graphics = new Graphics(new GraphicsHandler(args.Cr, pango, false)))
+					{
+						if (h.SelectedBackgroundColor != null)
+							graphics.Clear(h.SelectedBackgroundColor.Value);
+
+						h.Callback.OnPaint(h.Widget, new PaintEventArgs(graphics, rect.ToEto()));
+					}
+				}
+#endif
 			}
+
 #endif
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
@@ -75,7 +75,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				using (var graphics = new Graphics(new GraphicsHandler(h.Control, ev.Window)))
 				{
 					Rectangle rect = ev.Region.Clipbox.ToEto();
-					h.Callback.OnPaint(h.Widget, new PaintEventArgs (graphics, rect));
+					h.Callback.OnPaint(h.Widget, new PaintEventArgs(graphics, rect));
 				}
 			}
 #else

--- a/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
@@ -1,4 +1,3 @@
-//#define old
 using Eto.Drawing;
 using Eto.Forms;
 using Eto.GtkSharp.Drawing;
@@ -76,7 +75,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				using (var graphics = new Graphics(new GraphicsHandler(h.Control, ev.Window)))
 				{
 					Rectangle rect = ev.Region.Clipbox.ToEto();
-					h.Callback.OnPaint(h.Widget, new PaintEventArgs(graphics, rect));
+					h.Callback.OnPaint(h.Widget, new PaintEventArgs (graphics, rect));
 				}
 			}
 #else

--- a/test/Eto.Test/Sections/Drawing/DrawLoopSection.cs
+++ b/test/Eto.Test/Sections/Drawing/DrawLoopSection.cs
@@ -34,7 +34,7 @@ namespace Eto.Test.Sections.Drawing
 			renderer = new DirectDrawingRenderer();
 
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
-			layout.AddSeparateRow(null, UseTexturesAndGradients(), UseCreateGraphics(), null);
+			layout.AddSeparateRow(UseTexturesAndGradients(), UseTextCoordinates(), UseCreateGraphics());
 			layout.Add(content = new Panel { Content = drawable });
 			this.Content = layout;
 		}
@@ -112,7 +112,7 @@ namespace Eto.Test.Sections.Drawing
 				}
 				if (useCreateGraphics && drawable.SupportsCreateGraphics)
 					using (var graphics = drawable.CreateGraphics())
-						graphics.Clear();
+						graphics.Clear(Brushes.Black);
 			};
 			return control;
 		}
@@ -129,6 +129,29 @@ namespace Eto.Test.Sections.Drawing
 				useCreateGraphics = control.Checked ?? false;
 				renderer.RestartFPS();
 				Application.Instance.AsyncInvoke(SetMode);
+			};
+			return control;
+		}
+
+		Control UseTextCoordinates()
+		{
+			var control = new CheckBox
+			{
+				Text = "Show Text Coordinates",
+				Checked = renderer.ShowTextCoordinates
+			};
+
+			control.CheckedChanged += (sender, e) =>
+			{
+				renderer.ShowTextCoordinates = control.Checked ?? false;
+				lock (renderer.Boxes)
+				{
+					renderer.Boxes.Clear();
+					renderer.RestartFPS();
+				}
+				if (useCreateGraphics && drawable.SupportsCreateGraphics)
+					using (var graphics = drawable.CreateGraphics())
+						graphics.Clear(Brushes.Black);
 			};
 			return control;
 		}
@@ -151,20 +174,23 @@ namespace Eto.Test.Sections.Drawing
 	{
 		readonly Image texture;
 		readonly Font font;
-		readonly SolidBrush textBrush;
+		readonly SolidBrush textBrush;		
+		readonly SolidBrush eraseBrush;
 
 		public readonly Stopwatch Watch = new Stopwatch();
 		public int TotalFrames { get; set; }
 		public long PreviousFrameStartTicks { get; set; }
 		public readonly List<Box> Boxes = new List<Box>();
 		public bool UseTexturesAndGradients { get; set; }
+		public bool ShowTextCoordinates { get; set; }
 		public bool EraseBoxes { get; set; }
 
 		public DirectDrawingRenderer()
 		{
 			texture = TestIcons.Textures;
 			font = SystemFonts.Default();
-			textBrush = new SolidBrush(Colors.White);
+			textBrush = new SolidBrush(Colors.White);			
+			eraseBrush = new SolidBrush(Colors.Black);
 		}
 
 		public void RestartFPS()
@@ -186,6 +212,8 @@ namespace Eto.Test.Sections.Drawing
 			RectangleF position;
 			IMatrix transform;
 
+			bool DisplayTextCoordinates;
+
 			public SizeF Increment { get { return increment; } set { increment = value; } }
 
 			static Color GetRandomColor(Random random)
@@ -193,8 +221,9 @@ namespace Eto.Test.Sections.Drawing
 				return Color.FromArgb(random.Next(byte.MaxValue), random.Next(byte.MaxValue), random.Next(byte.MaxValue));
 			}
 
-			public Box(Size canvasSize, bool useTexturesAndGradients, DirectDrawingRenderer renderer)
+			public Box(Size canvasSize, bool useTexturesAndGradients, bool ShowTextCoordinates, DirectDrawingRenderer renderer)
 			{
+				DisplayTextCoordinates = ShowTextCoordinates;
 				var size = new SizeF(random.Next(50) + 50, random.Next(50) + 50);
 				var location = new PointF(random.Next(canvasSize.Width - (int)size.Width), random.Next(canvasSize.Height - (int)size.Height));
 				position = new RectangleF(location, size);
@@ -206,6 +235,8 @@ namespace Eto.Test.Sections.Drawing
 
 				angle = random.Next(360);
 				rotation = (random.Next(20) - 10f) / 4f;
+
+				
 
 				var rect = new RectangleF(size);
 				color = GetRandomColor(random);
@@ -295,6 +326,34 @@ namespace Eto.Test.Sections.Drawing
 				}
 			}
 
+			private string Coordinates()
+			{
+				return string.Format("{0}x{1}", position.X, position.Y);
+			}
+
+			public void CoordianateDisplay(Graphics graphics, Font font, Brush textbrush)
+			{
+				if (DisplayTextCoordinates)
+				{					
+					graphics.DrawText(font, textbrush, position.X, position.Y, Coordinates());
+				}
+			}
+
+			public void CoordianateErase(Graphics graphics, Font font, Brush erasebrush)
+			{
+				if (DisplayTextCoordinates)
+				{
+					// we can't just draw the text again in black or we leave "vapor trails" on the screen!
+					// so clobber the text area with a filled rectangle of erase color
+					var info = Coordinates();
+					var sizeinfo = graphics.MeasureString(font, info);
+					var rec = new RectangleF(position.X, position.Y, sizeinfo.Width, sizeinfo.Height);					
+					graphics.FillRectangle(erasebrush, rec);
+				}
+			}
+
+
+
 			public void Draw(Graphics graphics)
 			{
 				graphics.SaveTransform();
@@ -307,7 +366,7 @@ namespace Eto.Test.Sections.Drawing
 		void InitializeBoxes(Size canvasSize)
 		{
 			for (int i = 0; i < 20; i++)
-				Boxes.Add(new Box(canvasSize, UseTexturesAndGradients, this));
+				Boxes.Add(new Box(canvasSize, UseTexturesAndGradients, ShowTextCoordinates, this));
 		}
 
 		public void DrawFrame(Graphics graphics, Size canvasSize)
@@ -336,9 +395,13 @@ namespace Eto.Test.Sections.Drawing
 				foreach (var box in Boxes)
 				{
 					if (EraseBoxes)
+					{
+						box.CoordianateErase(graphics, font, eraseBrush);
 						box.Erase(graphics);
+					}
 					box.Move(bounds);
 					box.Draw(graphics);
+					box.CoordianateDisplay(graphics, font, textBrush);
 				}
 				TotalFrames++;
 			}

--- a/test/Eto.Test/Sections/Drawing/DrawLoopSection.cs
+++ b/test/Eto.Test/Sections/Drawing/DrawLoopSection.cs
@@ -174,7 +174,7 @@ namespace Eto.Test.Sections.Drawing
 	{
 		readonly Image texture;
 		readonly Font font;
-		readonly SolidBrush textBrush;		
+		readonly SolidBrush textBrush;
 		readonly SolidBrush eraseBrush;
 
 		public readonly Stopwatch Watch = new Stopwatch();
@@ -189,7 +189,7 @@ namespace Eto.Test.Sections.Drawing
 		{
 			texture = TestIcons.Textures;
 			font = SystemFonts.Default();
-			textBrush = new SolidBrush(Colors.White);			
+			textBrush = new SolidBrush(Colors.White);
 			eraseBrush = new SolidBrush(Colors.Black);
 		}
 
@@ -334,7 +334,7 @@ namespace Eto.Test.Sections.Drawing
 			public void CoordianateDisplay(Graphics graphics, Font font, Brush textbrush)
 			{
 				if (DisplayTextCoordinates)
-				{					
+				{
 					graphics.DrawText(font, textbrush, position.X, position.Y, Coordinates());
 				}
 			}


### PR DESCRIPTION
This augments the Draw Loop section of the test app to add displayed text coordinates to all the shapes. The purpose is to exercise/stress the raw text functions a bit more in the draw loop.  The mode has an on/off checkbox at the top of the display. 
As there is only 1 drawable control, leaks associated with this process will rise slower than if multiple drawable controls exist but any issues should still show a slow rise in process memory consumption over time (30 min+)