### PR TITLE
Mac: Add automatic code signing and notarization

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,7 @@ indent_size = 2
 indent_style = space
 indent_size = 2
 tab_size = 2
+
+[*.yml]
+intent_style = space
+indent_size = 2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,7 +90,7 @@ jobs:
         xcode-version: latest
 
     - name: Build
-      run: msbuild ${{ env.BuildParameters }} /p:Platform=Mac /t:Package /bl:artifacts/log/Build.Mac.binlog
+      run: msbuild ${{ env.BuildParameters }} /p:Platform=Mac /t:Package /p:EnableCodeSignBuild=True /bl:artifacts/log/Build.Mac.binlog
 
     - name: Build VS/Mac Extension
       run: msbuild ${{ env.BuildParameters }} /t:BuildAddins /bl:artifacts/log/Addin.Mac.binlog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -89,6 +89,14 @@ jobs:
         xamarin-mac-version: latest
         xcode-version: latest
 
+    - name: Import code signing certificate
+      uses: apple-actions/import-codesign-certs@v1
+      with:
+        p12-file-base64: ${{ secrets.DEVID_CERTIFICATE_P12 }}
+        p12-password: ${{ secrets.DEVID_CERTIFICATE_P12_PASSWORD }}
+
+    - run: xcrun altool -​-store-password-in-keychain-item "AC_PASSWORD" -u "${{ secrets.AC_USERNAME }}" -p ${{ secrets.AC_PASSWORD }}
+
     - name: Build
       run: msbuild ${{ env.BuildParameters }} /p:Platform=Mac /t:Package /p:EnableCodeSignBuild=True /bl:artifacts/log/Build.Mac.binlog
 

--- a/src/Eto.Mac/build/BuildDmg.targets
+++ b/src/Eto.Mac/build/BuildDmg.targets
@@ -1,0 +1,47 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0" >
+
+  <PropertyGroup>
+    <!-- File Name of the DMG -->
+    <DmgName Condition="$(DmgName) == ''">$(MacBundleName)</DmgName>
+    <!-- DMG volume name -->
+    <DmgVolumeName Condition="$(DmgVolumeName) == ''">$(DmgName)</DmgVolumeName>
+    <!-- Where to put the DMG -->
+    <DmgOutputPath Condition="$(DmgOutputPath) == ''">$(OutputPath)</DmgOutputPath>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <_MacDmgTempPath>$(IntermediateOutputPath)macdmg\</_MacDmgTempPath>
+    <_MacDmgContentPath>$(_MacDmgTempPath)content\</_MacDmgContentPath>
+    <_DmgPath>$(DmgOutputPath)$(DmgName).dmg</_DmgPath>
+  </PropertyGroup>
+
+  <Target Name="MacBuildDmg_Unsupported" AfterTargets="MacBuildAppBundle" DependsOnTargets="$(MacBuildDmgDependsOnTargets)" Condition="$(IsMac) != 'True'">
+    <Warning Text="Can only build dmg on macOS" />
+  </Target>
+
+  <Target Name="MacBuildDmg" AfterTargets="MacBuildAppBundle" DependsOnTargets="$(MacBuildDmgDependsOnTargets)" Condition="$(IsMac) == 'True'">
+
+    <Message Text="Creating $(DmgName).dmg" />
+
+    <RemoveDir Directories="$(_MacDmgTempPath)" />
+    <Delete Files="$(_DmgPath)" />
+
+    <ItemGroup>
+      <_DmgAppFiles Include="$(OutputAppPath)**\*" TargetPath="$([System.IO.Path]::GetFileName($(OutputAppPath.TrimEnd('/'))))\%(RecursiveDir)%(Filename)%(Extension)" />
+      <_DmgFiles Include="@(_DmgAppFiles)" TargetPath="$([System.IO.Path]::GetFileName($(OutputAppPath.TrimEnd('/'))))\%(RecursiveDir)%(Filename)%(Extension)" />
+      <_DmgFiles Include="@(DmgContent)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" Condition="%(TargetPath) == ''"/>
+      <_DmgFiles Include="@(DmgContent)" Condition="%(TargetPath) != ''"/>
+    </ItemGroup>
+
+    <Copy SourceFiles="@(_DmgFiles)" DestinationFiles="@(_DmgFiles->'$(_MacDmgContentPath)%(TargetPath)')" />
+
+    <Exec Command='hdiutil create "$(_DmgPath)" -ov -quiet -volname "$(DmgVolumeName)" -fs HFS+ -srcfolder "$(_MacDmgContentPath)"' />
+
+    <Message Text="$(MSBuildProjectName) -> $(_DmgPath)" Importance="high" />
+  </Target>
+
+  <Target Name="MacCleanDmg" AfterTargets="Clean" Condition="$(MacIsBuildingBundle) != 'True'">
+    <Delete Files="$(_DmgPath)" />
+  </Target>
+
+</Project>

