### PR TITLE
Mac: Drawable.CanFocus should enable first mouse down event

### DIFF
--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -62,14 +62,20 @@ namespace Eto.Mac.Forms.Controls
 
 			public bool CanFocus { get; set; }
 
-			public override bool AcceptsFirstResponder()
-			{
-				return CanFocus;
-			}
+			public override bool AcceptsFirstResponder() => CanFocus;
 
-			public override bool AcceptsFirstMouse(NSEvent theEvent)
+			public override bool AcceptsFirstMouse(NSEvent theEvent) => CanFocus || base.AcceptsFirstMouse(theEvent);
+
+			public override NSView HitTest(CGPoint aPoint)
 			{
-				return CanFocus;
+				var view = base.HitTest(aPoint);
+				if (view == ContentView)
+				{
+					// forward all events to this view, not the content view (which covers the drawable)
+					// the properly enables AcceptsFirstMouse above, since the ContentView returns false
+					return this;
+				}
+				return view;
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/MacEventView.cs
+++ b/src/Eto.Mac/Forms/Controls/MacEventView.cs
@@ -157,6 +157,12 @@ namespace Eto.Mac.Forms.Controls
 				AddCursorRect(new CGRect(CGPoint.Empty, Frame.Size), cursor.ControlObject as NSCursor);
 			}
 		}
+
+		public override bool AcceptsFirstMouse(NSEvent theEvent)
+		{
+			return Handler?.OnAcceptsFirstMouse(theEvent) ?? base.AcceptsFirstMouse(theEvent);
+		}
+
 	}
 }
 

--- a/src/Eto.WinForms/Forms/FormHandler.cs
+++ b/src/Eto.WinForms/Forms/FormHandler.cs
@@ -143,17 +143,6 @@ namespace Eto.WinForms.Forms
 			Control.Show();
 		}
 
-		public override bool ShowInTaskbar
-		{
-			get { return base.ShowInTaskbar; }
-			set
-			{
-				base.ShowInTaskbar = value;
-				if (Control is EtoForm etoForm)
-					etoForm.HideFromAltTab = !value;
-			}
-		}
-
 		public Color TransparencyKey
 		{
 			get { return Control.TransparencyKey.ToEto(); }

--- a/test/Eto.Test/UnitTests/Forms/Controls/DrawableTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/DrawableTests.cs
@@ -1,0 +1,46 @@
+using Eto.Drawing;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	[TestFixture]
+    public class DrawableTests : TestBase
+    {
+		[Test, ManualTest]
+		public void DrawableWithCanFocusShouldGetFirstMouseDownOnInactiveWindow()
+		{
+			bool wasClicked = false;
+			bool gotFocusBeforeClick = false;
+			Form(form => {
+			
+				var drawable = new Drawable();
+				var font = SystemFonts.Default();
+				drawable.Paint += (sender, e) => {
+					e.Graphics.FillRectangle(Colors.Blue, 0, 0, drawable.Width, drawable.Height);
+					e.Graphics.DrawText(font, SystemColors.ControlText, 0, 0, "Clicking once on this control should close the form");
+				};
+				drawable.Size = new Size(350, 200);
+				drawable.CanFocus = true;
+				drawable.MouseDown += (sender, e) => {
+					wasClicked = true;
+					form.Close();
+				};
+				form.Content = drawable;
+				form.GotFocus += (sender, e) => {
+					Application.Instance.AsyncInvoke(() => {
+						if (!wasClicked)
+							gotFocusBeforeClick = true;
+					});
+				};
+
+				form.ShowActivated = false;
+				form.Owner = Application.Instance.MainForm;
+			}, -1);
+
+			Assert.IsTrue(wasClicked, "#1 Drawable didn't get clicked");
+			Assert.IsFalse(gotFocusBeforeClick, "#2 Form should not have got focus before MouseDown event");
+		}
+        
+    }
+}


### PR DESCRIPTION
- When a window is not active, the CanFocus property should allow a Drawable to get a MouseDown event when clicked, even when the window is inactive.
- Added ability to override AcceptsFirstMouse behaviour for layouts with the MacView.AcceptsFirstMouse event.