### PR TITLE
Wpf/WinForms: Report per-monitor screen information when in system-dpi mode

### DIFF
--- a/src/Eto.WinForms/Forms/ScreenHandler.cs
+++ b/src/Eto.WinForms/Forms/ScreenHandler.cs
@@ -36,22 +36,28 @@ namespace Eto.WinForms.Forms
 
 		public Image GetImage(RectangleF rect)
 		{
-			var ss = Bounds.Size;
+			var bounds = Bounds;
+			var realBounds = bounds;
 
-			// get scale based on actual pixel size, we don't support high DPI on winforms (yet)
-			// and the CopyFromScreen API always requires actual pixel size.
-			using (var g = sd.Graphics.FromHwnd(IntPtr.Zero))
+			var hmonitor = Win32.MonitorFromPoint(bounds.Location.ToSDPoint(), 0);
+			if (hmonitor != IntPtr.Zero)
 			{
-				var hdc = g.GetHdc();
+				// get actual monitor dimentions
+				var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE) : Win32.DPI_AWARENESS_CONTEXT.NONE;
 
-				ss.Width = GetDeviceCaps(hdc, DESKTOPHORZRES);
-				ss.Height = GetDeviceCaps(hdc, DESKTOPVERTRES);
+				var info = new Win32.MONITORINFOEX();
+				Win32.GetMonitorInfo(new HandleRef(null, hmonitor), info);
+				realBounds = info.rcMonitor.ToSD().ToEto();
 
-				g.ReleaseHdc(hdc);
+				if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
+					Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
 			}
 
