### PR TITLE
Update dotnet-tt to 2.2.0 which now runs on .NET 5

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "dotnet-t4": {
-      "version": "2.0.5",
+      "version": "2.2.0",
       "commands": [
         "t4"
       ]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,18 +23,6 @@ jobs:
       with:
         submodules: true
 
-    # needed for dotnet-t4
-    - name: Setup .NET Core 2.1.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: "2.1.x"
-
-    # Can't use .NET 5 with msbuild until VS is updated to 16.8 in GitHub Actions
-    - name: Setup .NET Core 3.1.x
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: "3.1.x"
-
     - name: Setup .NET Core
       uses: actions/setup-dotnet@v1
       with:

--- a/src/Addins/global.json
+++ b/src/Addins/global.json
@@ -1,3 +1,0 @@
-{
-   "sdk": { "version": "3.1.302", "rollForward": "latestFeature" }
-}


### PR DESCRIPTION
No longer need .net core 2.x or 3.x for the build. 