### PR TITLE
CustomCell and PropertyGrid tweaks

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridColumnHandler.cs
@@ -6,6 +6,8 @@ namespace Eto.GtkSharp.Forms.Controls
 {
 	public interface IGridHandler
 	{
+		Gtk.TreeView Tree { get; }
+
 		bool IsEventHandled(string handler);
 
 		void ColumnClicked(GridColumnHandler column);
@@ -29,6 +31,8 @@ namespace Eto.GtkSharp.Forms.Controls
 		bool editable;
 		bool cellsAdded;
 		IGridHandler grid;
+
+		public IGridHandler GridHandler => grid;
 
 		public GridColumnHandler()
 		{
@@ -65,7 +69,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			set
 			{
 				autoSize = value;
-				Control.Sizing = value ? Gtk.TreeViewColumnSizing.GrowOnly : Gtk.TreeViewColumnSizing.Fixed;
+				Control.Sizing = value ? Gtk.TreeViewColumnSizing.Autosize : Gtk.TreeViewColumnSizing.Fixed;
 			}
 		}
 
@@ -100,7 +104,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				autoSize = value == -1;
 				Control.FixedWidth = value;
-				Control.Sizing = autoSize ? Gtk.TreeViewColumnSizing.GrowOnly : Gtk.TreeViewColumnSizing.Fixed;
+				Control.Sizing = autoSize ? Gtk.TreeViewColumnSizing.Autosize : Gtk.TreeViewColumnSizing.Fixed;
 			}
 		}
 
@@ -193,8 +197,24 @@ namespace Eto.GtkSharp.Forms.Controls
 			get => GtkConversions.ToEtoAlignment(Control.Alignment);
 			set => Control.Alignment = value.ToAlignment();
 		}
-		public int MinWidth { get => Control.MinWidth; set => Control.MinWidth = value; }
-		public int MaxWidth { get => Control.MaxWidth; set => Control.MaxWidth = value; }
+		public int MinWidth
+		{
+			get => Control.MinWidth == -1 ? 0 : Control.MinWidth;
+			set
+			{
+				Control.MinWidth = value;
+				GridHandler?.Tree?.ColumnsAutosize();
+			}
+		}
+		public int MaxWidth
+		{
+			get => Control.MaxWidth == -1 ? int.MaxValue : Control.MaxWidth;
+			set
+			{
+				Control.MaxWidth = value == int.MaxValue ? -1 : value;
+				GridHandler?.Tree?.ColumnsAutosize();
+			}
+		}
 	}
 }
 

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -28,6 +28,8 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		protected Gtk.TreeView Tree { get; private set; }
 
+		Gtk.TreeView IGridHandler.Tree => Tree;
+
 		protected Dictionary<int, int> ColumnMap { get { return columnMap; } }
 
 		public override Gtk.Widget EventControl => Tree;

--- a/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
@@ -72,7 +72,6 @@ namespace Eto.Mac.Forms.Cells
 
 			widthCell.DataContext = null;
 			return result;
-			//return Callback.OnGetPreferredWidth(Widget, new CellEventArgs(row, dataItem, CellStates.None));
 		}
 
 
@@ -149,6 +148,17 @@ namespace Eto.Mac.Forms.Cells
 				h.ColumnHandler.DataViewHandler.OnCellEditing(ee);
 			}
 
+			public override void Layout()
+			{
+				base.Layout();
+				var sv = this.Subviews;
+				if (sv.Length > 0)
+				{
+					var view = sv[0];
+					view.Frame = this.Bounds;
+				}
+			}
+
 		}
 
 		public override Color GetBackgroundColor(NSView view)
@@ -190,14 +200,11 @@ namespace Eto.Mac.Forms.Cells
 					Args = args,
 					EtoControl = control,
 					Identifier = identifier,
-					Frame = CGRect.Empty,
-					AutoresizingMask = NSViewResizingMask.HeightSizable | NSViewResizingMask.WidthSizable 
+					AutoresizingMask = NSViewResizingMask.HeightSizable | NSViewResizingMask.WidthSizable
 				};
 				if (control != null)
 				{
 					var childView = control.ToNative(true);
-					childView.AutoresizingMask = NSViewResizingMask.HeightSizable | NSViewResizingMask.WidthSizable;
-					childView.Frame = view.Frame;
 					view.AddSubview(childView);
 					view.Setup();
 				}

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -46,7 +46,7 @@ namespace Eto.Mac.Forms.Controls
 
 			public GridViewHandler Handler
 			{
-				get { return (GridViewHandler)WeakHandler.Target; }
+				get { return WeakHandler?.Target as GridViewHandler; }
 				set { WeakHandler = new WeakReference(value); }
 			}
 

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -543,7 +543,7 @@ namespace Eto.Mac.Forms.Controls
 
 			public TreeGridViewHandler Handler
 			{
-				get { return WeakHandler.Target as TreeGridViewHandler; }
+				get { return WeakHandler?.Target as TreeGridViewHandler; }
 				set { WeakHandler = new WeakReference(value); }
 			}
 

--- a/src/Eto.WinForms/Forms/Cells/CellHandler.cs
+++ b/src/Eto.WinForms/Forms/Cells/CellHandler.cs
@@ -7,6 +7,7 @@ namespace Eto.WinForms.Forms.Cells
 {
 	public interface ICellConfigHandler
 	{
+		Controls.IGridHandler GridHandler { get; }
 		swf.DataGridViewColumn Column { get; }
 
 		void Paint (sd.Graphics graphics, sd.Rectangle clipBounds, sd.Rectangle cellBounds, int rowIndex, swf.DataGridViewElementStates cellState, object value, object formattedValue, string errorText, swf.DataGridViewCellStyle cellStyle, swf.DataGridViewAdvancedBorderStyle advancedBorderStyle, ref swf.DataGridViewPaintParts paintParts);
@@ -42,6 +43,8 @@ namespace Eto.WinForms.Forms.Cells
 				InitializeColumn();
 			}
 		}
+
+		public Controls.IGridHandler GridHandler => CellConfig?.GridHandler;
 
 		public swf.DataGridViewColumn Column => CellConfig?.Column;
 

--- a/src/Eto.WinForms/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.WinForms/Forms/Cells/ImageTextCellHandler.cs
@@ -80,8 +80,11 @@ namespace Eto.WinForms.Forms.Cells
 			{
 				var size = base.GetPreferredSize(graphics, cellStyle, rowIndex, constraintSize);
 				var val = GetValue(rowIndex) as object[];
-				var img = val[0] as sd.Image;
-				if (img != null) size.Width += IconSize + IconPadding * 2;
+				if (val != null)
+				{
+					var img = val[0] as sd.Image;
+					if (img != null) size.Width += IconSize + IconPadding * 2;
+				}
 				size.Width += Handler.GetRowOffset(rowIndex);
 				return size;
 			}

--- a/src/Eto.WinForms/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridColumnHandler.cs
@@ -4,6 +4,7 @@ using Eto.Forms;
 using Eto.WinForms.Forms.Cells;
 using System;
 using System.Diagnostics;
+using System.Windows.Forms;
 
 namespace Eto.WinForms.Forms.Controls
 {
@@ -12,11 +13,22 @@ namespace Eto.WinForms.Forms.Controls
 	{
 		Cell dataCell;
 
+		class EtoDataGridViewColumn : swf.DataGridViewColumn
+		{
+			public GridColumnHandler Handler { get; set; }
+
+			public override int GetPreferredWidth(DataGridViewAutoSizeColumnMode autoSizeColumnMode, bool fixedHeight)
+			{
+				return Math.Min(Handler.MaxWidth, base.GetPreferredWidth(autoSizeColumnMode, fixedHeight));
+			}
+
+		}
+
 		public IGridHandler GridHandler { get; private set; }
 
 		public GridColumnHandler()
 		{
-			Control = new swf.DataGridViewColumn();
+			Control = new EtoDataGridViewColumn { Handler = this };
 			DataCell = new TextBoxCell();
 			Editable = false;
 			Resizable = true;
@@ -129,12 +141,23 @@ namespace Eto.WinForms.Forms.Controls
 			set => Control.HeaderCell.Style.Alignment = value.ToSWFGridViewContentAlignment();
 		}
 		public int MinWidth { get => Control.MinimumWidth; set => Control.MinimumWidth = value; }
+
+		int maxWidth = int.MaxValue;
 		public int MaxWidth
 		{
-			get => int.MaxValue;
+			get => maxWidth;
 			set
 			{
-				Debug.WriteLine("GridColumn.MaxWidth is not supported in WinForms");
+				maxWidth = value;
+				if (AutoSize)
+				{
+					Control.DataGridView?.AutoResizeColumn(Control.Index);
+				}
+				else if (Control.Width > maxWidth)
+				{
+					Control.Width = maxWidth;
+				}
+
 			}
 		}
 

--- a/src/Eto.WinForms/Forms/Controls/GridHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridHandler.cs
@@ -17,6 +17,9 @@ namespace Eto.WinForms.Forms.Controls
 		int GetRowOffset(GridColumnHandler column, int rowIndex);
 
 		bool CellMouseClick(GridColumnHandler column, swf.MouseEventArgs e, int rowIndex);
+		object GetItemAtRow(int row);
+
+		Grid Grid { get; }		
 	}
 
 	public abstract class GridHandler<TWidget, TCallback> : WindowsControl<swf.DataGridView, TWidget, TCallback>, Grid.IHandler, IGridHandler
@@ -34,7 +37,9 @@ namespace Eto.WinForms.Forms.Controls
 				isFirstSelection = true;
 		}
 
-		protected abstract object GetItemAtRow(int row);
+		public abstract object GetItemAtRow(int row);
+
+		Grid IGridHandler.Grid => Widget;
 
 		class EtoDataGridView : swf.DataGridView
 		{
@@ -228,9 +233,9 @@ namespace Eto.WinForms.Forms.Controls
 				if (col.AutoSize)
 				{
 					Control.AutoResizeColumn(colNum, colHandler.Control.InheritedAutoSizeMode);
-					var width = col.Width;
+					var width = colHandler.Control.Width;
 					colHandler.Control.AutoSizeMode = swf.DataGridViewAutoSizeColumnMode.None;
-					col.Width = width;
+					colHandler.Control.Width = width;
 				}
 				colNum++;
 			}

