### PR TITLE
Add GridColumn Expand, Min/MaxWidth, and HeaderTextAlignment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,9 +31,6 @@ jobs:
     - name: Setup msbuild
       uses: microsoft/setup-msbuild@v1
 
-    - name: Clear package cache # workaround for actions/setup-dotnet#155
-      run: dotnet nuget locals all --clear
-
     - name: Build
       run: dotnet build ${{ env.BuildParameters }} /p:Platform=Windows /t:Package /bl:artifacts/log/Build.Windows.binlog
 

--- a/nuget.config
+++ b/nuget.config
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <!--To inherit the global NuGet package sources remove the <clear/> line below -->
+    <clear />
+    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+  </packageSources>
+</configuration>

--- a/src/Eto.Gtk/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridColumnHandler.cs
@@ -96,8 +96,8 @@ namespace Eto.GtkSharp.Forms.Controls
 		public int Width
 		{
 			get { return Control.Width; }
-			set 
-			{ 
+			set
+			{
 				autoSize = value == -1;
 				Control.FixedWidth = value;
 				Control.Sizing = autoSize ? Gtk.TreeViewColumnSizing.GrowOnly : Gtk.TreeViewColumnSizing.Fixed;
@@ -182,6 +182,19 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			get { return Control; }
 		}
+
+		public bool Expand
+		{
+			get => Control.Expand;
+			set => Control.Expand = value;
+		}
+		public TextAlignment HeaderTextAlignment
+		{
+			get => GtkConversions.ToEtoAlignment(Control.Alignment);
+			set => Control.Alignment = value.ToAlignment();
+		}
+		public int MinWidth { get => Control.MinWidth; set => Control.MinWidth = value; }
+		public int MaxWidth { get => Control.MaxWidth; set => Control.MaxWidth = value; }
 	}
 }
 

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -34,11 +34,56 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public override Gtk.Widget DragControl => Tree;
 
+		class EtoScrolledWindow : Gtk.ScrolledWindow
+		{
+			WeakReference handler;
+			public IGtkControl Handler { get => handler?.Target as IGtkControl; set => handler = new WeakReference(value); }
+
+#if GTKCORE			
+
+			protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)
+			{
+				base.OnGetPreferredWidth(out minimum_width, out natural_width);
+
+				var h = Handler;
+				if (h != null)
+				{
+					var size = h.UserPreferredSize;
+					if (size.Width >= 0)
+					{
+						natural_width = Math.Min(size.Width, natural_width);
+						minimum_width = Math.Min(size.Width, minimum_width);
+					}
+				}
+			}
+
+			protected override void OnGetPreferredHeight(out int minimum_height, out int natural_height)
+			{
+				base.OnGetPreferredHeight(out minimum_height, out natural_height);
+				var h = Handler;
+				if (h != null)
+				{
+					var size = h.UserPreferredSize;
+					if (size.Height >= 0)
+					{
+						natural_height = Math.Min(size.Height, natural_height);
+						minimum_height = Math.Min(size.Height, minimum_height);
+					}
+				}
+			}
+#endif
+		}
+
 		protected GridHandler()
 		{
-			Control = new Gtk.ScrolledWindow
+			Control = new EtoScrolledWindow
 			{
-				ShadowType = Gtk.ShadowType.In
+				Handler = this,
+				ShadowType = Gtk.ShadowType.In,
+#if GTKCORE
+				PropagateNaturalHeight = true,
+				PropagateNaturalWidth = true
+#endif
 			};
 		}
 

--- a/src/Eto.Gtk/GtkConversions.cs
+++ b/src/Eto.Gtk/GtkConversions.cs
@@ -691,6 +691,17 @@ namespace Eto.GtkSharp
 			}
 		}
 
