### PR TITLE
Mac packaging: fix path issues when creating .dmg

### DIFF
--- a/src/Eto.Mac/build/Dmg.targets
+++ b/src/Eto.Mac/build/Dmg.targets
@@ -43,8 +43,8 @@
     <Delete Files="$(_DmgPath)" />
 
     <ItemGroup>
-      <_DmgAppFiles Include="$(OutputAppPath)**\*" TargetPath="$([System.IO.Path]::GetFileName($(OutputAppPath.TrimEnd('/'))))\%(RecursiveDir)%(Filename)%(Extension)" />
-      <_DmgFiles Include="@(_DmgAppFiles)" TargetPath="$([System.IO.Path]::GetFileName($(OutputAppPath.TrimEnd('/'))))\%(RecursiveDir)%(Filename)%(Extension)" />
+      <_DmgAppFiles Include="$(OutputAppPath)**\*" />
+      <_DmgFiles Include="@(_DmgAppFiles)" TargetPath="$(MacBundleName).app\%(RecursiveDir)%(Filename)%(Extension)" />
       <_DmgFiles Include="@(DmgContent)" TargetPath="%(RecursiveDir)%(Filename)%(Extension)" Condition="%(TargetPath) == ''"/>
       <_DmgFiles Include="@(DmgContent)" Condition="%(TargetPath) != ''"/>
     </ItemGroup>

--- a/src/Eto.Mac/build/Mac.targets
+++ b/src/Eto.Mac/build/Mac.targets
@@ -24,18 +24,21 @@
     <MacBuildBundle Condition="$(MacBuildBundle) == '' and $(ProjectTypeGuids) == '' and ( $(OutputType) == 'Exe' Or $(OutputType) == 'WinExe' )">True</MacBuildBundle>
 
     <!-- Specifies the name of the .app bundle, usually the same as the project -->
-    <MacBundleName Condition="'$(MacBundleName)'==''">$(MSBuildProjectName)</MacBundleName>
+    <MacBundleName Condition="$(MacBundleName) == '' AND $(OutputAppPath.TrimEnd('/').TrimEnd('\').EndsWith('.app')) == 'True'">$([System.IO.Path]::GetFileName($(OutputAppPath.TrimEnd('/').TrimEnd('\'))))</MacBundleName>
+    <MacBundleName Condition="$(MacBundleName.EndsWith('.app')) == 'True'">$(MacBundleName.SubString(0, $([MSBuild]::Subtract($(MacBundleName.Length), 4))))</MacBundleName>
+    <MacBundleName Condition="$(MacBundleName) == ''">$(MSBuildProjectName)</MacBundleName>
     
     <!-- Specifies a folder to copy verbatim into the .app bundle (useful for frameworks, etc) -->
-    <InputAppPath Condition="'$(InputAppPath)'==''"></InputAppPath>
+    <InputAppPath Condition="$(InputAppPath) == ''"></InputAppPath>
     
     <!-- Sets the default run configuration, or false to use a special 'Mac' configuration.
     If False, the default configuration of the project will run using the GTK platform when using Eto's platform detection.
     -->
-    <MacSetDefaultRunConfiguration Condition="'$(MacSetDefaultRunConfiguration)' == ''">True</MacSetDefaultRunConfiguration>
+    <MacSetDefaultRunConfiguration Condition="$(MacSetDefaultRunConfiguration) == ''">True</MacSetDefaultRunConfiguration>
     
     <!-- Specifies the full output .app path.  When building for more than one runtime identifier, this is ignored. -->
-    <OutputAppPath Condition="'$(OutputAppPath)'=='' AND $(BaseOutputAppPath) != ''">$(BaseOutputAppPath)$(MacBundleName).app\</OutputAppPath>
+    <OutputAppPath Condition="$(OutputAppPath) == '' AND $(BaseOutputAppPath) != ''">$(BaseOutputAppPath)$(MacBundleName).app\</OutputAppPath>
+    <OutputAppPath Condition="$(OutputAppPath.EndsWith('/')) == 'False' AND $(OutputAppPath.EndsWith('\')) == 'False'">$(OutputAppPath)\</OutputAppPath>
     
   </PropertyGroup>
 


### PR DESCRIPTION
- MacBundleName can now be derived from the OutputAppPath, if specified

Sometimes the contents of the .dmg didn't correctly have the app name as the OutputAppPath could have either forward or backward slashes so we now trim both, and assign it to MacBundleName if necessary.