--- a/src/Eto.WinForms/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridViewHandler.cs
@@ -11,7 +11,7 @@ namespace Eto.WinForms.Forms.Controls
 	{
 		CollectionHandler collection;
 
-		protected override object GetItemAtRow(int row)
+		public override object GetItemAtRow(int row)
 		{
 			if (row >= 0 && collection != null && collection.Collection != null && collection.Count > row)
 				return collection.ElementAt(row);

--- a/src/Eto.WinForms/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/SplitterHandler.cs
@@ -10,7 +10,7 @@ namespace Eto.WinForms.Forms.Controls
 	public class SplitterHandler : WindowsControl<swf.SplitContainer, Splitter, Splitter.ICallback>, Splitter.IHandler
 	{
 		Control panel1, panel2;
-        int panel1MinimumSize, panel2MinimumSize;
+		int panel1MinimumSize, panel2MinimumSize;
 		int? position;
 		double relative = double.NaN;
 		int suppressSplitterMoved;
@@ -75,7 +75,7 @@ namespace Eto.WinForms.Forms.Controls
 					else
 					{
 						// both get at least the preferred size
-						size1.Width = (int)Math.Round(Math.Max(size1.Width/relative, size2.Width/(1-relative)));
+						size1.Width = (int)Math.Round(Math.Max(size1.Width / relative, size2.Width / (1 - relative)));
 						if (Widget.Loaded && Control.IsHandleCreated)
 							size1.Width = Math.Min(Control.Width - SplitterWidth, size1.Width);
 						size2.Width = 0;
@@ -101,7 +101,7 @@ namespace Eto.WinForms.Forms.Controls
 					else
 					{
 						// both get at least the preferred size
-						size1.Height = (int)Math.Round(Math.Max(size1.Height/relative, size2.Height/(1-relative)));
+						size1.Height = (int)Math.Round(Math.Max(size1.Height / relative, size2.Height / (1 - relative)));
 						if (Widget.Loaded && Control.IsHandleCreated)
 							size1.Height = Math.Min(Control.Height - SplitterWidth, size1.Height);
 						size2.Height = 0;
@@ -115,7 +115,8 @@ namespace Eto.WinForms.Forms.Controls
 
 		public SplitterHandler()
 		{
-			Control = new EtoSplitContainer {
+			Control = new EtoSplitContainer
+			{
 				Handler = this,
 				AutoSize = true,
 				FixedPanel = swf.FixedPanel.Panel1,
@@ -128,24 +129,29 @@ namespace Eto.WinForms.Forms.Controls
 				HookEvents();
 				SetFixedPanel();
 			};
-            Control.SplitterMoved += (sender, e) => CheckSplitterPos();
-        }
+			Control.SplitterMoved += (sender, e) => CheckSplitterPos();
+		}
 
-        private void CheckSplitterPos()
-        {
-            var controlsize = (Orientation == Orientation.Horizontal) ? Control.Width : Control.Height;
+		int splitterMoving;
+		private void CheckSplitterPos()
+		{
+			if (splitterMoving > 0)
+				return;
 
-            if (controlsize <= panel1MinimumSize)
-                return;
+			var controlsize = (Orientation == Orientation.Horizontal) ? Control.Width : Control.Height;
+			if (controlsize <= panel1MinimumSize)
+				return;
 
-            if (Control.SplitterDistance > controlsize - panel2MinimumSize)
-                Control.SplitterDistance = controlsize - panel2MinimumSize;
+			splitterMoving++;
+			if (Control.SplitterDistance > controlsize - panel2MinimumSize)
+				Control.SplitterDistance = controlsize - panel2MinimumSize;
 
-            if (Control.SplitterDistance < panel1MinimumSize)
-                Control.SplitterDistance = panel1MinimumSize;
-        }
+			if (Control.SplitterDistance < panel1MinimumSize)
+				Control.SplitterDistance = panel1MinimumSize;
+			splitterMoving--;
+		}
 
-        void HookEvents()
+		void HookEvents()
 		{
 			Control.SplitterMoved += (sender, e) =>
 			{
@@ -260,17 +266,24 @@ namespace Eto.WinForms.Forms.Controls
 			var size = GetAvailableSize();
 			if (size <= 0)
 				return;
-			switch (fixedPanel)
+			try
 			{
-				case SplitterFixedPanel.Panel1:
+				switch (fixedPanel)
+				{
+					case SplitterFixedPanel.Panel1:
 					Control.SplitterDistance = Math.Max(0, Math.Min(size, (int)Math.Round(relative)));
-					break;
-				case SplitterFixedPanel.Panel2:
+						break;
+					case SplitterFixedPanel.Panel2:
 					Control.SplitterDistance = Math.Max(0, Math.Min(size, size - (int)Math.Round(relative)));
-					break;
-				case SplitterFixedPanel.None:
+						break;
+					case SplitterFixedPanel.None:
 					Control.SplitterDistance = Math.Max(0, Math.Min(size, (int)Math.Round(size * relative)));
-					break;
+						break;
+				}
+			}
+			catch
+			{
+				// ignore
 			}
 		}
 
@@ -491,27 +504,27 @@ namespace Eto.WinForms.Forms.Controls
 			get { return panel2 != null && panel2.GetWindowsHandler().InternalVisible; }
 		}
 
-        public int Panel1MinimumSize
-        {
-            get { return panel1MinimumSize; }
-            set
-            {
-                panel1MinimumSize = value;
-                CheckSplitterPos();
-            }
-        }
+		public int Panel1MinimumSize
+		{
+			get { return panel1MinimumSize; }
+			set
+			{
+				panel1MinimumSize = value;
+				CheckSplitterPos();
+			}
+		}
 
-        public int Panel2MinimumSize
-        {
-            get { return panel2MinimumSize; }
-            set
-            {
-                panel2MinimumSize = value;
-                CheckSplitterPos();
-            }
-        }
+		public int Panel2MinimumSize
+		{
+			get { return panel2MinimumSize; }
+			set
+			{
+				panel2MinimumSize = value;
+				CheckSplitterPos();
+			}
+		}
 
-        void c1_VisibleChanged(object sender, EventArgs e)
+		void c1_VisibleChanged(object sender, EventArgs e)
 		{
 			VisibleChanged(Panel1Visible);
 		}

--- a/src/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
@@ -25,7 +25,7 @@ namespace Eto.WinForms.Forms.Controls
 
 		TreeController controller;
 
-		protected override object GetItemAtRow(int row)
+		public override object GetItemAtRow(int row)
 		{
 			if (row >= controller.Count)
 				return null;

--- a/src/Eto.WinForms/Forms/WindowsControl.cs
+++ b/src/Eto.WinForms/Forms/WindowsControl.cs
@@ -629,7 +629,18 @@ namespace Eto.WinForms.Forms
 		public virtual Color BackgroundColor
 		{
 			get { return Control.BackColor.ToEto(); }
-			set { backgroundColorSet = true; Control.BackColor = value.ToSD(); }
+			set
+			{
+				backgroundColorSet = true;
+				try
+				{
+					Control.BackColor = value.ToSD();
+				}
+				catch
+				{
+					// some controls don't support transparent colors, ignore..
+				}
+			}
 		}
 		bool backgroundColorSet;
 		public bool BackgroundColorSet {

--- a/src/Eto/Forms/Cells/CustomCell.cs
+++ b/src/Eto/Forms/Cells/CustomCell.cs
@@ -170,7 +170,7 @@ namespace Eto.Forms
 		/// <param name="cellState">State of the cell.</param>
 		[Obsolete("Use constructor with column number and control")]
 		public CellEventArgs(Grid grid, Cell cell, int row, object item, CellStates cellState)
-			: this(null, null, row, -1, item, cellState, null)
+			: this(grid, cell, row, -1, item, cellState, null)
 		{
 		}
 

--- a/src/Eto/Forms/ThemedControls/ThemedPropertyGridHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedPropertyGridHandler.cs
@@ -15,63 +15,63 @@ using System.ComponentModel.DataAnnotations;
 
 namespace Eto.Forms.ThemedControls
 {
-    /// <summary>
-    /// Themed handler for the <see cref="PropertyGrid"/> control.
-    /// </summary>
-    public class ThemedPropertyGridHandler : ThemedControlHandler<ThemedPropertyGrid, PropertyGrid, PropertyGrid.ICallback>, PropertyGrid.IHandler
-    {
-        /// <summary>
-        /// Gets or sets the selected object for the grid to edit
-        /// </summary>
-        public object SelectedObject
-        {
-            get => Control.SelectedObject;
-            set => Control.SelectedObject = value;
-        }
+	/// <summary>
+	/// Themed handler for the <see cref="PropertyGrid"/> control.
+	/// </summary>
+	public class ThemedPropertyGridHandler : ThemedControlHandler<ThemedPropertyGrid, PropertyGrid, PropertyGrid.ICallback>, PropertyGrid.IHandler
+	{
+		/// <summary>
+		/// Gets or sets the selected object for the grid to edit
+		/// </summary>
+		public object SelectedObject
+		{
+			get => Control.SelectedObject;
+			set => Control.SelectedObject = value;
+		}
 
-        /// <summary>
-        /// Gets or sets the selected objects for the grid to edit
-        /// </summary>
-        /// <remarks>
-        /// Only common properties (with the same name and type) will be shown.
-        /// </remarks>
-        public IEnumerable<object> SelectedObjects
-        {
-            get => Control.SelectedObjects;
-            set => Control.SelectedObjects = value;
-        }
+		/// <summary>
+		/// Gets or sets the selected objects for the grid to edit
+		/// </summary>
+		/// <remarks>
+		/// Only common properties (with the same name and type) will be shown.
+		/// </remarks>
+		public IEnumerable<object> SelectedObjects
+		{
+			get => Control.SelectedObjects;
+			set => Control.SelectedObjects = value;
+		}
 
-        /// <summary>
-        /// Gets or sets a value indicating that the categories should be shown
-        /// </summary>
-        public bool ShowCategories
-        {
-            get => Control.ShowCategories;
-            set => Control.ShowCategories = value;
-        }
+		/// <summary>
+		/// Gets or sets a value indicating that the categories should be shown
+		/// </summary>
+		public bool ShowCategories
+		{
+			get => Control.ShowCategories;
+			set => Control.ShowCategories = value;
+		}
 
-        /// <summary>
-        /// Gets or sets a value indicating that the description panel should be shown
-        /// </summary>
-        /// <remarks>
-        /// The description panel shows the name and description of the selected property
-        /// </remarks>
-        public bool ShowDescription
-        {
-            get => Control.ShowDescription;
-            set => Control.ShowDescription = value;
-        }
+		/// <summary>
+		/// Gets or sets a value indicating that the description panel should be shown
+		/// </summary>
+		/// <remarks>
+		/// The description panel shows the name and description of the selected property
+		/// </remarks>
+		public bool ShowDescription
+		{
+			get => Control.ShowDescription;
+			set => Control.ShowDescription = value;
+		}
 
-        /// <summary>
-        /// Refreshes the grid with new values from the selected object(s)
-        /// </summary>
-        public void Refresh() => Control.Refresh();
+		/// <summary>
+		/// Refreshes the grid with new values from the selected object(s)
+		/// </summary>
+		public void Refresh() => Control.Refresh();
 
-        /// <summary>
-        /// Creates the control for this handler
-        /// </summary>
-        /// <returns>The control instance</returns>
-        protected override ThemedPropertyGrid CreateControl() => new ThemedPropertyGrid();
+		/// <summary>
+		/// Creates the control for this handler
+		/// </summary>
+		/// <returns>The control instance</returns>
+		protected override ThemedPropertyGrid CreateControl() => new ThemedPropertyGrid();
 
 		/// <summary>
 		/// Attaches the specified event to the platform-specific control
@@ -99,1255 +99,1263 @@ namespace Eto.Forms.ThemedControls
 		}
 	}
 
-    /// <summary>
-    /// Implementation of the PropertyGrid using the TreeGridView and PropertyCell
-    /// </summary>
-    public class ThemedPropertyGrid : Panel, IValueTypeWrapperHost
-    {
-        List<object> _selectedObjects;
-        IComparer<IPropertyDescriptor> _propertySort = Comparer<IPropertyDescriptor>.Create((x, y) => string.Compare(x.Name, y.Name, StringComparison.CurrentCulture));
-        IComparer<string> _categorySort = Comparer<string>.Default;
-        bool _showCategories = true;
-        bool _showDescription = true;
-        TreeGridView _tree;
-        PropertyCell _propertyCell;
-        ObservableCollection<PropertyCellType> _customTypes;
-
-        static Font s_DefaultFont = SystemFonts.Default();
-        static Font s_BoldFont = SystemFonts.Bold();
-
-        /// <summary>
-        /// Event to handle when a property value has changed
-        /// </summary>
-        public event EventHandler<PropertyValueChangedEventArgs> PropertyValueChanged;
-
-        /// <summary>
-        /// Creates a cell value binding for a particular type when you want to add your own cell types to <see cref="PropertyCellTypes"/>
-        /// </summary>
-        /// <typeparam name="T">Value type</typeparam>
-        /// <returns>A binding to use for custom cell types</returns>
-        public IndirectBinding<T> CreateCellValueBinding<T>() => Binding.Property<T>(nameof(PropertyItem.Value));
-
-        /// <summary>
-        /// Gets a collection of custom property cell types to use as well as the built-in types.
-        /// </summary>
-        public IList<PropertyCellType> PropertyCellTypes => _customTypes ?? (_customTypes = CreateCustomTypes());
-
-
-        ObservableCollection<PropertyCellType> CreateCustomTypes()
-        {
-            _customTypes = new ObservableCollection<PropertyCellType>();
-            _customTypes.CollectionChanged += customTypes_CollectionChanged;
-            return _customTypes;
-
-        }
-
-        private void customTypes_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-        {
-            SetupTypes();
-        }
-
-        void SetupTypes()
-        {
-            if (_propertyCell == null)
-                return;
-
-            _propertyCell.Types.Clear();
-            var itemTypeBinding = Binding.Property((PropertyItem p) => p.PropertyType);
-
-            if (_customTypes != null)
-            {
-                for (int i = 0; i < _customTypes.Count; i++)
-                {
-                    _propertyCell.Types.Add(_customTypes[i]);
-                }
-            }
-
-            _propertyCell.Types.Add(new PropertyCellTypeArray());
-            _propertyCell.Types.Add(new PropertyCellTypeCustom());
-            _propertyCell.Types.Add(new PropertyCellTypeReadOnly());
-            _propertyCell.Types.Add(Setup(new PropertyCellTypeColor()));
-            _propertyCell.Types.Add(Setup(new PropertyCellTypeString()));
-            _propertyCell.Types.Add(Setup(new PropertyCellTypeNumber { ItemTypeBinding = itemTypeBinding }));
-            _propertyCell.Types.Add(Setup(new PropertyCellTypeBoolean { ItemThreeStateBinding = Binding.Property((PropertyItem p) => p.IsNullable) }));
-            _propertyCell.Types.Add(Setup(new PropertyCellTypeDateTime()));
-            _propertyCell.Types.Add(Setup(new PropertyCellTypeEnum { ItemTypeBinding = itemTypeBinding }));
-            _propertyCell.Types.Add(new PropertyCellTypeObject());
-        }
-
-        /// <summary>
-        /// Gets or sets the selected objects for the grid to edit
-        /// </summary>
-        /// <remarks>
-        /// Only common properties (with the same name and type) will be shown.
-        /// </remarks>
-        public IEnumerable<object> SelectedObjects
-        {
-            get => _selectedObjects?.Select(UnwrapValueType);
-            set
-            {
-                _selectedObjects = WrapValueType(value);
-                UpdateProperties();
-            }
-        }
-
-        object UnwrapValueType(object value)
-        {
-            if (value is IValueTypeWrapper wrapper)
-                return _selectedObjects[(int)wrapper.Key];
-            return value;
-        }
-
-        List<object> WrapValueType(IEnumerable<object> values)
-        {
-            if (values == null)
-                return null;
-            var newValues = new List<object>();
-            var index = 0;
-            foreach (var value in values)
-            {
-                newValues.Add(WrapValueType(value, index++));
-            }
-            return newValues;
-        }
-
-        object WrapValueType(object value, int index)
-        {
-            if (value == null)
-                return null;
-            // can't mutate it, so we wrap!
-            return ValueTypeWrapper.Wrap(this, index, value);
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating that value types should use their default to determine if the property is changed (shown as bold)
-        /// </summary>
-        public bool UseValueTypeDefaults { get; set; } = true;
-
-        /// <summary>
-        /// Gets or sets the selected object 
-        /// </summary>
-        public object SelectedObject
-        {
-            get => _selectedObjects?.FirstOrDefault();
-            set => SelectedObjects = value != null ? new[] { value } : null;
-        }
-
-        /// <summary>
-        /// Event to handle when the <see cref="ShowCategories"/> property has changed.
-        /// </summary>
-        public event EventHandler<EventArgs> ShowCategoriesChanged;
-
-        /// <summary>
-        /// Gets or sets a value indicating that the categories should be shown
-        /// </summary>
-        [DefaultValue(true)]
-        public bool ShowCategories
-        {
-            get => _showCategories;
-            set
-            {
-                if (_showCategories != value)
-                {
-                    _showCategories = value;
-                    UpdateProperties();
-                    ShowCategoriesChanged?.Invoke(this, EventArgs.Empty);
-                }
-            }
-        }
-
-        /// <summary>
-        /// Gets or sets a value indicating that the description panel should be shown
-        /// </summary>
-        /// <remarks>
-        /// The description panel shows the name and description of the selected property
-        /// </remarks>
-        [DefaultValue(true)]
-        public bool ShowDescription
-        {
-            get => _showDescription;
-            set
-            {
-                if (_showDescription != value)
-                {
-                    _showDescription = value;
-                    CreateLayout();
-                }
-            }
-        }
-
-        IComparer<IPropertyDescriptor> PropertySort
-        {
-            get => _propertySort;
-            set
-            {
-                _propertySort = value;
-                UpdateProperties();
-            }
-        }
-
-        IComparer<string> CategorySort
-        {
-            get => _categorySort;
-            set
-            {
-                _categorySort = value;
-                UpdateProperties();
-            }
-        }
-
-        interface IItem
-        {
-            string Name { get; }
-            Color TitleTextColor { get; }
-            Font TitleFont { get; }
-        }
-
-        class CategoryItem : TreeGridItem, IItem
-        {
-            public string Name { get; set; }
-
-            public Color TitleTextColor => SystemColors.ControlText;
-
-            public Font TitleFont => s_BoldFont;
-        }
-
-        class PropertyItem : TreeGridItem, INotifyPropertyChanged, ITreeGridStore<ITreeGridItem>, IItem
-        {
-            ThemedPropertyGrid _grid;
-            string _description;
-            bool? _isReadOnly;
-            object _propertyCellType;
-            object _defaultValue;
-            string _name;
-            Lazy<string> _dataTypeText;
-            Lazy<Type> _elementType;
-            Lazy<PropertyGridTypeEditor> _editor;
-            bool? _expandable;
-            Lazy<sc.TypeConverter> _converter;
-            bool _childrenInitialized;
-
-            public event PropertyChangedEventHandler PropertyChanged;
-
-            void OnPropertyChanged([CallerMemberName] string name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
-
-            public IPropertyDescriptor Property { get; set; }
-
-            public object GetPropertyValue(object instance)
-            {
-                if (Parent is PropertyItem propertyItem)
-                {
-                    instance = propertyItem.GetPropertyValue(instance);
-                }
-                var prop = GetProperty(instance);
-                if (prop == null)
-                    return DefaultValue;
-                return prop.GetValue(instance);
-            }
-
-            public bool SetPropertyValue(object instance, object value)
-            {
-                if (Parent is PropertyItem propertyItem)
-                {
-                    instance = propertyItem.GetPropertyValue(instance);
-                }
-                var prop = GetProperty(instance);
-                if (prop == null || prop.IsReadOnly)
-                    return false;
-
-                prop.SetValue(instance, value);
-
-                _childrenInitialized = false;
-
-                return true;
-            }
-
-            public IPropertyDescriptor GetProperty(object instance)
-            {
-                if (instance == null)
-                    return null;
-
-                // cache per type?
-                var instanceType = instance.GetType();
-                var prop = Property;
-                if (!prop.ComponentType.GetTypeInfo().IsAssignableFrom(instanceType.GetTypeInfo()))
-                {
-                    prop = EtoTypeDescriptor.GetProperty(instanceType, prop.Name);
-                }
-                return prop;
-            }
-
-            public string Name => _name ?? (_name = GetName());
-            public string Description => _description ?? (_description = GetDescription());
-
-            public bool IsReadOnly => _isReadOnly ?? (_isReadOnly = GetIsReadOnly()) ?? false;
-
-            public object DefaultValue => _defaultValue ?? (_defaultValue = GetDefaultValue());
-
-            public object PropertyCellType => _propertyCellType ?? (_propertyCellType = GetPropertyCellType());
-
-            public Type ElementType => (_elementType ?? (_elementType = new Lazy<Type>(GetElementType))).Value;
-
-            public Type PropertyType => Property.PropertyType;
-
-            public string ReadOnlyValue => GetDisplayString();
-
-            public bool IsNullable => PropertyType.GetTypeInfo().IsClass || Nullable.GetUnderlyingType(PropertyType) != null;
-
-            public PropertyGridTypeEditor Editor => (_editor ?? (_editor = new Lazy<PropertyGridTypeEditor>(CreateEditor))).Value;
-
-            PropertyGridTypeEditor CreateEditor()
-            {
-                var editorType = GetEditorType();
-                if (editorType == null)
-                    return null;
-                return Activator.CreateInstance(editorType) as PropertyGridTypeEditor;
-            }
-
-            Type GetEditorType()
-            {
-                var editor = EditorAttributeWrapper.Get(Property) ?? EditorAttributeWrapper.Get(PropertyType);
-                if (editor == null || editor.EditorBaseTypeName != typeof(PropertyGridTypeEditor).AssemblyQualifiedName)
-                    return null;
-                return Type.GetType(editor.EditorTypeName);
-            }
-
-            object GetPropertyCellType()
-            {
-                if (GetEditorType() != null)
-                    return typeof(PropertyCellTypeCustom);
-
-                if (IsReadOnly)
-                    return typeof(PropertyCellTypeReadOnly);
-
-                var type = PropertyType;
-                if (type == typeof(object))
-                {
-                    // use current value for type
-                    type = Value?.GetType() ?? type;
-                }
-                return type;
-            }
-
-            public sc.TypeConverter Converter => (_converter ?? (_converter = new Lazy<sc.TypeConverter>(GetConverter))).Value;
-
-            public string DisplayText => GetDisplayString();
-
-            string GetDisplayString()
-            {
-                return Converter?.ConvertToString(Value) ?? Convert.ToString(Value);
-            }
-
-            sc.TypeConverter GetConverter()
-            {
-                return sc.TypeDescriptor.GetConverter(PropertyType);
-            }
-
-            Type GetElementType()
-            {
-                if (PropertyType.HasElementType)
-                    return PropertyType.GetElementType();
-                else
-                {
-                    var interfaces = PropertyType.GetTypeInfo().ImplementedInterfaces;
-                    foreach (var i in interfaces)
-                    {
-                        if (i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)
-                            && i.GenericTypeArguments.Length == 1)
-                        {
-                            return i.GenericTypeArguments[0];
-                        }
-                    }
-                }
-
-                return null;
-            }
-
-            string GetName()
-            {
-                return DisplayAttributeWrapper.Get(Property)?.GetName()
-                    ?? Property.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName
-                    ?? Property.Name;
-            }
-
-            public PropertyItem(ThemedPropertyGrid grid, PropertyInfo property)
-                : this(grid, new PropertyInfoDescriptor(property))
-            {
-            }
-
-            public PropertyItem(ThemedPropertyGrid grid, IPropertyDescriptor property)
-            {
-                _grid = grid;
-                Property = property;
-            }
-
-            public bool HasValue => Value != null;
-
-            public object Value
-            {
-                get => _grid.GetValue(this);
-                set
-                {
-                    _grid.SetValue(this, value);
-                    OnPropertyChanged(nameof(DisplayFont));
-                    _dataTypeText = null;
-                    OnPropertyChanged(nameof(DataTypeText));
-                    OnPropertyChanged(nameof(DisplayText));
-                }
-            }
-
-            public override bool Expandable => _expandable ?? (_expandable = GetIsExpandable()).Value && HasValue;
-
-            public string DataTypeText => (_dataTypeText ?? (_dataTypeText = new Lazy<string>(GetDataTypeText))).Value;
-
-            string GetDataTypeText()
-            {
-                if (!HasValue)
-                    return null;
-                if (PropertyType.IsArray)
-                    return string.Format(Application.Instance.Localize(_grid, "{0} Array"), PropertyType.Name);
-                if (typeof(IList).GetTypeInfo().IsAssignableFrom(PropertyType.GetTypeInfo()))
-                    return Application.Instance.Localize(_grid, "(Collection)");
-
-                return null;
-            }
-
-            static MethodInfo s_GetPropertiesSupportedMethod = typeof(sc.TypeConverter).GetRuntimeMethod("GetPropertiesSupported", new Type[0]);
-            static MethodInfo s_GetPropertiesMethod = typeof(sc.TypeConverter).GetRuntimeMethod("GetProperties", new Type[] { typeof(object) });
-
-            public bool GetIsExpandable()
-            {
-                if (s_GetPropertiesSupportedMethod == null || Converter == null)
-                    return false;
-                return (bool)s_GetPropertiesSupportedMethod.Invoke(Converter, null);
-            }
-
-            public bool CanSetCollection
-            {
-                get
-                {
-                    if (PropertyType.IsArray)
-                        return !IsReadOnly;
-
-                    return !IsReadOnly || HasValue;
-                }
-            }
-
-            public bool IsDefaultValue => Equals(Value, DefaultValue);
-
-            public Font DisplayFont => IsReadOnly || IsDefaultValue
-                ? s_DefaultFont
-                : s_BoldFont;
-
-            public Color DisplayTextColor
-            {
-                get
-                {
-                    if (IsReadOnly)
-                        return IsSelected ? new Color(SystemColors.HighlightText, 0.8f) : SystemColors.DisabledText;
-                    else
-                        return IsSelected ? SystemColors.HighlightText : SystemColors.ControlText;
-                }
-            }
-
-            object GetDefaultValue()
-            {
-                var attr = Property.GetCustomAttribute<DefaultValueAttribute>();
-                if (attr != null)
-                {
-                    var val = attr.Value;
-                    if (val != null)
-                    {
-                        var tc = sc.TypeDescriptor.GetConverter(PropertyType);
-                        if (tc != null && tc.CanConvertFrom(val.GetType()))
-                            val = tc.ConvertFrom(val);
-                    }
-                    return val;
-                }
-                if (_grid.UseValueTypeDefaults && PropertyType.GetTypeInfo().IsValueType)
-                {
-                    // is it nullable?  return null for default.
-                    if (IsNullable)
-                        return null;
-                    return Activator.CreateInstance(PropertyType);
-                }
-                return null;
-            }
-
-            string GetDescription()
-            {
-                return DisplayAttributeWrapper.Get(Property)?.GetDescription()
-                    ?? Property.GetCustomAttribute<DescriptionAttribute>()?.Description;
-            }
-
-            bool IsArray => PropertyType.IsArray;
-
-            bool IsCollection
-            {
-                get
-                {
-                    if (typeof(IList).GetTypeInfo().IsAssignableFrom(PropertyType.GetTypeInfo()))
-                        return true;
-                    return false;
-                }
-            }
-
-            bool GetIsReadOnly()
-            {
-                var isReadOnlyAttribute = Property.GetCustomAttribute<ReadOnlyAttribute>();
-                if (isReadOnlyAttribute != null)
-                    return isReadOnlyAttribute.IsReadOnly;
-
-                if (!Property.IsReadOnly)
-                    return false;
-
-                // can't use object editor for string
-                if (PropertyType == typeof(string))
-                    return true;
-
-                // array editor
-                if (IsCollection && !IsArray)
-                    return !HasValue;
-
-                var typeInfo = PropertyType.GetTypeInfo();
-
-                // we can use the object editor to edit a read-only property
-                if (!(typeInfo.IsValueType || typeInfo.IsArray || typeInfo.IsInterface))
-                    return !HasValue;
-
-                return true;
-            }
-
-            public object CreateNewValue()
-            {
-                if (PropertyType.GetConstructor(new Type[0]) == null)
-                    return null;
-                return Activator.CreateInstance(PropertyType);
-            }
-
-            public void SetCollection(IEnumerable<object> newCollection)
-            {
-                if (PropertyType.IsArray)
-                {
-                    // it's an array, we need to replace the whole thing
-                    var coll = newCollection.ToList();
-                    var newArray = Array.CreateInstance(ElementType, coll.Count);
-                    int index = 0;
-                    for (int i = 0; i < coll.Count; i++)
-                    {
-                        newArray.SetValue(coll[i], index++);
-                    }
-                    Value = newArray;
-                }
-
-                var value = Value;
-                bool setValue = false;
-                if (value == null)
-                {
-                    value = CreateNewValue();
-                    setValue = true;
-                }
-
-                if (value is IList saveList && !saveList.IsFixedSize)
-                {
-                    saveList.Clear();
-
-                    foreach (var item in newCollection)
-                    {
-                        saveList.Add(item);
-                    }
-
-                    if (setValue)
-                    {
-                        Value = value;
-                    }
-                }
-
-            }
-
-            void EnsureChildren()
-            {
-                if (_childrenInitialized || s_GetPropertiesMethod == null || Converter == null || !HasValue || !PropertyDescriptorDescriptor.IsSupported)
-                    return;
-
-                _childrenInitialized = true;
-                Children.Clear();
-                var properties = (IList)s_GetPropertiesMethod.Invoke(Converter, new object[] { Value });
-                if (properties == null)
-                    return;
-
-                var descriptors = new List<IPropertyDescriptor>();
-                for (int i = 0; i < properties.Count; i++)
-                {
+	/// <summary>
+	/// Implementation of the PropertyGrid using the TreeGridView and PropertyCell
+	/// </summary>
+	public class ThemedPropertyGrid : Panel, IValueTypeWrapperHost
+	{
+		List<object> _selectedObjects;
+		IComparer<IPropertyDescriptor> _propertySort = Comparer<IPropertyDescriptor>.Create((x, y) => string.Compare(x.Name, y.Name, StringComparison.CurrentCulture));
+		IComparer<string> _categorySort = Comparer<string>.Default;
+		bool _showCategories = true;
+		bool _showDescription = true;
+		TreeGridView _tree;
+		PropertyCell _propertyCell;
+		ObservableCollection<PropertyCellType> _customTypes;
+
+		static Font s_DefaultFont = SystemFonts.Default();
+		static Font s_BoldFont = SystemFonts.Bold();
+		const double MaxNameColumnRatio = 0.5;
+
+		/// <summary>
+		/// Event to handle when a property value has changed
+		/// </summary>
+		public event EventHandler<PropertyValueChangedEventArgs> PropertyValueChanged;
+
+		/// <summary>
+		/// Creates a cell value binding for a particular type when you want to add your own cell types to <see cref="PropertyCellTypes"/>
+		/// </summary>
+		/// <typeparam name="T">Value type</typeparam>
+		/// <returns>A binding to use for custom cell types</returns>
+		public IndirectBinding<T> CreateCellValueBinding<T>() => Binding.Property<T>(nameof(PropertyItem.Value));
+
+		/// <summary>
+		/// Gets a collection of custom property cell types to use as well as the built-in types.
+		/// </summary>
+		public IList<PropertyCellType> PropertyCellTypes => _customTypes ?? (_customTypes = CreateCustomTypes());
+
+
+		ObservableCollection<PropertyCellType> CreateCustomTypes()
+		{
+			_customTypes = new ObservableCollection<PropertyCellType>();
+			_customTypes.CollectionChanged += customTypes_CollectionChanged;
+			return _customTypes;
+
+		}
+
+		private void customTypes_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			SetupTypes();
+		}
+
+		void SetupTypes()
+		{
+			if (_propertyCell == null)
+				return;
+
+			_propertyCell.Types.Clear();
+			var itemTypeBinding = Binding.Property((PropertyItem p) => p.PropertyType);
+
+			if (_customTypes != null)
+			{
+				for (int i = 0; i < _customTypes.Count; i++)
+				{
+					_propertyCell.Types.Add(_customTypes[i]);
+				}
+			}
+
+			_propertyCell.Types.Add(new PropertyCellTypeArray());
+			_propertyCell.Types.Add(new PropertyCellTypeCustom());
+			_propertyCell.Types.Add(new PropertyCellTypeReadOnly());
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeColor()));
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeString()));
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeNumber { ItemTypeBinding = itemTypeBinding }));
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeBoolean { ItemThreeStateBinding = Binding.Property((PropertyItem p) => p.IsNullable) }));
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeDateTime()));
+			_propertyCell.Types.Add(Setup(new PropertyCellTypeEnum { ItemTypeBinding = itemTypeBinding }));
+			_propertyCell.Types.Add(new PropertyCellTypeObject());
+		}
+
+		/// <summary>
+		/// Gets or sets the selected objects for the grid to edit
+		/// </summary>
+		/// <remarks>
+		/// Only common properties (with the same name and type) will be shown.
+		/// </remarks>
+		public IEnumerable<object> SelectedObjects
+		{
+			get => _selectedObjects?.Select(UnwrapValueType);
+			set
+			{
+				_selectedObjects = WrapValueType(value);
+				UpdateProperties();
+			}
+		}
+
+		object UnwrapValueType(object value)
+		{
+			if (value is IValueTypeWrapper wrapper)
+				return _selectedObjects[(int)wrapper.Key];
+			return value;
+		}
+
+		List<object> WrapValueType(IEnumerable<object> values)
+		{
+			if (values == null)
+				return null;
+			var newValues = new List<object>();
+			var index = 0;
+			foreach (var value in values)
+			{
+				newValues.Add(WrapValueType(value, index++));
+			}
+			return newValues;
+		}
+
+		object WrapValueType(object value, int index)
+		{
+			if (value == null)
+				return null;
+			// can't mutate it, so we wrap!
+			return ValueTypeWrapper.Wrap(this, index, value);
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating that value types should use their default to determine if the property is changed (shown as bold)
+		/// </summary>
+		public bool UseValueTypeDefaults { get; set; } = true;
+
+		/// <summary>
+		/// Gets or sets the selected object 
+		/// </summary>
+		public object SelectedObject
+		{
+			get => _selectedObjects?.FirstOrDefault();
+			set => SelectedObjects = value != null ? new[] { value } : null;
+		}
+
+		/// <summary>
+		/// Event to handle when the <see cref="ShowCategories"/> property has changed.
+		/// </summary>
+		public event EventHandler<EventArgs> ShowCategoriesChanged;
+
+		/// <summary>
+		/// Gets or sets a value indicating that the categories should be shown
+		/// </summary>
+		[DefaultValue(true)]
+		public bool ShowCategories
+		{
+			get => _showCategories;
+			set
+			{
+				if (_showCategories != value)
+				{
+					_showCategories = value;
+					UpdateProperties();
+					ShowCategoriesChanged?.Invoke(this, EventArgs.Empty);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating that the description panel should be shown
+		/// </summary>
+		/// <remarks>
+		/// The description panel shows the name and description of the selected property
+		/// </remarks>
+		[DefaultValue(true)]
+		public bool ShowDescription
+		{
+			get => _showDescription;
+			set
+			{
+				if (_showDescription != value)
+				{
+					_showDescription = value;
+					CreateLayout();
+				}
+			}
+		}
+
+		IComparer<IPropertyDescriptor> PropertySort
+		{
+			get => _propertySort;
+			set
+			{
+				_propertySort = value;
+				UpdateProperties();
+			}
+		}
+
+		IComparer<string> CategorySort
+		{
+			get => _categorySort;
+			set
+			{
+				_categorySort = value;
+				UpdateProperties();
+			}
+		}
+
+		interface IItem
+		{
+			string Name { get; }
+			Color TitleTextColor { get; }
+			Font TitleFont { get; }
+		}
+
+		class CategoryItem : TreeGridItem, IItem
+		{
+			public string Name { get; set; }
+
+			public Color TitleTextColor => SystemColors.ControlText;
+
+			public Font TitleFont => s_BoldFont;
+		}
+
+		class PropertyItem : TreeGridItem, INotifyPropertyChanged, ITreeGridStore<ITreeGridItem>, IItem
+		{
+			ThemedPropertyGrid _grid;
+			string _description;
+			bool? _isReadOnly;
+			object _propertyCellType;
+			object _defaultValue;
+			string _name;
+			Lazy<string> _dataTypeText;
+			Lazy<Type> _elementType;
+			Lazy<PropertyGridTypeEditor> _editor;
+			bool? _expandable;
+			Lazy<sc.TypeConverter> _converter;
+			bool _childrenInitialized;
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			void OnPropertyChanged([CallerMemberName] string name = null) => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+
+			public IPropertyDescriptor Property { get; set; }
+
+			public object GetPropertyValue(object instance)
+			{
+				if (Parent is PropertyItem propertyItem)
+				{
+					instance = propertyItem.GetPropertyValue(instance);
+				}
+				var prop = GetProperty(instance);
+				if (prop == null)
+					return DefaultValue;
+				return prop.GetValue(instance);
+			}
+
+			public bool SetPropertyValue(object instance, object value)
+			{
+				if (Parent is PropertyItem propertyItem)
+				{
+					instance = propertyItem.GetPropertyValue(instance);
+				}
+				var prop = GetProperty(instance);
+				if (prop == null || prop.IsReadOnly)
+					return false;
+
+				prop.SetValue(instance, value);
+
+				_childrenInitialized = false;
+
+				return true;
+			}
+
+			public IPropertyDescriptor GetProperty(object instance)
+			{
+				if (instance == null)
+					return null;
+
+				// cache per type?
+				var instanceType = instance.GetType();
+				var prop = Property;
+				if (!prop.ComponentType.GetTypeInfo().IsAssignableFrom(instanceType.GetTypeInfo()))
+				{
+					prop = EtoTypeDescriptor.GetProperty(instanceType, prop.Name);
+				}
+				return prop;
+			}
+
+			public string Name => _name ?? (_name = GetName());
+			public string Description => _description ?? (_description = GetDescription());
+
+			public bool IsReadOnly => _isReadOnly ?? (_isReadOnly = GetIsReadOnly()) ?? false;
+
+			public object DefaultValue => _defaultValue ?? (_defaultValue = GetDefaultValue());
+
+			public object PropertyCellType => _propertyCellType ?? (_propertyCellType = GetPropertyCellType());
+
+			public Type ElementType => (_elementType ?? (_elementType = new Lazy<Type>(GetElementType))).Value;
+
+			public Type PropertyType => Property.PropertyType;
+
+			public string ReadOnlyValue => GetDisplayString();
+
+			public bool IsNullable => PropertyType.GetTypeInfo().IsClass || Nullable.GetUnderlyingType(PropertyType) != null;
+
+			public PropertyGridTypeEditor Editor => (_editor ?? (_editor = new Lazy<PropertyGridTypeEditor>(CreateEditor))).Value;
+
+			PropertyGridTypeEditor CreateEditor()
+			{
+				var editorType = GetEditorType();
+				if (editorType == null)
+					return null;
+				return Activator.CreateInstance(editorType) as PropertyGridTypeEditor;
+			}
+
+			Type GetEditorType()
+			{
+				var editor = EditorAttributeWrapper.Get(Property) ?? EditorAttributeWrapper.Get(PropertyType);
+				if (editor == null || editor.EditorBaseTypeName != typeof(PropertyGridTypeEditor).AssemblyQualifiedName)
+					return null;
+				return Type.GetType(editor.EditorTypeName);
+			}
+
+			object GetPropertyCellType()
+			{
+				if (GetEditorType() != null)
+					return typeof(PropertyCellTypeCustom);
+
+				if (IsReadOnly)
+					return typeof(PropertyCellTypeReadOnly);
+
+				var type = PropertyType;
+				if (type == typeof(object))
+				{
+					// use current value for type
+					type = Value?.GetType() ?? type;
+				}
+				return type;
+			}
+
+			public sc.TypeConverter Converter => (_converter ?? (_converter = new Lazy<sc.TypeConverter>(GetConverter))).Value;
+
+			public string DisplayText => GetDisplayString();
+
+			string GetDisplayString()
+			{
+				return Converter?.ConvertToString(Value) ?? Convert.ToString(Value);
+			}
+
+			sc.TypeConverter GetConverter()
+			{
+				return sc.TypeDescriptor.GetConverter(PropertyType);
+			}
+
+			Type GetElementType()
+			{
+				if (PropertyType.HasElementType)
+					return PropertyType.GetElementType();
+				else
+				{
+					var interfaces = PropertyType.GetTypeInfo().ImplementedInterfaces;
+					foreach (var i in interfaces)
+					{
+						if (i.GetTypeInfo().IsGenericType && i.GetGenericTypeDefinition() == typeof(IEnumerable<>)
+							&& i.GenericTypeArguments.Length == 1)
+						{
+							return i.GenericTypeArguments[0];
+						}
+					}
+				}
+
+				return null;
+			}
+
+			string GetName()
+			{
+				return DisplayAttributeWrapper.Get(Property)?.GetName()
+					?? Property.GetCustomAttribute<DisplayNameAttribute>()?.DisplayName
+					?? Property.Name;
+			}
+
+			public PropertyItem(ThemedPropertyGrid grid, PropertyInfo property)
+				: this(grid, new PropertyInfoDescriptor(property))
+			{
+			}
+
+			public PropertyItem(ThemedPropertyGrid grid, IPropertyDescriptor property)
+			{
+				_grid = grid;
+				Property = property;
+			}
+
+			public bool HasValue => Value != null;
+
+			public object Value
+			{
+				get => _grid.GetValue(this);
+				set
+				{
+					_grid.SetValue(this, value);
+					OnPropertyChanged(nameof(DisplayFont));
+					_dataTypeText = null;
+					OnPropertyChanged(nameof(DataTypeText));
+					OnPropertyChanged(nameof(DisplayText));
+				}
+			}
+
+			public override bool Expandable => _expandable ?? (_expandable = GetIsExpandable()).Value && HasValue;
+
+			public string DataTypeText => (_dataTypeText ?? (_dataTypeText = new Lazy<string>(GetDataTypeText))).Value;
+
+			string GetDataTypeText()
+			{
+				if (!HasValue)
+					return null;
+				if (PropertyType.IsArray)
+					return string.Format(Application.Instance.Localize(_grid, "{0} Array"), PropertyType.Name);
+				if (typeof(IList).GetTypeInfo().IsAssignableFrom(PropertyType.GetTypeInfo()))
+					return Application.Instance.Localize(_grid, "(Collection)");
+
+				return null;
+			}
+
+			static MethodInfo s_GetPropertiesSupportedMethod = typeof(sc.TypeConverter).GetRuntimeMethod("GetPropertiesSupported", new Type[0]);
+			static MethodInfo s_GetPropertiesMethod = typeof(sc.TypeConverter).GetRuntimeMethod("GetProperties", new Type[] { typeof(object) });
+
+			public bool GetIsExpandable()
+			{
+				if (s_GetPropertiesSupportedMethod == null || Converter == null)
+					return false;
+				return (bool)s_GetPropertiesSupportedMethod.Invoke(Converter, null);
+			}
+
+			public bool CanSetCollection
+			{
+				get
+				{
+					if (PropertyType.IsArray)
+						return !IsReadOnly;
+
+					return !IsReadOnly || HasValue;
+				}
+			}
+
+			public bool IsDefaultValue => Equals(Value, DefaultValue);
+
+			public Font DisplayFont => IsReadOnly || IsDefaultValue
+				? s_DefaultFont
+				: s_BoldFont;
+
+			public Color DisplayTextColor
+			{
+				get
+				{
+					if (IsReadOnly)
+						return IsSelected ? new Color(SystemColors.HighlightText, 0.8f) : SystemColors.DisabledText;
+					else
+						return IsSelected ? SystemColors.HighlightText : SystemColors.ControlText;
+				}
+			}
+
+			object GetDefaultValue()
+			{
+				var attr = Property.GetCustomAttribute<DefaultValueAttribute>();
+				if (attr != null)
+				{
+					var val = attr.Value;
+					if (val != null)
+					{
+						var tc = sc.TypeDescriptor.GetConverter(PropertyType);
+						if (tc != null && tc.CanConvertFrom(val.GetType()))
+							val = tc.ConvertFrom(val);
+					}
+					return val;
+				}
+				if (_grid.UseValueTypeDefaults && PropertyType.GetTypeInfo().IsValueType)
+				{
+					// is it nullable?  return null for default.
+					if (IsNullable)
+						return null;
+					return Activator.CreateInstance(PropertyType);
+				}
+				return null;
+			}
+
+			string GetDescription()
+			{
+				return DisplayAttributeWrapper.Get(Property)?.GetDescription()
+					?? Property.GetCustomAttribute<DescriptionAttribute>()?.Description;
+			}
+
+			bool IsArray => PropertyType.IsArray;
+
+			bool IsCollection
+			{
+				get
+				{
+					if (typeof(IList).GetTypeInfo().IsAssignableFrom(PropertyType.GetTypeInfo()))
+						return true;
+					return false;
+				}
+			}
+
+			bool GetIsReadOnly()
+			{
+				var isReadOnlyAttribute = Property.GetCustomAttribute<ReadOnlyAttribute>();
+				if (isReadOnlyAttribute != null)
+					return isReadOnlyAttribute.IsReadOnly;
+
+				if (!Property.IsReadOnly)
+					return false;
+
+				// can't use object editor for string
+				if (PropertyType == typeof(string))
+					return true;
+
+				// array editor
+				if (IsCollection && !IsArray)
+					return !HasValue;
+
+				var typeInfo = PropertyType.GetTypeInfo();
+
+				// we can use the object editor to edit a read-only property
+				if (!(typeInfo.IsValueType || typeInfo.IsArray || typeInfo.IsInterface))
+					return !HasValue;
+
+				return true;
+			}
+
+			public object CreateNewValue()
+			{
+				if (PropertyType.GetConstructor(new Type[0]) == null)
+					return null;
+				return Activator.CreateInstance(PropertyType);
+			}
+
+			public void SetCollection(IEnumerable<object> newCollection)
+			{
+				if (PropertyType.IsArray)
+				{
+					// it's an array, we need to replace the whole thing
+					var coll = newCollection.ToList();
+					var newArray = Array.CreateInstance(ElementType, coll.Count);
+					int index = 0;
+					for (int i = 0; i < coll.Count; i++)
+					{
+						newArray.SetValue(coll[i], index++);
+					}
+					Value = newArray;
+				}
+
+				var value = Value;
+				bool setValue = false;
+				if (value == null)
+				{
+					value = CreateNewValue();
+					setValue = true;
+				}
+
+				if (value is IList saveList && !saveList.IsFixedSize)
+				{
+					saveList.Clear();
+
+					foreach (var item in newCollection)
+					{
+						saveList.Add(item);
+					}
+
+					if (setValue)
+					{
+						Value = value;
+					}
+				}
+
+			}
+
+			void EnsureChildren()
+			{
+				if (_childrenInitialized || s_GetPropertiesMethod == null || Converter == null || !HasValue || !PropertyDescriptorDescriptor.IsSupported)
+					return;
+
+				_childrenInitialized = true;
+				Children.Clear();
+				var properties = (IList)s_GetPropertiesMethod.Invoke(Converter, new object[] { Value });
+				if (properties == null)
+					return;
+
+				var descriptors = new List<IPropertyDescriptor>();
+				for (int i = 0; i < properties.Count; i++)
+				{
 					var descriptor = EtoTypeDescriptor.Get(properties[i]);
 					if (descriptor != null)
 						descriptors.Add(descriptor);
-                }
+				}
 
-                if (_grid.PropertySort != null)
-                    descriptors.Sort(_grid.PropertySort);
+				if (_grid.PropertySort != null)
+					descriptors.Sort(_grid.PropertySort);
 
-                for (int i = 0; i < descriptors.Count; i++)
-                {
-                    Children.Add(new PropertyItem(_grid, descriptors[i]));
-                }
-            }
+				for (int i = 0; i < descriptors.Count; i++)
+				{
+					Children.Add(new PropertyItem(_grid, descriptors[i]));
+				}
+			}
 
-            int IDataStore<ITreeGridItem>.Count
-            {
-                get
-                {
-                    EnsureChildren();
-                    return base.Count;
-                }
-            }
+			int IDataStore<ITreeGridItem>.Count
+			{
+				get
+				{
+					EnsureChildren();
+					return base.Count;
+				}
+			}
 
-            bool _isSelected;
-            public bool IsSelected
-            {
-                get => _isSelected;
-                set
-                {
-                    if (_isSelected != value)
-                    {
-                        _isSelected = value;
-                        OnPropertyChanged();
-                        OnPropertyChanged(nameof(DisplayTextColor));
-                    }
-                }
-            }
+			bool _isSelected;
+			public bool IsSelected
+			{
+				get => _isSelected;
+				set
+				{
+					if (_isSelected != value)
+					{
+						_isSelected = value;
+						OnPropertyChanged();
+						OnPropertyChanged(nameof(DisplayTextColor));
+					}
+				}
+			}
 
-            public Color TitleTextColor => DisplayTextColor;
+			public Color TitleTextColor => DisplayTextColor;
 
-            public Font TitleFont => s_DefaultFont;
-        }
+			public Font TitleFont => s_DefaultFont;
+		}
 
-        private void SetValue(PropertyItem propertyItem, object value)
-        {
-            if (_selectedObjects == null)
-                return;
+		private void SetValue(PropertyItem propertyItem, object value)
+		{
+			if (_selectedObjects == null)
+				return;
 
-            var wasUpdated = false;
-            for (int i = 0; i < _selectedObjects.Count; i++)
-            {
-                object obj = _selectedObjects[i];
-                var oldValue = propertyItem.GetPropertyValue(obj);
-                if (propertyItem.SetPropertyValue(obj, value))
-                {
-                    wasUpdated = true;
-                    PropertyValueChanged?.Invoke(this, new PropertyValueChangedEventArgs(propertyItem.Name, oldValue, obj));
-                }
-            }
-            if (wasUpdated && propertyItem.Expandable)
-                _tree.ReloadItem(propertyItem, true);
-        }
+			var wasUpdated = false;
+			for (int i = 0; i < _selectedObjects.Count; i++)
+			{
+				object obj = _selectedObjects[i];
+				var oldValue = propertyItem.GetPropertyValue(obj);
+				if (propertyItem.SetPropertyValue(obj, value))
+				{
+					wasUpdated = true;
+					PropertyValueChanged?.Invoke(this, new PropertyValueChangedEventArgs(propertyItem.Name, oldValue, obj));
+				}
+			}
+			if (wasUpdated && propertyItem.Expandable)
+				_tree.ReloadItem(propertyItem, true);
+		}
 
-        private object GetValue(PropertyItem propertyItem)
-        {
-            if (_selectedObjects?.Count > 0)
-            {
-                return propertyItem?.GetPropertyValue(_selectedObjects[0]);
-            }
-            return propertyItem.DefaultValue;
-        }
+		private object GetValue(PropertyItem propertyItem)
+		{
+			if (_selectedObjects?.Count > 0)
+			{
+				return propertyItem?.GetPropertyValue(_selectedObjects[0]);
+			}
+			return propertyItem.DefaultValue;
+		}
 
-        PropertyCellType<T> Setup<T>(PropertyCellType<T> cell)
-        {
-            cell.ItemBinding = CreateCellValueBinding<T>();
-            return cell;
-        }
+		PropertyCellType<T> Setup<T>(PropertyCellType<T> cell)
+		{
+			cell.ItemBinding = CreateCellValueBinding<T>();
+			return cell;
+		}
 
-        class CollectionEditorDialog : Dialog<bool>
-        {
-            public CollectionEditor Editor { get; }
+		class CollectionEditorDialog : Dialog<bool>
+		{
+			public CollectionEditor Editor { get; }
 
-            static Size? s_defaultSize;
+			static Size? s_defaultSize;
 
-            public CollectionEditorDialog(CollectionEditor editor)
-            {
-                Editor = editor;
-                Resizable = true;
-                Padding = 6;
-                MinimumSize = new Size(200, 200);
-                ClientSize = new Size(600, 400);
-                if (s_defaultSize != null)
-                    Size = s_defaultSize.Value;
+			public CollectionEditorDialog(CollectionEditor editor)
+			{
+				Editor = editor;
+				Resizable = true;
+				Padding = 6;
+				MinimumSize = new Size(200, 200);
+				ClientSize = new Size(600, 400);
+				if (s_defaultSize != null)
+					Size = s_defaultSize.Value;
 
-                var cancelButton = new Button { Text = Application.Instance.Localize(this, "Cancel") };
-                cancelButton.Click += CancelButton_Click;
-                var okButton = new Button { Text = Application.Instance.Localize(this, Platform.IsMac ? "Apply" : "OK") };
-                okButton.Click += OkButton_Click;
-                DefaultButton = okButton;
-                AbortButton = cancelButton;
+				var cancelButton = new Button { Text = Application.Instance.Localize(this, "Cancel") };
+				cancelButton.Click += CancelButton_Click;
+				var okButton = new Button { Text = Application.Instance.Localize(this, Platform.IsMac ? "Apply" : "OK") };
+				okButton.Click += OkButton_Click;
+				DefaultButton = okButton;
+				AbortButton = cancelButton;
 
-                if (editor.ControlObject is ThemedCollectionEditor themedCollectionEditor)
-                {
-                    var buttons = new TableLayout
-                    {
-                        Padding = 4,
-                        Spacing = new Size(6, 0),
-                        Rows = { null, new TableRow(cancelButton, okButton), null }
-                    };
-                    themedCollectionEditor.ExtraContent = buttons;
-                    Content = editor;
-                }
-                else
-                {
-                    Content = editor;
-                    PositiveButtons.Add(okButton);
-                    NegativeButtons.Add(cancelButton);
-                }
-            }
+				if (editor.ControlObject is ThemedCollectionEditor themedCollectionEditor)
+				{
+					var buttons = new TableLayout
+					{
+						Padding = 4,
+						Spacing = new Size(6, 0),
+						Rows = { null, new TableRow(cancelButton, okButton), null }
+					};
+					themedCollectionEditor.ExtraContent = buttons;
+					Content = editor;
+				}
+				else
+				{
+					Content = editor;
+					PositiveButtons.Add(okButton);
+					NegativeButtons.Add(cancelButton);
+				}
+			}
 
-            protected override void OnClosing(CancelEventArgs e)
-            {
-                base.OnClosing(e);
-                s_defaultSize = RestoreBounds.Size;
-            }
+			protected override void OnClosing(CancelEventArgs e)
+			{
+				base.OnClosing(e);
+				s_defaultSize = RestoreBounds.Size;
+			}
 
-            private void OkButton_Click(object sender, EventArgs e) => Close(true);
+			private void OkButton_Click(object sender, EventArgs e) => Close(true);
 
-            private void CancelButton_Click(object sender, EventArgs e) => Close(false);
-        }
-
-
-        class PropertyCellTypeArray : PropertyCellType
-        {
-            public override string Identifier => "PropertyCellTypeArray";
-
-            public override bool CanDisplay(object itemType)
-            {
-                var type = itemType as Type;
-                if (type == null)
-                    return false;
-                if (type.IsArray)
-                    return true;
-                if (typeof(IList).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
-                    return true;
-                return false;
-            }
-
-            public override Control OnCreate(CellEventArgs args)
-            {
-                var label = new Label();
-                label.VerticalAlignment = VerticalAlignment.Center;
-                label.TextBinding.BindDataContext((PropertyItem p) => p.DataTypeText);
-                var button = new Button { MinimumSize = Size.Empty, Text = "…" };
-                button.BindDataContext(c => c.Enabled, (PropertyItem p) => p.CanSetCollection);
-                button.Click += (sender, e) =>
-                {
-                    var b = sender as Button;
-                    if (b.DataContext is PropertyItem pi)
-                    {
-                        var elementType = pi.ElementType;
-                        var value = pi.Value ?? pi.CreateNewValue();
-                        var collection = value as IEnumerable<object>;
-                        if (collection == null && value is IList list)
-                            collection = list.OfType<object>();
-
-                        var editor = new CollectionEditor();
-                        editor.ElementType = pi.ElementType;
-                        editor.DataStore = collection;
-                        var editorDialog = new CollectionEditorDialog(editor);
-                        editorDialog.Title = $"{pi.ElementType.Name} Collection Editor";
-
-                        if (editorDialog.ShowModal(button))
-                        {
-                            pi.SetCollection(editor.DataStore);
-
-                        }
-                    }
-                };
-                return new TableLayout(new TableRow(new TableCell(label, true), button));
-            }
-
-            public override void OnPaint(CellPaintEventArgs args)
-            {
-                if (args.Item is PropertyItem pi)
-                {
-                    pi.IsSelected = args.IsSelected;
-                    var color = pi.DisplayTextColor;
-                    var font = pi.DisplayFont;
-                    args.DrawCenteredText(pi.DataTypeText, color, font);
-                }
-            }
-        }
+			private void CancelButton_Click(object sender, EventArgs e) => Close(false);
+		}
 
 
-        class PropertyGridDialog : Dialog<bool>
-        {
-            public ThemedPropertyGrid Editor { get; }
+		class PropertyCellTypeArray : PropertyCellType
+		{
+			public override string Identifier => "PropertyCellTypeArray";
 
-            static Size? s_defaultSize;
+			public override bool CanDisplay(object itemType)
+			{
+				var type = itemType as Type;
+				if (type == null)
+					return false;
+				if (type.IsArray)
+					return true;
+				if (typeof(IList).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()))
+					return true;
+				return false;
+			}
 
-            public PropertyGridDialog(ThemedPropertyGrid editor)
-            {
-                Editor = editor;
-                Resizable = true;
-                MinimumSize = new Size(200, 200);
-                ClientSize = new Size(400, 400);
-                if (s_defaultSize != null)
-                    Size = s_defaultSize.Value;
+			public override Control OnCreate(CellEventArgs args)
+			{
+				var label = new Label();
+				label.Wrap = WrapMode.None;
+				label.VerticalAlignment = VerticalAlignment.Center;
+				label.TextBinding.BindDataContext((PropertyItem p) => p.DataTypeText);
+				var button = new Button { MinimumSize = Size.Empty, Text = "…" };
+				button.BindDataContext(c => c.Enabled, (PropertyItem p) => p.CanSetCollection);
+				button.Click += (sender, e) =>
+				{
+					var b = sender as Button;
+					if (b.DataContext is PropertyItem pi)
+					{
+						var elementType = pi.ElementType;
+						var value = pi.Value ?? pi.CreateNewValue();
+						var collection = value as IEnumerable<object>;
+						if (collection == null && value is IList list)
+							collection = list.OfType<object>();
 
-                var cancelButton = new Button { Text = Application.Instance.Localize(this, "Cancel") };
-                cancelButton.Click += CancelButton_Click;
-                var okButton = new Button { Text = Application.Instance.Localize(this, Platform.IsMac ? "Apply" : "OK") };
-                okButton.Click += OkButton_Click;
-                DefaultButton = okButton;
-                AbortButton = cancelButton;
+						var editor = new CollectionEditor();
+						editor.ElementType = pi.ElementType;
+						editor.DataStore = collection;
+						var editorDialog = new CollectionEditorDialog(editor);
+						editorDialog.Title = $"{pi.ElementType.Name} Collection Editor";
 
-                var layout = new DynamicLayout();
-                layout.DefaultSpacing = new Size(4, 4);
-                layout.Add(editor, yscale: true);
-                layout.AddSeparateRow(spacing: new Size(6, 0), controls: new[] { null, cancelButton, okButton });
-                Padding = 6;
-                Content = layout;
-            }
+						if (editorDialog.ShowModal(button))
+						{
+							pi.SetCollection(editor.DataStore);
 
-            protected override void OnClosing(CancelEventArgs e)
-            {
-                base.OnClosing(e);
-                s_defaultSize = RestoreBounds.Size;
-            }
+						}
+					}
+				};
+				return new TableLayout(new TableRow(new TableCell(label, true), button));
+			}
 
-            private void OkButton_Click(object sender, EventArgs e) => Close(true);
+			public override void OnPaint(CellPaintEventArgs args)
+			{
+				if (args.Item is PropertyItem pi)
+				{
+					pi.IsSelected = args.IsSelected;
+					var color = pi.DisplayTextColor;
+					var font = pi.DisplayFont;
+					args.DrawCenteredText(pi.DataTypeText, color, font);
+				}
+			}
+		}
 
-            private void CancelButton_Click(object sender, EventArgs e) => Close(false);
-        }
 
-        class PropertyCellTypeObject : PropertyCellType
-        {
-            public override string Identifier => "PropertyCellTypeObject";
+		class PropertyGridDialog : Dialog<bool>
+		{
+			public ThemedPropertyGrid Editor { get; }
 
-            public override bool CanDisplay(object itemType)
-            {
-                var type = itemType as Type;
-                if (type == null)
-                    return false;
-                var typeInfo = type.GetTypeInfo();
-                if (typeInfo.IsValueType || typeInfo.IsArray || typeInfo.IsInterface)
-                    return false;
-                return true;
-            }
+			static Size? s_defaultSize;
 
-            public override Control OnCreate(CellEventArgs args)
-            {
-                var label = new Label();
-                label.VerticalAlignment = VerticalAlignment.Center;
-                label.TextBinding.BindDataContext((PropertyItem p) => p.DisplayText);
-                var button = new Button { MinimumSize = Size.Empty, Text = "…" };
-                button.BindDataContext(c => c.Enabled, Binding.Property((PropertyItem p) => p.IsReadOnly).ToBool(false, true));
-                button.BindDataContext(c => c.Visible, Binding.Property((PropertyItem p) => p.Expandable).ToBool(false, true));
-                button.Click += (sender, e) =>
-                {
-                    var b = sender as Button;
-                    if (b.DataContext is PropertyItem pi)
-                    {
-                        var editor = new ThemedPropertyGrid();
-                        var value = pi.Value ?? pi.CreateNewValue();
-                        editor.SelectedObject = value;
-                        var editorDialog = new PropertyGridDialog(editor);
-                        editorDialog.Title = $"{pi.PropertyType.Name} Editor";
+			public PropertyGridDialog(ThemedPropertyGrid editor)
+			{
+				Editor = editor;
+				Resizable = true;
+				MinimumSize = new Size(200, 200);
+				ClientSize = new Size(400, 400);
+				if (s_defaultSize != null)
+					Size = s_defaultSize.Value;
 
-                        if (editorDialog.ShowModal(button))
-                        {
-                            if (!pi.HasValue)
-                                pi.Value = value;
+				var cancelButton = new Button { Text = Application.Instance.Localize(this, "Cancel") };
+				cancelButton.Click += CancelButton_Click;
+				var okButton = new Button { Text = Application.Instance.Localize(this, Platform.IsMac ? "Apply" : "OK") };
+				okButton.Click += OkButton_Click;
+				DefaultButton = okButton;
+				AbortButton = cancelButton;
 
-                        }
-                    }
-                };
-                return new TableLayout(new TableRow(new TableCell(label, true), button));
-            }
+				var layout = new DynamicLayout();
+				layout.DefaultSpacing = new Size(4, 4);
+				layout.Add(editor, yscale: true);
+				layout.AddSeparateRow(spacing: new Size(6, 0), controls: new[] { null, cancelButton, okButton });
+				Padding = 6;
+				Content = layout;
+			}
 
-            public override void OnPaint(CellPaintEventArgs args)
-            {
-                if (args.Item is PropertyItem pi)
-                {
-                    pi.IsSelected = args.IsSelected;
-                    var color = pi.DisplayTextColor;
-                    var font = pi.DisplayFont;
-                    args.DrawCenteredText(pi.DisplayText, color, font);
-                }
-            }
-        }
+			protected override void OnClosing(CancelEventArgs e)
+			{
+				base.OnClosing(e);
+				s_defaultSize = RestoreBounds.Size;
+			}
 
-        class PropertyCellTypeReadOnly : PropertyCellType
-        {
-            public override string Identifier => "PropertyCellTypeReadOnly";
+			private void OkButton_Click(object sender, EventArgs e) => Close(true);
 
-            public override bool CanDisplay(object itemType) => itemType as Type == typeof(PropertyCellTypeReadOnly);
+			private void CancelButton_Click(object sender, EventArgs e) => Close(false);
+		}
 
-            public override Control OnCreate(CellEventArgs args)
-            {
-                var control = new TextBox { ShowBorder = false, BackgroundColor = Colors.Transparent, ReadOnly = true };
-                control.BindDataContext(c => c.Text, (PropertyItem p) => p.ReadOnlyValue);
-                control.BindDataContext(c => c.ToolTip, (PropertyItem p) => p.ReadOnlyValue);
-                return control;
-            }
+		class PropertyCellTypeObject : PropertyCellType
+		{
+			public override string Identifier => "PropertyCellTypeObject";
 
-            public override void OnConfigure(CellEventArgs args, Control control)
-            {
-                base.OnConfigure(args, control);
-                if (control is TextBox tb)
-                {
-                    if (args.IsSelected && !Eto.Platform.Instance.IsMac)
-                        tb.TextColor = new Color(SystemColors.HighlightText, 0.8f);
-                    else
-                        tb.TextColor = SystemColors.DisabledText;
-                }
-            }
+			public override bool CanDisplay(object itemType)
+			{
+				var type = itemType as Type;
+				if (type == null)
+					return false;
+				var typeInfo = type.GetTypeInfo();
+				if (typeInfo.IsValueType || typeInfo.IsArray || typeInfo.IsInterface)
+					return false;
+				return true;
+			}
 
-            public override void OnPaint(CellPaintEventArgs args)
-            {
-                if (args.Item is PropertyItem pi)
-                {
-                    pi.IsSelected = args.IsSelected;
-                    var color = pi.DisplayTextColor;
-                    var font = pi.DisplayFont;
-                    args.DrawCenteredText(pi.ReadOnlyValue, color, font);
-                }
-            }
-        }
+			public override Control OnCreate(CellEventArgs args)
+			{
+				var label = new Label();
+				label.Wrap = WrapMode.None;
+				label.VerticalAlignment = VerticalAlignment.Center;
+				label.TextBinding.BindDataContext((PropertyItem p) => p.DisplayText);
+				var button = new Button { MinimumSize = Size.Empty, Text = "…" };
+				button.BindDataContext(c => c.Enabled, Binding.Property((PropertyItem p) => p.IsReadOnly).ToBool(false, true));
+				button.BindDataContext(c => c.Visible, Binding.Property((PropertyItem p) => p.Expandable).ToBool(false, true));
+				button.Click += (sender, e) =>
+				{
+					var b = sender as Button;
+					if (b.DataContext is PropertyItem pi)
+					{
+						var editor = new ThemedPropertyGrid();
+						var value = pi.Value ?? pi.CreateNewValue();
+						editor.SelectedObject = value;
+						var editorDialog = new PropertyGridDialog(editor);
+						editorDialog.Title = $"{pi.PropertyType.Name} Editor";
 
-        class PropertyCellTypeCustom : PropertyCellType
-        {
-            public override string Identifier => "PropertyCellTypeCustom";
+						if (editorDialog.ShowModal(button))
+						{
+							if (!pi.HasValue)
+								pi.Value = value;
 
-            public override bool CanDisplay(object itemType) => Equals(itemType, typeof(PropertyCellTypeCustom));
+						}
+					}
+				};
+				return new TableLayout(new TableRow(new TableCell(label, true), button));
+			}
 
-            public override Control OnCreate(CellEventArgs args)
-            {
-                if (args.Item is PropertyItem propertyItem)
-                {
-                    return propertyItem.Editor?.CreateControl(args);
-                }
+			public override void OnPaint(CellPaintEventArgs args)
+			{
+				if (args.Item is PropertyItem pi)
+				{
+					pi.IsSelected = args.IsSelected;
+					var color = pi.DisplayTextColor;
+					var font = pi.DisplayFont;
+					args.DrawCenteredText(pi.DisplayText, color, font);
+				}
+			}
+		}
 
-                return null;
-            }
+		class PropertyCellTypeReadOnly : PropertyCellType
+		{
+			public override string Identifier => "PropertyCellTypeReadOnly";
 
-            public override void OnPaint(CellPaintEventArgs args)
-            {
-                if (args.Item is PropertyItem propertyItem)
-                {
-                    propertyItem.Editor?.PaintCell(args);
-                }
-            }
-        }
+			public override bool CanDisplay(object itemType) => itemType as Type == typeof(PropertyCellTypeReadOnly);
 
-        class NameCell : CustomCell
-        {
-            Grid _parent;
-            public NameCell(Grid parent)
-            {
-                _parent = parent;
-            }
-            protected override Control OnCreateCell(CellEventArgs args)
-            {
-                var control = new Label();
-                control.VerticalAlignment = VerticalAlignment.Center;
-                control.TextBinding.BindDataContext(Binding.Delegate((IItem c) => c.Name));
-                control.BindDataContext(c => c.TextColor, (IItem m) => m.TitleTextColor);
-                control.BindDataContext(c => c.Font, (IItem m) => m.TitleFont);
-                args.PropertyChanged += (sender, e) =>
-                {
-                    if (e.PropertyName == nameof(args.IsSelected) && control.DataContext is PropertyItem pi)
-                    {
-                        pi.IsSelected = args.IsSelected && _parent.HasFocus;
-                    }
-                };
-                return control;
-            }
+			public override Control OnCreate(CellEventArgs args)
+			{
+				var control = new TextBox { ShowBorder = false, BackgroundColor = Colors.Transparent, ReadOnly = true };
+				control.BindDataContext(c => c.Text, (PropertyItem p) => p.ReadOnlyValue);
+				control.BindDataContext(c => c.ToolTip, (PropertyItem p) => p.ReadOnlyValue);
+				return control;
+			}
 
-            protected override void OnPaint(CellPaintEventArgs args)
-            {
-                if (args.Item is IItem item)
-                {
-                    if (args.Item is PropertyItem pi)
-                        pi.IsSelected = args.IsSelected;
-                    args.DrawCenteredText(item.Name, item.TitleTextColor, item.TitleFont);
-                }
-            }
-        }
+			public override void OnConfigure(CellEventArgs args, Control control)
+			{
+				base.OnConfigure(args, control);
+				if (control is TextBox tb)
+				{
+					if (args.IsSelected && !Eto.Platform.Instance.IsMac)
+						tb.TextColor = new Color(SystemColors.HighlightText, 0.8f);
+					else
+						tb.TextColor = SystemColors.DisabledText;
+				}
+			}
 
-        /// <summary>
-        /// Initializes a new instance of the ThemedPropertyGrid
-        /// </summary>
-        public ThemedPropertyGrid()
-        {
-            var orientation = Orientation.Vertical;
+			public override void OnPaint(CellPaintEventArgs args)
+			{
+				if (args.Item is PropertyItem pi)
+				{
+					pi.IsSelected = args.IsSelected;
+					var color = pi.DisplayTextColor;
+					var font = pi.DisplayFont;
+					args.DrawCenteredText(pi.ReadOnlyValue, color, font);
+				}
+			}
+		}
 
-            switch (orientation)
-            {
-                case Orientation.Horizontal:
-                    break;
-                case Orientation.Vertical:
-                    break;
-                default:
-                    break;
-            }
+		class PropertyCellTypeCustom : PropertyCellType
+		{
+			public override string Identifier => "PropertyCellTypeCustom";
 
-            _tree = new TreeGridView();
+			public override bool CanDisplay(object itemType) => Equals(itemType, typeof(PropertyCellTypeCustom));
+
+			public override Control OnCreate(CellEventArgs args)
+			{
+				if (args.Item is PropertyItem propertyItem)
+				{
+					return propertyItem.Editor?.CreateControl(args);
+				}
+
+				return null;
+			}
+
+			public override void OnPaint(CellPaintEventArgs args)
+			{
+				if (args.Item is PropertyItem propertyItem)
+				{
+					propertyItem.Editor?.PaintCell(args);
+				}
+			}
+		}
+
+		class NameCell : CustomCell
+		{
+			Grid _parent;
+			public NameCell(Grid parent)
+			{
+				_parent = parent;
+			}
+			protected override Control OnCreateCell(CellEventArgs args)
+			{
+				var control = new Label();
+				control.Wrap = WrapMode.None;
+				control.VerticalAlignment = VerticalAlignment.Center;
+				control.TextBinding.BindDataContext(Binding.Delegate((IItem c) => c.Name));
+				control.BindDataContext(c => c.TextColor, (IItem m) => m.TitleTextColor);
+				control.BindDataContext(c => c.Font, (IItem m) => m.TitleFont);
+				args.PropertyChanged += (sender, e) =>
+				{
+					if (e.PropertyName == nameof(args.IsSelected) && control.DataContext is PropertyItem pi)
+					{
+						pi.IsSelected = args.IsSelected && _parent.HasFocus;
+					}
+				};
+				return control;
+			}
+
+			protected override float OnGetPreferredWidth(CellEventArgs args)
+			{
+				if (args.Item is IItem m && m.Name != null)
+				{
+					var font = m.TitleFont ?? SystemFonts.Default();
+					return font.MeasureString(m.Name).Width;
+				}
+				return base.OnGetPreferredWidth(args);
+			}
+
+			protected override void OnPaint(CellPaintEventArgs args)
+			{
+				if (args.Item is IItem item)
+				{
+					if (args.Item is PropertyItem pi)
+						pi.IsSelected = args.IsSelected;
+					args.DrawCenteredText(item.Name, item.TitleTextColor, item.TitleFont);
+				}
+			}
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the ThemedPropertyGrid
+		/// </summary>
+		public ThemedPropertyGrid()
+		{
+			var orientation = Orientation.Vertical;
+
+			switch (orientation)
+			{
+				case Orientation.Horizontal:
+					break;
+				case Orientation.Vertical:
+					break;
+				default:
+					break;
+			}
+
+			_tree = new TreeGridView();
             _tree.ShowHeader = false;
-            _tree.SizeChanged += tree_SizeChanged;
-            _tree.Columns.Add(new GridColumn
-            {
-                AutoSize = false,
-                DataCell = new NameCell(_tree)
-            });
-            _propertyCell = new GridPropertyCell(this);
-            _propertyCell.TypeBinding = Binding.Property((PropertyItem p) => p.PropertyCellType);
-            SetupTypes();
+			_tree.SizeChanged += tree_SizeChanged;
+			_tree.Columns.Add(new GridColumn
+			{
+                AutoSize = true,
+				DataCell = new NameCell(_tree)
+			});
+			_propertyCell = new GridPropertyCell(this);
+			_propertyCell.TypeBinding = Binding.Property((PropertyItem p) => p.PropertyCellType);
+			SetupTypes();
 
-            _tree.Columns.Add(new GridColumn
-            {
-                AutoSize = false,
-                Editable = true,
-                DataCell = _propertyCell
-            });
-            CreateLayout();
-        }
+			_tree.Columns.Add(new GridColumn
+			{
+				AutoSize = false,
+				Expand = true,
+				Editable = true,
+				DataCell = _propertyCell
+			});
+			CreateLayout();
+		}
 
-        void CreateLayout()
-        {
-            if (ShowDescription)
-            {
-                var helpTitle = new Label { Font = SystemFonts.Bold() };
-                helpTitle.TextBinding.BindDataContext((PropertyItem p) => p.Name);
+		void CreateLayout()
+		{
+			if (ShowDescription)
+			{
+				var helpTitle = new Label { Font = SystemFonts.Bold() };
+				helpTitle.TextBinding.BindDataContext((PropertyItem p) => p.Name);
 
-                var helpText = new Label { Wrap = WrapMode.Word };
-                helpText.TextBinding.BindDataContext((PropertyItem p) => p.Description);
+				var helpText = new Label { Wrap = WrapMode.Word };
+				helpText.TextBinding.BindDataContext((PropertyItem p) => p.Description);
 
-                var helpPanel = new TableLayout(helpTitle, helpText);
-                helpPanel.Bind(c => c.DataContext, _tree, t => t.SelectedItem);
+				var helpPanel = new TableLayout(helpTitle, helpText);
+				helpPanel.Bind(c => c.DataContext, _tree, t => t.SelectedItem);
 
-                var splitter = new Splitter
-                {
-                    Orientation = Orientation.Vertical,
-                    FixedPanel = SplitterFixedPanel.Panel2,
-                    RelativePosition = 60,
-                    Panel1 = _tree,
-                    Panel2 = helpPanel
-                };
-                Content = splitter;
-            }
-            else
-            {
-                Content = _tree;
-            }
-        }
+				var splitter = new Splitter
+				{
+					Orientation = Orientation.Vertical,
+					FixedPanel = SplitterFixedPanel.Panel2,
+					RelativePosition = 60,
+					Panel1 = _tree,
+					Panel2 = helpPanel
+				};
+				Content = splitter;
+			}
+			else
+			{
+				Content = _tree;
+			}
+		}
 
-        class GridPropertyCell : PropertyCell
-        {
-            private ThemedPropertyGrid _grid;
+		class GridPropertyCell : PropertyCell
+		{
+			private ThemedPropertyGrid _grid;
 
-            public GridPropertyCell(ThemedPropertyGrid grid)
-            {
-                _grid = grid;
-            }
+			public GridPropertyCell(ThemedPropertyGrid grid)
+			{
+				_grid = grid;
+			}
 
-            protected override Control OnCreateCell(CellEventArgs args)
-            {
-                var ctl = base.OnCreateCell(args);
-                if (ctl is Container container)
-                {
-                    container.Styles.Add<CommonControl>(null, child =>
-                    {
-                        if (child is Button)
-                            return;
-                        child.BindDataContext(c => c.Font, (PropertyItem p) => p.DisplayFont);
-                    });
-                    container.Styles.Add<TextControl>(null, child =>
-                    {
-                        if (child is Button)
-                            return;
-                        child.BindDataContext(c => c.TextColor, (PropertyItem p) => p.DisplayTextColor);
-                    });
-                }
-                return ctl;
-            }
+			protected override Control OnCreateCell(CellEventArgs args)
+			{
+				var ctl = base.OnCreateCell(args);
+				if (ctl is Container container)
+				{
+					container.Styles.Add<CommonControl>(null, child =>
+					{
+						if (child is Button)
+							return;
+						child.BindDataContext(c => c.Font, (PropertyItem p) => p.DisplayFont);
+					});
+					container.Styles.Add<TextControl>(null, child =>
+					{
+						if (child is Button)
+							return;
+						child.BindDataContext(c => c.TextColor, (PropertyItem p) => p.DisplayTextColor);
+					});
+				}
+				return ctl;
+			}
 
-        }
+		}
 
 
-        private void tree_SizeChanged(object sender, EventArgs e)
-        {
-            SetColumnWidths();
-        }
+		private void tree_SizeChanged(object sender, EventArgs e)
+		{
+			SetColumnWidths();
+		}
 
-        private void SetColumnWidths()
-        {
-            var width = _tree.Size.Width;
-            if (_tree.Border != BorderType.None)
-                width -= 2;
-            if (Platform.IsWinForms || Platform.IsWpf)
-                width -= 18; // hack: for scrollbar, should use something like _tree.ClientSize
-            width /= 2;
-            var columns = _tree.Columns;
-            for (int i = 0; i < columns.Count; i++)
-            {
-                columns[i].Width = width;
-            }
-        }
+		private void SetColumnWidths()
+		{
+			var width = _tree.Size.Width;
+			if (_tree.Border != BorderType.None)
+				width -= 2;
+			if (width > 0)
+			{
+				_tree.Columns[0].MaxWidth = (int)(width * MaxNameColumnRatio);
+			}
+		}
 
-        /// <summary>
-        /// Refreshes the properties of the grid
-        /// </summary>
-        public void Refresh()
-        {
-            UpdateProperties();
-        }
+		/// <summary>
+		/// Refreshes the properties of the grid
+		/// </summary>
+		public void Refresh()
+		{
+			UpdateProperties();
+		}
 
-        /// <summary>
-        /// Called when the grid is loaded onto a form
-        /// </summary>
-        /// <param name="e">Event arguments</param>
-        protected override void OnLoad(EventArgs e)
-        {
-            base.OnLoad(e);
-            UpdateProperties();
-        }
+		/// <summary>
+		/// Called when the grid is loaded onto a form
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+			UpdateProperties();
+		}
 
-        void UpdateProperties()
-        {
-            if (!Loaded)
-                return;
-            Task.Run(() =>
-            {
-                // do this stuff in the background
-                var properties = GetCommonProperties();
-                var top = new TreeGridItem();
-                if (ShowCategories)
-                {
-                    var categories = SplitIntoCategories(properties);
-                    //if (categories.Count > 1)
-                    ToTreeWithCategories(top, categories);
-                    //else
-                    //    ToTreeWithProperties(top, categories.Values.FirstOrDefault());
-                }
-                else
-                {
-                    ToTreeWithProperties(top, properties);
-                }
-                Application.Instance.Invoke(() =>
-                {
-                    _tree.DataStore = top;
+		void UpdateProperties()
+		{
+			if (!Loaded)
+				return;
+			Task.Run(() =>
+			{
+				// do this stuff in the background
+				var properties = GetCommonProperties();
+				var top = new TreeGridItem();
+				if (ShowCategories)
+				{
+					var categories = SplitIntoCategories(properties);
+					//if (categories.Count > 1)
+					ToTreeWithCategories(top, categories);
+					//else
+					//    ToTreeWithProperties(top, categories.Values.FirstOrDefault());
+				}
+				else
+				{
+					ToTreeWithProperties(top, properties);
+				}
+				Application.Instance.Invoke(() =>
+				{
+					_tree.DataStore = top;
+				});
+			});
+		}
 
-                    // on mac, the width is enlarged by the expanded nodes.. needs to be fixed.
-                    SetColumnWidths();
-                });
-            });
-        }
+		private void ToTreeWithCategories(TreeGridItem top, Dictionary<string, IList<IPropertyDescriptor>> categories)
+		{
+			IEnumerable<string> categoryKeys = categories.Keys;
+			if (CategorySort != null)
+				categoryKeys = categoryKeys.OrderBy(c => c, CategorySort);
+			foreach (var category in categoryKeys)
+			{
+				var categoryItem = new CategoryItem();
+				categoryItem.Expanded = true;
+				categoryItem.Name = category;
 
-        private void ToTreeWithCategories(TreeGridItem top, Dictionary<string, IList<IPropertyDescriptor>> categories)
-        {
-            IEnumerable<string> categoryKeys = categories.Keys;
-            if (CategorySort != null)
-                categoryKeys = categoryKeys.OrderBy(c => c, CategorySort);
-            foreach (var category in categoryKeys)
-            {
-                var categoryItem = new CategoryItem();
-                categoryItem.Expanded = true;
-                categoryItem.Name = category;
+				ToTreeWithProperties(categoryItem, categories[category]);
+				top.Children.Add(categoryItem);
+			}
+		}
 
-                ToTreeWithProperties(categoryItem, categories[category]);
-                top.Children.Add(categoryItem);
-            }
-        }
+		private void ToTreeWithProperties(TreeGridItem categoryItem, IEnumerable<IPropertyDescriptor> properties)
+		{
+			if (properties == null)
+				return;
+			if (PropertySort != null)
+				properties = properties.OrderBy(c => c, PropertySort);
+			foreach (var property in properties)
+			{
+				var propertyItem = new PropertyItem(this, property);
 
-        private void ToTreeWithProperties(TreeGridItem categoryItem, IEnumerable<IPropertyDescriptor> properties)
-        {
-            if (properties == null)
-                return;
-            if (PropertySort != null)
-                properties = properties.OrderBy(c => c, PropertySort);
-            foreach (var property in properties)
-            {
-                var propertyItem = new PropertyItem(this, property);
+				categoryItem.Children.Add(propertyItem);
+			}
+		}
 
-                categoryItem.Children.Add(propertyItem);
-            }
-        }
+		Dictionary<string, IList<IPropertyDescriptor>> SplitIntoCategories(IEnumerable<IPropertyDescriptor> properties)
+		{
+			var categories = new Dictionary<string, IList<IPropertyDescriptor>>();
+			foreach (var prop in properties)
+			{
+				string categoryName =
+					DisplayAttributeWrapper.Get(prop)?.GetGroupName()
+					?? prop.GetCustomAttribute<CategoryAttribute>()?.Category
+					?? Application.Instance.Localize(this, "Misc");
 
-        Dictionary<string, IList<IPropertyDescriptor>> SplitIntoCategories(IEnumerable<IPropertyDescriptor> properties)
-        {
-            var categories = new Dictionary<string, IList<IPropertyDescriptor>>();
-            foreach (var prop in properties)
-            {
-                string categoryName =
-                    DisplayAttributeWrapper.Get(prop)?.GetGroupName()
-                    ?? prop.GetCustomAttribute<CategoryAttribute>()?.Category
-                    ?? Application.Instance.Localize(this, "Misc");
+				if (!categories.TryGetValue(categoryName, out var categoryProperties))
+				{
+					categories[categoryName] = categoryProperties = new List<IPropertyDescriptor>();
+				}
+				categoryProperties.Add(prop);
+			}
 
-                if (!categories.TryGetValue(categoryName, out var categoryProperties))
-                {
-                    categories[categoryName] = categoryProperties = new List<IPropertyDescriptor>();
-                }
-                categoryProperties.Add(prop);
-            }
+			return categories;
+		}
 
-            return categories;
-        }
+		List<IPropertyDescriptor> GetTypeProperties(Type type)
+		{
+			List<IPropertyDescriptor> properties = new List<IPropertyDescriptor>();
+			foreach (var prop in EtoTypeDescriptor.GetProperties(type))
+			{
+				if (!prop.CanRead)
+					continue;
 
-        List<IPropertyDescriptor> GetTypeProperties(Type type)
-        {
-            List<IPropertyDescriptor> properties = new List<IPropertyDescriptor>();
-            foreach (var prop in EtoTypeDescriptor.GetProperties(type))
-            {
-                if (!prop.CanRead)
-                    continue;
+				var browsable = prop.GetCustomAttribute<BrowsableAttribute>();
+				if (browsable?.Browsable == false)
+					continue;
 
-                var browsable = prop.GetCustomAttribute<BrowsableAttribute>();
-                if (browsable?.Browsable == false)
-                    continue;
+				properties.Add(prop);
+			}
+			return properties;
+		}
 
-                properties.Add(prop);
-            }
-            return properties;
-        }
+		IEnumerable<IPropertyDescriptor> GetCommonProperties()
+		{
+			if (_selectedObjects == null)
+				return Enumerable.Empty<IPropertyDescriptor>();
+			List<IPropertyDescriptor> properties = null;
+			var types = new HashSet<Type>();
+			for (int i = 0; i < _selectedObjects.Count; i++)
+			{
+				object obj = _selectedObjects[i];
+				if (obj == null)
+					continue;
+				var type = obj.GetType();
+				if (types.Contains(type))
+					continue;
+				types.Add(type);
+				var currentProperties = GetTypeProperties(type);
 
-        IEnumerable<IPropertyDescriptor> GetCommonProperties()
-        {
-            if (_selectedObjects == null)
-                return Enumerable.Empty<IPropertyDescriptor>();
-            List<IPropertyDescriptor> properties = null;
-            var types = new HashSet<Type>();
-            for (int i = 0; i < _selectedObjects.Count; i++)
-            {
-                object obj = _selectedObjects[i];
-                if (obj == null)
-                    continue;
-                var type = obj.GetType();
-                if (types.Contains(type))
-                    continue;
-                types.Add(type);
-                var currentProperties = GetTypeProperties(type);
+				if (properties == null)
+					properties = currentProperties;
+				else
+				{
+					for (int j = properties.Count - 1; j >= 0; j--)
+					{
+						var prop = properties[j];
 
-                if (properties == null)
-                    properties = currentProperties;
-                else
-                {
-                    for (int j = properties.Count - 1; j >= 0; j--)
-                    {
-                        var prop = properties[j];
+						var currentProp = currentProperties.FirstOrDefault(r => r.Name == prop.Name);
+						if (currentProp == null || currentProp.PropertyType != prop.PropertyType)
+							properties.RemoveAt(j);
+					}
+				}
+			}
+			return properties ?? Enumerable.Empty<IPropertyDescriptor>();
+		}
 
-                        var currentProp = currentProperties.FirstOrDefault(r => r.Name == prop.Name);
-                        if (currentProp == null || currentProp.PropertyType != prop.PropertyType)
-                            properties.RemoveAt(j);
-                    }
-                }
-            }
-            return properties ?? Enumerable.Empty<IPropertyDescriptor>();
-        }
+		object IValueTypeWrapperHost.GetValue(object key)
+		{
+			return _selectedObjects[(int)key];
+		}
 
-        object IValueTypeWrapperHost.GetValue(object key)
-        {
-            return _selectedObjects[(int)key];
-        }
-
-        void IValueTypeWrapperHost.SetValue(object key, object value)
-        {
-            _selectedObjects[(int)key] = value;
-        }
-    }
+		void IValueTypeWrapperHost.SetValue(object key, object value)
+		{
+			_selectedObjects[(int)key] = value;
+		}
+	}
 }

--- a/test/Eto.Test/Sections/Controls/PropertyGridSection.cs
+++ b/test/Eto.Test/Sections/Controls/PropertyGridSection.cs
@@ -1,9 +1,15 @@
-﻿using System;using System.Globalization;using System.ComponentModel;using System.Collections.Generic;
-using Eto.Drawing;using Eto.Forms;
-using System.Linq;using sc = System.ComponentModel;
+﻿using System;
+using System.Globalization;
+using System.ComponentModel;
+using System.Collections.Generic;
+using Eto.Drawing;
+using Eto.Forms;
+using System.Linq;
+using sc = System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
 
-namespace Eto.Test.Sections.Controls{
+namespace Eto.Test.Sections.Controls
+{
 	[Section("Controls", typeof(PropertyGrid))]
 	public class PropertyGridSection : Panel
 	{
@@ -31,7 +37,17 @@ namespace Eto.Test.Sections.Controls{
 		}
 	}
 
-	public class CustomEditor : PropertyGridTypeEditor	{		public override Control CreateControl(CellEventArgs args)		{			return new Label { Text = "Custom Editor!" };		}		public override void PaintCell(CellPaintEventArgs args)		{		}	}
+	public class CustomEditor : PropertyGridTypeEditor
+	{
+		public override Control CreateControl(CellEventArgs args)
+		{
+			return new Label { Text = "Custom Editor!" };
+		}
+
+		public override void PaintCell(CellPaintEventArgs args)
+		{
+		}
+	}
 
 	public enum MyEnum
 	{
@@ -155,7 +171,7 @@ namespace Eto.Test.Sections.Controls{
 
 		public bool? NullableBoolProperty { get; set; }
 
-		public DateTime DateTimeProperty { get; set; }
+		public DateTime DateTimeProperty { get; set; } = DateTime.Now;
 
 		public DateTime? NullableDateTimeProperty { get; set; }
 
@@ -316,4 +332,6 @@ namespace Eto.Test.Sections.Controls{
 		public int[] IntArrayProperty { get; set; }
 
 		public List<int> IntListProperty { get; set; }
-	}}
+	}
+
+}

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
@@ -137,10 +137,10 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			});
 		}
 