+		public static TextAlignment ToEtoAlignment(float align)
+		{
+			if (align == 0f)
+				return TextAlignment.Left;
+			else if (align == 0.5f)
+				return TextAlignment.Center;
+			else if (align == 1f)
+				return TextAlignment.Right;
+			return TextAlignment.Left;
+		}
+
 		public static float ToAlignment(this TextAlignment alignment)
 		{
 			switch (alignment)

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -135,7 +135,7 @@ namespace Eto.Mac.Forms.Controls
 				FocusRingType = NSFocusRingType.None;
 				DataSource = new EtoTableViewDataSource { Handler = handler };
 				Delegate = new EtoTableDelegate { Handler = handler };
-				ColumnAutoresizingStyle = NSTableViewColumnAutoresizingStyle.None;
+				ColumnAutoresizingStyle = NSTableViewColumnAutoresizingStyle.Uniform;
 				SetDraggingSourceOperationMask(NSDragOperation.All, true);
 				SetDraggingSourceOperationMask(NSDragOperation.All, false);
 			}
@@ -416,16 +416,7 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void ColumnDidResize(NSNotification notification)
 			{
-				if (!Handler.IsAutoSizingColumns)
-				{
-					// when the user resizes the column, don't autosize anymore when data/scroll changes
-					var column = notification.UserInfo["NSTableColumn"] as NSTableColumn;
-					if (column != null)
-					{
-						var colHandler = Handler.GetColumn(column);
-						colHandler.AutoSize = false;
-					}
-				}
+				Handler?.ColumnDidResize(notification);
 			}
 
 			public override NSView GetViewForItem(NSTableView tableView, NSTableColumn tableColumn, nint row)

--- a/src/Eto.WinForms/Forms/Controls/GridHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridHandler.cs
@@ -20,8 +20,8 @@ namespace Eto.WinForms.Forms.Controls
 	}
 
 	public abstract class GridHandler<TWidget, TCallback> : WindowsControl<swf.DataGridView, TWidget, TCallback>, Grid.IHandler, IGridHandler
