### PR TITLE
Wpf: Graphics.ResetClip() can reset transform if one exists

### DIFF
--- a/src/Eto.Wpf/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Wpf/Drawing/GraphicsHandler.cs
@@ -616,11 +616,13 @@ namespace Eto.Wpf.Drawing
 
 		public void ResetClip()
 		{
-			if (clipBounds != null)
+			if (clipBounds != null || clipPath != null)
 			{
-				Control.Pop();
+				RewindTransform();
+				RewindClip();
 				clipBounds = null;
 				clipPath = null;
+				ApplyTransform();
 			}
 		}
 


### PR DESCRIPTION
Transform comes after clip, so we need to rewind the transform then reapply.