### PR TITLE
Gtk: Add missing numpad keys to key mapping

### DIFF
--- a/src/Eto.Gtk/KeyMap.cs
+++ b/src/Eto.Gtk/KeyMap.cs
@@ -93,6 +93,18 @@ namespace Eto.GtkSharp
 			keymap.Add(Gdk.Key.F10, Keys.F10);
 			keymap.Add(Gdk.Key.F11, Keys.F11);
 			keymap.Add(Gdk.Key.F12, Keys.F12);
+			keymap.Add(Gdk.Key.F13, Keys.F13);
+			keymap.Add(Gdk.Key.F14, Keys.F14);
+			keymap.Add(Gdk.Key.F15, Keys.F15);
+			keymap.Add(Gdk.Key.F16, Keys.F16);
+			keymap.Add(Gdk.Key.F17, Keys.F17);
+			keymap.Add(Gdk.Key.F18, Keys.F18);
+			keymap.Add(Gdk.Key.F19, Keys.F19);
+			keymap.Add(Gdk.Key.F20, Keys.F20);
+			keymap.Add(Gdk.Key.F21, Keys.F21);
+			keymap.Add(Gdk.Key.F22, Keys.F22);
+			keymap.Add(Gdk.Key.F23, Keys.F23);
+			keymap.Add(Gdk.Key.F24, Keys.F24);
 			keymap.Add(Gdk.Key.Key_0, Keys.D0);
 			keymap.Add(Gdk.Key.Key_1, Keys.D1);
 			keymap.Add(Gdk.Key.Key_2, Keys.D2);
@@ -132,11 +144,10 @@ namespace Eto.GtkSharp
 			keymap.Add(Gdk.Key.Help, Keys.Help);
 			keymap.Add(Gdk.Key.Pause, Keys.Pause);
 			keymap.Add(Gdk.Key.Clear, Keys.Clear);
-			keymap.Add(Gdk.Key.KP_Equal, Keys.KeypadEqual);
+			keymap.Add(Gdk.Key.equal, Keys.Equal);
 			//keymap.Add(Gdk.Key.Alt_R, Keys.Menu);
 			//keymap.Add(Gdk.Key.Alt_L, Keys.Menu);
 			keymap.Add(Gdk.Key.backslash, Keys.Backslash);
-			keymap.Add(Gdk.Key.equal, Keys.Equal);
 			keymap.Add(Gdk.Key.semicolon, Keys.Semicolon);
 			keymap.Add(Gdk.Key.apostrophe, Keys.Quote);
 			keymap.Add(Gdk.Key.comma, Keys.Comma);
@@ -163,11 +174,22 @@ namespace Eto.GtkSharp
 			keymap.Add(Gdk.Key.Alt_R, Keys.RightAlt);
 			keymap.Add(Gdk.Key.Meta_L, Keys.LeftApplication);
 			keymap.Add(Gdk.Key.Meta_R, Keys.RightApplication);
+			keymap.Add(Gdk.Key.KP_Enter, Keys.Enter);
+			keymap.Add(Gdk.Key.KP_Up, Keys.Up);
+			keymap.Add(Gdk.Key.KP_Down, Keys.Down);
+			keymap.Add(Gdk.Key.KP_Left, Keys.Left);
+			keymap.Add(Gdk.Key.KP_Right, Keys.Right);
+			keymap.Add(Gdk.Key.KP_Page_Down, Keys.PageDown);
+			keymap.Add(Gdk.Key.KP_Page_Up, Keys.PageUp);
+			keymap.Add(Gdk.Key.KP_Home, Keys.Home);
+			keymap.Add(Gdk.Key.KP_End, Keys.End);
+			keymap.Add(Gdk.Key.KP_Insert, Keys.Insert);
+			keymap.Add(Gdk.Key.KP_Equal, Keys.Equal);
+			keymap.Add(Gdk.Key.KP_Delete, Keys.Delete);
 
 			if (EtoEnvironment.Platform.IsMac)
 			{
 				// os x
-				keymap.Add(Gdk.Key.KP_Enter, Keys.Insert);
 				keymap.Add((Gdk.Key)0x1000010, Keys.ContextMenu);
 			}
 			keymap.Add(Gdk.Key.a, Keys.A);

--- a/src/Eto.Gtk/NativeMethods.cs
+++ b/src/Eto.Gtk/NativeMethods.cs
@@ -1,11 +1,4 @@
 ﻿
-
-
-
-
-
-
-
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -22,7 +15,6 @@ namespace Eto.GtkSharp
 		const string ver = "3";
 #endif
 
