### PR TITLE
Fix templates for VS 16.8

### DIFF
--- a/src/Addins/Eto.Addin.Shared/ProjectWizardPageModel.cs
+++ b/src/Addins/Eto.Addin.Shared/ProjectWizardPageModel.cs
@@ -27,7 +27,7 @@ namespace Eto.Addin.Shared
 			if (SupportsBase)
 				Base = "Panel";
 			if (SupportsFramework)
-				SelectedFrameworks = new[] { SupportedFrameworks[0] };
+				SelectedFramework = SupportedFrameworks[0];
 		}
 
 		public bool IsValid
@@ -40,7 +40,7 @@ namespace Eto.Addin.Shared
 					if (string.IsNullOrWhiteSpace(AppName) || AppNameInvalid)
 						return false;
 				}
-				if (SupportsFramework && !SelectedFrameworks.Any())
+				if (SupportsFramework && SelectedFramework == null)
 					return false;
 				return true;
 			}
@@ -231,21 +231,21 @@ namespace Eto.Addin.Shared
 
 		static readonly FrameworkInfo[] frameworkInformation =
 		{
-			new FrameworkInfo { Text = "Full .NET Framework", Value = "full", CanUseCombined = true },
-			new FrameworkInfo { Text = ".NET Core", Value = "core", CanUseCombined = false }
+			new FrameworkInfo { Text = ".NET 5", Value = "net5.0", CanUseCombined = false },
+			new FrameworkInfo { Text = ".NET Core 3.1", Value = "netcoreapp3.1", CanUseCombined = false },
+			new FrameworkInfo { Text = ".NET Framework 4.7.2 / Mono", Value = "net472", CanUseCombined = true },
 		};
 
-		List<FrameworkInfo> _selectedFrameworks;
+		FrameworkInfo _selectedFramework;
 
-		public IEnumerable<object> SelectedFrameworks
+		public FrameworkInfo SelectedFramework
 		{
-			get => _selectedFrameworks ?? Enumerable.Empty<FrameworkInfo>();
+			get => _selectedFramework;
 			set
 			{
-				_selectedFrameworks = (value?.OfType<FrameworkInfo>() ?? Enumerable.Empty<FrameworkInfo>()).ToList();
+				_selectedFramework = value;
 
-				string parameterValue = _selectedFrameworks.Count == 1 ? _selectedFrameworks[0].Value : "both";
-				Source.SetParameter("Framework", parameterValue);
+				Source.SetParameter("TargetFrameworkOverride", value.Value);
 
 				if (!AllowCombined)
 					Combined = false;
@@ -255,7 +255,7 @@ namespace Eto.Addin.Shared
 			}
 		}
 
-		public bool AllowCombined => _selectedFrameworks?.All(r => r.CanUseCombined) == true;
+		public bool AllowCombined => _selectedFramework?.CanUseCombined == true;
 
 
 		struct TypeInfo
@@ -347,8 +347,7 @@ namespace Eto.Addin.Shared
 
 				if (SupportsFramework)
 				{
-					var frameworks = string.Join(" and ", _selectedFrameworks?.Select(r => r.Text) ?? Enumerable.Empty<string>());
-					text.Add($"For {frameworks} framework(s).");
+					text.Add($"For {SelectedFramework.Text}.");
 				}
 
 				return string.Join("\n\n", text);

--- a/src/Addins/Eto.Addin.Shared/ProjectWizardPageView.cs
+++ b/src/Addins/Eto.Addin.Shared/ProjectWizardPageView.cs
@@ -97,13 +97,21 @@ namespace Eto.Addin.Shared
 
 			if (model.SupportsFramework)
 			{
+				var frameworkDropDown = new DropDown();
+				frameworkDropDown.BindDataContext(c => c.DataStore, (ProjectWizardPageModel m) => m.SupportedFrameworks);
+				frameworkDropDown.ItemTextBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Text);
+				frameworkDropDown.ItemKeyBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Value);
+				frameworkDropDown.SelectedValueBinding.BindDataContext((ProjectWizardPageModel m) => m.SelectedFramework);
+
+				/*
 				var frameworkCheckBoxes = new CheckBoxList();
 				frameworkCheckBoxes.BindDataContext(c => c.DataStore, (ProjectWizardPageModel m) => m.SupportedFrameworks);
 				frameworkCheckBoxes.ItemTextBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Text);
 				frameworkCheckBoxes.ItemKeyBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Value);
 				frameworkCheckBoxes.SelectedValuesBinding.BindDataContext((ProjectWizardPageModel m) => m.SelectedFrameworks);
+				*/
 
-				content.AddRow(HeadingLabel("Framework:"), frameworkCheckBoxes);
+				content.AddRow(HeadingLabel("Framework:"), frameworkDropDown);
 			}
 
 			if (model.SupportsProjectType)
@@ -179,9 +187,9 @@ namespace Eto.Addin.Shared
 			}
 
 #if DEBUG
-			var showColorsButton = new Button { Text = "Show all themed colors" };
-			showColorsButton.Click += (sender, e) => new ThemedColorsDialog().ShowModal(this);
-			content.AddRow(new Panel(), showColorsButton);
+			//var showColorsButton = new Button { Text = "Show all themed colors" };
+			//showColorsButton.Click += (sender, e) => new ThemedColorsDialog().ShowModal(this);
+			//content.AddRow(new Panel(), showColorsButton);
 #endif
 
 			var informationLabel = new Label();

