### PR TITLE
#1816 fix parenting/close behavior for Gtk drop-down dialog box

### DIFF
--- a/src/Eto.Gtk/CustomControls/BaseComboBox.gtk3.cs
+++ b/src/Eto.Gtk/CustomControls/BaseComboBox.gtk3.cs
@@ -24,7 +24,10 @@ namespace Eto.GtkSharp.CustomControls
 		{
 			if (args.Event.X > AllocatedWidth - ArrowWidth && Sensitive)
 			{
-				OnPopupButtonClicked(EventArgs.Empty);
+				if (args.Event.Type == Gdk.EventType.ButtonPress)
+				{
+					OnPopupButtonClicked(EventArgs.Empty);
+				}
 			}
 		}
 

--- a/src/Eto.Gtk/CustomControls/DateComboBox.cs
+++ b/src/Eto.Gtk/CustomControls/DateComboBox.cs
@@ -99,6 +99,8 @@ namespace Eto.GtkSharp.CustomControls
 				// if we are still up somehow, take the old dialog down..
 				if (dlg != null)
 				{
+					// this will appear to the user as a click that doesn't 
+					// bring up a window..
 					dlg.Close();
 					dlg = null;
 				}
@@ -127,7 +129,7 @@ namespace Eto.GtkSharp.CustomControls
 		/// <param name="args"></param>
 		private void Entry_FocusOutEvent(object o, Gtk.FocusOutEventArgs args)
 		{
-			// if we are up and lose
+			// if we are up, close the dialog
 			if (dlg != null)
 			{
 				dlg.CloseDialog();

--- a/src/Eto.Gtk/CustomControls/DateComboBox.cs
+++ b/src/Eto.Gtk/CustomControls/DateComboBox.cs
@@ -115,11 +115,21 @@ namespace Eto.GtkSharp.CustomControls
 						ValidateDateRange();
 						SetValue();
 					};			
-					// get nofications when the dialog closes
-					dlg.DialogClosed += HandleDialogClose;					
+					dlg.Destroyed += Dlg_Destroyed;
 					dlg.ShowPopup(this);
 				}
 			};
+		}
+
+		/// <summary>
+		/// remove our reference to the dialog ONLY when we know it's 
+		/// really gone..
+		/// </summary>
+		/// <param name="sender"></param>
+		/// <param name="e"></param>
+		private void Dlg_Destroyed(object sender, EventArgs e)
+		{
+			dlg = null;
 		}
 
 		/// <summary>
@@ -129,7 +139,7 @@ namespace Eto.GtkSharp.CustomControls
 		/// <param name="args"></param>
 		private void Entry_FocusOutEvent(object o, Gtk.FocusOutEventArgs args)
 		{
-			// if we are up, close the dialog
+			// if the pull-down is are up, close it
 			if (dlg != null)
 			{
 				dlg.CloseDialog();

--- a/src/Eto.Gtk/CustomControls/DateComboBoxDialog.cs
+++ b/src/Eto.Gtk/CustomControls/DateComboBoxDialog.cs
@@ -16,8 +16,6 @@ namespace Eto.GtkSharp.CustomControls
 		public event EventHandler<EventArgs> DateChanged;
 		public event EventHandler<EventArgs> DialogClosed;
 
-		int start_count = 0;
-
 		protected virtual void OnDateChanged (EventArgs e)
 		{
 			if (DateChanged != null)
@@ -93,10 +91,7 @@ namespace Eto.GtkSharp.CustomControls
 
 			ShowAll();
 
-			start_count++;
-
 			//if (! this.HasGrab) this.Grab ();
-			
 		}
 
 #if GTK2
@@ -121,9 +116,6 @@ namespace Eto.GtkSharp.CustomControls
 
 		public void CloseDialog ()
 		{
-
-			start_count--;
-
 			if (this.HasGrab)
 			{
 				this.RemoveGrab();

--- a/src/Eto.Gtk/CustomControls/DateComboBoxDialog.cs
+++ b/src/Eto.Gtk/CustomControls/DateComboBoxDialog.cs
@@ -14,18 +14,12 @@ namespace Eto.GtkSharp.CustomControls
 		Gtk.SpinButton secondsSpin;
 		
 		public event EventHandler<EventArgs> DateChanged;
-		public event EventHandler<EventArgs> DialogClosed;
+		
 
 		protected virtual void OnDateChanged (EventArgs e)
 		{
 			if (DateChanged != null)
 				DateChanged (this, e);
-		}
-
-		protected virtual void OnDialogClosed(EventArgs e)
-		{
-			if (DialogClosed != null)
-				DialogClosed(this, e);
 		}
 
 		bool HasTime {
@@ -116,19 +110,11 @@ namespace Eto.GtkSharp.CustomControls
 
 		public void CloseDialog ()
 		{
-			if (this.HasGrab)
-			{
-				this.RemoveGrab();
-			}
-
 #if GTKCORE
-			Close();
-			
-			// let the parent know we closed...			
-			DialogClosed(this, EventArgs.Empty);
-
+			Close();		
+		
 #else
-		Destroy();
+			Destroy();
 #endif
 		}
 


### PR DESCRIPTION
This still needs some cleanup but the control no longer loses parenting for the drop-down on a form.  This result is still messed up if the control is located on a Dialog - guessing the two fight for the always on top but at least will behave on a Form. I have seen this problem in other Gtk situations and my response is to turn all my "dialogs" into forms so the only remaining are the "system" dialogs e.g. Save/Open/Print. Basically the code changes allow the combo-box part of the control to manage the lifetime of the dialog and will pull the dialog down when focus is lost to the control

As far as root cause -- the "Close" on the dialog gets called but seems to only partially close the window -- perhaps the underlying controls in Gtk-land abort the Close or there is a race condition or..???   I originally thought a race condition or non-UI thread since these are coming in from events - but I tested calling/sending the Close request to the context used to create the control to no effect -- seems something is "cancelling" the close request somehow.  I may move my investigation over to the UNIX side so I can debug into GtkSharp and see what's going on down below.