--- a/src/Eto.Mac/build/BundleDotNetCore.targets
+++ b/src/Eto.Mac/build/BundleDotNetCore.targets
@@ -1,7 +1,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0" InitialTargets="MacTouchApp">
 
   
-  <PropertyGroup Condition="$(MacBuildBundle) == 'True'">
+  <PropertyGroup>
     <!-- properties you can override in your project file -->
   
     <!-- Set to True to automatically publish the bundle during build -->
@@ -10,6 +10,9 @@
     <!-- Set to True to bundle .NET Core runtime, false to use a shared runtime (useful to speed up debug builds) -->
     <MacBundleDotNet Condition="$(MacBundleDotNet) == '' AND $(Configuration) == 'Release'">True</MacBundleDotNet>
     <MacBundleDotNet Condition="$(MacBundleDotNet) == ''">False</MacBundleDotNet>
+
+    <!-- Set the default code signing entitlements for .NET Core if none specified -->
+    <CodeSignEntitlements Condition="$(CodeSignEntitlements) == ''">$(MSBuildThisFileDirectory)DotNetCore.entitlements</CodeSignEntitlements>
   </PropertyGroup>
 
   <ItemGroup Condition="$(MacBundleRuntimeIdentifiers) == ''">
@@ -17,29 +20,26 @@
     <MacBundleRuntimeIdentifiers Include="$(RuntimeIdentifiers)" Condition="$(RuntimeIdentifiers) != ''" />
     <MacBundleRuntimeIdentifiers Include="$(RuntimeIdentifier)" Condition="$(RuntimeIdentifier) != ''" />
   </ItemGroup>  
-  <PropertyGroup  Condition="$(MacBundleRuntimeIdentifiers) == ''">
-
-  </PropertyGroup>
   <ItemGroup>
     <!-- runtime identifiers have been explicitly set -->
     <MacBundleRuntimeIdentifiers Include="$(MacBundleRuntimeIdentifiers)" Condition="$(MacBundleRuntimeIdentifiers) != ''" />
   </ItemGroup>
 
-  <Target Name="MacTouchApp" Condition="$(MacBuildBundle) == 'True'">
+  <Target Name="MacTouchApp">
     <!-- This makes it so we can debug in VS for Mac right away without building first -->
     <MakeDir Directories="$(OutputAppPath)" Condition="$(IsMac) == 'True' AND $(VisualStudioVersion) != '' AND $(TargetFramework) != '' AND $(RuntimeIdentifier) != ''" />
   </Target>
   
   <!-- Build target to automatically publish -->
-  <Target Name="MacBuildAppBundle" AfterTargets="AfterBuild" Condition="$(MacAutoPublishBundle) == 'True' AND $(MacIsBuildingBundle) != 'True'" Outputs="$(OutputAppPath)">
+  <Target Name="MacBuildAppBundle" AfterTargets="AfterBuild" DependsOnTargets="$(MacBuildAppBundleDependsOn)" Condition="$(MacAutoPublishBundle) == 'True' AND $(MacIsBuildingBundle) != 'True'" Outputs="$(OutputAppPath)">
     <Error Text="No RuntimeIdentifiers or MacRuntimeIdentifiers have been specified" Condition="@(MacBundleRuntimeIdentifiers->Count()) == 0" />
     <PropertyGroup>
       <MacTempBuildPath>$(IntermediateOutputPath)macbuild\</MacTempBuildPath>
-      
+
       <MacBuildProperties>MacIsBuildingBundle=True</MacBuildProperties>
       <MacBuildProperties>$(MacBuildProperties);MacBundlingProject=$(MSBuildProjectFullPath)</MacBuildProperties>
       <MacBuildProperties>$(MacBuildProperties);TargetFramework=$(TargetFramework)</MacBuildProperties>
