### PR TITLE
Update framework selection for addins and template

### DIFF
--- a/src/Addins/Eto.Addin.Shared/ProjectWizardPageModel.cs
+++ b/src/Addins/Eto.Addin.Shared/ProjectWizardPageModel.cs
@@ -233,7 +233,9 @@ namespace Eto.Addin.Shared
 		{
 			new FrameworkInfo { Text = ".NET 5", Value = "net5.0", CanUseCombined = false },
 			new FrameworkInfo { Text = ".NET Core 3.1", Value = "netcoreapp3.1", CanUseCombined = false },
-			new FrameworkInfo { Text = ".NET Framework 4.7.2 / Mono", Value = "net472", CanUseCombined = true },
+			new FrameworkInfo { Text = ".NET Framework 4.8", Value = "net48", CanUseCombined = true },
+			new FrameworkInfo { Text = ".NET Framework 4.7.2", Value = "net472", CanUseCombined = true },
+			new FrameworkInfo { Text = ".NET Framework 4.6.2", Value = "net462", CanUseCombined = true },
 		};
 
 		FrameworkInfo _selectedFramework;

--- a/src/Addins/Eto.Addin.Shared/ProjectWizardPageView.cs
+++ b/src/Addins/Eto.Addin.Shared/ProjectWizardPageView.cs
@@ -45,6 +45,25 @@ namespace Eto.Addin.Shared
 				content.AddRow(HeadingLabel((model.IsLibrary ? "Library" : "App") + " Name:"), label);
 			}
 
+			if (model.SupportsFramework)
+			{
+				var frameworkDropDown = new DropDown();
+				frameworkDropDown.BindDataContext(c => c.DataStore, (ProjectWizardPageModel m) => m.SupportedFrameworks);
+				frameworkDropDown.ItemTextBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Text);
+				frameworkDropDown.ItemKeyBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Value);
+				frameworkDropDown.SelectedValueBinding.BindDataContext((ProjectWizardPageModel m) => m.SelectedFramework);
+
+				/*
+				var frameworkCheckBoxes = new CheckBoxList();
+				frameworkCheckBoxes.BindDataContext(c => c.DataStore, (ProjectWizardPageModel m) => m.SupportedFrameworks);
+				frameworkCheckBoxes.ItemTextBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Text);
+				frameworkCheckBoxes.ItemKeyBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Value);
+				frameworkCheckBoxes.SelectedValuesBinding.BindDataContext((ProjectWizardPageModel m) => m.SelectedFrameworks);
+				*/
+
+				content.AddRow(HeadingLabel("Framework:"), frameworkDropDown);
+			}
+
 			if (model.SupportsCombined)
 			{
 				var platformTypeList = new RadioButtonList
@@ -57,11 +76,13 @@ namespace Eto.Addin.Shared
 						new ListItem { Text = "Single Windows, Linux, and Mac desktop project", Key = "combined" }
 					}
 				};
-				platformTypeList.BindDataContext(c => c.Enabled, (ProjectWizardPageModel m) => m.AllowCombined);
+				platformTypeList.BindDataContext(c => c.Visible, (ProjectWizardPageModel m) => m.AllowCombined);
 				platformTypeList.SelectedKeyBinding
 				                .Convert(v => v == "combined", v => v ? "combined" : "separate")
 				                .BindDataContext((ProjectWizardPageModel m) => m.Combined);
-				content.AddRow(HeadingLabel("Launcher:"), platformTypeList);
+				var heading = HeadingLabel("Launcher:");
+				heading.BindDataContext(c => c.Visible, (ProjectWizardPageModel m) => m.AllowCombined);
+				content.AddRow(heading, platformTypeList);
 			}
 
 			if (model.SupportsXamMac)
@@ -94,25 +115,6 @@ namespace Eto.Addin.Shared
 
 			content.Rows.Add(new TableRow(new Label { Text = "Platforms:", TextAlignment = TextAlignment.Right }, platformCheckBoxes));
 			/**/
-
-			if (model.SupportsFramework)
-			{
-				var frameworkDropDown = new DropDown();
-				frameworkDropDown.BindDataContext(c => c.DataStore, (ProjectWizardPageModel m) => m.SupportedFrameworks);
-				frameworkDropDown.ItemTextBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Text);
-				frameworkDropDown.ItemKeyBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Value);
-				frameworkDropDown.SelectedValueBinding.BindDataContext((ProjectWizardPageModel m) => m.SelectedFramework);
-
-				/*
-				var frameworkCheckBoxes = new CheckBoxList();
-				frameworkCheckBoxes.BindDataContext(c => c.DataStore, (ProjectWizardPageModel m) => m.SupportedFrameworks);
-				frameworkCheckBoxes.ItemTextBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Text);
-				frameworkCheckBoxes.ItemKeyBinding = Binding.Property((ProjectWizardPageModel.FrameworkInfo i) => i.Value);
-				frameworkCheckBoxes.SelectedValuesBinding.BindDataContext((ProjectWizardPageModel m) => m.SelectedFrameworks);
-				*/
-
-				content.AddRow(HeadingLabel("Framework:"), frameworkDropDown);
-			}
 
 			if (model.SupportsProjectType)
 			{

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/.template.config/template.json
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/.template.config/template.json
@@ -84,8 +84,16 @@
 					"description": ".NET Core 3.1"
 				},
 				{
+					"choice": "net48",
+					"description": ".NET Framework 4.8"
+				},
+				{
+					"choice": "net472",
+					"description": ".NET Framework 4.7.2"
+				},
+				{
 					"choice": "net462",
-					"description": ".NET Framework 4.6.2 / Mono"
+					"description": ".NET Framework 4.6.2"
 				}
 			]
 		},

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/.template.config/template.json
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/.template.config/template.json
@@ -109,8 +109,16 @@
 					"description": ".NET Core 3.1"
 				},
 				{
+					"choice": "net48",
+					"description": ".NET Framework 4.8"
+				},
+				{
+					"choice": "net472",
+					"description": ".NET Framework 4.7.2"
+				},
+				{
 					"choice": "net462",
-					"description": ".NET Framework 4.6.2 / Mono"
+					"description": ".NET Framework 4.6.2"
 				}
 			]
 		},


### PR DESCRIPTION
This adds a few more options for frameworks, .NET 4.7.2 and 4.8, and hide the UI to create separate vs. combined projects when not applicable.