-			var realRect = Rectangle.Ceiling(rect * (float)(ss.Width / Bounds.Width));
-			var screenBmp = new sd.Bitmap(realRect.Width, realRect.Height, sd.Imaging.PixelFormat.Format32bppArgb);
+			var adjustedRect = rect;
+			adjustedRect.Size *= (float)(realBounds.Width / bounds.Width);
+			adjustedRect.Location += realBounds.Location;
+			var realRect = Rectangle.Ceiling(adjustedRect);
+			var screenBmp = new sd.Bitmap(realRect.Width, realRect.Height, sd.Imaging.PixelFormat.Format32bppRgb);
 			using (var bmpGraphics = sd.Graphics.FromImage(screenBmp))
 			{
 				bmpGraphics.CopyFromScreen(realRect.X, realRect.Y, 0, 0, realRect.Size.ToSD());

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -10,6 +10,7 @@ namespace Eto
 	{
 #pragma warning disable 0649
 		// Analysis disable InconsistentNaming
+		[StructLayout(LayoutKind.Sequential)]
 		public struct RECT
 		{
 			public int left;
@@ -18,6 +19,20 @@ namespace Eto
 			public int bottom;
 			public int width => right - left;
 			public int height => bottom - top;
+
+			public System.Drawing.Rectangle ToSD() => new System.Drawing.Rectangle(left, top, width, height);
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		public struct POINT
+		{
+			public int x;
+			public int y;
+			public POINT(int x, int y)
+			{
+				this.x = x;
+				this.y = y;
+			}
 		}
 #pragma warning restore 0649
 

--- a/src/Eto.Wpf/Forms/MouseHandler.cs
+++ b/src/Eto.Wpf/Forms/MouseHandler.cs
@@ -15,8 +15,21 @@ namespace Eto.Wpf.Forms
 
 		public PointF Position
 		{
-			get => swf.Control.MousePosition.ScreenToLogical();
-			set => swf.Cursor.Position = Point.Round(value.LogicalToScreen()).ToSD();
+			get
+			{
+				var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : Win32.DPI_AWARENESS_CONTEXT.NONE;
+				var result = swf.Control.MousePosition.ScreenToLogical();
+				if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
+					Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
+				return result;
+			}
+			set
+			{
+				var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : Win32.DPI_AWARENESS_CONTEXT.NONE;
+				swf.Cursor.Position = Point.Round(value.LogicalToScreen()).ToSD();
+				if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
+					Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
+			}
 		}
 
 		public static int s_CursorSetCount;

--- a/src/Eto.Wpf/Forms/ScreenHandler.cs
+++ b/src/Eto.Wpf/Forms/ScreenHandler.cs
@@ -50,8 +50,10 @@ namespace Eto.Wpf.Forms
 
 		public Image GetImage(RectangleF rect)
 		{
-			var realRect = Rectangle.Ceiling(rect * Widget.LogicalPixelSize);
-			using (var screenBmp = new sd.Bitmap(realRect.Width, realRect.Height, sd.Imaging.PixelFormat.Format32bppArgb))
+			var adjustedRect = rect * Widget.LogicalPixelSize;
+			adjustedRect.Location += Control.Bounds.Location.ToEto();
+			var realRect = Rectangle.Ceiling(adjustedRect);
+			using (var screenBmp = new sd.Bitmap(realRect.Width, realRect.Height, sd.Imaging.PixelFormat.Format32bppRgb))
 			{
 				using (var bmpGraphics = sd.Graphics.FromImage(screenBmp))
 				{
@@ -71,9 +73,9 @@ namespace Eto.Wpf.Forms
 
 		public float Scale => 96f / 72f;
 
-		public RectangleF Bounds => Control.Bounds.ScreenToLogical();
+		public RectangleF Bounds => Control.GetBounds().ScreenToLogical();
 
-		public RectangleF WorkingArea => Control.WorkingArea.ScreenToLogical();
+		public RectangleF WorkingArea => Control.GetWorkingArea().ScreenToLogical();
 
 		public int BitsPerPixel => Control.BitsPerPixel;
 

--- a/src/Eto.Wpf/LogicalScreenHelper.cs
+++ b/src/Eto.Wpf/LogicalScreenHelper.cs
@@ -23,30 +23,6 @@ namespace Eto
 
 		public virtual float GetMaxLogicalPixelSize() => AllScreens.Max((Func<T, float>)GetLogicalPixelSize);
 
-		T FindLeftScreen(T screen) =>
-			AllScreens
-			.Where(r => GetBounds(r).X >= 0 && GetBounds(r).Right == GetBounds(screen).X)
-			.OrderBy(r => GetLogicalPixelSize(r))
-			.FirstOrDefault();
-
-		T FindRightScreen(T screen) =>
-			AllScreens
-			.Where(r => GetBounds(r).X < 0 && GetBounds(r).X == GetBounds(screen).Right)
-			.OrderBy(r => GetLogicalPixelSize(r))
-			.FirstOrDefault();
-
-		T FindTopScreen(T screen) =>
-			AllScreens
-			.Where(r => GetBounds(r).Y >= 0 && GetBounds(r).Bottom == GetBounds(screen).Y)
-			.OrderBy(r => GetLogicalPixelSize(r))
-			.FirstOrDefault();
-
-		T FindBottomScreen(T screen) =>
-			AllScreens
-			.Where(r => GetBounds(r).Y < 0 && GetBounds(r).Y == GetBounds(screen).Bottom)
-			.OrderBy(r => GetLogicalPixelSize(r))
-			.FirstOrDefault();
-
 		public Eto.Drawing.PointF GetLogicalLocation(T screen)
 		{
 			/**/
@@ -61,11 +37,14 @@ namespace Eto
 			// to calculate it's logical position
 
 			// if it is not adjacent, we use the maximum pixel size to figure out its position.
+			var allScreens = AllScreens.ToList();
+
+			var maxLogicalPixelSize = GetMaxLogicalPixelSize();
 
 			if (bounds.X < primaryBounds.X)
 			{
 				var adjacentScreen = primaryScreen;
-				foreach (var scn in AllScreens.OrderByDescending(s => GetBounds(s).X))
+				foreach (var scn in allScreens.OrderByDescending(s => GetBounds(s).X))
 				{
 					var scnBounds = GetBounds(scn);
 					if (scnBounds.X > primaryBounds.X || (!scn.Equals(screen) && bounds.Right > scnBounds.X))
@@ -83,13 +62,13 @@ namespace Eto
 				}
 				if (!adjacentScreen.Equals(screen))
 				{
-					location.X = bounds.X / GetMaxLogicalPixelSize();
+					location.X = bounds.X / maxLogicalPixelSize;
 				}
 			}
 			else if (bounds.X > primaryBounds.X)
 			{
 				var adjacentScreen = primaryScreen;
-				foreach (var scn in AllScreens.OrderBy(s => GetBounds(s).X))
+				foreach (var scn in allScreens.OrderBy(s => GetBounds(s).X))
 				{
 					var scnBounds = GetBounds(scn);
 					if (scnBounds.X < primaryBounds.X || (!scn.Equals(screen) && bounds.X < scnBounds.Right))
@@ -107,14 +86,14 @@ namespace Eto
 				}
 				if (!adjacentScreen.Equals(screen))
 				{
-					location.X = bounds.X / GetMaxLogicalPixelSize();
+					location.X = bounds.X / maxLogicalPixelSize;
 				}
 			}
 
 			if (bounds.Y < primaryBounds.Y)
 			{
 				var adjacentScreen = primaryScreen;
-				foreach (var scn in AllScreens.OrderByDescending(s => GetBounds(s).Y))
+				foreach (var scn in allScreens.OrderByDescending(s => GetBounds(s).Y))
 				{
 					var scnBounds = GetBounds(scn);
 					if (scnBounds.Y > primaryBounds.Y || (!scn.Equals(screen) && bounds.Bottom > scnBounds.Y))
@@ -132,13 +111,13 @@ namespace Eto
 				}
 				if (!adjacentScreen.Equals(screen))
 				{
-					location.Y = bounds.Y / GetMaxLogicalPixelSize();
+					location.Y = bounds.Y / maxLogicalPixelSize;
 				}
 			}
 			else if (bounds.Y > primaryBounds.Y)
 			{
 				var adjacentScreen = primaryScreen;
-				foreach (var scn in AllScreens.OrderBy(s => GetBounds(s).Y))
+				foreach (var scn in allScreens.OrderBy(s => GetBounds(s).Y))
 				{
 					var scnBounds = GetBounds(scn);
 					if (scnBounds.Y < primaryBounds.Y || (!scn.Equals(screen) && bounds.Y < scnBounds.Bottom))
@@ -156,51 +135,11 @@ namespace Eto
 				}
 				if (!adjacentScreen.Equals(screen))
 				{
-					location.Y = bounds.Y / GetMaxLogicalPixelSize();
+					location.Y = bounds.Y / maxLogicalPixelSize;
 				}
 			}
 
 			return location;
-			/**
-
-			var bounds = GetBounds(screen);
-			float x, y;
-			if (bounds.X > 0)
-			{
-				var left = FindLeftScreen(screen);
-				if (left != null)
-					x = GetLogicalLocation(left).X + GetLogicalSize(left).Width;
-				else
-					x = bounds.X / GetMaxLogicalPixelSize();
-			}
-			else if (bounds.X < 0)
-			{
-				var right = FindRightScreen(screen);
-				if (right != null)
-					x = GetLogicalLocation(right).X - GetLogicalSize(screen).Width;
-				else
-					x = bounds.X / GetLogicalPixelSize(screen);
-			}
-			else x = bounds.X;
-			if (bounds.Y > 0)
-			{
-				var top = FindTopScreen(screen);
-				if (top != null)
-					y = GetLogicalLocation(top).Y + GetLogicalSize(top).Height;
-				else
-					y = bounds.Y / GetMaxLogicalPixelSize();
-			}
-			else if (bounds.Y < 0)
-			{
-				var bottom = FindBottomScreen(screen);
-				if (bottom != null)
-					y = GetLogicalLocation(bottom).Y - GetLogicalSize(screen).Height;
-				else
-					y = bounds.Y / GetLogicalPixelSize(screen);
-			}
-			else y = bounds.Y;
-			return new Eto.Drawing.PointF(x, y);
-			/**/
 		}
 	}
 }

--- a/test/Eto.Test.Wpf/app.manifest
+++ b/test/Eto.Test.Wpf/app.manifest
@@ -52,8 +52,15 @@
   <application xmlns="urn:schemas-microsoft-com:asm.v3">
     <windowsSettings>
       <!-- dpiAwareness is for Windows 10 RC1, dpiAware is to support older systems -->
+
+	  <!-- We need to ensure Eto works well with per monitor awareness, system awareness, or no awareness. -->
+
+	  <!-- Use this to test per-monitor DPI awareness -->
       <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2,PerMonitor</dpiAwareness>
       <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/PM</dpiAware>
+	  
+	  <!-- Use this to test system-dpi aware applications -->
+      <!-- <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware> -->
     </windowsSettings>
   </application>
 

--- a/test/Eto.Test/Sections/Behaviors/ScreenSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ScreenSection.cs
@@ -2,9 +2,16 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 using System.Linq;
+using System.Collections.Generic;
 
 namespace Eto.Test.Sections.Behaviors
 {
+	/// <summary>
+	/// Tests screen information and behaviour of window and cursor positions.
+	/// </summary>
+	/// <remarks>
+	/// Ensure you test this with Per-monitor and System DPI settings in app.manifest
+	/// </remarks>
 	[Section("Behaviors", "Screen")]
 	public class ScreenSection : Scrollable
 	{
@@ -28,15 +35,19 @@ namespace Eto.Test.Sections.Behaviors
 
 		public ScreenSection()
 		{
+			TestApplication.Settings.LastFormPosition = null;
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
 
 			var showScreenContent = new CheckBox { Text = "Show screen content" };
 			showScreenContent.CheckedBinding.Bind(this, c => c.ShowScreenContent);
 
+			var showWindowsAtCorners = new CheckBox { Text = "Create windows at screen corners" };
+			showWindowsAtCorners.CheckedChanged += showWindowsAtCorners_CheckedChanged;
+
 			screens = Screen.Screens.ToArray();
 
 			layout.BeginCentered();
-			layout.Add(showScreenContent);
+			layout.AddSeparateRow(showScreenContent, showWindowsAtCorners, null);
 			layout.Add($"Display Bounds: {displayBounds}");
 			layout.BeginVertical(Padding.Empty);
 			var num = 0;
@@ -59,6 +70,140 @@ namespace Eto.Test.Sections.Behaviors
 			Content = layout;
 		}
 
+		List<Form> cornerWindows = new List<Form>();
+
+		bool RestorePosition(Window window)
+		{
+			if (TestApplication.Settings.LastFormPosition == null)
+				return false;
+			var etoRectangle = TestApplication.Settings.LastFormPosition.Value;
+			// If the font face or size is different or the save rectangle is empty then bail
+			// Returns a Screen for the display that contains the point. In multiple
+			// display environments where no display contains the point, the display
+			// closest to the specified point is returned.
+			var screen_bounds = Screen.FromRectangle(etoRectangle).Bounds;
+			// Inflate the bounding rectangle by 1 pixel on all sides to make sure
+			// edge cases work
+			screen_bounds.Inflate(1, 1);
+			// Force the rectangle onto the nearest screen
+			var bounds = ForceToNearestScreen(etoRectangle);
+			// If the restore rectangle is not completely within the screen bounding
+			// rectangle then don't do anything
+			if (!screen_bounds.Contains(bounds)) return false;
+
+			var restore_bounds = window.RestoreBounds;
+			// Set the window location
+			window.Location = bounds.Location;
+			// Only restore the size for a manually sized window.
+			//if (window.SizeToContent == SizeToContent.Manual)
+			if (window.Resizable)
+			{
+				// Set the window width and height
+				window.Size = bounds.Size;
+			}
+			// Return true if the location or size changed
+			return (window.RestoreBounds != restore_bounds);
+		}
+
+		static Rectangle ForceToNearestScreen(Rectangle rectangle)
+		{
+			var result = rectangle;
+			// Returns a Screen for the display that contains the point. In multiple
+			// display environments where no display contains the point, the display
+			// closest to the specified point is returned.
+			var screen_bounds = Rectangle.Round(Screen.FromRectangle(rectangle).Bounds);
+			// Position the rectangle in the appropriate monitor display space
+			if (result.Right > screen_bounds.Right)
+				result.Offset(screen_bounds.Right - result.Right, 0);
+			if (result.Bottom > screen_bounds.Bottom)
+				result.Offset(0, screen_bounds.Bottom - result.Bottom);
+			if (result.Left < screen_bounds.Left)
+				result.Offset((screen_bounds.Left - result.Left), 0);
+			if (result.Top < screen_bounds.Top)
+				result.Offset(0, (screen_bounds.Top - result.Top));
+			return result;
+		}
+
+		public void SavePosition(Window window)
+		{
+			TestApplication.Settings.LastFormPosition = window.RestoreBounds;
+		}
+
+		private void showWindowsAtCorners_CheckedChanged(object sender, EventArgs e)
+		{
+			CloseCornerWindows();
+			Form CreateWindow()
+			{
+				var form = new Form
+				{
+					WindowStyle = WindowStyle.None,
+					Resizable = false,
+					Size = new Size(100, 100),
+					ShowActivated = false,
+					CanFocus = false,
+					ShowInTaskbar = false,
+					Padding = 10,
+					Content = new Panel { BackgroundColor = Colors.Blue }
+				};
+				// use anonymous method to prevent event reference
+				form.LocationChanged += (_, __) => Invalidate();
+				form.Shown += (_, __) => Invalidate();
+				form.Closed += (_, __) => Invalidate();
+				return form;
+			};
+
+			var showWindowsAtCorners = (CheckBox)sender;
+			if (showWindowsAtCorners.Checked != true)
+				return;
+
+			var restoreForm = new Form {
+				Content = "This form should restore its size and position", 
+				Resizable = true,
+				MinimumSize = new Size(450, 300),
+				ShowActivated = false
+			};
+			restoreForm.LocationChanged += (_, __) => Invalidate();
+			restoreForm.SizeChanged += (_, __) => Invalidate();
+			RestorePosition(restoreForm);
+			restoreForm.Closing += (_, __) => SavePosition(restoreForm);
+			restoreForm.Show();
+
+			cornerWindows.Add(restoreForm);
+
+
+			foreach (var screen in Screen.Screens)
+			{
+				var topLeft = CreateWindow();
+				topLeft.Location = Point.Truncate(screen.Bounds.TopLeft);
+				topLeft.Show();
+				cornerWindows.Add(topLeft);
+
+				var topRight = CreateWindow();
+				topRight.Location = Point.Truncate(screen.Bounds.TopRight - new Size(topRight.Width, 0));
+				topRight.Show();
+				cornerWindows.Add(topRight);
+
+				var bottomLeft = CreateWindow();
+				bottomLeft.Location = Point.Truncate(screen.Bounds.BottomLeft - new Size(0, bottomLeft.Height));
+				bottomLeft.Show();
+				cornerWindows.Add(bottomLeft);
+
+				var bottomRight = CreateWindow();
+				bottomRight.Location = Point.Truncate(screen.Bounds.BottomRight - bottomLeft.Size);
+				bottomRight.Show();
+				cornerWindows.Add(bottomRight);
+			}
+		}
+
+		private void CloseCornerWindows()
+		{
+			foreach (var window in cornerWindows.ToArray())
+			{
+				window.Close();
+			}
+			cornerWindows.Clear();
+		}
+
 		protected override void OnLoadComplete(EventArgs e)
 		{
 			base.OnLoadComplete(e);
@@ -70,11 +215,12 @@ namespace Eto.Test.Sections.Behaviors
 		{
 			base.OnUnLoad(e);
 			parentWindow.LocationChanged -= HandleLocationChanged;
+			CloseCornerWindows();
 		}
 
 		void HandleLocationChanged(object sender, EventArgs e)
 		{
-			windowPositionLabel.Text = $"Window Bounds: {parentWindow.Bounds}";
+			windowPositionLabel.Text = $"Window Bounds: {parentWindow.Bounds}, RestoreBounds: {parentWindow.RestoreBounds}";
 			Invalidate();
 		}
 
@@ -100,7 +246,7 @@ namespace Eto.Test.Sections.Behaviors
 				foreach (var screen in screens)
 				{
 					var screenBounds = (screen.Bounds * scale) + offset;
-                    screenBounds.Size -= 1;
+					screenBounds.Size -= 1;
 
 					var workingArea = (screen.WorkingArea * scale) + offset;
 					var screenImage = showScreenContent ? screen.GetImage(new RectangleF(screen.Bounds.Size)) : null;
@@ -119,14 +265,28 @@ namespace Eto.Test.Sections.Behaviors
 					pe.Graphics.DrawRectangle(Colors.Black, screenBounds);
 				}
 
-                var windowBounds = ((RectangleF)ParentWindow.Bounds * scale) + offset;
-                windowBounds.Size -= 1;
-
-				if (!hasScreenImages)
+				void DrawWindow(Window window)
 				{
-					pe.Graphics.FillRectangle(new Color(Colors.LightSkyBlue, 0.8f), windowBounds);
+					var windowBounds = ((RectangleF)window.Bounds * scale) + offset;
+					windowBounds.Size -= 1;
+
+					if (!hasScreenImages)
+					{
+						pe.Graphics.FillRectangle(new Color(Colors.LightSkyBlue, 0.8f), windowBounds);
+					}
+					pe.Graphics.DrawRectangle(Colors.White, windowBounds);
 				}
-                pe.Graphics.DrawRectangle(Colors.White, windowBounds);
+
+				DrawWindow(ParentWindow);
+
+				if (cornerWindows != null)
+				{
+					foreach (var window in cornerWindows)
+					{
+						DrawWindow(window);
+					}
+				}
+
 
 				var mousePosition = Mouse.Position * scale + offset;
 				var mouseRect = new RectangleF(mousePosition, SizeF.Empty);

--- a/test/Eto.Test/Settings.cs
+++ b/test/Eto.Test/Settings.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.IO;
+using Eto.Drawing;
 
 namespace Eto.Test
 {
@@ -14,6 +15,8 @@ namespace Eto.Test
 		public bool SaveInitialSection { get; set; }
 
 		public string LastUnitTestFilter { get; set; }
+
+		public Rectangle? LastFormPosition { get; set; }
 
 		public static Settings Load()
 		{


### PR DESCRIPTION
This fixes issues getting screen information when running an application in system-DPI mode, and ensures that getting/setting the window position works when using multiple monitor setups with different DPI's.  This effectively will make Eto API's multi-monitor aware even if the running application is not aware.