-      <MacBuildProperties Condition="$(PublishSingleFile) == '' AND $(Configuration) == 'Release'">$(MacBuildProperties);PublishSingleFile=True</MacBuildProperties>
+      <MacBuildProperties Condition="$(PublishSingleFile) == '' AND $(Configuration) == 'Release' AND $(MacEnableCodeSigning) != 'True'">$(MacBuildProperties);PublishSingleFile=True</MacBuildProperties>
       <MacBuildProperties Condition="$(PublishTrimmed) == '' AND $(Configuration) == 'Release'">$(MacBuildProperties);PublishTrimmed=True</MacBuildProperties>
       <MacBuildProperties>$(MacBuildProperties);SelfContained=$(MacBundleDotNet)</MacBuildProperties>
       <MacBuildProperties>$(MacBuildProperties);MacTempBuildPath=$(MacTempBuildPath)</MacBuildProperties>
@@ -55,7 +55,7 @@
              Condition="$([System.String]::Copy(%(MacBundleRuntimeIdentifiers.Identity)).StartsWith('osx'))" />
   </Target>
 
-  <Target Name="MacCleanAppBundle" AfterTargets="AfterClean" Condition="$(MacBuildBundle) == 'True'">
+  <Target Name="MacCleanAppBundle" AfterTargets="AfterClean">
     <RemoveDir Directories="$(MacTempBuildPath)" />
   </Target>
   
@@ -70,7 +70,7 @@
   </Target>
   
   <!-- Publish with bundled runtime -->
-  <Target Name="MacPublishAppBundle" AfterTargets="Publish" Condition="$(MacBuildBundle) == 'True'" DependsOnTargets="MacInitializeBundle">
+  <Target Name="MacPublishAppBundle" AfterTargets="Publish" DependsOnTargets="MacInitializeBundle">
     <ItemGroup>
       <LauncherFiles Include="$(PublishDir)**\*" />
       <LauncherFiles Remove="$(PublishDir)**\*.pdb" Condition="$(MacIncludeSymbols) != 'True'" />

--- a/src/Eto.Mac/build/BundleMono.targets
+++ b/src/Eto.Mac/build/BundleMono.targets
@@ -14,15 +14,18 @@
 
     <!-- minimum installed version of mono required to run -->
     <MacMonoMinimumVersion Condition="$(MacMonoMinimumVersion) == ''">6.0</MacMonoMinimumVersion>
+
+    <!-- Set the default code signing entitlements for Mono if none specified -->
+    <CodeSignEntitlements Condition="$(CodeSignEntitlements) == ''">$(MSBuildThisFileDirectory)Mono.entitlements</CodeSignEntitlements>
   </PropertyGroup>
-  
-  <Target Name="MacTouchApp" Condition="$(MacBuildBundle) == 'True'">
+
+  <Target Name="MacTouchApp">
     <!-- This makes it so we can debug in VS for Mac right away without building first -->
     <MakeDir Directories="$(OutputAppPath)" Condition="$(IsMac) == 'True' AND $(VisualStudioVersion) != '' AND $(TargetFramework) != '' AND $(RuntimeIdentifier) == ''" />
   </Target>
 
   <!-- Build target -->
-  <Target Name="BuildAppBundle" AfterTargets="AfterBuild" DependsOnTargets="DetectMkBundle" Condition="$(MacBuildBundle) == 'True'" Outputs="$(OutputAppPath)">
+  <Target Name="MacBuildAppBundle" AfterTargets="AfterBuild" DependsOnTargets="DetectMkBundle;$(MacBuildAppBundleDependsOn)" Outputs="$(OutputAppPath)">
     <!-- bundle mono with mkbundle -->
     <CallTarget Targets="MacBundleMono" Condition="$(MacBundleMono) == 'True'" />
     <!-- copy executables and run with installed mono -->