-		where TWidget: Grid
-		where TCallback: Grid.ICallback
+		where TWidget : Grid
+		where TCallback : Grid.ICallback
 	{
 		ColumnCollection columns;
 		bool isFirstSelection = true;
@@ -42,16 +42,51 @@ namespace Eto.WinForms.Forms.Controls
 
 			public EtoDataGridView() { DoubleBuffered = true; }
 
+			sd.Size GetSizeWithData(sd.Size proposedSize)
+			{
+				int width = RowHeadersWidth;
+				int height = 0;
+				if (ColumnHeadersVisible)
+					height += ColumnHeadersHeight;
+
+				if (BorderStyle == swf.BorderStyle.Fixed3D)
+				{
+					width += 4;
+					height += 4;
+				}
+				else if (BorderStyle == swf.BorderStyle.FixedSingle)
+				{
+					width += 2;
+					height += 2;
+				}
+
+				height += RowCount * (RowTemplate.Height + RowTemplate.DividerHeight);
+
+				for (int i = 0; i < ColumnCount; i++)
+				{
+					var col = Columns[i];
+					if (col.Visible)
+					{
+						width += col.GetPreferredWidth(swf.DataGridViewAutoSizeColumnMode.DisplayedCells, true);
+					}
+				}
+
+				if (proposedSize.Height > 0 && proposedSize.Height < height)
+					width += swf.SystemInformation.VerticalScrollBarWidth;
+
+				return new sd.Size(width, height);
+			}
+
 			public override sd.Size GetPreferredSize(sd.Size proposedSize)
 			{
-				var size = base.GetPreferredSize(proposedSize);
+				var size = GetSizeWithData(proposedSize);
+
 				var def = Handler.UserPreferredSize;
 				if (def.Width >= 0)
 					size.Width = def.Width;
 				if (def.Height >= 0)
 					size.Height = def.Height;
-				else
-					size.Height = Math.Min(size.Height, 100);
+
 				return size;
 			}
 
@@ -134,8 +169,8 @@ namespace Eto.WinForms.Forms.Controls
 					}
 				}
 				else if (e.Modifiers == Keys.Control
-					&& hitTest.RowIndex >= 0 
-					&& Control.SelectedRows.Count == 1 
+					&& hitTest.RowIndex >= 0
+					&& Control.SelectedRows.Count == 1
 					&& Control.SelectedRows[0].Index == hitTest.RowIndex)
 				{
 					// don't allow user to deselect all items
@@ -390,7 +425,7 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			get { return Control.RowTemplate.Height; }
 			set
-			{ 
+			{
 				Control.RowTemplate.Height = value;
 				foreach (swf.DataGridViewRow row in Control.Rows)
 				{

--- a/src/Eto.WinForms/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/LabelHandler.cs
@@ -111,7 +111,7 @@ namespace Eto.WinForms.Forms.Controls
 				var bordersAndPadding = Padding.Size;
 				if (proposedSize.Width <= 1)
 					proposedSize.Width = int.MaxValue;
-				else if (Width > 1)
+				else if (IsHandleCreated && Width > 1)
 					proposedSize.Width = Width;
 
 				sd.SizeF size;

--- a/src/Eto.WinForms/Forms/Controls/TextStepperHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/TextStepperHandler.cs
@@ -17,9 +17,16 @@ namespace Eto.WinForms.Forms.Controls
 			public event EventHandler DownButtonClicked;
 			public event EventHandler UpButtonClicked;
 
+#if NETCOREAPP
+			static FieldInfo DefaultButtonsWidthField = typeof(swf.UpDownBase).GetField("_defaultButtonsWidth", BindingFlags.Static | BindingFlags.NonPublic);
+			static FieldInfo TextBoxField = typeof(swf.UpDownBase).GetField("_upDownEdit", BindingFlags.Instance | BindingFlags.NonPublic);
+			static FieldInfo UpDownButtonsField = typeof(swf.UpDownBase).GetField("_upDownButtons", BindingFlags.Instance | BindingFlags.NonPublic);
+#else
 			static FieldInfo DefaultButtonsWidthField = typeof(swf.UpDownBase).GetField("defaultButtonsWidth", BindingFlags.Static | BindingFlags.NonPublic);
 			static FieldInfo TextBoxField = typeof(swf.UpDownBase).GetField("upDownEdit", BindingFlags.Instance | BindingFlags.NonPublic);
 			static FieldInfo UpDownButtonsField = typeof(swf.UpDownBase).GetField("upDownButtons", BindingFlags.Instance | BindingFlags.NonPublic);
+#endif
+
 
 			public swf.TextBox TextBox => TextBoxField?.GetValue(this) as swf.TextBox;
 
@@ -59,7 +66,7 @@ namespace Eto.WinForms.Forms.Controls
 
 			protected override void OnLayout(swf.LayoutEventArgs e)
 			{
-				if (!UpDownButtons.Visible)
+				if (UpDownButtons != null && !UpDownButtons.Visible)
 				{
 					var oldVal = DefaultButtonsWidth;
 					DefaultButtonsWidth = 0;

--- a/src/Eto.WinForms/WinConversions.cs
+++ b/src/Eto.WinForms/WinConversions.cs
@@ -603,6 +603,47 @@ namespace Eto.WinForms
 			}
 		}
 
+		public static swf.DataGridViewContentAlignment ToSWFGridViewContentAlignment(this TextAlignment alignment, VerticalAlignment vertical = VerticalAlignment.Center)
+		{
+			switch (alignment)
+			{
+				default:
+				case TextAlignment.Left:
+					switch (vertical)
+					{
+						case VerticalAlignment.Top:
+							return swf.DataGridViewContentAlignment.TopLeft;	
+						default:
+						case VerticalAlignment.Center:
+							return swf.DataGridViewContentAlignment.MiddleLeft;	
+						case VerticalAlignment.Bottom:
+							return swf.DataGridViewContentAlignment.BottomLeft;	
+					}
+				case TextAlignment.Center:
+					switch (vertical)
+					{
+						case VerticalAlignment.Top:
+							return swf.DataGridViewContentAlignment.TopCenter;	
+						default:
+						case VerticalAlignment.Center:
+							return swf.DataGridViewContentAlignment.MiddleCenter;	
+						case VerticalAlignment.Bottom:
+							return swf.DataGridViewContentAlignment.BottomCenter;	
+					}
+				case TextAlignment.Right:
+					switch (vertical)
+					{
+						case VerticalAlignment.Top:
+							return swf.DataGridViewContentAlignment.TopRight;	
+						default:
+						case VerticalAlignment.Center:
+							return swf.DataGridViewContentAlignment.MiddleRight;	
+						case VerticalAlignment.Bottom:
+							return swf.DataGridViewContentAlignment.BottomRight;	
+					}
+			}
+		}
+
 		public static VerticalAlignment ToEtoVerticalAlignment(this swf.DataGridViewContentAlignment existing)
 		{
 			switch (existing)

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -13,6 +13,7 @@ using Eto.Wpf.Forms.Menu;
 using Eto.Drawing;
 using Eto.Wpf.Drawing;
 using Eto.Wpf.CustomControls.TreeGridView;
+using System.Windows;
 
 namespace Eto.Wpf.Forms.Controls
 {
@@ -277,6 +278,20 @@ namespace Eto.Wpf.Forms.Controls
 			//    the cell is selected.
 			HandleEvent(Eto.Forms.Control.MouseDownEvent);
 			HandleEvent(Eto.Forms.Control.MouseUpEvent);
+
+			Control.Loaded += Control_Loaded;
+		}
+
+		private void Control_Loaded(object sender, RoutedEventArgs e)
+		{
+			// expanded columns don't get autosized, so we flip to star width after they are auto sized.
+			foreach (var col in Widget.Columns)
+			{
+				if (col.Handler is IGridColumnHandler columnHandler)
+				{
+					columnHandler.OnLoad();
+				}
+			}
 		}
 
 		protected class ColumnCollection : EnumerableChangedHandler<GridColumn, GridColumnCollection>

--- a/src/Eto/Forms/Controls/GridColumn.cs
+++ b/src/Eto/Forms/Controls/GridColumn.cs
@@ -104,6 +104,49 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Gets or sets a value indicating whether this column should expand to fill the available space in the Grid
+		/// </summary>
+		/// <remarks>
+		/// If more than one column has this set, they will share the space evenly.
+		/// </remarks>
+		/// <value><c>true</c> to expand the column; otherwise, <c>false</c></value>
+		public bool Expand
+		{
+			get => Handler.Expand;
+			set => Handler.Expand = value;
+		}
+
+		/// <summary>
+		/// Gets or sets a value to specify the header text alignment for this column
+		/// </summary>
+		/// <value>TextAlignment for the column header</value>
+		public TextAlignment HeaderTextAlignment
+		{
+			get => Handler.HeaderTextAlignment;
+			set => Handler.HeaderTextAlignment = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the minimum width for the column
+		/// </summary>
+		/// <value>The column minimum width</value>
+		public int MinWidth
+		{
+			get => Handler.MinWidth;
+			set => Handler.MinWidth = value;
+		}
+
+		/// <summary>
+		/// Gets or sets the maximum width for the column
+		/// </summary>
+		/// <value>The column maximum width</value>
+		public int MaxWidth
+		{
+			get => Handler.MaxWidth;
+			set => Handler.MaxWidth = value;
+		}
+
+		/// <summary>
 		/// Handler interface for the <see cref="GridColumn"/>.
 		/// </summary>
 		public new interface IHandler : Widget.IHandler
@@ -159,6 +202,33 @@ namespace Eto.Forms
 			/// </summary>
 			/// <value><c>true</c> if visible; otherwise, <c>false</c>.</value>
 			bool Visible { get; set; }
+
+			/// <summary>
+			/// Gets or sets a value indicating whether this column should expand to fill the available space in the Grid
+			/// </summary>
+			/// <remarks>
+			/// If more than one column has this set, they will share the space evenly.
+			/// </remarks>
+			/// <value><c>true</c> to expand the column; otherwise, <c>false</c></value>
+			bool Expand { get; set; }
+
+			/// <summary>
+			/// Gets or sets a value to specify the header text alignment for this column
+			/// </summary>
+			/// <value>TextAlignment for the column header</value>
+			TextAlignment HeaderTextAlignment { get; set; }
+
+			/// <summary>
+			/// Gets or sets the minimum width for the column
+			/// </summary>
+			/// <value>The column minimum width</value>
+			int MinWidth { get; set; }
+
+			/// <summary>
+			/// Gets or sets the maximum width for the column
+			/// </summary>
+			/// <value>The column maximum width</value>
+			int MaxWidth { get; set; }
 		}
 	}
 }

--- a/test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -111,6 +111,7 @@ namespace Eto.Test.Sections.Controls
 			layout.AddSeparateRow(null,
 						ReloadDataButton(grid),
 						SetDataButton(grid),
+						SetTextBoxWidth(grid),
 						null
 					);
 			layout.AddSeparateRow(null,
@@ -127,15 +128,25 @@ namespace Eto.Test.Sections.Controls
 			return layout;
 		}
 
+		Control SetTextBoxWidth(GridView grid)
+		{
+			var button = new Button { Text = "Set TextBoxCell.Width" };
+			var textBoxCell = grid.Columns.FirstOrDefault(r => r.DataCell is TextBoxCell);
+			button.Click += (sender, e) => textBoxCell.Width = 100;
+			return button;
+		}
+
 		Control TextAlignmentDropDown(GridView grid)
 		{
 			var control = new EnumDropDown<TextAlignment>();
 
-			var textBoxCell = grid.Columns.Select(r => r.DataCell).OfType<TextBoxCell>().First();
-			control.SelectedValueBinding.Bind(textBoxCell, c => c.TextAlignment);
+			var textBoxCell = grid.Columns.Select(r => r.DataCell).OfType<TextBoxCell>().FirstOrDefault();
+			if (textBoxCell != null)
+				control.SelectedValueBinding.Bind(textBoxCell, c => c.TextAlignment);
 
-			var imageTextCell = grid.Columns.Select(r => r.DataCell).OfType<ImageTextCell>().First();
-			control.SelectedValueBinding.Bind(imageTextCell, c => c.TextAlignment);
+			var imageTextCell = grid.Columns.Select(r => r.DataCell).OfType<ImageTextCell>().FirstOrDefault();
+			if (imageTextCell != null)
+				control.SelectedValueBinding.Bind(imageTextCell, c => c.TextAlignment);
 			return control;
 		}
 
@@ -143,11 +154,13 @@ namespace Eto.Test.Sections.Controls
 		{
 			var control = new EnumDropDown<VerticalAlignment>();
 
-			var textBoxCell = grid.Columns.Select(r => r.DataCell).OfType<TextBoxCell>().First();
-			control.SelectedValueBinding.Bind(textBoxCell, c => c.VerticalAlignment);
+			var textBoxCell = grid.Columns.Select(r => r.DataCell).OfType<TextBoxCell>().FirstOrDefault();
+			if (textBoxCell != null)
+				control.SelectedValueBinding.Bind(textBoxCell, c => c.VerticalAlignment);
 
-			var imageTextCell = grid.Columns.Select(r => r.DataCell).OfType<ImageTextCell>().First();
-			control.SelectedValueBinding.Bind(imageTextCell, c => c.VerticalAlignment);
+			var imageTextCell = grid.Columns.Select(r => r.DataCell).OfType<ImageTextCell>().FirstOrDefault();
+			if (imageTextCell != null)
+				control.SelectedValueBinding.Bind(imageTextCell, c => c.VerticalAlignment);
 			return control;
 		}
 
@@ -155,11 +168,13 @@ namespace Eto.Test.Sections.Controls
 		{
 			var control = new EnumDropDown<AutoSelectMode>();
 
-			var textBoxCell = grid.Columns.Select(r => r.DataCell).OfType<TextBoxCell>().First();
-			control.SelectedValueBinding.Bind(textBoxCell, c => c.AutoSelectMode);
+			var textBoxCell = grid.Columns.Select(r => r.DataCell).OfType<TextBoxCell>().FirstOrDefault();
+			if (textBoxCell != null)
+				control.SelectedValueBinding.Bind(textBoxCell, c => c.AutoSelectMode);
 
-			var imageTextCell = grid.Columns.Select(r => r.DataCell).OfType<ImageTextCell>().First();
-			control.SelectedValueBinding.Bind(imageTextCell, c => c.AutoSelectMode);
+			var imageTextCell = grid.Columns.Select(r => r.DataCell).OfType<ImageTextCell>().FirstOrDefault();
+			if (imageTextCell != null)
+				control.SelectedValueBinding.Bind(imageTextCell, c => c.AutoSelectMode);
 			return control;
 		}
 

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
@@ -13,7 +13,7 @@ using System.Threading;
 namespace Eto.Test.UnitTests.Forms.Controls
 {
 	public abstract class GridTests<T> : TestBase
-		where T: Grid, new()
+		where T : Grid, new()
 	{
 		class GridTestItem : TreeGridItem
 		{
@@ -40,7 +40,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					if (!CustomCell.SupportsControlView)
 					{
 						cell.GetPreferredWidth = args => 100;
-						cell.Paint += (sender, e) => {
+						cell.Paint += (sender, e) =>
+						{
 							e.Graphics.DrawText(SystemFonts.Default(), Brushes.Black, e.ClipRectangle, "Cell", alignment: FormattedTextAlignment.Center);
 						};
 					}
@@ -61,7 +62,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 
 						// ugly, there should be a better way to do this..
 						var colorBinding = textBox.Bind(c => c.TextColor, args, Binding.Property((CellEventArgs a) => a.CellTextColor).Convert(c => args.IsEditing ? SystemColors.ControlText : c));
-						args.PropertyChanged += (sender, e) => {
+						args.PropertyChanged += (sender, e) =>
+						{
 							if (e.PropertyName == nameof(CellEventArgs.IsEditing))
 								colorBinding.Update();
 						};
@@ -81,7 +83,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				var customCell2 = new CustomCell();
 				customCell2.CreateCell = args =>
 				{
-					var dropDown = new DropDown { Items = { "Item 1", "Item 2", "Item 3" }};
+					var dropDown = new DropDown { Items = { "Item 1", "Item 2", "Item 3" } };
 
 					return dropDown;
 				};
@@ -100,7 +102,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 
 				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(nameof(GridTestItem.Text)), HeaderText = "TextBoxCell", Editable = true });
 
-				var list = new List<GridTestItem>();
+				var list = new TreeGridItemCollection();
 				list.Add(new GridTestItem { Text = "Item 1" });
 				list.Add(new GridTestItem { Text = "Item 2" });
 				list.Add(new GridTestItem { Text = "Item 3" });
@@ -108,19 +110,22 @@ namespace Eto.Test.UnitTests.Forms.Controls
 
 				// using MouseDown so the buttons don't get focus
 				var beginEditButton = new Button { Text = "BeginEdit" };
-				beginEditButton.MouseDown += (sender, e) => {
+				beginEditButton.MouseDown += (sender, e) =>
+				{
 					grid.BeginEdit(1, 0);
 					e.Handled = true;
 				};
 
 				var commitEditButton = new Button { Text = "CommitEdit" };
-				commitEditButton.MouseDown += (sender, e) => {
+				commitEditButton.MouseDown += (sender, e) =>
+				{
 					grid.CommitEdit();
 					e.Handled = true;
 				};
 
 				var cancelEditButton = new Button { Text = "CancelEdit" };
-				cancelEditButton.MouseDown += (sender, e) => {
+				cancelEditButton.MouseDown += (sender, e) =>
+				{
 					grid.CancelEdit();
 					e.Handled = true;
 				};
@@ -129,6 +134,135 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					TableLayout.Horizontal(4, beginEditButton, commitEditButton, cancelEditButton, null),
 					grid
 					);
+			});
+		}
+
+		IEnumerable<object> CreateDataStore()
+		{
+			var list = new TreeGridItemCollection();
+			for (int i = 0; i < 20; i++)
+			{
+				list.Add(new GridTestItem { Text = $"Item {i}", Values = new[] { $"col {i}.2", $"col {i}.3", $"col {i}.4" } });
+			}
+			return list;
+		}
+
+		[ManualTest]
+		[TestCase(0)]
+		[TestCase(1)]
+		[TestCase(2)]
+		public void ExpandedColumnShouldExpand(int columnToExpand)
+		{
+			ManualForm("First Column should be expanded, and change size with the Grid", form =>
+			{
+				var grid = new T();
+				SetDataStore(grid, CreateDataStore());
+
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell { Binding = Binding.Property((GridTestItem m) => m.Text) } });
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(0) });
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(1) });
+
+				var expandColumn = grid.Columns[columnToExpand];
+				expandColumn.HeaderText = "Expanded";
+				expandColumn.Expand = true;
+
+
+				return grid;
+			});
+		}
+
+		[ManualTest]
+		[TestCase(0)]
+		[TestCase(1)]
+		[TestCase(2)]
+		public void ExpandedColumnShouldAutoSize(int columnToExpand)
+		{
+			ManualForm("First Column should be expanded, and change size with the Grid", form =>
+			{
+				var grid = new T();
+				SetDataStore(grid, CreateDataStore());
+
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell { Binding = Binding.Property((GridTestItem m) => m.Text) } });
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(0) });
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(1) });
+
+				var expandColumn = grid.Columns[columnToExpand];
+				expandColumn.HeaderText = "Expanded";
+				expandColumn.Expand = true;
+
+				return TableLayout.AutoSized(grid);
+			});
+		}
+
+		[Test, ManualTest]
+		public void HeaderTextAlignmentShouldWork()
+		{
+			ManualForm("Check alignment for each header", form =>
+			{
+				var grid = new T();
+				grid.Height = 200;
+				SetDataStore(grid, CreateDataStore());
+
+				grid.Columns.Add(new GridColumn
+				{
+					DataCell = new TextBoxCell { Binding = Binding.Property((GridTestItem m) => m.Text) },
+					HeaderText = "Left Aligned",
+					Width = 200
+				});
+				grid.Columns.Add(new GridColumn
+				{
+					DataCell = new TextBoxCell(0),
+					HeaderText = "Also Left",
+					HeaderTextAlignment = TextAlignment.Left,
+					Width = 200
+				});
+				grid.Columns.Add(new GridColumn
+				{
+					DataCell = new TextBoxCell(1),
+					HeaderText = "Center",
+					HeaderTextAlignment = TextAlignment.Center,
+					Width = 200
+				});
+				grid.Columns.Add(new GridColumn
+				{
+					DataCell = new TextBoxCell(2),
+					HeaderText = "Right",
+					HeaderTextAlignment = TextAlignment.Right,
+					Width = 200
+				});
+
+				return grid;
+			});
+		}
+
+		[Test, ManualTest]
+		public void SettingWidthShouldDisableAutosize()
+		{
+			ManualForm("Width of column should be 300px and not change when scrolling",
+			form =>
+			{
+				var control = new T();
+				control.Width = 400;
+				control.Height = 200;
+				var column = new GridColumn
+				{
+					DataCell = new TextBoxCell(0),
+					AutoSize = true,
+					Width = 300, // setting width should set AutoSize to false
+					HeaderText = "Cell"
+				};
+				control.Columns.Add(column);
+
+				Assert.IsFalse(column.AutoSize, "#1");
+
+				var dd = new TreeGridItemCollection();
+				for (int i = 0; i < 1000; i++)
+				{
+					dd.Add(new TreeGridItem { Values = new[] { "Row " + i } });
+				}
+				SetDataStore(control, dd);
+
+				return control;
 			});
 		}
 
