### PR TITLE
Fixing problem with CheckToolItem in GTK

### DIFF
--- a/src/Eto.Gtk/Forms/ToolBar/CheckToolItemHandler.cs
+++ b/src/Eto.Gtk/Forms/ToolBar/CheckToolItemHandler.cs
@@ -37,24 +37,18 @@ namespace Eto.GtkSharp.Forms.ToolBar
 			Control.NoShowAll = true;
 			Control.Visible = Visible;
 			tb.Insert(Control, index);
-			Control.Toggled += Connector.HandleToggled;
+			Control.Toggled += Control_CheckedChanged;
+			Control.Clicked += Control_Click;
 		}
 
-		protected new CheckToolItemConnector Connector { get { return (CheckToolItemConnector)base.Connector; } }
-
-		protected override WeakConnector CreateConnector()
+		private void Control_Click(object sender, EventArgs e)
 		{
-			return new CheckToolItemConnector();
+			Widget.OnClick(EventArgs.Empty);
 		}
 
-		protected class CheckToolItemConnector : WeakConnector
+		private void Control_CheckedChanged(object sender, EventArgs e)
 		{
-			public new CheckToolItemHandler Handler { get { return (CheckToolItemHandler)base.Handler; } }
-
-			public void HandleToggled(object sender, EventArgs e)
-			{
-				Handler.Widget.OnClick(EventArgs.Empty);
-			}
+			Widget.OnCheckedChanged(EventArgs.Empty);
 		}
 	}
 }


### PR DESCRIPTION
Firstly, this is my first PR so let me thank you for this excellent library!

While playing with CheckToolItem on Linux, I found that it is not correctly reporting the control state. I had the following code in my MainForm:
```fsharp
let toolBar = new ToolBar()

let autoScrollToolItem = new CheckToolItem(Text = "Test")
[| autoScrollToolItem :> ToolItem |] |> Array.iter toolBar.Items.Add
base.ToolBar <- toolBar

autoScrollToolItem.Bind((fun c -> c.Checked), viewModel, (fun m -> m.AutoScroll)) |> ignore
autoScrollToolItem.Bind((fun c -> c.Command :?> CheckCommand), viewModel, (fun m -> m.AutoScrollCommand)) |> ignore
```
and the viewmodel:
```fsharp
member _.AutoScrollCommand
    with get () =
        let f (cmd : obj) _ =
            let cmd = cmd :?> CheckCommand
            autoscroll <- cmd.Checked // BUG: always false
        CheckCommand(EventHandler<EventArgs>(f))

member _.AutoScroll = // BUG: never called
    with get () = autoscroll
    and set v = autoscroll <- v
```
In the current version, the `AutoScroll` property was never called and the `cmd.Checked` (in the `AutoScrollCommand`) has been always set to `false`. When I compared the `CheckToolItemHandler.cs` in Eto.Gtk with Eto.Wpf, I noticed the logic in the Gtk version is more complex and goes through some additional handler. Maybe I'm missing something here, but when I replaced this handler with direct methods (as in the Wpf version), everything is working correctly. 