--- a/src/Eto.Mac/build/CodeSign.targets
+++ b/src/Eto.Mac/build/CodeSign.targets
@@ -1,0 +1,67 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0" >
+
+  <PropertyGroup>
+    <!-- search key for the code signing identity for the .app (partial strings match) -->
+    <CodeSigningKey Condition="$(CodeSigningKey) == ''"></CodeSigningKey>
+    <!-- search key for the code signing identity for the .dmg (partial strings match) -->
+    <DmgCodeSigningKey Condition="$(DmgCodeSigningKey) == ''">$(CodeSigningKey)</DmgCodeSigningKey>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <MacBuildDmgDependsOnTargets>$(MacBuildDmgDependsOnTargets);MacCodeSignApp_Unsupported;MacCodeSignApp</MacBuildDmgDependsOnTargets>
+  </PropertyGroup>
+
+  <Target Name="MacCodeSignApp_Unsupported" AfterTargets="MacBuildAppBundle" DependsOnTargets="$(MacCodeSignDependsOnTargets)" Condition="$(IsMac) != 'True'">
+    <Warning Text="Can only code sign an app on macOS" />
+  </Target>
+
+  <Target Name="MacCodeSignApp" AfterTargets="MacBuildAppBundle" DependsOnTargets="$(MacCodeSignDependsOnTargets)" Condition="$(IsMac) == 'True'">
+
+    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="_MacResolveCodeSignIdentity" Properties="CodeSignSearchKey=$(CodeSigningKey)" >
+      <Output TaskParameter="TargetOutputs" PropertyName="ResolvedCodeSigningKey" />
+    </MSBuild>
+
+    <PropertyGroup>
+      <CodeSignEntitlements Condition="$(CodeSignEntitlements) != '' AND !Exists($(CodeSignEntitlements)) AND Exists('$(MSBuildProjectDirectory)\$(CodeSignEntitlements)')">$(MSBuildProjectDirectory)\$(CodeSignEntitlements)</CodeSignEntitlements>
+
+      <_CodeSignOptions Condition="$(CodeSignEntitlements) != ''">--entitlements "$(CodeSignEntitlements)"</_CodeSignOptions>
+    </PropertyGroup>
+
+    <ItemGroup>
+      <_CodeSignFiles Include="$(OutputAppPath)" CodeSignOptions="--deep --options runtime $(_CodeSignOptions)" />
+    </ItemGroup>
+
+    <Exec Command='codesign --force %(_CodeSignFiles.CodeSignOptions) --sign "$(ResolvedCodeSigningKey)" "@(_CodeSignFiles)"' />
+  </Target>
+
+  <Target Name="MacCodeSignDmg" AfterTargets="MacBuildDmg" Condition="$(IsMac) == 'True'">
+
+    <MSBuild Projects="$(MSBuildThisFileFullPath)" Targets="_MacResolveCodeSignIdentity" Properties="CodeSignSearchKey=$(DmgCodeSigningKey)" >
+      <Output TaskParameter="TargetOutputs" PropertyName="ResolvedDmgCodeSigningKey" />
+    </MSBuild>
+
+    <Exec Command='codesign --force --sign "$(ResolvedDmgCodeSigningKey)" "$(_DmgPath)"' />
+  </Target>
+
+  <!-- Resolve a code sign identity.  Parameters: CodeSignSearchKey -->
+  <Target Name="_MacResolveCodeSignIdentity" Outputs="$(ResolvedCodeSignIdentity)">
+
+    <!-- get valid identities that match -->
+    <Exec Command="security find-identity -v -p codesigning | grep -v 'valid identities found' | grep '$(CodeSignSearchKey)' | awk '{print $2}'"
+          ConsoleToMSBuild="True"
+          StandardOutputImportance="normal">
+        <Output TaskParameter="ConsoleOutput" ItemName="MatchingIdentities"/>
+    </Exec>
+
+    <Error Text="Could not find code sign key matching '$(CodeSignSearchKey)'. Ensure you have installed your code sign certificate."
+           Condition="@(MatchingIdentities->Count()) == '0'" />
+
+    <Error Text="More than one valid code signing certificate matches '$(CodeSignSearchKey)'. Enter a more specific key for the certificate."
+           Condition="@(MatchingIdentities->Count()) > '1'" />
+
+    <PropertyGroup>
+      <ResolvedCodeSignIdentity>@(MatchingIdentities)</ResolvedCodeSignIdentity>
+    </PropertyGroup>
+  </Target>
+
+</Project>

