### PR TITLE
Gtk: Fix Window.LogicalPixelSize on high DPI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ jobs:
     - name: Setup msbuild
       uses: microsoft/setup-msbuild@v1
 
+    - name: Clear package cache # workaround for actions/setup-dotnet#155
+      run: dotnet nuget locals all --clear
+
     - name: Build
       run: dotnet build ${{ env.BuildParameters }} /p:Platform=Windows /t:Package /bl:artifacts/log/Build.Windows.binlog
 

--- a/src/Eto.Gtk/Forms/GtkWindow.cs
+++ b/src/Eto.Gtk/Forms/GtkWindow.cs
@@ -726,6 +726,15 @@ namespace Eto.GtkSharp.Forms
 		{
 			get
 			{
+#if GTKCORE
+				var screen = Control.Screen;
+				var gdkWindow = Control.GetWindow();
+				if (screen != null && gdkWindow != null)
+				{
+					var monitor = screen.Display.GetMonitorAtWindow(gdkWindow);
+					return monitor?.ScaleFactor ?? 1f;
+				}
+#endif
 				return 1f;
 			}
 		}


### PR DESCRIPTION
This fixes showing the Eto.Veldrid viewport in the correct size with high DPI enabled on linux.  See https://github.com/picoe/Eto.Veldrid/issues/22.