@@ -319,7 +453,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			protected override Control OnCreateCell(CellEventArgs args)
 			{
 				var label = new Label { Text = "Hello" };
-				
+
 				var button = new Button { MinimumSize = Size.Empty, Text = "..." };
 				button.Bind(c => c.Visible, args, a => a.IsSelected); // kaboom when reloading!
 
@@ -389,7 +523,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					HeaderText = "Text Cell"
 				});
 				control.DataStore = dd;
-				Application.Instance.AsyncInvoke(() => {
+				Application.Instance.AsyncInvoke(() =>
+				{
 					// can crash when had selection initially but no selection after.
 					try
 					{
@@ -407,36 +542,6 @@ namespace Eto.Test.UnitTests.Forms.Controls
 
 			if (exception != null)
 				ExceptionDispatchInfo.Capture(exception).Throw();
-		}
-
-		[Test, ManualTest]
-		public void SettingWidthShouldDisableAutosize()
-		{
-			ManualForm("Width of column should be 300px and not change when scrolling",
-			form => {
-				var control = new GridView();
-				control.Width = 400;
-				control.Height = 200;
-				var column = new GridColumn
-				{
-					DataCell = new TextBoxCell(0),
-					AutoSize = true,
-					Width = 300, // setting width should set AutoSize to false
-					HeaderText = "Cell"
-				};
-				control.Columns.Add(column);
-
-				Assert.IsFalse(column.AutoSize, "#1");
-
-				var dd = new List<GridItem>();
-				for (int i = 0; i < 1000; i++)
-				{
-					dd.Add(new GridItem { Values = new[] { "Row " + i } });
-				}
-				control.DataStore = dd;
-
-				return control;
-			});
 		}
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/Controls/TreeGridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TreeGridViewTests.cs
@@ -4,11 +4,12 @@ using Eto.Forms;
 using System.Linq;
 using Eto.Drawing;
 using System.Runtime.ExceptionServices;
+using System.Collections.Generic;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {
 	[TestFixture]
-	public class TreeGridViewTests : TestBase
+	public class TreeGridViewTests : GridTests<TreeGridView>
 	{
 		[Test]
 		public void SelectedItemsShouldNotCrash()
@@ -151,6 +152,11 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			if (exception != null)
 				ExceptionDispatchInfo.Capture(exception).Throw();
 
+		}
+
+		protected override void SetDataStore(TreeGridView grid, IEnumerable<object> dataStore)
+		{
+			grid.DataStore = (ITreeGridStore<ITreeGridItem>)dataStore;
 		}
 	}
 }


### PR DESCRIPTION
This adds new properties to `GridColumn`:
**Expand**: Sets that the column expands to the width of the grid.  Multiple columns share the space. Fixes #822. Fixes #718
**HeaderTextAlignment**: Sets the alignment of the header text. Fixes #819
**Min/MaxWidth**: Sets the minimum or maximum widths of each column

Also:
- Gtk/WinForms/Mac: Tree/GridView now can autosize to its content (Wpf already does)
- Mac: Fix showing expanders when TreeGridView is initially populated (in some but not all cases :/)
- WinForms: Fix initial label auto sizing
- WinForms: Fix TextStepper crashing on .NET 5
- CI: Better fix for nuget restore issue