### PR TITLE
Wpf: More fixes getting proper screen bounds and image when using system dpi

### DIFF
--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -21,6 +21,7 @@ namespace Eto
 			public int height => bottom - top;
 
 			public System.Drawing.Rectangle ToSD() => new System.Drawing.Rectangle(left, top, width, height);
+			public Eto.Drawing.Rectangle ToEto() => new Eto.Drawing.Rectangle(left, top, width, height);
 		}
 
 		[StructLayout(LayoutKind.Sequential)]

--- a/src/Eto.Wpf/Forms/MouseHandler.cs
+++ b/src/Eto.Wpf/Forms/MouseHandler.cs
@@ -18,15 +18,16 @@ namespace Eto.Wpf.Forms
 			get
 			{
 				var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : Win32.DPI_AWARENESS_CONTEXT.NONE;
-				var result = swf.Control.MousePosition.ScreenToLogical();
+				var result = swf.Control.MousePosition;
 				if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
 					Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
-				return result;
+				return result.ScreenToLogical();
 			}
 			set
 			{
+				var pos = value.LogicalToScreen();
 				var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : Win32.DPI_AWARENESS_CONTEXT.NONE;
-				swf.Cursor.Position = Point.Round(value.LogicalToScreen()).ToSD();
+				swf.Cursor.Position = Point.Round(pos).ToSD();
 				if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
 					Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
 			}

--- a/src/Eto.Wpf/Forms/ScreenHandler.cs
+++ b/src/Eto.Wpf/Forms/ScreenHandler.cs
@@ -51,7 +51,13 @@ namespace Eto.Wpf.Forms
 		public Image GetImage(RectangleF rect)
 		{
 			var adjustedRect = rect * Widget.LogicalPixelSize;
-			adjustedRect.Location += Control.Bounds.Location.ToEto();
+			//adjustedRect.Location += Control.Bounds.Location.ToEto();
+
+			var info = new Win32.MONITORINFOEX();
+			Win32.GetMonitorInfo(Control, ref info);
+			adjustedRect.Location += info.rcMonitor.ToEto().Location;
+
+			var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : Win32.DPI_AWARENESS_CONTEXT.NONE;
 			var realRect = Rectangle.Ceiling(adjustedRect);
 			using (var screenBmp = new sd.Bitmap(realRect.Width, realRect.Height, sd.Imaging.PixelFormat.Format32bppRgb))
 			{
@@ -63,6 +69,9 @@ namespace Eto.Wpf.Forms
 						IntPtr.Zero,
 						sw.Int32Rect.Empty,
 						sw.Media.Imaging.BitmapSizeOptions.FromEmptyOptions());
+
+					if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
+						Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
 
 					return new Bitmap(new BitmapHandler(bitmapSource));
 				}

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -594,20 +594,23 @@ namespace Eto.Wpf.Forms
 				var handle = WindowHandle;
 				if (handle != IntPtr.Zero)
 				{
+					Point? location = null;
 					// Left/Top doesn't always report correct location when maximized, so use Win32 when we can.
 					var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : Win32.DPI_AWARENESS_CONTEXT.NONE;
 					try
 					{
-
 						Win32.RECT rect;
 						if (Win32.GetWindowRect(handle, out rect))
-							return Point.Round(new Point(rect.left, rect.top).ScreenToLogical(SwfScreen));
+							location = new Point(rect.left, rect.top);
 					}
 					finally
 					{
 						if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
 							Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
 					}
+
+					if (location != null)
+						return Point.Round(location.Value.ScreenToLogical(SwfScreen));
 				}
 				// in WPF, left/top of a window is transformed by the (current) screen dpi, which makes absolutely no sense.
 				var left = Control.Left;


### PR DESCRIPTION
This fixes some issues when left secondary monitor has lower DPI than primary monitor, when in system dpi mode.