### PR TITLE
Extract dependencies to normal nuget references

### DIFF
--- a/src/Eto.WinForms/Eto.WinForms.csproj
+++ b/src/Eto.WinForms/Eto.WinForms.csproj
@@ -36,7 +36,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
   </PropertyGroup>
 
   <PropertyGroup>
-    <EmbedReferences>Microsoft.WindowsAPICodePack;Microsoft.WindowsAPICodePack.Shell;Interop.SHDocVw</EmbedReferences>
+    <EmbedReferences>Interop.SHDocVw</EmbedReferences>
     <EmbedPrefix>Eto.WinForms.CustomControls.Assemblies</EmbedPrefix>
   </PropertyGroup>
 
@@ -110,7 +110,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Windows7APICodePack-Shell" Version="1.1.0" PrivateAssets="all" />
+    <PackageReference Include="Windows7APICodePack-Shell" Version="1.1.0" />
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -42,7 +42,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
   </PropertyGroup>
 
   <PropertyGroup>
-    <EmbedReferences>Microsoft.WindowsAPICodePack;Microsoft.WindowsAPICodePack.Shell;Xceed.Wpf.Toolkit;Interop.SHDocVw</EmbedReferences>
+    <EmbedReferences>Interop.SHDocVw</EmbedReferences>
     <EmbedPrefix>Eto.Wpf.CustomControls.Assemblies</EmbedPrefix>
   </PropertyGroup>
 
@@ -152,9 +152,9 @@ You do not need to use any of the classes of this assembly (unless customizing t
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" PrivateAssets="all" />
-    <PackageReference Include="Windows7APICodePack-Shell" Version="1.1.0" PrivateAssets="all" />
-	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
+    <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" />
+    <PackageReference Include="Windows7APICodePack-Shell" Version="1.1.0" />
+  	<PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" PrivateAssets="all" />
   </ItemGroup>
 
   <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />


### PR DESCRIPTION
To be a good citizen, we should not be embedding nuget references.  Doing this also simplifies extending handlers in Eto.Wpf and Eto.WinForms as you don't have to reference Extended.Wpf.Toolkit or WindowsAPICodePack manually.

Note that this means you'll get extra dll's when compiling for WPF or WinForms, but now you will have control over the version of said assemblies. 🎉