### PR TITLE
Gtk: Fix styling of Stepper so the buttons aren't chopped off.

### DIFF
--- a/src/Eto.Gtk/Platform.cs
+++ b/src/Eto.Gtk/Platform.cs
@@ -77,7 +77,8 @@ namespace Eto.GtkSharp
 			Style.Add<ThemedStepperHandler>(null, h =>
 			{
 				h.Orientation = Orientation.Horizontal;
-				h.Widget.Size = new Size(50, 30);
+				h.Widget.Size = new Size(-1, -1);
+				h.Font = SystemFonts.Default();
 				if (h.Control.Content.Handler is TableLayoutHandler table)
 				{
 					table.Control.StyleContext.AddClass("linked");


### PR DESCRIPTION
Before:

<img width="87" alt="Screen Shot 2020-12-29 at 11 49 51 AM" src="https://user-images.githubusercontent.com/367446/103310245-facf2400-49cb-11eb-92c8-239cb49c1699.png">

After:

<img width="92" alt="Screen Shot 2020-12-29 at 11 42 53 AM" src="https://user-images.githubusercontent.com/367446/103310260-04588c00-49cc-11eb-9537-fe1cc648c349.png">