--- a/src/Eto.Mac/build/DotNetCore.entitlements
+++ b/src/Eto.Mac/build/DotNetCore.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/src/Eto.Mac/build/Mac.targets
+++ b/src/Eto.Mac/build/Mac.targets
@@ -275,4 +275,9 @@
 
   <Import Project="BundleMono.targets" Condition="$(MacUseDotNetCore) != 'True' AND $(MacBuildBundle) == 'True'" />
   <Import Project="BundleDotNetCore.targets" Condition="$(MacUseDotNetCore) == 'True' AND $(MacBuildBundle) == 'True'" />
+
+  <Import Project="BuildDmg.targets" Condition="$(MacBuildDmg) == 'True' AND $(MacIsBuildingBundle) != 'True' AND $(MacBuildBundle) == 'True'" />
+  <Import Project="CodeSign.targets" Condition="$(MacEnableCodeSigning) == 'True' AND $(MacIsBuildingBundle) != 'True' AND $(MacBuildBundle) == 'True'" />
+  <Import Project="Notarization.targets" Condition="$(MacEnableNotarization) == 'True' AND $(MacIsBuildingBundle) != 'True' AND $(MacBuildBundle) == 'True'" />
+
 </Project>

--- a/src/Eto.Mac/build/Mono.entitlements
+++ b/src/Eto.Mac/build/Mono.entitlements
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.cs.allow-jit</key>
+	<true/>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+	<true/>
+	<key>com.apple.security.cs.allow-dyld-environment-variables</key>
+	<true/>
+	<key>com.apple.security.cs.disable-library-validation</key>
+	<true/>
+</dict>
+</plist>