-
 		static class NMWindows
 		{
 #if GTK2
@@ -37,228 +29,168 @@ namespace Eto.GtkSharp
 			const string libpango = "libpango-" + plat + ver + ext;
 			const string libwebkit = "libwebkit2gtk-4.0.so.37";
 
-
 			[DllImport(libgobject, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void g_signal_stop_emission_by_name(IntPtr instance, string name);
-
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_new();
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_uri(IntPtr web_view, string uri);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_uri(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_html(IntPtr web_view, string content, string base_uri);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_title(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_reload(IntPtr web_view);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_stop_loading(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_back(IntPtr web_view);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_back(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_forward(IntPtr web_view);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_forward(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_run_javascript(IntPtr web_view, string script, IntPtr cancellable, Delegate callback, IntPtr user_data);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_run_javascript_finish(IntPtr web_view, IntPtr result, IntPtr error);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_global_context(IntPtr js_result);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_value(IntPtr js_result);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr JSValueToStringCopy(IntPtr context, IntPtr value, IntPtr idk);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static int JSStringGetMaximumUTF8CStringSize(IntPtr js_str_value);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringGetUTF8CString(IntPtr js_str_value, IntPtr str_value, int str_length);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringRelease(IntPtr js_str_value);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_navigation_policy_decision_get_request(IntPtr decision);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_uri_request_get_uri(IntPtr request);
 
-
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_clipboard_wait_for_targets(IntPtr cp, out IntPtr atoms, out int number);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_entry_set_placeholder_text(IntPtr entry, string text);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_print_settings_get_page_ranges(IntPtr handle, out int num_ranges);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_color_chooser_dialog_new(string title, IntPtr parent);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_get_rgba(IntPtr chooser, out RGBA color);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_rgba(IntPtr chooser, double[] color);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_use_alpha(IntPtr chooser, bool use_alpha);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_color_chooser_get_use_alpha(IntPtr chooser);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_dialog_new(string title, IntPtr parent);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_get_font(IntPtr fontchooser);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_font_chooser_set_font(IntPtr fontchooser, string fontname);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr g_file_new_for_path(string path);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_app_chooser_dialog_new(IntPtr parrent, int flags, IntPtr file);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_application_prefers_app_menu(IntPtr application);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_header_bar_new();
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_window_set_titlebar(IntPtr window, IntPtr widget);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_start(IntPtr bar, IntPtr child);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_end(IntPtr bar, IntPtr child);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_set_show_close_button(IntPtr bar, bool setting);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_selection_data_get_uris(IntPtr raw);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_selection_data_set_uris(IntPtr raw, IntPtr[] uris);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_print_unix_dialog_get_embed_page_setup(IntPtr raw);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_button_get_event_window(IntPtr button);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_major_version();
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_minor_version();
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_micro_version();
 
-
-
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
-
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_get_default_root_window();
 
-
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
 
-
-
 			[DllImport(libpango, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool pango_font_has_char(IntPtr font, int wc);
-
 		}
-
 
 		static class NMLinux
 		{
@@ -274,228 +206,168 @@ namespace Eto.GtkSharp
 			const string libpango = "libpango-" + plat + ver + ext;
 			const string libwebkit = "libwebkit2gtk-4.0.so.37";
 
-
 			[DllImport(libgobject, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void g_signal_stop_emission_by_name(IntPtr instance, string name);
-
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_new();
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_uri(IntPtr web_view, string uri);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_uri(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_html(IntPtr web_view, string content, string base_uri);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_title(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_reload(IntPtr web_view);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_stop_loading(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_back(IntPtr web_view);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_back(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_forward(IntPtr web_view);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_forward(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_run_javascript(IntPtr web_view, string script, IntPtr cancellable, Delegate callback, IntPtr user_data);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_run_javascript_finish(IntPtr web_view, IntPtr result, IntPtr error);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_global_context(IntPtr js_result);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_value(IntPtr js_result);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr JSValueToStringCopy(IntPtr context, IntPtr value, IntPtr idk);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static int JSStringGetMaximumUTF8CStringSize(IntPtr js_str_value);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringGetUTF8CString(IntPtr js_str_value, IntPtr str_value, int str_length);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringRelease(IntPtr js_str_value);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_navigation_policy_decision_get_request(IntPtr decision);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_uri_request_get_uri(IntPtr request);
 
-
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_clipboard_wait_for_targets(IntPtr cp, out IntPtr atoms, out int number);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_entry_set_placeholder_text(IntPtr entry, string text);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_print_settings_get_page_ranges(IntPtr handle, out int num_ranges);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_color_chooser_dialog_new(string title, IntPtr parent);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_get_rgba(IntPtr chooser, out RGBA color);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_rgba(IntPtr chooser, double[] color);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_use_alpha(IntPtr chooser, bool use_alpha);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_color_chooser_get_use_alpha(IntPtr chooser);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_dialog_new(string title, IntPtr parent);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_get_font(IntPtr fontchooser);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_font_chooser_set_font(IntPtr fontchooser, string fontname);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr g_file_new_for_path(string path);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_app_chooser_dialog_new(IntPtr parrent, int flags, IntPtr file);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_application_prefers_app_menu(IntPtr application);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_header_bar_new();
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_window_set_titlebar(IntPtr window, IntPtr widget);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_start(IntPtr bar, IntPtr child);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_end(IntPtr bar, IntPtr child);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_set_show_close_button(IntPtr bar, bool setting);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_selection_data_get_uris(IntPtr raw);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_selection_data_set_uris(IntPtr raw, IntPtr[] uris);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_print_unix_dialog_get_embed_page_setup(IntPtr raw);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_button_get_event_window(IntPtr button);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_major_version();
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_minor_version();
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_micro_version();
 
-
-
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
-
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_get_default_root_window();
 
-
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
 
-
-
 			[DllImport(libpango, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool pango_font_has_char(IntPtr font, int wc);
-
 		}
-
 
 		static class NMMac
 		{
@@ -511,228 +383,168 @@ namespace Eto.GtkSharp
 			const string libpango = "libpango-" + plat + ver + ext;
 			const string libwebkit = "libwebkit2gtk-4.0.so.37";
 
-
 			[DllImport(libgobject, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void g_signal_stop_emission_by_name(IntPtr instance, string name);
-
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_new();
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_uri(IntPtr web_view, string uri);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_uri(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_load_html(IntPtr web_view, string content, string base_uri);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_get_title(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_reload(IntPtr web_view);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_stop_loading(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_back(IntPtr web_view);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_back(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool webkit_web_view_can_go_forward(IntPtr web_view);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_go_forward(IntPtr web_view);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void webkit_web_view_run_javascript(IntPtr web_view, string script, IntPtr cancellable, Delegate callback, IntPtr user_data);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_web_view_run_javascript_finish(IntPtr web_view, IntPtr result, IntPtr error);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_global_context(IntPtr js_result);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_javascript_result_get_value(IntPtr js_result);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr JSValueToStringCopy(IntPtr context, IntPtr value, IntPtr idk);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static int JSStringGetMaximumUTF8CStringSize(IntPtr js_str_value);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringGetUTF8CString(IntPtr js_str_value, IntPtr str_value, int str_length);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void JSStringRelease(IntPtr js_str_value);
 
-
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_navigation_policy_decision_get_request(IntPtr decision);
-
 
 			[DllImport(libwebkit, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr webkit_uri_request_get_uri(IntPtr request);
 
-
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_clipboard_wait_for_targets(IntPtr cp, out IntPtr atoms, out int number);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_entry_set_placeholder_text(IntPtr entry, string text);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_print_settings_get_page_ranges(IntPtr handle, out int num_ranges);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_color_chooser_dialog_new(string title, IntPtr parent);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_get_rgba(IntPtr chooser, out RGBA color);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_rgba(IntPtr chooser, double[] color);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_color_chooser_set_use_alpha(IntPtr chooser, bool use_alpha);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_color_chooser_get_use_alpha(IntPtr chooser);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_dialog_new(string title, IntPtr parent);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_font_chooser_get_font(IntPtr fontchooser);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_font_chooser_set_font(IntPtr fontchooser, string fontname);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr g_file_new_for_path(string path);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_app_chooser_dialog_new(IntPtr parrent, int flags, IntPtr file);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_application_prefers_app_menu(IntPtr application);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_header_bar_new();
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_window_set_titlebar(IntPtr window, IntPtr widget);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_start(IntPtr bar, IntPtr child);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_pack_end(IntPtr bar, IntPtr child);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_header_bar_set_show_close_button(IntPtr bar, bool setting);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_selection_data_get_uris(IntPtr raw);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_selection_data_set_uris(IntPtr raw, IntPtr[] uris);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gtk_print_unix_dialog_get_embed_page_setup(IntPtr raw);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top);
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gtk_button_get_event_window(IntPtr button);
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_major_version();
 
-
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_minor_version();
-
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_micro_version();
 
-
-
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
-
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_get_default_root_window();
 
-
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
 
-
-
 			[DllImport(libpango, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool pango_font_has_char(IntPtr font, int wc);
-
 		}
-
 
 		public static string GetString(IntPtr handle)
 		{
@@ -748,10 +560,8 @@ namespace Eto.GtkSharp
 			return Encoding.UTF8.GetString(bytes);
 		}
 
-
 		public static void g_signal_stop_emission_by_name(IntPtr instance, string name)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.g_signal_stop_emission_by_name(instance, name);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -760,10 +570,8 @@ namespace Eto.GtkSharp
 				NMWindows.g_signal_stop_emission_by_name(instance, name);
 		}
 
-
 		public static bool gtk_clipboard_wait_for_targets(IntPtr cp, out IntPtr atoms, out int number)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_clipboard_wait_for_targets(cp, out atoms, out number);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -772,10 +580,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_clipboard_wait_for_targets(cp, out atoms, out number);
 		}
 
-
 		public static void gtk_entry_set_placeholder_text(IntPtr entry, string text)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_entry_set_placeholder_text(entry, text);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -784,10 +590,8 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_entry_set_placeholder_text(entry, text);
 		}
 
-
 		public static IntPtr gtk_print_settings_get_page_ranges(IntPtr handle, out int num_ranges)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_print_settings_get_page_ranges(handle, out num_ranges);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -796,10 +600,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_print_settings_get_page_ranges(handle, out num_ranges);
 		}
 
-
 		public static IntPtr gtk_color_chooser_dialog_new(string title, IntPtr parent)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_color_chooser_dialog_new(title, parent);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -808,10 +610,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_color_chooser_dialog_new(title, parent);
 		}
 
-
 		public static void gtk_color_chooser_get_rgba(IntPtr chooser, out RGBA color)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_color_chooser_get_rgba(chooser, out color);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -820,10 +620,8 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_color_chooser_get_rgba(chooser, out color);
 		}
 
-
 		public static void gtk_color_chooser_set_rgba(IntPtr chooser, double[] color)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_color_chooser_set_rgba(chooser, color);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -832,10 +630,8 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_color_chooser_set_rgba(chooser, color);
 		}
 
-
 		public static void gtk_color_chooser_set_use_alpha(IntPtr chooser, bool use_alpha)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_color_chooser_set_use_alpha(chooser, use_alpha);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -844,10 +640,8 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_color_chooser_set_use_alpha(chooser, use_alpha);
 		}
 
-
 		public static bool gtk_color_chooser_get_use_alpha(IntPtr chooser)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_color_chooser_get_use_alpha(chooser);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -856,10 +650,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_color_chooser_get_use_alpha(chooser);
 		}
 
-
 		public static IntPtr gtk_font_chooser_dialog_new(string title, IntPtr parent)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_font_chooser_dialog_new(title, parent);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -868,10 +660,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_font_chooser_dialog_new(title, parent);
 		}
 
-
 		public static string gtk_font_chooser_get_font(IntPtr fontchooser)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return GetString(NMLinux.gtk_font_chooser_get_font(fontchooser));
 			else if (EtoEnvironment.Platform.IsMac)
@@ -880,10 +670,8 @@ namespace Eto.GtkSharp
 				return GetString(NMWindows.gtk_font_chooser_get_font(fontchooser));
 		}
 
-
 		public static void gtk_font_chooser_set_font(IntPtr fontchooser, string fontname)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_font_chooser_set_font(fontchooser, fontname);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -892,10 +680,8 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_font_chooser_set_font(fontchooser, fontname);
 		}
 
-
 		public static IntPtr g_file_new_for_path(string path)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.g_file_new_for_path(path);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -904,10 +690,8 @@ namespace Eto.GtkSharp
 				return NMWindows.g_file_new_for_path(path);
 		}
 
-
 		public static IntPtr gtk_app_chooser_dialog_new(IntPtr parrent, int flags, IntPtr file)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_app_chooser_dialog_new(parrent, flags, file);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -916,10 +700,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_app_chooser_dialog_new(parrent, flags, file);
 		}
 
-
 		public static bool gtk_application_prefers_app_menu(IntPtr application)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_application_prefers_app_menu(application);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -928,10 +710,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_application_prefers_app_menu(application);
 		}
 
-
 		public static IntPtr gtk_header_bar_new()
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_header_bar_new();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -940,10 +720,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_header_bar_new();
 		}
 
-
 		public static void gtk_window_set_titlebar(IntPtr window, IntPtr widget)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_window_set_titlebar(window, widget);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -952,10 +730,8 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_window_set_titlebar(window, widget);
 		}
 
-
 		public static void gtk_header_bar_pack_start(IntPtr bar, IntPtr child)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_header_bar_pack_start(bar, child);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -964,10 +740,8 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_header_bar_pack_start(bar, child);
 		}
 
-
 		public static void gtk_header_bar_pack_end(IntPtr bar, IntPtr child)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_header_bar_pack_end(bar, child);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -976,10 +750,8 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_header_bar_pack_end(bar, child);
 		}
 
-
 		public static void gtk_header_bar_set_show_close_button(IntPtr bar, bool setting)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_header_bar_set_show_close_button(bar, setting);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -988,10 +760,8 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_header_bar_set_show_close_button(bar, setting);
 		}
 
-
 		public static IntPtr gtk_selection_data_get_uris(IntPtr raw)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_selection_data_get_uris(raw);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1000,10 +770,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_selection_data_get_uris(raw);
 		}
 
-
 		public static bool gtk_selection_data_set_uris(IntPtr raw, IntPtr[] uris)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_selection_data_set_uris(raw, uris);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1012,10 +780,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_selection_data_set_uris(raw, uris);
 		}
 
-
 		public static bool gtk_print_unix_dialog_get_embed_page_setup(IntPtr raw)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_print_unix_dialog_get_embed_page_setup(raw);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1024,10 +790,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_print_unix_dialog_get_embed_page_setup(raw);
 		}
 
-
 		public static void gtk_print_unix_dialog_set_embed_page_setup(IntPtr raw, bool embed)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.gtk_print_unix_dialog_set_embed_page_setup(raw, embed);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1036,10 +800,8 @@ namespace Eto.GtkSharp
 				NMWindows.gtk_print_unix_dialog_set_embed_page_setup(raw, embed);
 		}
 
-
 		public static IntPtr gtk_grid_get_child_at(IntPtr raw, int left, int top)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_grid_get_child_at(raw, left, top);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1048,10 +810,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_grid_get_child_at(raw, left, top);
 		}
 
-
 		public static IntPtr gtk_button_get_event_window(IntPtr button)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_button_get_event_window(button);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1060,10 +820,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_button_get_event_window(button);
 		}
 
-
 		public static uint gtk_get_major_version()
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_get_major_version();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1072,10 +830,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_get_major_version();
 		}
 