--- a/src/Addins/Eto.Addin.VisualStudio.sln
+++ b/src/Addins/Eto.Addin.VisualStudio.sln
@@ -19,6 +19,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Serialization.Xaml", ".
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Eto.Forms.Templates", "Eto.Forms.Templates\Eto.Forms.Templates.csproj", "{F3B5405C-64C3-4EEE-B32E-C028F48DB745}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{F132CF00-BA1F-41E0-BFD9-0F691C47C5FE}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\build\Common.props = ..\..\build\Common.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/src/Addins/Eto.Addin.VisualStudio/Eto.Addin.VisualStudio.csproj
+++ b/src/Addins/Eto.Addin.VisualStudio/Eto.Addin.VisualStudio.csproj
@@ -27,6 +27,7 @@
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
     <TargetFrameworkProfile />
     <TargetVsixContainerName>Eto.Addin.VisualStudio-$(PackageVersion).vsix</TargetVsixContainerName>
+    <AutoGenerateBindingRedirects>True</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup>
     <StartAction>Program</StartAction>
@@ -190,81 +191,11 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="EnvDTE, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="envdte80, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
     <Reference Include="Microsoft.Build">
       <EmbedInteropTypes>False</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="Microsoft.VisualStudio.ComponentModelHost, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.CoreUtility, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Editor, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Language.Intellisense, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.OLE.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.15.0, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Framework, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.10.0, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.11.0, Version=11.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.12.0, Version=12.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.15.3.DesignTime, Version=15.3.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Shell.Interop.9.0, Version=9.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Microsoft.VisualStudio.TemplateWizardInterface">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Data, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.Logic, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Text.UI.Wpf, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TextManager.Interop, Version=7.1.40304.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.TextManager.Interop.8.0, Version=8.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Microsoft.VisualStudio.Utilities, Version=16.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <Private>False</Private>
     </Reference>
     <Reference Include="PresentationCore" />
@@ -283,9 +214,6 @@
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-    <Reference Include="VSLangProj, Version=7.0.3300.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </Reference>
     <Reference Include="WindowsBase" />
     <Reference Include="WindowsFormsIntegration" />
   </ItemGroup>
@@ -301,11 +229,16 @@
     </COMReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="FSharp.Core" Version="4.3.1" />
-    <PackageReference Include="Portable.Xaml" Version="0.24.0" />
+    <PackageReference Include="FSharp.Core" Version="5.0.0" />
+    <PackageReference Include="Portable.Xaml" Version="0.26.0" />
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" />
-    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.202" ExcludeAssets="runtime" />
-    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.4.1057" />
+    <PackageReference Include="Microsoft.VisualStudio.SDK" Version="16.0.206" ExcludeAssets="runtime">
+      <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Version="16.8.3038">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Page Include="theme\WindowStyles.xaml">
@@ -335,6 +268,9 @@
       <ReferencePath Update="%(ReferencePath.Identity)" Condition="%(Filename) == 'FSharp.Compiler.CodeDom'" CopyLocal="True" />
     </ItemGroup>
     <Message Text="CopyLocal: %(ReferencePath.Identity), %(Filename)" Condition="%(ReferencePath.CopyLocal) == 'True'" Importance="high" />
+  </Target>
+  <Target Name="ClearTemplateCache" AfterTargets="AfterBuild">
+    <RemoveDir Directories="$(HOMEDRIVE)$(HOMEPATH)\.templateengine\vs" />
   </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/Addins/Eto.Addin.VisualStudio/Templates/App-CSharp/App.vstemplate
+++ b/src/Addins/Eto.Addin.VisualStudio/Templates/App-CSharp/App.vstemplate
@@ -15,7 +15,6 @@
     <LanguageTag>CSharp</LanguageTag>
     <Icon>App.ico</Icon>
     <DefaultName>EtoApp</DefaultName>
-    <RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
 
     <CreateNewFolder>true</CreateNewFolder>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/src/Addins/Eto.Addin.VisualStudio/Templates/App-FSharp/App.vstemplate
+++ b/src/Addins/Eto.Addin.VisualStudio/Templates/App-FSharp/App.vstemplate
@@ -15,7 +15,6 @@
     <LanguageTag>FSharp</LanguageTag>
     <Icon>App.ico</Icon>
     <DefaultName>EtoApp</DefaultName>
-    <RequiredFrameworkVersion>4.5</RequiredFrameworkVersion>
     
     <CreateNewFolder>false</CreateNewFolder>
     <ProvideDefaultName>true</ProvideDefaultName>

--- a/src/Addins/Eto.Addin.VisualStudio/Wizards/ProjectWizard.cs
+++ b/src/Addins/Eto.Addin.VisualStudio/Wizards/ProjectWizard.cs
@@ -31,9 +31,9 @@ namespace Eto.Addin.VisualStudio.Wizards
         {
             get
             {
-                Version ver;
-                if (Version.TryParse(replacements["$targetframeworkversion$"], out ver))
-                    return ver;
+//                Version ver;
+//                if (Version.TryParse(replacements["$targetframeworkversion$"], out ver))
+//                    return ver;
                 return new Version(4, 5);
             }
         }