--- a/src/Eto.Mac/build/Notarization.targets
+++ b/src/Eto.Mac/build/Notarization.targets
@@ -1,0 +1,136 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0" >
+
+  <PropertyGroup>
+    <!--
+      Wait for notarization to complete and staple the DMG.
+      Note that this can make the build take a long time waiting for your app to be notarized.
+      -->
+    <EnableNotarizationStapler Condition="$(EnableNotarizationStapler) == ''">True</EnableNotarizationStapler>
+
+    <!-- Identifier for the notarization, which is returned in the notarization email to identify what has been notarized -->
+    <NotarizationBundleIdentifier Condition="$(NotarizationBundleIdentifier) == ''">$(DmgName).dmg</NotarizationBundleIdentifier>
+
+    <!-- The notarization user name. The username can be inferred from the password keychain entry if not specified. -->
+    <NotarizationUserName Condition="$(NotarizationUserName) == ''"></NotarizationUserName>
+
+    <!--
+      The notarization password. To use from the keychain (the default), use the following command:
+      xcrun altool -​-store-password-in-keychain-item "AC_PASSWORD" -u "<NotarizationUserName>" -p <secret_password>
+    -->
+    <NotarizationPassword Condition="$(NotarizationPassword) == ''">@keychain:AC_PASSWORD</NotarizationPassword>
+  </PropertyGroup>
+
+  <Target Name="MacNotarize_Unsupported" AfterTargets="MacBuildDmg_Unsupported" DependsOnTargets="$(MacNotarizeDependsOnTargets)" Condition="$(IsMac) != 'True'">
+    <Warning Text="Can only notarize on macOS" />
+  </Target>
+
+  <Target Name="MacNotarize" AfterTargets="MacBuildDmg" DependsOnTargets="$(MacNotarizeDependsOnTargets)" Condition="$(IsMac) == 'True'">
+
+    <PropertyGroup>
+      <_DmgZipPath>$(_MacDmgTempPath)$(DmgName).zip</_DmgZipPath>
+
+      <_NotarizationParameters>--primary-bundle-id '$(NotarizationBundleIdentifier)'</_NotarizationParameters>
+      <_NotarizationParameters Condition="$(NotarizationUserName) != ''">$(_NotarizationParameters) --username '$(NotarizationUserName)'</_NotarizationParameters>
+      <_NotarizationParameters>$(_NotarizationParameters) --password '$(NotarizationPassword)'</_NotarizationParameters>
+      <_NotarizationParameters>$(_NotarizationParameters) --file '$(_DmgZipPath)'</_NotarizationParameters>
+    </PropertyGroup>
+
+    <!-- Notarization could take a while, so always show this message -->
+    <Message Text="Notarizing $(DmgName).dmg" Importance="high" />
+
+    <Exec Command='/usr/bin/ditto -c -k --keepParent "$(_DmgPath)" "$(_DmgZipPath)"' />
+
+    <Message Text="Sending $(DmgName).dmg for Notarization" />
+    <Exec Command="xcrun altool --notarize-app $(_NotarizationParameters) 2>&amp;1 | grep RequestUUID | awk '{print $3}'" 
+      StandardOutputImportance="normal"
+      ConsoleToMSBuild="True">
+      <Output TaskParameter="ConsoleOutput" PropertyName="NotarizationUUID" />
+    </Exec>
+
+    <Message Text="Notarization RequestUUID: $(NotarizationUUID)" />
+
+    <Delete Files="$(_DmgZipPath)" />
+  </Target>
+
+  <PropertyGroup>
+    <!-- Bit of a hack, but we stop the loop when this file exists.. -->
+    <_NotarizationCompleteFile>$(IntermediateOutputPath)macbuild\notarization_complete</_NotarizationCompleteFile>
+  </PropertyGroup>
+
+  <Target Name="_MacGetNotarizationStatus" Outputs="$(_Progress)" Condition="!Exists($(_NotarizationCompleteFile))">
+
+    <PropertyGroup>
+      <_InProgressString>Status: in progress</_InProgressString>
+      <_NotarizationParameters>--notarization-info '$(NotarizationUUID)'</_NotarizationParameters>
+      <_NotarizationParameters Condition="$(NotarizationUserName) != ''">$(_NotarizationParameters) --username '$(NotarizationUserName)'</_NotarizationParameters>
+      <_NotarizationParameters>$(_NotarizationParameters) --password '$(NotarizationPassword)'</_NotarizationParameters>
+    </PropertyGroup>
+
+    <!-- check the notarization status... -->
+    <Exec Command="xcrun altool $(_NotarizationParameters) 2>&amp;1"
+          ConsoleToMSBuild="True">
+        <Output TaskParameter="ConsoleOutput" PropertyName="_Progress"/>
+    </Exec>
+
+    <Exec Command="sleep 30" Condition="$(_Progress.Contains($(_InProgressString))) == 'True'" />
+
+    <WriteLinesToFile File="$(_NotarizationCompleteFile)" 
+                      Overwrite="True"
+                      Lines="$(_Progress)"
+                      Condition="$(_Progress.Contains($(_InProgressString))) != 'True'" />
+
+  </Target>
+
+  <Target Name="MacStapler" AfterTargets="MacNotarize" Condition="$(EnableNotarizationStapler) == 'True' AND $(IsMac) == 'True'">
+    <!-- 
+      "Notarization completes for most software within 5 minutes, and for 98% of software within 15"
+      So, we keep retrying every 30 seconds for 15 minutes.
+     -->
+    <Message Text="Checking notarization status" />
+
+    <PropertyGroup>
+      <!-- lazy man's way of doing a loop in msbuild.. -->
+      <_Retries>1;2;3;4;5;6;7;8;9;10;11;12;13;14;15;16;17;18;19;20;21;22;23;24;25;26;27;28;29;30</_Retries>
+    </PropertyGroup>
+    <ItemGroup>
+      <_Retries Include="$(_Retries)" />
+    </ItemGroup>
+
+    <!-- in case we notarized before.. -->
+    <Delete Files="$(_NotarizationCompleteFile)" />
+
+    <!-- Wait a bit before we do the first check, it most likely won't be ready right away.. -->
+    <Exec Command="sleep 10" />
+
+    <!-- Check the status -->
+    <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="_MacGetNotarizationStatus" Properties="Retry=%(_Retries.Identity);NotarizationUUID=$(NotarizationUUID)" />
+
+    <!-- Read the status -->
+    <ReadLinesFromFile File="$(_NotarizationCompleteFile)">
+      <Output TaskParameter="Lines" PropertyName="_Progress" />
+    </ReadLinesFromFile>
+    <Delete Files="$(_NotarizationCompleteFile)" />
+
+    <PropertyGroup>
+      <_SuccessString>Status: success</_SuccessString>
+      <_InvalidString>Status: Invalid</_InvalidString>
+      <_InProgressString>Status: in progress</_InProgressString>
+    </PropertyGroup>
+
+    <Error Text="Error notarizing your app. Check the LogFileURL above and validate your app with 'codesign -vvv --deep --strict /path/to/MyApp.app'. See https://developer.apple.com/documentation/xcode/notarizing_macos_software_before_distribution/resolving_common_notarization_issues for troubleshooting tips."
+           Condition="$(_Progress.Contains($(_InvalidString))) == 'True'" />
+
+    <Error Text="Timeout notarizing. You may have to staple manually using 'xcrun stapler staple MyApp.dmg' after recieving the success notarization email"
+           Condition="$(_Progress.Contains($(_InProgressString))) == 'True'" />
+           
+    <Error Text="Error notarizing"
+           Condition="$(_Progress.Contains($(_SuccessString))) != 'True'" />
+
+    <!-- success if we got here, so staple the DMG -->
+    <Exec Command='xcrun stapler staple "$(_DmgPath)"' />
+
+    <Message Text="Stapled $(DmgName).dmg with notarization ticket" Importance="high" />
+
+  </Target>
+
+</Project>