-
 		public static uint gtk_get_minor_version()
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_get_minor_version();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1084,10 +840,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_get_minor_version();
 		}
 
-
 		public static uint gtk_get_micro_version()
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gtk_get_micro_version();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1096,10 +850,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gtk_get_micro_version();
 		}
 
-
 		public static IntPtr webkit_web_view_new()
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_web_view_new();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1108,10 +860,8 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_web_view_new();
 		}
 
-
 		public static void webkit_web_view_load_uri(IntPtr web_view, string uri)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_load_uri(web_view, uri);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1120,10 +870,8 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_load_uri(web_view, uri);
 		}
 
-
 		public static string webkit_web_view_get_uri(IntPtr web_view)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return GetString(NMLinux.webkit_web_view_get_uri(web_view));
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1132,10 +880,8 @@ namespace Eto.GtkSharp
 				return GetString(NMWindows.webkit_web_view_get_uri(web_view));
 		}
 
-
 		public static void webkit_web_view_load_html(IntPtr web_view, string content, string base_uri)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_load_html(web_view, content, base_uri);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1144,10 +890,8 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_load_html(web_view, content, base_uri);
 		}
 
-
 		public static string webkit_web_view_get_title(IntPtr web_view)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return GetString(NMLinux.webkit_web_view_get_title(web_view));
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1156,10 +900,8 @@ namespace Eto.GtkSharp
 				return GetString(NMWindows.webkit_web_view_get_title(web_view));
 		}
 
