### PR TITLE
Gtk/Mac Check/RadioToolItem event fixes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -61,7 +61,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-wpf",
-            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/${input:platform-core}/Eto.Test.Wpf.exe",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/${input:platform-core-win}/Eto.Test.Wpf.exe",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
@@ -81,7 +81,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-winforms",
-            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/${input:platform-core}/Eto.Test.WinForms.exe",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/${input:platform-core-win}/Eto.Test.WinForms.exe",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
@@ -101,7 +101,7 @@
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-direct2d",
-            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/${input:platform-core}/Eto.Test.Direct2D.exe",
+            "program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/${input:platform-core-win}/Eto.Test.Direct2D.exe",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart"
@@ -128,6 +128,15 @@
 			"description": "Platform",
 			"options": [
 				"net5.0",
+				"netcoreapp3.1"
+			]
+		},
+		{
+			"type": "pickString",
+			"id": "platform-core-win",
+			"description": "Platform",
+			"options": [
+				"net5.0-windows",
 				"netcoreapp3.1"
 			]
 		}

--- a/src/Eto.Gtk/Forms/ToolBar/CheckToolItemHandler.cs
+++ b/src/Eto.Gtk/Forms/ToolBar/CheckToolItemHandler.cs
@@ -38,6 +38,7 @@ namespace Eto.GtkSharp.Forms.ToolBar
 			Control.Visible = Visible;
 			tb.Insert(Control, index);
 			Control.Toggled += Connector.HandleToggled;
+			Control.Clicked += Connector.HandleClicked;
 		}
 
 		protected new CheckToolItemConnector Connector { get { return (CheckToolItemConnector)base.Connector; } }
@@ -52,6 +53,11 @@ namespace Eto.GtkSharp.Forms.ToolBar
 			public new CheckToolItemHandler Handler { get { return (CheckToolItemHandler)base.Handler; } }
 
 			public void HandleToggled(object sender, EventArgs e)
+			{
+				Handler.Widget.OnCheckedChanged(EventArgs.Empty);
+			}
+			
+			public void HandleClicked(object sender, EventArgs e)
 			{
 				Handler.Widget.OnClick(EventArgs.Empty);
 			}

--- a/src/Eto.Gtk/Forms/ToolBar/RadioToolItemHandler.cs
+++ b/src/Eto.Gtk/Forms/ToolBar/RadioToolItemHandler.cs
@@ -39,6 +39,7 @@ namespace Eto.GtkSharp.Forms.ToolBar
 			Control.Visible = Visible;
 			tb.Insert(Control, index);
 			Control.Toggled += Connector.HandleToggled;
+			Control.Clicked += Connector.HandleClicked;
 		}
 
 		protected new RadioToolItemConnector Connector { get { return (RadioToolItemConnector)base.Connector; } }
@@ -53,6 +54,11 @@ namespace Eto.GtkSharp.Forms.ToolBar
 			public new RadioToolItemHandler Handler { get { return (RadioToolItemHandler)base.Handler; } }
 
 			public void HandleToggled(object sender, EventArgs e)
+			{
+				Handler.Widget.OnCheckedChanged(EventArgs.Empty);
+			}
+			
+			public void HandleClicked(object sender, EventArgs e)
 			{
 				Handler.Widget.OnClick(EventArgs.Empty);
 			}

--- a/src/Eto.Mac/Forms/ToolBar/RadioToolItemHandler.cs
+++ b/src/Eto.Mac/Forms/ToolBar/RadioToolItemHandler.cs
@@ -49,6 +49,7 @@ namespace Eto.Mac.Forms.ToolBar
 		
 		public override void InvokeButton()
 		{
+			var wasChecked = isChecked;
 			if (toolbarHandler != null && toolbarHandler.Control != null)
 			{
 				isChecked = toolbarHandler.Control.SelectedItemIdentifier == Identifier;
@@ -62,7 +63,8 @@ namespace Eto.Mac.Forms.ToolBar
 				}
 			}
 			Widget.OnClick(EventArgs.Empty);