@@ -74,6 +74,15 @@ namespace Eto.Addin.VisualStudio.Wizards
 				var dialog = new BaseDialog { Content = panel, Title = model.Title, ClientSize = new Size(-1, 400), Style="themed" };
 				if (!dialog.ShowModal(Helpers.MainWindow))
 					throw new WizardBackoutException();
+
+				// super hack: Due to a bug in VS we cannot use item templates without it crashing..
+				// see Microsoft.VisualStudio.TemplateEngine.Wizard.TemplateEngineWizard.PostInvocationTelemetry
+				// for details on why it doesn't work... 
+				if (customParams[0] is string str && !str.Contains("~PC"))
+				{
+					str = str.Replace("~IC", "~PC");
+					customParams[0] = str;
+				}
 			}
 		}
 	}

--- a/src/Addins/Eto.Addin.VisualStudio/app.config
+++ b/src/Addins/Eto.Addin.VisualStudio/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0"/>
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>

--- a/src/Addins/Eto.Designer/Eto.Designer.csproj
+++ b/src/Addins/Eto.Designer/Eto.Designer.csproj
@@ -12,5 +12,6 @@
   <ItemGroup>
     <PackageReference Include="FSharp.Compiler.CodeDom" Version="1.0.0.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="3.7.0" ExcludeAssets="runtime" />
+    <PackageReference Include="System.ComponentModel.TypeConverter" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/src/Addins/Eto.Designer/app.config
+++ b/src/Addins/Eto.Designer/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />

--- a/src/Addins/Eto.Forms.Templates/Eto.Forms.Templates.csproj
+++ b/src/Addins/Eto.Forms.Templates/Eto.Forms.Templates.csproj
@@ -26,7 +26,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="content\NuGet.Config" />
+    <PackageReference Remove="Microsoft.NETCore.App" />
+    
+    <None Include="content\NuGet.Config" />
 		<None Include="content\Directory.*" />
 		<Content Include="content\**\*">
 			<PackagePath>%(RelativeDir)%(Filename)%(Extension)</PackagePath>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/.template.config/dotnetcli.host.json
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/.template.config/dotnetcli.host.json
@@ -5,13 +5,14 @@
 			"longName": "mode",
 			"shortName": "m"
 		},
-		"GtkVersion": {
-			"longName": "gtk-version",
-			"shortName": "g"
-		},
 		"Combined": {
 			"longName": "combined",
 			"shortName": "c"
+		},
+		"TargetFrameworkOverride": {
+			"isHidden": "true",
+			"longName": "target-framework-override",
+			"shortName": ""
 		},
 		"Framework": {
 			"longName": "framework",

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/.template.config/template.json
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/.template.config/template.json
@@ -37,31 +37,6 @@
 				}
 			]
 		},
-		"GtkVersion": {
-			"type": "parameter",
-			"description": "The Gtk# version to target",
-			"dataType": "choice",
-			"defaultValue": "Gtk",
-			"onlyIf": [
-				{ "after": ".Platform." },
-				{ "after": ".Platforms." }
-			],
-			"choices": [
-				{
-					"choice": "Gtk",
-					"description": "Gtk# 3.14+"
-				},
-				{
-					"choice": "Gtk2",
-					"description": "Gtk# 2.12 (deprecated)"
-				},
-				{
-					"choice": "Gtk3",
-					"description": "GTK# 3.0 (deprecated)"
-				}
-			],
-			"replaces": "Gtk"
-		},
 		"Combined": {
 			"type": "parameter",
 			"description": "Use a combined project to launch the application (Full .NET Framework only)",
@@ -86,23 +61,31 @@
 			"dataType": "bool",
 			"defaultValue": "false"
 		},
+		"TargetFrameworkOverride": {
+			"type": "parameter",
+			"description": "Overrides the target framework",
+			"replaces": "TargetFrameworkOverride",
+			"datatype": "string",
+			"defaultValue": ""
+		},
 		"Framework": {
 			"type": "parameter",
 			"description": "Specify the framework(s) to support",
 			"dataType": "choice",
-			"defaultValue": "core",
+			"defaultValue": "net5.0",
+			"replaces": "net5.0",
 			"choices": [
 				{
-					"choice": "full",
-					"description": "Full .NET Framework and/or Mono"
+					"choice": "net5.0",
+					"description": ".NET 5.0"
 				},
 				{
-					"choice": "core",
-					"description": ".NET Core"
+					"choice": "netcoreapp3.1",
+					"description": ".NET Core 3.1"
 				},
 				{
-					"choice": "both",
-					"description": "Target both .NET Core and .NET Framework / Mono"
+					"choice": "net462",
+					"description": ".NET Framework 4.6.2 / Mono"
 				}
 			]
 		},
@@ -140,16 +123,6 @@
 			"replaces": "2020",
 			"parameters": {
 				"format": "yyyy"
-			}
-		},
-		/* Support SDK 2.0.0 */
-		"namespace-for-old-sdk": {
-			"type": "generated",
-			"generator": "coalesce",
-			"replaces": "EtoApp._1",
-			"parameters": {
-				"sourceVariableName": "safe_namespace",
-				"fallbackVariableName": "safe_name"
 			}
 		}
 	},