-
 		public static void webkit_web_view_reload(IntPtr web_view)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_reload(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1168,10 +910,8 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_reload(web_view);
 		}
 
-
 		public static void webkit_web_view_stop_loading(IntPtr web_view)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_stop_loading(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1180,10 +920,8 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_stop_loading(web_view);
 		}
 
-
 		public static bool webkit_web_view_can_go_back(IntPtr web_view)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_web_view_can_go_back(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1192,10 +930,8 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_web_view_can_go_back(web_view);
 		}
 
-
 		public static void webkit_web_view_go_back(IntPtr web_view)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_go_back(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1204,10 +940,8 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_go_back(web_view);
 		}
 
-
 		public static bool webkit_web_view_can_go_forward(IntPtr web_view)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_web_view_can_go_forward(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1216,10 +950,8 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_web_view_can_go_forward(web_view);
 		}
 
-
 		public static void webkit_web_view_go_forward(IntPtr web_view)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_go_forward(web_view);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1228,10 +960,8 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_go_forward(web_view);
 		}
 
-
 		public static void webkit_web_view_run_javascript(IntPtr web_view, string script, IntPtr cancellable, Delegate callback, IntPtr user_data)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.webkit_web_view_run_javascript(web_view, script, cancellable, callback, user_data);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1240,10 +970,8 @@ namespace Eto.GtkSharp
 				NMWindows.webkit_web_view_run_javascript(web_view, script, cancellable, callback, user_data);
 		}
 