-			Widget.OnCheckedChanged(EventArgs.Empty);
+			if (wasChecked != isChecked)
+				Widget.OnCheckedChanged(EventArgs.Empty);
 		}
 	}
 }

--- a/test/Eto.Test/MainForm.cs
+++ b/test/Eto.Test/MainForm.cs
@@ -336,21 +336,21 @@ namespace Eto.Test
 				if (Platform.Supports<CheckToolItem>())
 				{
 					ToolBar.Items.Add(new SeparatorToolItem { Type = SeparatorToolItemType.Divider });
-					ToolBar.Items.Add(new CheckToolItem { Text = "Check", Image = TestIcons.TestImage });
+					ToolBar.Items.Add(LogEvents(new CheckToolItem { Text = "Check", Image = TestIcons.TestImage }));
 				}
 				ToolBar.Items.Add(new SeparatorToolItem { Type = SeparatorToolItemType.Space });
-				ButtonToolItem clickButton = new ButtonToolItem { Text = "Click Me", Image = TestIcons.Logo };
+				ButtonToolItem clickButton = LogEvents(new ButtonToolItem { Text = "Click Me", Image = TestIcons.Logo });
 				ToolBar.Items.Add(clickButton);
 				if (Platform.Supports<RadioToolItem>())
 				{
 					ToolBar.Items.Add(new SeparatorToolItem { Type = SeparatorToolItemType.FlexibleSpace });
-					ToolBar.Items.Add(new RadioToolItem { Text = "Radio1", Image = TestIcons.Logo, Checked = true });
-					ToolBar.Items.Add(new RadioToolItem { Text = "Radio2", Image = TestIcons.TestImage });
-					ToolBar.Items.Add(new RadioToolItem { Text = "Radio3 (Disabled)", Image = TestIcons.TestImage, Enabled = false });
+					ToolBar.Items.Add(LogEvents(new RadioToolItem { Text = "Radio1", Image = TestIcons.Logo, Checked = true }));
+					ToolBar.Items.Add(LogEvents(new RadioToolItem { Text = "Radio2", Image = TestIcons.TestImage }));
+					ToolBar.Items.Add(LogEvents(new RadioToolItem { Text = "Radio3 (Disabled)", Image = TestIcons.TestImage, Enabled = false }));
 				}
 
 				// add an invisible button and separator and allow them to be toggled.
-				var invisibleButton = new ButtonToolItem { Text = "Invisible", Visible = false };
+				var invisibleButton = LogEvents(new ButtonToolItem { Text = "Invisible", Visible = false });
 				var sep = new SeparatorToolItem { Type = SeparatorToolItemType.Divider, Visible = false };
 				ToolBar.Items.Add(sep);
 				ToolBar.Items.Add(invisibleButton);
@@ -360,6 +360,24 @@ namespace Eto.Test
 					sep.Visible = invisibleButton.Visible;
 				};
 			}
+		}
+
+		RadioToolItem LogEvents(RadioToolItem item)
+		{
+			item.CheckedChanged += (sender, e) => Log.Write(sender, $"CheckedChanged: {item.Text}");
+			item.Click += (sender, e) => Log.Write(sender, $"Click: {item.Text}");
+			return item;
+		}
+		CheckToolItem LogEvents(CheckToolItem item)
+		{
+			item.CheckedChanged += (sender, e) => Log.Write(sender, $"CheckedChanged: {item.Text}");
+			item.Click += (sender, e) => Log.Write(sender, $"Click: {item.Text}");
+			return item;
+		}
+		ButtonToolItem LogEvents(ButtonToolItem item)
+		{
+			item.Click += (sender, e) => Log.Write(sender, $"Click: {item.Text}");
+			return item;
 		}
 
 		protected override void OnWindowStateChanged(EventArgs e)


### PR DESCRIPTION
- Gtk: Fix Check/RadioToolItem.CheckedChanged event
- Mac: Only fire RadioToolItem.CheckedChanged when it has changed
- Added logging for test app to test ToolItem events

Fixes #792
Fixes #1813