### PR TITLE
Fix crashes with Windows 8.1 due to recent DPI changes

### DIFF
--- a/src/Eto.WinForms/Forms/ScreenHandler.cs
+++ b/src/Eto.WinForms/Forms/ScreenHandler.cs
@@ -43,14 +43,14 @@ namespace Eto.WinForms.Forms
 			if (hmonitor != IntPtr.Zero)
 			{
 				// get actual monitor dimentions
-				var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE) : Win32.DPI_AWARENESS_CONTEXT.NONE;
+				var oldDpiAwareness = Win32.SetThreadDpiAwarenessContextSafe(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE);
 
 				var info = new Win32.MONITORINFOEX();
 				Win32.GetMonitorInfo(new HandleRef(null, hmonitor), info);
 				realBounds = info.rcMonitor.ToSD().ToEto();
 
 				if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
-					Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
+					Win32.SetThreadDpiAwarenessContextSafe(oldDpiAwareness);
 			}
 
 			var adjustedRect = rect;

--- a/src/Eto.Wpf/Forms/MouseHandler.cs
+++ b/src/Eto.Wpf/Forms/MouseHandler.cs
@@ -17,19 +17,19 @@ namespace Eto.Wpf.Forms
 		{
 			get
 			{
-				var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : Win32.DPI_AWARENESS_CONTEXT.NONE;
+				var oldDpiAwareness = Win32.SetThreadDpiAwarenessContextSafe(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2);
 				var result = swf.Control.MousePosition;
 				if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
-					Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
+					Win32.SetThreadDpiAwarenessContextSafe(oldDpiAwareness);
 				return result.ScreenToLogical();
 			}
 			set
 			{
 				var pos = value.LogicalToScreen();
-				var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : Win32.DPI_AWARENESS_CONTEXT.NONE;
+				var oldDpiAwareness = Win32.SetThreadDpiAwarenessContextSafe(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2);
 				swf.Cursor.Position = Point.Round(pos).ToSD();
 				if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
-					Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
+					Win32.SetThreadDpiAwarenessContextSafe(oldDpiAwareness);
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/ScreenHandler.cs
+++ b/src/Eto.Wpf/Forms/ScreenHandler.cs
@@ -57,7 +57,7 @@ namespace Eto.Wpf.Forms
 			Win32.GetMonitorInfo(Control, ref info);
 			adjustedRect.Location += info.rcMonitor.ToEto().Location;
 
-			var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : Win32.DPI_AWARENESS_CONTEXT.NONE;
+			var oldDpiAwareness = Win32.SetThreadDpiAwarenessContextSafe(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2);
 			var realRect = Rectangle.Ceiling(adjustedRect);
 			using (var screenBmp = new sd.Bitmap(realRect.Width, realRect.Height, sd.Imaging.PixelFormat.Format32bppRgb))
 			{
@@ -71,7 +71,7 @@ namespace Eto.Wpf.Forms
 						sw.Media.Imaging.BitmapSizeOptions.FromEmptyOptions());
 
 					if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
-						Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
+						Win32.SetThreadDpiAwarenessContextSafe(oldDpiAwareness);
 
 					return new Bitmap(new BitmapHandler(bitmapSource));
 				}

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -596,7 +596,7 @@ namespace Eto.Wpf.Forms
 				{
 					Point? location = null;
 					// Left/Top doesn't always report correct location when maximized, so use Win32 when we can.
-					var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : Win32.DPI_AWARENESS_CONTEXT.NONE;
+					var oldDpiAwareness = Win32.SetThreadDpiAwarenessContextSafe(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2);
 					try
 					{
 						Win32.RECT rect;
@@ -606,7 +606,7 @@ namespace Eto.Wpf.Forms
 					finally
 					{
 						if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
-							Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
+							Win32.SetThreadDpiAwarenessContextSafe(oldDpiAwareness);
 					}
 
 					if (location != null)
@@ -657,14 +657,14 @@ namespace Eto.Wpf.Forms
 
 		void SetLocation(PointF location)
 		{
-			var oldDpiAwareness = Win32.PerMonitorDpiSupported ? Win32.SetThreadDpiAwarenessContext(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : Win32.DPI_AWARENESS_CONTEXT.NONE;
+			var oldDpiAwareness = Win32.SetThreadDpiAwarenessContextSafe(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2);
 
 			var handle = WindowHandle;
 			var loc = location.LogicalToScreen();
 
 			Win32.SetWindowPos(WindowHandle, IntPtr.Zero, loc.X, loc.Y, 0, 0, Win32.SWP.NOSIZE | Win32.SWP.NOACTIVATE);
 			if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
-				Win32.SetThreadDpiAwarenessContext(oldDpiAwareness);
+				Win32.SetThreadDpiAwarenessContextSafe(oldDpiAwareness);
 		}
 
 		public WindowState WindowState


### PR DESCRIPTION
PerMonitorDpiSupported = true on Windows 8.1, but `SetThreadDpiAwarenessContext` is only in Windows 10 or later. So, we need to check for that API directly.