-
 		public static IntPtr webkit_web_view_run_javascript_finish(IntPtr web_view, IntPtr result, IntPtr error)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_web_view_run_javascript_finish(web_view, result, error);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1252,10 +980,8 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_web_view_run_javascript_finish(web_view, result, error);
 		}
 
-
 		public static IntPtr webkit_javascript_result_get_global_context(IntPtr js_result)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_javascript_result_get_global_context(js_result);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1264,10 +990,8 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_javascript_result_get_global_context(js_result);
 		}
 
-
 		public static IntPtr webkit_javascript_result_get_value(IntPtr js_result)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_javascript_result_get_value(js_result);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1276,10 +1000,8 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_javascript_result_get_value(js_result);
 		}
 
-
 		public static IntPtr JSValueToStringCopy(IntPtr context, IntPtr value, IntPtr idk)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.JSValueToStringCopy(context, value, idk);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1288,10 +1010,8 @@ namespace Eto.GtkSharp
 				return NMWindows.JSValueToStringCopy(context, value, idk);
 		}
 
-
 		public static int JSStringGetMaximumUTF8CStringSize(IntPtr js_str_value)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.JSStringGetMaximumUTF8CStringSize(js_str_value);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1300,10 +1020,8 @@ namespace Eto.GtkSharp
 				return NMWindows.JSStringGetMaximumUTF8CStringSize(js_str_value);
 		}
 