@@ -206,6 +179,22 @@
 	"primaryOutputs": [
 		{ "path": "EtoApp.1/EtoApp.1.csproj" },
 		{
+			"path": "EtoApp.1/MainForm.cs",
+			"condition": "UseCode"
+		},
+		{
+			"path": "EtoApp.1/MainForm.eto.cs",
+			"condition": "UseCodePreview"
+		},
+		{
+			"path": "EtoApp.1/MainForm.xeto",
+			"condition": "UseXeto"
+		},
+		{
+			"path": "EtoApp.1/MainForm.jeto",
+			"condition": "UseJeto"
+		},
+		{
 			"path": "EtoApp.1.Desktop/EtoApp.1.Desktop.csproj",
 			"condition": "(Combined)"
 		},
@@ -228,22 +217,6 @@
 		{
 			"path": "EtoApp.1.XamMac/EtoApp.1.XamMac.csproj",
 			"condition": "(IncludeXamMac)"
-		},
-		{
-			"path": "EtoApp.1/MainForm.cs",
-			"condition": "UseCode"
-		},
-		{
-			"path": "EtoApp.1/MainForm.eto.cs",
-			"condition": "UseCodePreview"
-		},
-		{
-			"path": "EtoApp.1/MainForm.xeto",
-			"condition": "UseXeto"
-		},
-		{
-			"path": "EtoApp.1/MainForm.jeto",
-			"condition": "UseJeto"
 		}
 	],
 	"guids": [
@@ -286,5 +259,17 @@
 				}
 			]
 		}
-	}
+	},
+	"postActions": [
+		{
+			"condition": "(HostIdentifier != \"dotnetcli\" && HostIdentifier != \"dotnetcli-preview\")",
+			"description": "Opens MainForm in the editor",
+			"manualInstructions": [],
+			"actionId": "84C0DA21-51C8-4541-9940-6CA19AF04EE6",
+			"args": {
+				"files": "1"
+			},
+			"continueOnError": true
+		}
+	]
 }

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.csproj
@@ -2,8 +2,8 @@
 	
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472</TargetFrameworks>
-    <AssemblySearchPaths Condition="$(GtkVersion)=='Gtk2' or $(GtkVersion)=='Gtk3'">$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
+    <TargetFramework Condition="$(TargetFrameworkOverride) == ''">net5.0</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) != ''">TargetFrameworkOverride</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Desktop/Program.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Desktop/Program.cs
@@ -2,7 +2,7 @@
 using Eto.Forms;
 using Eto.Drawing;
 
