### PR TITLE
GroupBox fixes

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/GroupBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GroupBoxHandler.cs
@@ -5,6 +5,7 @@ using Eto.Forms;
 using Eto.Drawing;
 using Eto.Wpf.Drawing;
 using System;
+using System.Windows;
 
 namespace Eto.Wpf.Forms.Controls
 {
@@ -20,13 +21,34 @@ namespace Eto.Wpf.Forms.Controls
 
 	public class GroupBoxHandler : WpfPanel<swc.GroupBox, GroupBox, GroupBox.ICallback>, GroupBox.IHandler
 	{
-		swc.Label Header { get; set; }
-		swc.AccessText AccessText { get { return (swc.AccessText)Header.Content; } }
+		sw.Thickness? headerPadding;
+		public swc.Label Header { get; set; }
+		swc.AccessText AccessText => (swc.AccessText)Header.Content;
 
 		public GroupBoxHandler()
 		{
 			Control = new EtoGroupBox { Handler = this };
-			Header = new swc.Label { Content = new swc.AccessText() };
+			Control.Loaded += Control_Loaded;
+			Header = new swc.Label { Content = new swc.AccessText(), Padding = new sw.Thickness(0) };
+			Control.Header = Header;
+		}
+
+		private void Control_Loaded(object sender, RoutedEventArgs e)
+		{
+			SetHeaderPadding();
+		}
+
+		protected virtual swc.Border HeaderControl => Control.FindChild<swc.Border>("Header");
+
+		private void SetHeaderPadding()
+		{
+			var header = HeaderControl;
+			if (header == null)
+				return;
+			if (headerPadding == null)
+				headerPadding = header.Padding;
+			var noHeader = string.IsNullOrEmpty(Text);
+			header.Padding = noHeader ? new sw.Thickness(0) : headerPadding.Value;
 		}
 
 		public override void SetContainerContent(sw.FrameworkElement content)
@@ -58,7 +80,8 @@ namespace Eto.Wpf.Forms.Controls
 			set
 			{
 				AccessText.Text = value.ToPlatformMnemonic();
-				Control.Header = string.IsNullOrEmpty(value) ? null : Header;
+				if (Control.IsLoaded)
+					SetHeaderPadding();
 				UpdatePreferredSize();
 			}
 		}

--- a/test/Eto.Test/Sections/Controls/GroupBoxSection.cs
+++ b/test/Eto.Test/Sections/Controls/GroupBoxSection.cs
@@ -10,20 +10,20 @@ namespace Eto.Test.Sections.Controls
 		{
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
 
-			layout.AddRow(new Label { Text = "Default" }, Default());
+			layout.AddRow(new Label { Text = "Default" }, Default(), null);
 
-			layout.AddRow(new Label { Text = "With Header" }, Header());
+			layout.AddRow(new Label { Text = "With Header" }, Header(), null);
 
 			layout.Add(null, null, true);
 
 			Content = layout;
 		}
 
-		Control Default()
+		GroupBox Default()
 		{
 			var control = new GroupBox();
 
-			control.Content = new CheckBoxSection { Border = BorderType.None };
+			control.Content = new Panel { Size = new Size(100, 100), BackgroundColor = Colors.Blue, Content = "Content" };
 			return control;
 
 		}
@@ -32,7 +32,7 @@ namespace Eto.Test.Sections.Controls
 		{
 			var control = new GroupBox { Text = "Some Header" };
 
-			control.Content = new LabelSection();
+			control.Content = new Panel { Size = new Size(100, 100), Content = "Content" };
 			return control;
 		}
 	}

--- a/test/Eto.Test/UnitTests/Forms/Controls/GroupBoxTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GroupBoxTests.cs
@@ -1,0 +1,24 @@
+using Eto.Drawing;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	[TestFixture]
+	public class GroupBoxTests : TestBase
+	{
+		[Test]
+		public void GroupBoxShouldHaveCorrectlySizedContent()
+		{
+			GroupBox groupBox = null;
+			Shown(form =>
+			{
+				groupBox = new GroupBox { Content = new Panel { Size = new Size(200, 200) } };
+				return TableLayout.AutoSized(groupBox);
+			}, c =>
+			{
+				Assert.AreEqual(new Size(200, 200), groupBox.Content.Size, "#1 Content Size should auto size to its desired size");
+			});
+		}
+	}
+}


### PR DESCRIPTION
Mac: Properly size the GroupBox based on its content without hardcoding values
Mac: Allow GroupBox ContentViewMargins to be changed and keep the correct size
Mac: Don't reserve space for the GroupBox title when empty.
Wpf: Hide GroupBox header gap when empty