-
 		public static void JSStringGetUTF8CString(IntPtr js_str_value, IntPtr str_value, int str_length)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.JSStringGetUTF8CString(js_str_value, str_value, str_length);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1312,10 +1030,8 @@ namespace Eto.GtkSharp
 				NMWindows.JSStringGetUTF8CString(js_str_value, str_value, str_length);
 		}
 
-
 		public static void JSStringRelease(IntPtr js_str_value)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				NMLinux.JSStringRelease(js_str_value);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1324,10 +1040,8 @@ namespace Eto.GtkSharp
 				NMWindows.JSStringRelease(js_str_value);
 		}
 
-
 		public static IntPtr webkit_navigation_policy_decision_get_request(IntPtr decision)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.webkit_navigation_policy_decision_get_request(decision);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1336,10 +1050,8 @@ namespace Eto.GtkSharp
 				return NMWindows.webkit_navigation_policy_decision_get_request(decision);
 		}
 
-
 		public static string webkit_uri_request_get_uri(IntPtr request)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return GetString(NMLinux.webkit_uri_request_get_uri(request));
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1348,10 +1060,8 @@ namespace Eto.GtkSharp
 				return GetString(NMWindows.webkit_uri_request_get_uri(request));
 		}
 
-
 		public static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gdk_cairo_get_clip_rectangle(context, rect);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1360,10 +1070,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gdk_cairo_get_clip_rectangle(context, rect);
 		}
 
-
 		public static IntPtr gdk_get_default_root_window()
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gdk_get_default_root_window();
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1372,10 +1080,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gdk_get_default_root_window();
 		}
 
-
 		public static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.gdk_pixbuf_get_from_window(window, x, y, width, height);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1384,10 +1090,8 @@ namespace Eto.GtkSharp
 				return NMWindows.gdk_pixbuf_get_from_window(window, x, y, width, height);
 		}
 
-
 		public static bool pango_font_has_char(IntPtr font, int wc)
 		{
-
 			if (EtoEnvironment.Platform.IsLinux)
 				return NMLinux.pango_font_has_char(font, wc);
 			else if (EtoEnvironment.Platform.IsMac)
@@ -1395,6 +1099,5 @@ namespace Eto.GtkSharp
 			else
 				return NMWindows.pango_font_has_char(font, wc);
 		}
-
 	}
 }

--- a/src/Eto.Mac/KeyMap.cs
+++ b/src/Eto.Mac/KeyMap.cs
@@ -41,11 +41,16 @@ namespace Eto.Mac
 		static Dictionary<ushort, Keys> Map => _map ?? (_map = GetMap());
 		static Dictionary<Keys, string> InverseMap = _inverseMap ?? (_inverseMap = GetInverseMap());
 
