### PR TITLE
Build for .NET 5.0

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -1,0 +1,12 @@
+{
+  "version": 1,
+  "isRoot": true,
+  "tools": {
+    "dotnet-t4": {
+      "version": "2.0.5",
+      "commands": [
+        "t4"
+      ]
+    }
+  }
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     types: [ published ]
 
 env:
-  DotNetVersion: "3.1.301"
+  DotNetVersion: "5.0.100"
   BuildConfiguration: "Release"
   BuildParameters: "build/Build.proj /v:Minimal /p:Configuration=Release /p:BuildVersion=${{ github.run_id }} /p:BuildBranch=${{ github.ref }}"
 
@@ -32,7 +32,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1
 
     - name: Build
-      run: msbuild ${{ env.BuildParameters }} /p:Platform=Windows /t:Package /bl:artifacts/log/Build.Windows.binlog
+      run: dotnet build ${{ env.BuildParameters }} /p:Platform=Windows /t:Package /bl:artifacts/log/Build.Windows.binlog
 
     - name: Build VS/Win Extension
       run: msbuild ${{ env.BuildParameters }} /t:BuildAddins /bl:artifacts/log/Addin.Windows.binlog
@@ -90,7 +90,7 @@ jobs:
         xcode-version: latest
 
     - name: Build
-      run: msbuild ${{ env.BuildParameters }} /p:Platform=Mac /t:Package /bl:artifacts/log/Build.Mac.binlog
+      run: dotnet build ${{ env.BuildParameters }} /p:Platform=Mac /t:Package /bl:artifacts/log/Build.Mac.binlog
 
     - name: Build VS/Mac Extension
       run: msbuild ${{ env.BuildParameters }} /t:BuildAddins /bl:artifacts/log/Addin.Mac.binlog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,13 @@ jobs:
       with:
         submodules: true
 
+    # use preview version of VS for now to support .NET 5
+    - run: dotnet tool update -g dotnet-vs
+    - run: echo "name=MSB::$(vs where preview --prop=InstallationPath)" >> $GITHUB_ENV
+    - run: vs install preview sku:enterprise --quiet +Microsoft.VisualStudio.Component.ManagedDesktop.Core +Microsoft.NetCore.Component.DevelopmentTools
+      if: env.MSB == ''
+    - run: echo "::add-path::$(vs where preview --prop=InstallationPath)\MSBuild\Current\Bin"
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,12 @@ jobs:
       with:
         submodules: true
 
+    # needed for dotnet-t4
+    - name: Setup .NET Core 2.1.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: "2.1.x"
+
     # Can't use .NET 5 with msbuild until VS is updated to 16.8 in GitHub Actions
     - name: Setup .NET Core 3.1.x
       uses: actions/setup-dotnet@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,12 +34,6 @@ jobs:
     - name: Build
       run: dotnet build ${{ env.BuildParameters }} /p:Platform=Windows /t:Package /bl:artifacts/log/Build.Windows.binlog
 
-    # Can't use .NET 5 with msbuild until VS is updated to 16.8 in GitHub Actions
-    - name: Setup .NET Core 3.1.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: "3.1.x"
-
     - name: Build VS/Win Extension
       run: msbuild ${{ env.BuildParameters }} /t:BuildAddins /bl:artifacts/log/Addin.Windows.binlog
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,8 +40,8 @@ jobs:
       with:
         dotnet-version: ${{ env.DotNetVersion }}
 
-    - name: Setup msbuild
-      uses: microsoft/setup-msbuild@v1
+    # - name: Setup msbuild
+    #   uses: microsoft/setup-msbuild@v1
 
     - name: Build
       run: dotnet build ${{ env.BuildParameters }} /p:Platform=Windows /t:Package /bl:artifacts/log/Build.Windows.binlog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ on:
 env:
   DotNetVersion: "5.0.100"
   BuildConfiguration: "Release"
-  BuildParameters: "build/Build.proj /v:Minimal /p:Configuration=Release /p:BuildVersion=${{ github.run_id }} /p:BuildBranch=${{ github.ref }}"
+  BuildParameters: "build/Build.proj /v:Minimal /consoleLoggerParameters:NoSummary /p:Configuration=Release /p:BuildVersion=${{ github.run_id }} /p:BuildBranch=${{ github.ref }}"
 
 jobs:
   build-windows:
@@ -83,7 +83,7 @@ jobs:
         dotnet-version: ${{ env.DotNetVersion }}
 
     - name: setup-xamarin
-      uses: maxim-lobanov/setup-xamarin@v1.1
+      uses: maxim-lobanov/setup-xamarin@v1
       with:
         mono-version: latest
         xamarin-mac-version: latest

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,6 +30,11 @@ jobs:
       if: env.MSB == ''
     - run: echo "$(vs where preview --prop=InstallationPath)\MSBuild\Current\Bin" >> $GITHUB_PATH
 
+    - name: Install .NET Core 2.1 for t4 templates
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: '2.1.x'
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,10 @@ jobs:
 
     # use preview version of VS for now to support .NET 5
     - run: dotnet tool update -g dotnet-vs
-    - run: echo "name=MSB::$(vs where preview --prop=InstallationPath)" >> $GITHUB_ENV
-    - run: vs install preview sku:enterprise --quiet +Microsoft.VisualStudio.Component.ManagedDesktop.Core +Microsoft.NetCore.Component.DevelopmentTools
+    - run: echo "MSB=$(vs where preview --prop=InstallationPath)" >> $GITHUB_ENV
+    - run: vs install preview --sku=enterprise --quiet +Microsoft.VisualStudio.Component.ManagedDesktop.Core +Microsoft.NetCore.Component.DevelopmentTools
       if: env.MSB == ''
-    - run: echo "::add-path::$(vs where preview --prop=InstallationPath)\MSBuild\Current\Bin"
+    - run: echo "$(vs where preview --prop=InstallationPath)\MSBuild\Current\Bin" >> $GITHUB_PATH
 
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,28 +23,22 @@ jobs:
       with:
         submodules: true
 
-    # use preview version of VS for now to support .NET 5
-    - run: dotnet tool update -g dotnet-vs
-    - run: echo "MSB=$(vs where preview --prop=InstallationPath)" >> $GITHUB_ENV
-    - run: vs install preview --sku=enterprise --quiet +Microsoft.VisualStudio.Component.ManagedDesktop.Core +Microsoft.NetCore.Component.DevelopmentTools
-      if: env.MSB == ''
-    - run: echo "$(vs where preview --prop=InstallationPath)\MSBuild\Current\Bin" >> $GITHUB_PATH
-
-    - name: Install .NET Core 2.1 for t4 templates
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: '2.1.x'
-
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:
         dotnet-version: ${{ env.DotNetVersion }}
 
-    # - name: Setup msbuild
-    #   uses: microsoft/setup-msbuild@v1
+    - name: Setup msbuild
+      uses: microsoft/setup-msbuild@v1
 
     - name: Build
       run: dotnet build ${{ env.BuildParameters }} /p:Platform=Windows /t:Package /bl:artifacts/log/Build.Windows.binlog
+
+    # Can't use .NET 5 with msbuild until VS is updated to 16.8 in GitHub Actions
+    - name: Setup .NET Core 3.1.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: "3.1.x"
 
     - name: Build VS/Win Extension
       run: msbuild ${{ env.BuildParameters }} /t:BuildAddins /bl:artifacts/log/Addin.Windows.binlog

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,6 +23,12 @@ jobs:
       with:
         submodules: true
 
+    # Can't use .NET 5 with msbuild until VS is updated to 16.8 in GitHub Actions
+    - name: Setup .NET Core 3.1.x
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: "3.1.x"
+
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ AppPackages
 [Tt]humbs.db
 /artifacts
 packages/
+.store

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,19 +6,19 @@
             "type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-mac64",
-            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/netcoreapp3.1/Eto.Test.Mac64.app/Contents/MacOS/Eto.Test.Mac64",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/${input:platform-core}/Eto.Test.Mac64.app/Contents/MacOS/Eto.Test.Mac64",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
-			// requires mono extension from https://github.com/cwensley/vscode-mono-debug/releases
             "name": "Eto.Test.XamMac2",
             "type": "mono",
 			"request": "launch",
 			"preLaunchTask": "build-xammac2",
-			"program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/net472/Eto.Test.XamMac2.app/Contents/MacOS/Eto.Test.XamMac2",
-			"useRuntime": false,
+			"program": ".",
+			"runtimeExecutable": "${workspaceFolder}/artifacts/test/${config:var.configuration}/net472/Eto.Test.XamMac2.app/Contents/MacOS/Eto.Test.XamMac2",
+			"passDebugOptionsViaEnvironmentVariable": true,
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
@@ -28,10 +28,30 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-gtk",
-            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/netcoreapp3.1/Eto.Test.Gtk.dll",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/${input:platform-core}/Eto.Test.Gtk.dll",
             "args": [],
             "console": "internalConsole",
             "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": "Eto.Test.Gtk - mono",
+			"type": "mono",
+			"request": "launch",
+			"preLaunchTask": "build-gtk",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/net472/Eto.Test.Gtk.exe",
+            "args": [],
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+        {
+            "name": "Eto.Test.Gtk2",
+			"type": "mono",
+			"request": "launch",
+			"preLaunchTask": "build-gtk2",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/net472/Eto.Test.Gtk2.exe",
+            "args": [],
+            "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
@@ -39,7 +59,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-wpf",
-            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/netcoreapp3.1/Eto.Test.Wpf.exe",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/${input:platform-windows}/Eto.Test.Wpf.exe",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
@@ -49,10 +69,45 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-winforms",
-            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/netcoreapp3.1/Eto.Test.WinForms.exe",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/${input:platform-windows}/Eto.Test.WinForms.exe",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
-        }
+		},
+		{
+			"name": "Eto.Addin.VisualStudio.Mac",
+			"type": "mono",
+			"request": "launch",
+			"preLaunchTask": "build-addins",
+			"program": ".",
+			"runtimeExecutable": "/Applications/Visual Studio.app/Contents/MacOS/VisualStudio",
+			"passDebugOptionsViaEnvironmentVariable": true,
+			"args": [ "--no-redirect" ],
+			"env": {
+				"MONODEVELOP_CONSOLE_LOG_LEVEL": "All",
+				"MONODEVELOP_DEV_ADDINS": "${workspaceFolder}/artifacts/addin/${config:var.configuration}/net472/"
+			}
+		}
+	],
+	"inputs": [
+		{
+			"type": "pickString",
+			"id": "platform-windows",
+			"description": "Platform",
+			"options": [
+				"net5.0-windows",
+				"netcoreapp3.1",
+				"net472"
+			]
+		},
+		{
+			"type": "pickString",
+			"id": "platform-core",
+			"description": "Platform",
+			"options": [
+				"net5.0",
+				"netcoreapp3.1"
+			]
+		}
 	]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -3,10 +3,7 @@
 	"tasks": [
 		{
 			"label": "build",
-			"command": "msbuild /t:Build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/build/Build.proj",
-			"windows": {
-				"command": "${workspaceFolder}/build/msbuild.cmd /t:Build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/build/Build.proj"
-			},
+			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/build/Build.proj",
 			"type": "shell",
 			"problemMatcher": "$msCompile",
 			"group": {
@@ -18,7 +15,7 @@
 			}
 		},
 		{
-			"label": "build addins",
+			"label": "build-addins",
 			"command": "msbuild /t:BuildAddins ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/build/Build.proj",
 			"windows": {
 				"command": "${workspaceFolder}/build/msbuild.cmd /t:BuildAddins ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/build/Build.proj"
@@ -41,6 +38,16 @@
 			}
 		},
 		{
+			"label": "build-gtk2",
+			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Gtk/Eto.Test.Gtk2.csproj",
+			"type": "shell",
+			"group": "build",
+			"problemMatcher": "$msCompile",
+			"presentation": {
+				"clear": true
+			}
+		},
+		{
 			"label": "build-mac64",
 			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.Mac64.csproj",
 			"type": "shell",
@@ -52,7 +59,7 @@
 		},
 		{
 			"label": "build-xammac2",
-			"command": "msbuild /restore ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj",
+			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj",
 			"type": "shell",
 			"group": "build",
 			"problemMatcher": "$msCompile",

--- a/build/Common.Build.props
+++ b/build/Common.Build.props
@@ -26,7 +26,6 @@
 
   <!-- support t4 templates in projects -->
   <ItemGroup>
-    <DotNetCliToolReference Include="dotnet-t4-project-tool" Version="2.0.5"/>
     <TextTemplate Include="**\*.tt" />
     <AvailableItemName Include="TextTemplate" />
   </ItemGroup>

--- a/build/Common.Build.targets
+++ b/build/Common.Build.targets
@@ -57,13 +57,17 @@
     <Message Importance="high" Text="Embedding: @(FilesToEmbed->'%(Filename)%(Extension)', ', ')" />
   </Target>
   <Import Condition="Exists('$(BasePath)..\Eto.Common.targets')" Project="$(BasePath)..\Eto.Common.targets" />
-  
-  <PropertyGroup>
-    <AssemblySearchPaths Condition="$(FixGtkReferences)=='true'">$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
-  </PropertyGroup>
-  
-  
+
   <Target Name="FixGtkReferences" Condition="$(FixGtkReferences)=='true'" BeforeTargets="BeforeBuild">
+    <ItemGroup>
+      <GtkAssemblyFiles Include="\Library\Frameworks\Mono.framework\Versions\Current\lib\mono\gac\**\*.dll" />
+      <GtkAssemblyPaths Include="@(GtkAssemblyFiles->'%(RootDir)%(Directory)')"/>
+    </ItemGroup>
+    
+    <PropertyGroup>
+      <AssemblySearchPaths>$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
+      <AssemblySearchPaths>$(AssemblySearchPaths);@(GtkAssemblyPaths->'%(Identity)', ';')</AssemblySearchPaths>
+    </PropertyGroup>
     <!-- 
     Set the path of gtk references explicitly for linux msbuild support.
     msbuild on linux crashes with gtk references and uses the wrong references when 
@@ -125,5 +129,33 @@
       <Compile Include="%(TextTemplate.RelativeDir)%(TextTemplate.Filename).cs" />
     </ItemGroup>
   </Target>
+
+
+<UsingTask
+  TaskName="GetMetadata"
+  TaskFactory="$(MSBuildTaskFactoryType)" AssemblyFile="$(MSBuildTasksAssemblyFile)">
+  <ParameterGroup>
+    <ItemGroup ParameterType="Microsoft.Build.Framework.ITaskItem[]" Required="true" />
+    <Output Output="true" />
+  </ParameterGroup>
+  <Task>
+    <Using Namespace="System"/>
+    <Code Type="Fragment" Language="cs">
+      <![CDATA[
+          var command = new StringBuilder();
+          foreach (ITaskItem item in ItemGroup )
+          {
+              command.AppendLine(string.Format("ItemName={0}", item));
+              foreach (string parameter in item.MetadataNames)
+              {
+                  command.AppendLine(string.Format("  {0}={1}", parameter, item.GetMetadata(parameter)));
+              }
+              command.AppendLine();
+          }
+          Output = command.ToString();
+      ]]>
+    </Code>
+  </Task>
+</UsingTask>  
 
 </Project>

--- a/build/Common.Build.targets
+++ b/build/Common.Build.targets
@@ -124,6 +124,7 @@
     <ItemGroup>
       <Compile Remove="%(TextTemplate.RelativeDir)%(TextTemplate.Filename).cs" />
     </ItemGroup>
+    <Exec Command="dotnet tool restore" />
     <Exec WorkingDirectory="$(ProjectDir)" Command="dotnet t4 %(TextTemplate.Identity) --out %(TextTemplate.RelativeDir)%(TextTemplate.Filename).cs"/>
     <ItemGroup>
       <Compile Include="%(TextTemplate.RelativeDir)%(TextTemplate.Filename).cs" />

--- a/build/Xamarin.Mac.targets
+++ b/build/Xamarin.Mac.targets
@@ -32,6 +32,17 @@
     <MacBuildBundle>False</MacBuildBundle>
     <UseSGen Condition="$(UseSGen) == ''">True</UseSGen>
     <AOTMode Condition="$(AOTMode) == ''">None</AOTMode>
+
+    <!-- stuff needed for .NET Core tooling -->
+    <FrameworkPathOverride Condition="$(IsXamarinMacMobile) != 'True'">$(XamarinMacLibPath)4.5\</FrameworkPathOverride>
+    <FrameworkPathOverride Condition="$(IsXamarinMacMobile) == 'True'">$(XamarinMacLibPath)Xamarin.Mac\</FrameworkPathOverride>
+    <MSBuildRuntimeVersion Condition="$(MSBuildRuntimeVersion) == ''">16.8</MSBuildRuntimeVersion>
+  </PropertyGroup>
+
+    <!-- stuff needed for .NET Core tooling -->
+  <PropertyGroup Condition="'$(FrameworkPathOverride)' != '' AND $(IsXamarinMacMobile) == 'True'">
+    <_FullFrameworkReferenceAssemblyPaths>$(FrameworkPathOverride)</_FullFrameworkReferenceAssemblyPaths>
+    <_TargetFrameworkDirectories>$(FrameworkPathOverride)</_TargetFrameworkDirectories>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(UseXamarinMac) == 'True' AND $(TargetFramework.StartsWith('xamarinmac')) != 'True'">

--- a/samples/WinForms/EmbedEtoInWinForms/EmbedEtoInWinForms.csproj
+++ b/samples/WinForms/EmbedEtoInWinForms/EmbedEtoInWinForms.csproj
@@ -1,10 +1,9 @@
 <Project>
 
   <PropertyGroup>
-    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT'">true</HaveWindowsDesktopSdk>
   
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition="'$(NoNetFramework)'=='' or '$(NoNetFramework)'=='false'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 

--- a/samples/WinForms/EmbedWinFormsInEto/EmbedWinFormsInEto.csproj
+++ b/samples/WinForms/EmbedWinFormsInEto/EmbedWinFormsInEto.csproj
@@ -1,10 +1,9 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT'">true</HaveWindowsDesktopSdk>
   
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition="'$(NoNetFramework)'=='' or '$(NoNetFramework)'=='false'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 

--- a/samples/Wpf/EmbedEtoInWpf/EmbedEtoInWpf.csproj
+++ b/samples/Wpf/EmbedEtoInWpf/EmbedEtoInWpf.csproj
@@ -1,8 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition="'$(NoNetFramework)'=='' or '$(NoNetFramework)'=='false'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 

--- a/samples/Wpf/EmbedEtoInWpf/EmbedEtoInWpf.csproj
+++ b/samples/Wpf/EmbedEtoInWpf/EmbedEtoInWpf.csproj
@@ -1,6 +1,8 @@
 <Project>
 
   <PropertyGroup>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT'">true</HaveWindowsDesktopSdk>
+    
     <TargetFrameworks>net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
@@ -23,8 +25,7 @@
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Xaml">
-    </Reference>
+    <Reference Include="System.Xaml" />
     <Reference Include="WindowsBase" />
     <Reference Include="PresentationCore" />
     <Reference Include="PresentationFramework" />

--- a/samples/Wpf/EmbedWpfInEto/EmbedWpfInEto.csproj
+++ b/samples/Wpf/EmbedWpfInEto/EmbedWpfInEto.csproj
@@ -1,8 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition="'$(NoNetFramework)'=='' or '$(NoNetFramework)'=='false'">$(TargetFrameworks);net472</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 

--- a/samples/Wpf/EmbedWpfInEto/EmbedWpfInEto.csproj
+++ b/samples/Wpf/EmbedWpfInEto/EmbedWpfInEto.csproj
@@ -1,6 +1,8 @@
 <Project>
 
   <PropertyGroup>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT'">true</HaveWindowsDesktopSdk>
+    
     <TargetFrameworks>net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>

--- a/src/Addins/Eto.Addin.MonoDevelop/Editor/DisplayController.cs
+++ b/src/Addins/Eto.Addin.MonoDevelop/Editor/DisplayController.cs
@@ -26,20 +26,19 @@ namespace Eto.Addin.MonoDevelop.Editor
 
 		protected override async Task<IEnumerable<DocumentControllerDescription>> GetSupportedControllersAsync(FileDescriptor file)
 		{
-			var list = ImmutableList<DocumentControllerDescription>.Empty;
 			if (!enabled)
-				return list;
-
+				return Enumerable.Empty<DocumentControllerDescription>();
+			
 			var info = Eto.Designer.BuilderInfo.Find(file.FilePath);
 			if (info == null)
-				return list;
+				return Enumerable.Empty<DocumentControllerDescription>();
 
-			return list.Add(new DocumentControllerDescription
+			return new [] { new DocumentControllerDescription
 			{
 				Name = "Eto.Forms Visual Designer",
 				Role = DocumentControllerRole.VisualDesign,
 				CanUseAsDefault = true
-			});
+			} };
 		}
 
 		public override async Task<DocumentController> CreateController(FileDescriptor file, DocumentControllerDescription controllerDescription)

--- a/src/Addins/Eto.Addin.MonoDevelop/Eto.Addin.MonoDevelop.csproj
+++ b/src/Addins/Eto.Addin.MonoDevelop/Eto.Addin.MonoDevelop.csproj
@@ -5,7 +5,7 @@
   	<MDBinDir Condition="Exists('/opt/MonoDevelop/bin')">/opt/MonoDevelop/bin</MDBinDir>
   	<MDAddinsDir Condition="Exists('/opt/MonoDevelop/AddIns')">/opt/MonoDevelop/AddIns</MDAddinsDir>
     <OutputPath>$(ArtifactsDir)addin\$(Configuration)\</OutputPath>
-  	<MonoDevelopVersion>8.4</MonoDevelopVersion>
+  	<MonoDevelopVersion>8.8</MonoDevelopVersion>
     <Title>Eto.Addin.MonoDevelop</Title>
   </PropertyGroup>
   <ItemGroup>
@@ -22,13 +22,13 @@
     <PackageReference Include="MonoDevelop.Addins" Version="0.4.7" />
   </ItemGroup>
   <ItemGroup>
-    <AddinReference Include="MonoDevelop.Xml" Version="8.4" />
-    <AddinReference Include="MonoDevelop.DesignerSupport" Version="8.4" />
-    <AddinReference Include="MonoDevelop.PackageManagement" Version="8.4" />
-    <AddinReference Include="MonoDevelop.TextEditor" Version="8.4" />
+    <AddinReference Include="MonoDevelop.Xml" Version="8.8" />
+    <AddinReference Include="MonoDevelop.DesignerSupport" Version="8.8" />
+    <AddinReference Include="MonoDevelop.PackageManagement" Version="8.8" />
+    <AddinReference Include="MonoDevelop.TextEditor" Version="8.8" />
   </ItemGroup>
   <ItemGroup>
-	<None Remove="Templates\**\*" />
+	  <None Remove="Templates\**\*" />
     <None Remove="Images\project%402x.png" />
     <None Remove="Images\project.png" />
   </ItemGroup>

--- a/src/Addins/Eto.Addin.MonoDevelop/Properties/Manifest.addin.xml
+++ b/src/Addins/Eto.Addin.MonoDevelop/Properties/Manifest.addin.xml
@@ -32,7 +32,7 @@
 	<Extension path="/MonoDevelop/Ide/Templates">
 		<Template
 			id="Eto.App.CSharp"
-			path="Packages/Eto.Forms.Templates.2.5.6-dev.nupkg"
+			path="Packages/Eto.Forms.Templates.2.5.7-dev.nupkg"
 			imageId="eto-project"
 			wizard="Eto.Addin.MonoDevelop.ProjectWizard"
 			category="multiplat/app/eto"
@@ -40,7 +40,7 @@
 			/>
 		<Template
 			id="Eto.App.FSharp"
-			path="Packages/Eto.Forms.Templates.2.5.6-dev.nupkg"
+			path="Packages/Eto.Forms.Templates.2.5.7-dev.nupkg"
 			imageId="eto-project"
 			wizard="Eto.Addin.MonoDevelop.ProjectWizard"
 			category="multiplat/app/eto"

--- a/src/Addins/Eto.Addin.VisualStudio/Eto.Addin.VisualStudio.csproj
+++ b/src/Addins/Eto.Addin.VisualStudio/Eto.Addin.VisualStudio.csproj
@@ -242,7 +242,7 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface">
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Addins/Eto.Addin.VisualStudio/Eto.Addin.VisualStudio.csproj
+++ b/src/Addins/Eto.Addin.VisualStudio/Eto.Addin.VisualStudio.csproj
@@ -4,7 +4,7 @@
     <MinimumVisualStudioVersion>16.0</MinimumVisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
   </PropertyGroup>
-  <Import Project="..\..\Directory.Build.props" />
+  <!-- <Import Project="..\..\Directory.Build.props" /> -->
   <PropertyGroup>
     <PublishUrl>publish\</PublishUrl>
     <Install>true</Install>
@@ -242,7 +242,7 @@
     <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>False</Private>
     </Reference>
-    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+    <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.Text.Data, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/src/Addins/Eto.Designer/Eto.Designer.csproj
+++ b/src/Addins/Eto.Designer/Eto.Designer.csproj
@@ -11,6 +11,6 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="FSharp.Compiler.CodeDom" Version="1.0.0.1" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.4.0" ExcludeAssets="runtime" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" ExcludeAssets="runtime" />
   </ItemGroup>
 </Project>

--- a/src/Addins/Eto.Forms.Templates/Eto.Forms.Templates.csproj
+++ b/src/Addins/Eto.Forms.Templates/Eto.Forms.Templates.csproj
@@ -3,7 +3,7 @@
 	<PropertyGroup>
 		<PackageType>Template</PackageType>
 		<PackageId>Eto.Forms.Templates</PackageId>
-		<PackageVersion>2.5.6-dev</PackageVersion>
+		<PackageVersion>2.5.7-dev</PackageVersion>
 		<Authors>Curtis Wensley</Authors>
 		<Description>Project and File templates for Eto.Forms</Description>
 		<Tags>cross-platform;gui;ui-framework;desktop;winforms;wpf;mac;osx;gtk;eto;eto.forms;dotnet-new</Tags>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.csproj
@@ -11,10 +11,10 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Windows" Version="2.5.6-dev" Condition="$(IncludeWinForms) == 'True'" />
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.6-dev" />
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.6-dev" />
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.6-dev" />
+    <PackageReference Include="Eto.Platform.Windows" Version="2.5.7-dev" Condition="$(IncludeWinForms) == 'True'" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.7-dev" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.7-dev" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.7-dev" />
   </ItemGroup>
 	
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.6-dev" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.7-dev" />
   </ItemGroup>
 	
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Mac/EtoApp.1.Mac.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Mac/EtoApp.1.Mac.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.6-dev" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.7-dev" />
   </ItemGroup>
 	
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 	
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Windows" Version="2.5.6-dev" />
+    <PackageReference Include="Eto.Platform.Windows" Version="2.5.7-dev" />
   </ItemGroup>
 
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.6-dev" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.7-dev" />
   </ItemGroup>
 
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.csproj
@@ -86,7 +86,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Eto.Platform.XamMac2">
-      <Version>2.5.6-dev</Version>
+      <Version>2.5.7-dev</Version>
     </PackageReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/EtoApp.1.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/EtoApp.1.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Eto.Forms" Version="2.5.6-dev" />
-    <PackageReference Include="Eto.Serialization.Json" Version="2.5.6-dev" Condition="$(UseJeto) == 'True'" />
-    <PackageReference Include="Eto.Serialization.Xaml" Version="2.5.6-dev" Condition="$(UseXeto) == 'True'" />
+    <PackageReference Include="Eto.Forms" Version="2.5.7-dev" />
+    <PackageReference Include="Eto.Serialization.Json" Version="2.5.7-dev" Condition="$(UseJeto) == 'True'" />
+    <PackageReference Include="Eto.Serialization.Xaml" Version="2.5.7-dev" Condition="$(UseXeto) == 'True'" />
   </ItemGroup>
   
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.fsproj
@@ -15,9 +15,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.6-dev" />
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.6-dev" />
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.6-dev" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.7-dev" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.7-dev" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.7-dev" />
   </ItemGroup>
 
 

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.fsproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.6-dev" />
+    <PackageReference Include="Eto.Platform.Gtk" Version="2.5.7-dev" />
   </ItemGroup>
 
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Mac/EtoApp.1.Mac.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Mac/EtoApp.1.Mac.fsproj
@@ -22,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.6-dev" />
+    <PackageReference Include="Eto.Platform.Mac64" Version="2.5.7-dev" />
   </ItemGroup>
 
 

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.fsproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Windows" Version="2.5.6-dev" />
+    <PackageReference Include="Eto.Platform.Windows" Version="2.5.7-dev" />
   </ItemGroup>
 
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.fsproj
@@ -16,7 +16,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.6-dev" />
+    <PackageReference Include="Eto.Platform.Wpf" Version="2.5.7-dev" />
   </ItemGroup>
 
 </Project>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.fsproj
@@ -84,7 +84,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Eto.Platform.XamMac2">
-      <Version>2.5.6-dev</Version>
+      <Version>2.5.7-dev</Version>
     </PackageReference>
     <PackageReference Include="FSharp.Core">
       <Version>4.7.0</Version>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/EtoApp.1.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/EtoApp.1.fsproj
@@ -20,8 +20,8 @@
     </Compile>
     <EmbeddedResource Include="MainForm.xeto" Condition="$(UseXeto) == 'True'" />
     <EmbeddedResource Include="MainForm.jeto" Condition="$(UseJeto) == 'True'" />
-    <PackageReference Include="Eto.Forms" Version="2.5.6-dev" />
-    <PackageReference Include="Eto.Serialization.Json" Version="2.5.6-dev" Condition="$(UseJeto) == 'True'" />
-    <PackageReference Include="Eto.Serialization.Xaml" Version="2.5.6-dev" Condition="$(UseXeto) == 'True'" />
+    <PackageReference Include="Eto.Forms" Version="2.5.7-dev" />
+    <PackageReference Include="Eto.Serialization.Json" Version="2.5.7-dev" Condition="$(UseJeto) == 'True'" />
+    <PackageReference Include="Eto.Serialization.Xaml" Version="2.5.7-dev" Condition="$(UseXeto) == 'True'" />
   </ItemGroup>
 </Project>

--- a/src/Addins/global.json
+++ b/src/Addins/global.json
@@ -1,0 +1,3 @@
+{
+   "sdk": { "version": "3.1.302", "rollForward": "latestFeature" }
+}

--- a/src/Eto.Direct2D/Eto.Direct2D.csproj
+++ b/src/Eto.Direct2D/Eto.Direct2D.csproj
@@ -1,10 +1,9 @@
 ﻿<Project>
   
   <PropertyGroup>
-    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT'">true</HaveWindowsDesktopSdk>
 
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition="'$(NoNetFramework)'=='' or '$(NoNetFramework)'=='false'">$(TargetFrameworks);net45</TargetFrameworks>
+    <TargetFrameworks>net472</TargetFrameworks>
     <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 

--- a/src/Eto.Mac/build/Mac.targets
+++ b/src/Eto.Mac/build/Mac.targets
@@ -200,6 +200,7 @@
   <Target Name="MacInitializeBundle">
     <PropertyGroup>
       <HasXamMac>@(ReferenceCopyLocalPaths->AnyHaveMetadataValue('Filename', 'Eto.XamMac2'))</HasXamMac>
+      <MacIncludeSymbols Condition="'$(MacIncludeSymbols)' == '' AND $(Configuration) == 'Release'">false</MacIncludeSymbols>
       <MacIncludeSymbols Condition="'$(MacIncludeSymbols)' == ''">true</MacIncludeSymbols>
       <MacArch Condition="'$(MacArch)'==''">x86_64</MacArch>
 
@@ -260,11 +261,13 @@
     <FindUnderPath  
       Files="@(FileWrites)"
       Path="$(TargetDir)">
-            <Output TaskParameter="InPath" ItemName="MacExecutableFiles" />
+      <Output TaskParameter="InPath" ItemName="MacExecutableFiles" />
     </FindUnderPath>
 
     <ItemGroup>
-      <!--MacExecutableFiles Include="$(TargetDir)\**" Exclude="$(OutputAppPath)\**\*" /-->
+      <MacExecutableFiles>
+        <TargetPath>$([System.String]::Copy('%(FullPath)').SubString($(TargetDir.Length)))</TargetPath>
+      </MacExecutableFiles>
       <MacExecutableFiles Include="@(ReferenceCopyLocalPaths)" />
       <MacExecutableFiles Remove="@(MacExecutableFiles)" Condition="$(MacIncludeSymbols) != 'True' and %(Extension) == '.pdb'" />
 

--- a/src/Eto.WinForms/Eto.WinForms.csproj
+++ b/src/Eto.WinForms/Eto.WinForms.csproj
@@ -2,11 +2,10 @@
 <Project>
 
   <PropertyGroup>
-    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT'">true</HaveWindowsDesktopSdk>
     
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition="'$(NoNetFramework)'=='' or '$(NoNetFramework)'=='false'">$(TargetFrameworks);net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -1,11 +1,10 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT'">true</HaveWindowsDesktopSdk>
 
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition="'$(NoNetFramework)'=='' or '$(NoNetFramework)'=='false'">$(TargetFrameworks);net45</TargetFrameworks>
-    <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net45</TargetFrameworks>
+    <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
 
   <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />

--- a/test/Eto.Test.Direct2D/Eto.Test.Direct2D.csproj
+++ b/test/Eto.Test.Direct2D/Eto.Test.Direct2D.csproj
@@ -2,11 +2,9 @@
 <Project>
 
   <PropertyGroup>
-    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT'">true</HaveWindowsDesktopSdk>
 
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition="'$(NoNetFramework)'=='' or '$(NoNetFramework)'=='false'">$(TargetFrameworks);net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />

--- a/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj
+++ b/test/Eto.Test.Gtk/Eto.Test.Gtk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net472</TargetFrameworks>
     <DefineConstants>$(DefineConstants);CAIRO;GTK3</DefineConstants>
     <TreatWarningsAsErrors Condition="$(Configuration) == 'Release'">true</TreatWarningsAsErrors>
   </PropertyGroup>

--- a/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
@@ -6,7 +6,7 @@
   <Import Project="..\..\src\Eto.Mac\build\Mac.props" Condition="'$(ExcludeRestorePackageImports)' != 'true'" />
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net472</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;net472</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     
     <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
@@ -3,8 +3,7 @@
   <PropertyGroup>
     <UseXamarinMac>True</UseXamarinMac>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net472</TargetFrameworks>
-    <TargetFrameworks Condition="$(HasXamarinMac) == 'True'">$(TargetFrameworks);xamarinmac20</TargetFrameworks>
+    <TargetFrameworks>net472;xamarinmac20</TargetFrameworks>
     <RootNamespace>Eto.Test.Mac</RootNamespace>
     <EnableDefaultNoneItems>False</EnableDefaultNoneItems>
     <EnableDefaultContentItems>False</EnableDefaultContentItems>

--- a/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
+++ b/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
@@ -1,11 +1,9 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT'">true</HaveWindowsDesktopSdk>
 
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition="'$(NoNetFramework)'=='' or '$(NoNetFramework)'=='false'">$(TargetFrameworks);net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />

--- a/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
+++ b/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
@@ -1,11 +1,9 @@
 ﻿<Project>
 
   <PropertyGroup>
-    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT' and $([System.Version]::Parse($([MSBuild]::ValueOrDefault('$(VisualStudioVersion)', '1.0')))) &gt;= $([System.Version]::Parse('16.0'))">true</HaveWindowsDesktopSdk>
+    <HaveWindowsDesktopSdk Condition="$(HaveWindowsDesktopSdk) == '' and $(OS) == 'Windows_NT'">true</HaveWindowsDesktopSdk>
 
-    <TargetFrameworks></TargetFrameworks>
-    <TargetFrameworks Condition="'$(NoNetFramework)'=='' or '$(NoNetFramework)'=='false'">$(TargetFrameworks);net472</TargetFrameworks>
-    <TargetFrameworks Condition="'$(HaveWindowsDesktopSdk)' == 'true'">$(TargetFrameworks);netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net472;netcoreapp3.1;net5.0-windows</TargetFrameworks>
   </PropertyGroup>
 
   <Import Condition="'$(HaveWindowsDesktopSdk)' != 'true'" Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />


### PR DESCRIPTION
This builds test apps for .NET 5.0, and fixes a few issues.

- Fixes an issue as .NET 5 creates a "ref/MyMainAssembly.dll", which messed up building the .app bundle for Mac.
- Fixes compiling issues with VS for Mac 8.8
- Use dotnet build for everything as mono's msbuild can't build for .NET 5
- Update Xamarin.Mac.targets to work when building with dotnet tooling
- Update Gtk2 build so it works when building from dotnet tooling (on Mac only for now)