-namespace EtoApp._1.Desktop
+namespace EtoApp.1.Desktop
 {
 	class Program
 	{

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.csproj
@@ -2,15 +2,8 @@
 	
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks Condition="$(Framework) == 'full'">net472</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == 'core'">netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == '' OR $(Framework) == 'both'">net472;netcoreapp3.1</TargetFrameworks>
-    <AssemblySearchPaths Condition="$(GtkVersion)=='Gtk2' or $(GtkVersion)=='Gtk3'">$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
-  </PropertyGroup>
-
-  <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
-    <StartAction>Project</StartAction>
-    <ExternalConsole>false</ExternalConsole>
+    <TargetFramework Condition="$(TargetFrameworkOverride) == ''">net5.0</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) != ''">TargetFrameworkOverride</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Gtk/Program.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Gtk/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Eto.Forms;
 
-namespace EtoApp._1.Gtk
+namespace EtoApp.1.Gtk
 {
 	class MainClass
 	{

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Mac/EtoApp.1.Mac.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Mac/EtoApp.1.Mac.csproj
@@ -1,12 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFrameworks Condition="$(Framework) == 'full'">net472</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == 'core'">netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == '' OR $(Framework) == 'both'">net472;netcoreapp3.1</TargetFrameworks>
-    
-    <RuntimeIdentifiers Condition="$(Framework) != 'full'">osx-x64</RuntimeIdentifiers>
+    <OutputType>Exe</OutputType>
+    <TargetFramework Condition="$(TargetFrameworkOverride) == ''">net5.0</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) != ''">TargetFrameworkOverride</TargetFramework>
+
+    <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 	
   <ItemGroup>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Mac/Program.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Mac/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Eto.Forms;
 
-namespace EtoApp._1.Mac
+namespace EtoApp.1.Mac
 {
 	class MainClass
 	{

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks Condition="$(Framework) == 'full'">net472</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == 'core'">netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == '' OR $(Framework) == 'both'">net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="$(TargetFrameworkOverride) == ''">net5.0</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) != ''">TargetFrameworkOverride</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.WinForms/Program.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.WinForms/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Eto.Forms;
 
-namespace EtoApp._1.WinForms
+namespace EtoApp.1.WinForms
 {
 	class MainClass
 	{

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.csproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks Condition="$(Framework) == 'full'">net472</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == 'core'">netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == '' OR $(Framework) == 'both'">net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="$(TargetFrameworkOverride) == ''">net5.0</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) != ''">TargetFrameworkOverride</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Wpf/Program.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.Wpf/Program.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using Eto.Forms;
 
-namespace EtoApp._1.Wpf
+namespace EtoApp.1.Wpf
 {
 	class MainClass
 	{

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.csproj
@@ -6,7 +6,7 @@
     <ProjectGuid>{05DB20E8-D401-4094-8096-88499C50E28A}</ProjectGuid>
     <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
-    <RootNamespace>EtoApp._1.XamMac</RootNamespace>
+    <RootNamespace>EtoApp.1.XamMac</RootNamespace>
     <AssemblyName>EtoApp.1.XamMac</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.XamMac/Program.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1.XamMac/Program.cs
@@ -1,7 +1,7 @@
 ﻿using AppKit;
 using Eto.Forms;
 
-namespace EtoApp._1.XamMac
+namespace EtoApp.1.XamMac
 {
 	static class MainClass
 	{

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/EtoApp.1.csproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/EtoApp.1.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 	
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <DefineConstants Condition="$(Mode)==''">UseCode;IsWindow;IsForm</DefineConstants>
   </PropertyGroup>
   

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.cs
@@ -1,9 +1,9 @@
-﻿#if (UseCode || UseCodePreview)
+#if (UseCode || UseCodePreview)
 using System;
 using Eto.Forms;
 using Eto.Drawing;
 
-namespace EtoApp._1
+namespace EtoApp.1
 {
 	public partial class MainForm : Form
 	{
@@ -14,7 +14,7 @@ namespace EtoApp._1
 #else
 #if IsWindow
 			Title = "My Eto Form";
-			ClientSize = new Size(400, 350);
+			MinimumSize = new Size(200, 200);
 #endif
 
 			Content = new StackLayout

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.eto.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.eto.cs
@@ -1,9 +1,9 @@
-﻿#if (UseCodePreview)
+#if (UseCodePreview)
 using System;
 using Eto.Forms;
 using Eto.Drawing;
 
-namespace EtoApp._1
+namespace EtoApp.1
 {
 	partial class MainForm : Form
 	{
@@ -11,7 +11,7 @@ namespace EtoApp._1
 		{
 #if IsWindow
 			Title = "My Eto Form";
-			ClientSize = new Size(400, 350);
+			MinimumSize = new Size(200, 200);
 #endif
 			Padding = 10;
 

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.jeto
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.jeto
@@ -2,7 +2,7 @@
 	"$type": "Form",
 /*#if(IsWindow)*/
 	"Title": "My Eto Form",
-	"ClientSize": "400,350",
+	"MinimumSize": "200,200",
 /*#endif */
 	"Padding": "10",
 	"Content": {

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.jeto.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.jeto.cs
@@ -5,7 +5,7 @@ using Eto.Forms;
 using Eto.Drawing;
 using Eto.Serialization.Json;
 
-namespace EtoApp._1
+namespace EtoApp.1
 {	
 	public class MainForm : Form
 	{	

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.xeto
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.xeto
@@ -4,7 +4,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 <!--#if(IsWindow)-->
 	Title="My Eto Form"
-	ClientSize="400, 350"
+	MinimumSize="200,200"
 <!--#endif-->
 	Padding="10"
 	>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.xeto.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.xeto.cs
@@ -5,7 +5,7 @@ using Eto.Forms;
 using Eto.Drawing;
 using Eto.Serialization.Xaml;
 
-namespace EtoApp._1
+namespace EtoApp.1
 {	
 	public class MainForm : Form
 	{	

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/.template.config/dotnetcli.host.json
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/.template.config/dotnetcli.host.json
@@ -13,6 +13,11 @@
 			"longName": "combined",
 			"shortName": "c"
 		},
+		"TargetFrameworkOverride": {
+			"isHidden": "true",
+			"longName": "target-framework-override",
+			"shortName": ""
+		},
 		"Framework": {
 			"longName": "framework",
 			"shortName": "f"

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/.template.config/template.json
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/.template.config/template.json
@@ -86,23 +86,31 @@
 			"dataType": "bool",
 			"defaultValue": "false"
 		},
+		"TargetFrameworkOverride": {
+			"type": "parameter",
+			"description": "Overrides the target framework",
+			"replaces": "TargetFrameworkOverride",
+			"datatype": "string",
+			"defaultValue": ""
+		},
 		"Framework": {
 			"type": "parameter",
 			"description": "Specify the framework(s) to support",
 			"dataType": "choice",
-			"defaultValue": "core",
+			"defaultValue": "net5.0",
+			"replaces": "net5.0",
 			"choices": [
 				{
-					"choice": "full",
-					"description": "Full .NET Framework and/or Mono"
+					"choice": "net5.0",
+					"description": ".NET 5.0"
 				},
 				{
-					"choice": "core",
-					"description": ".NET Core"
+					"choice": "netcoreapp3.1",
+					"description": ".NET Core 3.1"
 				},
 				{
-					"choice": "both",
-					"description": "Target both .NET Core and .NET Framework / Mono"
+					"choice": "net462",
+					"description": ".NET Framework 4.6.2 / Mono"
 				}
 			]
 		},
@@ -141,16 +149,6 @@
 			"parameters": {
 				"format": "yyyy"
 			}
-		},
-		/* Support SDK 2.0.0 */
-		"namespace-for-old-sdk": {
-			"type": "generated",
-			"generator": "coalesce",
-			"parameters": {
-				"sourceVariableName": "safe_namespace",
-				"fallbackVariableName": "safe_name"
-			},
-			"replaces": "EtoApp._1"
 		}
 	},
 	"sources": [

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Desktop/EtoApp.1.Desktop.fsproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks>net472</TargetFrameworks>
-    <AssemblySearchPaths Condition="$(GtkVersion)=='Gtk2' or $(GtkVersion)=='Gtk3'">$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
+    <TargetFramework Condition="$(TargetFrameworkOverride) == ''">net5.0</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) != ''">TargetFrameworkOverride</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Desktop/Program.fs
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Desktop/Program.fs
@@ -1,8 +1,8 @@
-﻿namespace EtoApp._1.Desktop
+﻿namespace EtoApp.1.Desktop
 module Program =
 
     open System
-    open EtoApp._1
+    open EtoApp.1
 
     [<EntryPoint>]
     [<STAThread>]

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Gtk/EtoApp.1.Gtk.fsproj
@@ -2,10 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks Condition="$(Framework) == 'full'">net472</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == 'core'">netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == '' OR $(Framework) == 'both'">net472;netcoreapp3.1</TargetFrameworks>
-    <AssemblySearchPaths Condition="$(GtkVersion)=='Gtk2' or $(GtkVersion)=='Gtk3'">$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
+    <TargetFramework Condition="$(TargetFrameworkOverride) == ''">net5.0</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) != ''">TargetFrameworkOverride</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Gtk/Program.fs
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Gtk/Program.fs
@@ -1,8 +1,8 @@
-﻿namespace EtoApp._1.Gtk
+﻿namespace EtoApp.1.Gtk
 module Program =
 
     open System
-    open EtoApp._1
+    open EtoApp.1
 
     [<EntryPoint>]
     [<STAThread>]

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Mac/EtoApp.1.Mac.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Mac/EtoApp.1.Mac.fsproj
@@ -1,22 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
-    <TargetFrameworks Condition="$(Framework) == 'full'">net472</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == 'core'">netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == '' OR $(Framework) == 'both'">net472;netcoreapp3.1</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <TargetFramework Condition="$(TargetFrameworkOverride) == ''">net5.0</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) != ''">TargetFrameworkOverride</TargetFramework>
 
-    <RuntimeIdentifiers Condition="$(Framework) != 'full'">osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers>osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <ItemGroup>
     <Compile Include="Program.fs" />
   </ItemGroup>
   
-  <ItemGroup>
-    <Reference Include="System.Numerics" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\EtoApp.1\EtoApp.1.fsproj" />
   </ItemGroup>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Mac/Program.fs
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Mac/Program.fs
@@ -1,8 +1,8 @@
-﻿namespace EtoApp._1.Mac
+﻿namespace EtoApp.1.Mac
 module Program =
 
     open System
-    open EtoApp._1
+    open EtoApp.1
 
     [<EntryPoint>]
     [<STAThread>]

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.WinForms/EtoApp.1.WinForms.fsproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks Condition="$(Framework) == 'full'">net472</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == 'core'">netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == '' OR $(Framework) == 'both'">net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="$(TargetFrameworkOverride) == ''">net5.0</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) != ''">TargetFrameworkOverride</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.WinForms/Program.fs
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.WinForms/Program.fs
@@ -1,8 +1,8 @@
-﻿namespace EtoApp._1.WinForms
+﻿namespace EtoApp.1.WinForms
 module Program =
 
     open System
-    open EtoApp._1
+    open EtoApp.1
 
     [<EntryPoint>]
     [<STAThread>]

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Wpf/EtoApp.1.Wpf.fsproj
@@ -2,9 +2,8 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFrameworks Condition="$(Framework) == 'full'">net472</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == 'core'">netcoreapp3.1</TargetFrameworks>
-    <TargetFrameworks Condition="$(Framework) == '' OR $(Framework) == 'both'">net472;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework Condition="$(TargetFrameworkOverride) == ''">net5.0</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) != ''">TargetFrameworkOverride</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Wpf/Program.fs
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.Wpf/Program.fs
@@ -1,8 +1,8 @@
-﻿namespace EtoApp._1.Wpf
+﻿namespace EtoApp.1.Wpf
 module Program =
 
     open System
-    open EtoApp._1
+    open EtoApp.1
 
     [<EntryPoint>]
     [<STAThread>]

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.fsproj
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.XamMac/EtoApp.1.XamMac.fsproj
@@ -7,7 +7,7 @@
     <ProjectTypeGuids>{A3F8F2AB-B479-4A4A-A458-A89E7DC349F1};{F2A71F9B-5D33-465A-A702-920D77279786}</ProjectTypeGuids>
     <UseStandardResourceNames>true</UseStandardResourceNames>
     <OutputType>Exe</OutputType>
-    <RootNamespace>EtoApp._1.XamMac</RootNamespace>
+    <RootNamespace>EtoApp.1.XamMac</RootNamespace>
     <AssemblyName>EtoApp.1.XamMac</AssemblyName>
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
@@ -87,7 +87,7 @@
       <Version>2.5.8-dev</Version>
     </PackageReference>
     <PackageReference Include="FSharp.Core">
-      <Version>4.7.0</Version>
+      <Version>5.0.0</Version>
     </PackageReference>
   </ItemGroup>
   <ItemGroup>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.XamMac/Program.fs
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1.XamMac/Program.fs
@@ -1,8 +1,8 @@
-﻿namespace EtoApp._1.XamMac
+﻿namespace EtoApp.1.XamMac
 module Program =
 
     open System
-    open EtoApp._1
+    open EtoApp.1
 
     [<EntryPoint>]
     [<STAThread>]

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.eto.fs
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.eto.fs
@@ -1,5 +1,5 @@
 ﻿#if (UseCodePreview)
-namespace EtoApp._1
+namespace EtoApp.1
 
 open System
 open Eto.Forms
@@ -10,7 +10,7 @@ type MainFormBase () =
     member this.InitializeComponent() =
 #if IsWindow
         base.Title <- "My Eto Form"
-        base.ClientSize <- new Size(400, 350)
+        base.MinimumSize <- new Size(200, 200)
 #endif
 
         // table with three rows

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.fs
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.fs
@@ -1,5 +1,5 @@
 ﻿#if (UseCode || UseCodePreview)
-namespace EtoApp._1
+namespace EtoApp.1
 
 open System
 open Eto.Forms
@@ -15,7 +15,7 @@ type MainForm () as this =
     do
 #if IsWindow
         base.Title <- "My Eto Form"
-        base.ClientSize <- new Size(400, 350)
+        base.MinimumSize <- new Size(200, 200)
 #endif
 
         // table with three rows

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.jeto
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.jeto
@@ -2,7 +2,7 @@
 	"$type": "Form",
 /*#if(IsWindow)*/
 	"Title": "My Eto Form",
-	"ClientSize": "400,350",
+	"MinimumSize": "200,200",
 /*#endif */
 	"Padding": "10",
 	"Content": {

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.jeto.fs
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.jeto.fs
@@ -1,5 +1,5 @@
 ﻿#if (UseJeto)
-namespace EtoApp._1
+namespace EtoApp.1
 
 open System
 open Eto.Forms

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.xeto
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.xeto
@@ -4,7 +4,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 <!--#if(IsWindow)-->
 	Title="My Eto Form"
-	ClientSize="400, 350"
+	MinimumSize="200,200"
 <!--#endif-->
 	Padding="10"
 	>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.xeto.fs
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.xeto.fs
@@ -1,5 +1,5 @@
 ﻿#if (UseXeto)
-namespace EtoApp._1
+namespace EtoApp.1
 
 open System
 open Eto.Forms

--- a/src/Addins/Eto.Forms.Templates/content/File-CSharp/.template.config/template.json
+++ b/src/Addins/Eto.Forms.Templates/content/File-CSharp/.template.config/template.json
@@ -65,7 +65,7 @@
 		},
 		"Namespace": {
 			"description": "Namespace for the generated files",
-			"replaces": "EtoApp._1",
+			"replaces": "EtoApp.1",
 			"defaultValue": "EtoApp",
 			"type": "parameter"
 		},

--- a/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.cs
+++ b/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.cs
@@ -1,9 +1,9 @@
-﻿#if (UseCode || UseCodePreview)
+#if (UseCode || UseCodePreview)
 using System;
 using Eto.Forms;
 using Eto.Drawing;
 
-namespace EtoApp._1
+namespace EtoApp.1
 {
 	public partial class MainForm : Form
 	{
@@ -14,7 +14,7 @@ namespace EtoApp._1
 #else
 #if IsWindow
 			Title = "My Eto Form";
-			ClientSize = new Size(400, 350);
+			MinimumSize = new Size(200, 200);
 #endif
 
 			Content = new StackLayout

--- a/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.eto.cs
+++ b/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.eto.cs
@@ -1,9 +1,9 @@
-﻿#if (UseCodePreview)
+#if (UseCodePreview)
 using System;
 using Eto.Forms;
 using Eto.Drawing;
 
-namespace EtoApp._1
+namespace EtoApp.1
 {
 	partial class MainForm : Form
 	{
@@ -11,7 +11,7 @@ namespace EtoApp._1
 		{
 #if IsWindow
 			Title = "My Eto Form";
-			ClientSize = new Size(400, 350);
+			MinimumSize = new Size(200, 200);
 #endif
 			Padding = 10;
 

--- a/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.jeto
+++ b/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.jeto
@@ -2,7 +2,7 @@
 	"$type": "Form",
 /*#if(IsWindow)*/
 	"Title": "My Eto Form",
-	"ClientSize": "400,350",
+	"MinimumSize": "200,200",
 /*#endif */
 	"Padding": "10",
 	"Content": {

--- a/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.jeto.cs
+++ b/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.jeto.cs
@@ -5,7 +5,7 @@ using Eto.Forms;
 using Eto.Drawing;
 using Eto.Serialization.Json;
 
-namespace EtoApp._1
+namespace EtoApp.1
 {	
 	public class MainForm : Form
 	{	

--- a/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.xeto
+++ b/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.xeto
@@ -4,7 +4,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 <!--#if(IsWindow)-->
 	Title="My Eto Form"
-	ClientSize="400, 350"
+	MinimumSize="200,200"
 <!--#endif-->
 	Padding="10"
 	>

--- a/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.xeto.cs
+++ b/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.xeto.cs
@@ -5,7 +5,7 @@ using Eto.Forms;
 using Eto.Drawing;
 using Eto.Serialization.Xaml;
 
-namespace EtoApp._1
+namespace EtoApp.1
 {	
 	public class MainForm : Form
 	{	

--- a/src/Addins/Eto.Forms.Templates/content/File-FSharp/.template.config/template.json
+++ b/src/Addins/Eto.Forms.Templates/content/File-FSharp/.template.config/template.json
@@ -65,7 +65,7 @@
 		},
 		"Namespace": {
 			"description": "Namespace for the generated files",
-			"replaces": "EtoApp._1",
+			"replaces": "EtoApp.1",
 			"defaultValue": "EtoApp",
 			"type": "parameter"
 		},

--- a/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.eto.fs
+++ b/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.eto.fs
@@ -1,5 +1,5 @@
 ﻿#if (UseCodePreview)
-namespace EtoApp._1
+namespace EtoApp.1
 
 open System
 open Eto.Forms
@@ -10,7 +10,7 @@ type MainFormBase () =
     member this.InitializeComponent() =
 #if IsWindow
         base.Title <- "My Eto Form"
-        base.ClientSize <- new Size(400, 350)
+        base.MinimumSize <- new Size(200, 200)
 #endif
 
         // table with three rows

--- a/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.fs
+++ b/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.fs
@@ -1,5 +1,5 @@
 ﻿#if (UseCode || UseCodePreview)
-namespace EtoApp._1
+namespace EtoApp.1
 
 open System
 open Eto.Forms
@@ -15,7 +15,7 @@ type MainForm () as this =
     do
 #if IsWindow
         base.Title <- "My Eto Form"
-        base.ClientSize <- new Size(400, 350)
+        base.MinimumSize <- new Size(200, 200)
 #endif
 
         // table with three rows

--- a/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.jeto
+++ b/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.jeto
@@ -2,7 +2,7 @@
 	"$type": "Form",
 /*#if(IsWindow)*/
 	"Title": "My Eto Form",
-	"ClientSize": "400,350",
+	"MinimumSize": "200,200",
 /*#endif */
 	"Padding": "10",
 	"Content": {

--- a/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.jeto.fs
+++ b/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.jeto.fs
@@ -1,5 +1,5 @@
 ﻿#if (UseJeto)
-namespace EtoApp._1
+namespace EtoApp.1
 
 open System
 open Eto.Forms

--- a/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.xeto
+++ b/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.xeto
@@ -4,7 +4,7 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 <!--#if(IsWindow)-->
 	Title="My Eto Form"
-	ClientSize="400, 350"
+	MinimumSize="200,200"
 <!--#endif-->
 	Padding="10"
 	>

--- a/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.xeto.fs
+++ b/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.xeto.fs
@@ -1,5 +1,5 @@
 ﻿#if (UseXeto)
-namespace EtoApp._1
+namespace EtoApp.1
 
 open System
 open Eto.Forms

--- a/src/Eto.Serialization.Xaml/Eto.Serialization.Xaml.csproj
+++ b/src/Eto.Serialization.Xaml/Eto.Serialization.Xaml.csproj
@@ -29,7 +29,7 @@ https://github.com/picoe/Eto/wiki
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="Portable.Xaml" Version="0.24.0" />
+    <PackageReference Include="Portable.Xaml" Version="0.26.0" />
   </ItemGroup>
   
   <ItemGroup Condition="$(TargetFramework) == 'netstandard1.0'">

--- a/src/Eto.Wpf/Forms/ApplicationHandler.cs
+++ b/src/Eto.Wpf/Forms/ApplicationHandler.cs
@@ -76,6 +76,12 @@ namespace Eto.Wpf.Forms
 			if (!EnableCustomThemes)
 				return;
 
+			// ensure the Xceed.Wpf.Toolkit assembly is loaded here.
+			// kind of pointless, but adding the resource dictionary below fails unless this assembly is loaded..
+			var xceedWpfToolkit = typeof(Xceed.Wpf.Toolkit.ButtonSpinner).Assembly;
+			if (xceedWpfToolkit == null)
+				throw new InvalidOperationException("Could not load Xceed.Wpf.Toolkit");
+
 			// Add themes to our controls
 			var assemblyName = typeof(ApplicationHandler).Assembly.GetName().Name;
 			Control.Resources.MergedDictionaries.Add(new sw.ResourceDictionary { Source = new Uri($"pack://application:,,,/{assemblyName};component/themes/generic.xaml", UriKind.RelativeOrAbsolute) });


### PR DESCRIPTION
- Change Framework property to use tfm's. Fixes #1827
- Correctly show convertible types
- Allow selecting a single framework
- Default to net 5.0
- Fix creating file templates. Fixes #1811
- Remove Gtk2/3 options from templates
- Fix loading wpf