-		public static Keys MapKey(ushort key)
+		public static Keys MapKey(ushort key, NSEventModifierMask modifiers)
 		{
 			Keys value;
 			if (Map.TryGetValue(key, out value))
+			{
+				// special case, fn+return is usually interpreted as insert key on macOS, even though it is actually enter.
+				if (value == Keys.Enter && modifiers.HasFlag(NSEventModifierMask.FunctionKeyMask))
+					return Keys.Insert;
 				return value;
+			}
 			Debug.WriteLine($"Unknown key '{key}'");
 			return Keys.None;
 		}
@@ -160,6 +165,18 @@ namespace Eto.Mac
 			keymap.Add(109, Keys.F10);
 			keymap.Add(103, Keys.F11);
 			keymap.Add(111, Keys.F12);
+			keymap.Add(105, Keys.F13);
+			keymap.Add(107, Keys.F14);
+			keymap.Add(113, Keys.F15);
+			keymap.Add(106, Keys.F16);
+			keymap.Add(64, Keys.F17);
+			keymap.Add(79, Keys.F18);
+			keymap.Add(80, Keys.F19);
+			// keymap.Add(80, Keys.F20);
+			// keymap.Add(80, Keys.F21);
+			// keymap.Add(80, Keys.F22);
+			// keymap.Add(80, Keys.F23);
+			// keymap.Add(80, Keys.F24);
 			keymap.Add(18, Keys.D1);
 			keymap.Add(19, Keys.D2);
 			keymap.Add(20, Keys.D3);
@@ -172,7 +189,7 @@ namespace Eto.Mac
 			keymap.Add(29, Keys.D0);
 			keymap.Add(27, Keys.Minus);
 			keymap.Add(50, Keys.Grave);
-			keymap.Add(76, Keys.Insert);
+			keymap.Add(76, Keys.Enter); // numpad
 			keymap.Add(115, Keys.Home);
 			keymap.Add(121, Keys.PageDown);
 			keymap.Add(116, Keys.PageUp);
@@ -199,7 +216,7 @@ namespace Eto.Mac
 			keymap.Add(114, Keys.Help);
 			//keymap.Add(, Keys.Pause);
 			keymap.Add(71, Keys.Clear);