-		IEnumerable<object> CreateDataStore()
+		public IEnumerable<object> CreateDataStore(int rows = 20)
 		{
 			var list = new TreeGridItemCollection();
-			for (int i = 0; i < 20; i++)
+			for (int i = 0; i < rows; i++)
 			{
 				list.Add(new GridTestItem { Text = $"Item {i}", Values = new[] { $"col {i}.2", $"col {i}.3", $"col {i}.4" } });
 			}
@@ -148,10 +148,13 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		}
 
 		[ManualTest]
-		[TestCase(0)]
-		[TestCase(1)]
-		[TestCase(2)]
-		public void ExpandedColumnShouldExpand(int columnToExpand)
+		[TestCase(0, -1)]
+		[TestCase(1, -1)]
+		[TestCase(2, -1)]
+		[TestCase(0, 1)]
+		[TestCase(1, 2)]
+		[TestCase(0, 2)]
+		public void ExpandedColumnShouldExpand(int columnToExpand, int secondColumn)
 		{
 			ManualForm("First Column should be expanded, and change size with the Grid", form =>
 			{
@@ -166,16 +169,25 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				expandColumn.HeaderText = "Expanded";
 				expandColumn.Expand = true;
 
+				if (secondColumn != -1)
+				{
+					var expandColumn2 = grid.Columns[secondColumn];
+					expandColumn2.HeaderText = "Expanded2";
+					expandColumn2.Expand = true;
+				}
 
 				return grid;
 			});
 		}
 
 		[ManualTest]