--- a/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
@@ -11,7 +11,12 @@
     
     <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
-  
+
+  <PropertyGroup Condition="$([MSBuild]::IsOsPlatform(OSX)) AND $(Configuration) == 'Release' AND $(EnableCodeSignBuild) == 'True' AND $(TargetFramework) == 'netcoreapp3.1'">
+    <MacBuildDmg>True</MacBuildDmg>
+    <MacEnableCodeSigning>True</MacEnableCodeSigning>
+    <MacEnableNotarization>True</MacEnableNotarization>
+  </PropertyGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\..\src\Eto\Eto.csproj" />


### PR DESCRIPTION
This adds the ability to create DMG's, code sign, and notarize your Eto.Mac64 apps automatically. This only works on a Mac.

New properties that control these features:

DMG Creation
```
    <!-- add to your csproj -->
    <MacBuildDmg>True</MacBuildDmg>

    <!-- File Name of the DMG -->
    <DmgName Condition="$(DmgName) == ''">$(MacBundleName)</DmgName>
    <!-- DMG volume name -->
    <DmgVolumeName Condition="$(DmgVolumeName) == ''">$(DmgName)</DmgVolumeName>
    <!-- Where to put the DMG -->
    <DmgOutputPath Condition="$(DmgOutputPath) == ''">$(OutputPath)</DmgOutputPath>
```

Code Signing:
```
    <!-- add to your csproj -->
    <MacEnableCodeSigning>True</MacEnableCodeSigning>

    <!-- search key for the code signing identity for the .app (partial strings match) -->
    <CodeSigningKey Condition="$(CodeSigningKey) == ''"></CodeSigningKey>
    <!-- search key for the code signing identity for the .dmg (partial strings match) -->
    <DmgCodeSigningKey Condition="$(DmgCodeSigningKey) == ''">$(CodeSigningKey)</DmgCodeSigningKey>
```

Notarization:
```
    <!-- add to your csproj -->
    <MacEnableNotarization>True</MacEnableNotarization>

    <!--
      Wait for notarization to complete and staple the DMG.
      Note that this can make the build take a long time waiting for your app to be notarized.
      -->
    <EnableNotarizationStapler Condition="$(EnableNotarizationStapler) == ''">True</EnableNotarizationStapler>

    <!-- Identifier for the notarization, which is returned in the notarization email to identify what has been notarized -->
    <NotarizationBundleIdentifier Condition="$(NotarizationBundleIdentifier) == ''">$(DmgName).dmg</NotarizationBundleIdentifier>

    <!-- The notarization user name. The username can be inferred from the password keychain entry if not specified. -->
    <NotarizationUserName Condition="$(NotarizationUserName) == ''"></NotarizationUserName>

    <!--
      The notarization password. To use from the keychain (the default), use the following command:
      xcrun altool -​-store-password-in-keychain-item "AC_PASSWORD" -u "<NotarizationUserName>" -p <secret_password>
    -->
    <NotarizationPassword Condition="$(NotarizationPassword) == ''">@keychain:AC_PASSWORD</NotarizationPassword>
```

Fixes #1748