### PR TITLE
Mac Big Sur updates

### DIFF
--- a/src/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
@@ -64,16 +64,22 @@ namespace Eto.Mac.Forms.Controls
 		public override CGRect DrawingRectForBounds(CGRect theRect)
 		{
 			var rect = base.DrawingRectForBounds(theRect);
-			rect.Y += ButtonOffset;
-			rect.Y += Offset;
+			if (!MacVersion.IsAtLeast(10, 16)) // big sur
+			{
+				rect.Y += ButtonOffset;
+				rect.Y += Offset;
+			}
 			return rect;
 		}
 
 		public override CGRect TitleRectForBounds(CGRect theRect)
 		{
 			var rect = base.TitleRectForBounds(theRect);
-			rect.Y -= ButtonOffset;
-			rect.Y -= Offset;
+			if (!MacVersion.IsAtLeast(10, 16)) // big sur
+			{
+				rect.Y -= ButtonOffset;
+				rect.Y -= Offset;
+			}
 			return rect;
 		}
 	}

--- a/src/Eto.Mac/build/BundleDotNetCore.targets
+++ b/src/Eto.Mac/build/BundleDotNetCore.targets
@@ -8,6 +8,7 @@
     <MacAutoPublishBundle Condition="$(MacAutoPublishBundle) == ''">True</MacAutoPublishBundle>
     
     <!-- Set to True to bundle .NET Core runtime, false to use a shared runtime (useful to speed up debug builds) -->
+    <MacBundleDotNet Condition="$(MacBundleDotNet) == '' AND $(SelfContained) == 'True'">True</MacBundleDotNet>
     <MacBundleDotNet Condition="$(MacBundleDotNet) == '' AND $(Configuration) == 'Release'">True</MacBundleDotNet>
     <MacBundleDotNet Condition="$(MacBundleDotNet) == ''">False</MacBundleDotNet>
   </PropertyGroup>
@@ -41,7 +42,7 @@
       <MacBuildProperties>$(MacBuildProperties);MacSelfContained=$(MacBundleDotNet)</MacBuildProperties>
       <MacBuildProperties>$(MacBuildProperties);MacTempBuildPath=$(MacTempBuildPath)</MacBuildProperties>
       <MacBuildProperties>$(MacBuildProperties);MacOutputPath=$(OutputPath)</MacBuildProperties>
-      <MacBuildProperties Condition="@(MacBundleRuntimeIdentifiers->Count()) > 1">$(MacBuildProperties);MacAppendRuntimeIdentifierToOutputPath=True</MacBuildProperties>
+      <MacBuildProperties Condition="@(MacBundleRuntimeIdentifiers->Count()) > 1 AND $(RuntimeIdentifier) == ''">$(MacBuildProperties);MacAppendRuntimeIdentifierToOutputPath=True</MacBuildProperties>
 
       <_MacPublishTarget Condition="$(MacBundleDotNet) == 'True'">Publish</_MacPublishTarget>
       <_MacPublishTarget Condition="$(_MacPublishTarget) == ''">Build</_MacPublishTarget>

--- a/src/Eto.Mac/build/BundleMono.targets
+++ b/src/Eto.Mac/build/BundleMono.targets
@@ -10,7 +10,7 @@
     <MkBundleTargetServer Condition="$(MkBundleTargetServer) == '' AND $(MacBundleTarget) == ''">http://pages.picoe.ca/runtimes/</MkBundleTargetServer>
 
     <!-- Target when bundling mono, or 'default' to use system mono.  See mkbundle -list-targets -->
-    <MacBundleTarget Condition="$(MacBundleTarget) == ''">mono-6.8.0-osx-10.9-x64-eto.zip</MacBundleTarget>
+    <MacBundleTarget Condition="$(MacBundleTarget) == ''">mono-6.12.0-osx-10.9-x64-eto.zip</MacBundleTarget>
 
     <!-- minimum installed version of mono required to run -->
     <MacMonoMinimumVersion Condition="$(MacMonoMinimumVersion) == ''">6.0</MacMonoMinimumVersion>

--- a/src/Eto.Mac/build/Mac.targets
+++ b/src/Eto.Mac/build/Mac.targets
@@ -44,7 +44,7 @@
 
   <PropertyGroup>
     <!-- internal properties -->
-    <MacUseDotNetCore Condition="$(MacUseDotNetCore) == '' AND ( $(TargetFramework.StartsWith('netcoreapp')) OR $(TargetFramework.StartsWith('net5')) )">True</MacUseDotNetCore>
+    <MacUseDotNetCore Condition="$(MacUseDotNetCore) == '' AND !$(TargetFramework.StartsWith('net4'))">True</MacUseDotNetCore>
     <MacUseDotNetCore Condition="$(MacUseDotNetCore) == ''">False</MacUseDotNetCore>
     <OutputContents>$(OutputAppPath)Contents\</OutputContents>
     <OutputResourcesPath>$(OutputContents)Resources\</OutputResourcesPath>

--- a/src/Eto/Info.plist
+++ b/src/Eto/Info.plist
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>MinimumOSVersion</key>
-	<string>3.0</string>
-</dict>
-</plist>


### PR DESCRIPTION
- Fix position of checkbox/radio button when font is larger
- Bundling mono now runs on Big Sur
- When building a project with a specific RID, it no longer adds the RID to the path twice for the output of the .app bundle
- MacBundleDotNet now will use the SelfContained property if set to true
- Properly bundle apps when using .NET 6.0 preview builds