-		[TestCase(0)]
-		[TestCase(1)]
-		[TestCase(2)]
-		public void ExpandedColumnShouldAutoSize(int columnToExpand)
+		[TestCase(0, -1)]
+		[TestCase(1, -1)]
+		[TestCase(2, -1)]
+		[TestCase(0, 1)]
+		[TestCase(1, 2)]
+		[TestCase(0, 2)]
+		public void ExpandedColumnShouldAutoSize(int columnToExpand, int secondColumn)
 		{
 			ManualForm("First Column should be expanded, and change size with the Grid", form =>
 			{
@@ -189,6 +201,13 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				var expandColumn = grid.Columns[columnToExpand];
 				expandColumn.HeaderText = "Expanded";
 				expandColumn.Expand = true;
+
+				if (secondColumn != -1)
+				{
+					var expandColumn2 = grid.Columns[secondColumn];
+					expandColumn2.HeaderText = "Expanded2";
+					expandColumn2.Expand = true;
+				}
 
 				return TableLayout.AutoSized(grid);
 			});
@@ -267,6 +286,23 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		}
 
 		protected abstract void SetDataStore(T grid, IEnumerable<object> dataStore);
+
+
+		[Test, ManualTest]
+		public void ColumnWidthShouldNotIncludeSpacing() => ManualForm("Columns should be exactly 100 pixels wide", form =>
+		{
+			var grid = new T();
+			grid.Width = 250;
+			grid.Height = 200;
+			grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(0), Width = 100 });
+			grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(1), Width = 100 });
+
+			var data = CreateDataStore(10);
+			SetDataStore(grid, data);
+
+			return grid;
+		});
+
 	}
 
 	[TestFixture]


### PR DESCRIPTION
- Utilize GridColumn.Expand for PropertyGrid
- PropertyGrid name column now autosizes and only takes max 50% width
- Mac: Fix some sizing issues with expanded cells
- Mac: Fix issues setting GridColumn.MaxWidth while sizing the control
- Mac: Fix getting correct autosize of columns in the outline column of a TreeGridView
- Mac: Fix expanded column sizes for Big Sur
- WinForms: Implementation of editing for CustomCell
- WinForms: Fix some Splitter crashing issues
- WinForms: Ignore crashes when setting control background color to transparent
- Gtk: Allow autosized columns to shrink
- Gtk: Fix setting GridColumn.MaxWidth while sizing the control
- Gtk: Use CustomCell.GetPreferredWidth event to determine auto size of column