-			keymap.Add(81, Keys.KeypadEqual);
+			keymap.Add(81, Keys.Equal);
 			//keymap.Add(, Keys.Menu);
 			keymap.Add(42, Keys.Backslash);
 			keymap.Add(24, Keys.Equal);

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -388,7 +388,7 @@ namespace Eto.Mac
 		public static KeyEventArgs ToEtoKeyEventArgs(this NSEvent theEvent)
 		{
 			char keyChar = !string.IsNullOrEmpty(theEvent.Characters) ? theEvent.Characters[0] : '\0';
-			Keys key = KeyMap.MapKey(theEvent.KeyCode);
+			Keys key = KeyMap.MapKey(theEvent.KeyCode, theEvent.ModifierFlags);
 			KeyEventArgs kpea;
 			Keys modifiers = theEvent.ModifierFlags.ToEto();
 			key |= modifiers;

--- a/src/Eto.WinForms/KeyMap.cs
+++ b/src/Eto.WinForms/KeyMap.cs
@@ -122,6 +122,18 @@ namespace Eto.WinForms
 			keymap.Add(swf.Keys.F10, Keys.F10);
 			keymap.Add(swf.Keys.F11, Keys.F11);
 			keymap.Add(swf.Keys.F12, Keys.F12);
+			keymap.Add(swf.Keys.F13, Keys.F13);
+			keymap.Add(swf.Keys.F14, Keys.F14);
+			keymap.Add(swf.Keys.F15, Keys.F15);
+			keymap.Add(swf.Keys.F16, Keys.F16);
+			keymap.Add(swf.Keys.F17, Keys.F17);
+			keymap.Add(swf.Keys.F18, Keys.F18);
+			keymap.Add(swf.Keys.F19, Keys.F19);
+			keymap.Add(swf.Keys.F20, Keys.F20);
+			keymap.Add(swf.Keys.F21, Keys.F21);
+			keymap.Add(swf.Keys.F22, Keys.F22);
+			keymap.Add(swf.Keys.F23, Keys.F23);
+			keymap.Add(swf.Keys.F24, Keys.F24);
 			keymap.Add(swf.Keys.D0, Keys.D0);
 			keymap.Add(swf.Keys.D1, Keys.D1);
 			keymap.Add(swf.Keys.D2, Keys.D2);

--- a/src/Eto.Wpf/KeyMap.cs
+++ b/src/Eto.Wpf/KeyMap.cs
@@ -115,6 +115,18 @@ namespace Eto.Wpf
 			keymap.Add(swi.Key.F10, Keys.F10);
 			keymap.Add(swi.Key.F11, Keys.F11);
 			keymap.Add(swi.Key.F12, Keys.F12);
+			keymap.Add(swi.Key.F13, Keys.F13);
+			keymap.Add(swi.Key.F14, Keys.F14);
+			keymap.Add(swi.Key.F15, Keys.F15);
+			keymap.Add(swi.Key.F16, Keys.F16);
+			keymap.Add(swi.Key.F17, Keys.F17);
+			keymap.Add(swi.Key.F18, Keys.F18);
+			keymap.Add(swi.Key.F19, Keys.F19);
+			keymap.Add(swi.Key.F20, Keys.F20);
+			keymap.Add(swi.Key.F21, Keys.F21);
+			keymap.Add(swi.Key.F22, Keys.F22);
+			keymap.Add(swi.Key.F23, Keys.F23);
+			keymap.Add(swi.Key.F24, Keys.F24);
 			keymap.Add(swi.Key.D0, Keys.D0);
 			keymap.Add(swi.Key.D1, Keys.D1);
 			keymap.Add(swi.Key.D2, Keys.D2);

--- a/src/Eto/Forms/Key.cs
+++ b/src/Eto/Forms/Key.cs
@@ -175,6 +175,7 @@ namespace Eto.Forms
 		/// <summary>The Clear key</summary>
 		Clear = 0x004E,
 		/// <summary>The Equal '=' key on the keypad/number pad</summary>
+		[Obsolete("Since 2.5.11. Use Equal instead.")]
 		KeypadEqual = 0x004F,
 
 		/// <summary>The menu (alt) key</summary>
@@ -244,6 +245,30 @@ namespace Eto.Forms
 		LeftApplication = 0x0080,
 		/// <summary>The right application/windows key</summary>
 		RightApplication = 0x0081,
+		/// <summary>The F13 key</summary>
+		F13 = 0x0082,
+		/// <summary>The F14 key</summary>
+		F14 = 0x0083,
+		/// <summary>The F15 key</summary>
+		F15 = 0x0084,
+		/// <summary>The F16 key</summary>
+		F16 = 0x0085,
+		/// <summary>The F17 key</summary>
+		F17 = 0x0086,
+		/// <summary>The F18 key</summary>
+		F18 = 0x0087,
+		/// <summary>The F19 key</summary>
+		F19 = 0x0088,
+		/// <summary>The F20 key</summary>
+		F20 = 0x0089,
+		/// <summary>The F21 key</summary>
+		F21 = 0x008A,
+		/// <summary>The F22 key</summary>
+		F22 = 0x008B,
+		/// <summary>The F23 key</summary>
+		F23 = 0x008C,
+		/// <summary>The F24 key</summary>
+		F24 = 0x008D,
 
 		/// <summary>The Shift Key Modifier</summary>
 		Shift = 0x1000,
@@ -291,7 +316,9 @@ namespace Eto.Forms
 			{ Keys.Divide, "/" },
 			{ Keys.Decimal, "." },
 			{ Keys.Backslash, "\\" },
+#pragma warning disable 618
 			{ Keys.KeypadEqual, "=" },
+#pragma warning restore 618
 			{ Keys.Multiply, "*" },
 			{ Keys.Add, "+" },
 			{ Keys.Subtract, "-" },

--- a/test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
+++ b/test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
@@ -204,8 +204,7 @@ namespace Eto.Test.Sections.Behaviors
 			var control = new Drawable { Size = new Size(100, 30), CanFocus = true };
 			control.Paint += delegate(object sender, PaintEventArgs pe)
 			{
-				if (control.BackgroundColor.A <= 0)
-					pe.Graphics.FillRectangle(Brushes.Blue, pe.ClipRectangle);
+				pe.Graphics.FillRectangle(Brushes.Blue, pe.ClipRectangle);
 				var size = pe.Graphics.MeasureString(SystemFonts.Label(), "Drawable");
 				pe.Graphics.DrawText(SystemFonts.Label(), Brushes.White, (PointF)((control.Size - size) / 2), "Drawable");
 			};


### PR DESCRIPTION
Adds many of the missing numeric keypad keys on Gtk.
Add F13-F24 keys
Mac: Enter on numpad now maps to enter (vs. insert), unless fn is pressed
Deprecate Keys.KeypadEqual in favour of mapping to Equal.

Fixes #1880