### PR TITLE
Wpf: Inherit DataGrid.ColumnHeaderStyle when header text is aligned

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
@@ -1,12 +1,16 @@
 using Eto.Wpf.Forms.Cells;
 using swc = System.Windows.Controls;
 using sw = System.Windows;
+using swd = System.Windows.Data;
 using Eto.Forms;
+using System.Globalization;
+using System;
 
 namespace Eto.Wpf.Forms.Controls
 {
 	public interface IGridHandler
 	{
+		EtoDataGrid Control { get; }
 		Grid Widget { get; }
 		bool Loaded { get; }
 		bool DisableAutoScrollToSelection { get; }
@@ -20,6 +24,8 @@ namespace Eto.Wpf.Forms.Controls
 		swc.DataGridColumn Control { get; }
 
 		void OnLoad();
+
+		void SetHeaderStyle();
 	}
 
 
@@ -27,7 +33,7 @@ namespace Eto.Wpf.Forms.Controls
 	{
 		Cell dataCell;
 
-		public IGridHandler GridHandler { get; set; }
+		public IGridHandler GridHandler { get; private set; }
 
 		protected override void Initialize()
 		{
@@ -182,6 +188,7 @@ namespace Eto.Wpf.Forms.Controls
 		public void Setup(IGridHandler gridHandler)
 		{
 			GridHandler = gridHandler;
+			SetHeaderStyle();
 		}
 
 		public sw.FrameworkElement SetupCell(ICellHandler handler, sw.FrameworkElement defaultContent, swc.DataGridCell cell)
@@ -225,17 +232,24 @@ namespace Eto.Wpf.Forms.Controls
 			set
 			{
 				if (Widget.Properties.TrySet(HeaderTextAlignment_Key, value))
-				{
-					if (value == TextAlignment.Left)
-						Control.HeaderStyle = null;
-					else
-					{
-						var style = new sw.Style();
-						style.TargetType = typeof(swc.Primitives.DataGridColumnHeader);
-						style.Setters.Add(new sw.Setter(swc.Primitives.DataGridColumnHeader.HorizontalContentAlignmentProperty, value.ToWpf()));
-						Control.HeaderStyle = style;
-					}
-				}
+					SetHeaderStyle();
+			}
+		}
+
+		public virtual void SetHeaderStyle()
+		{
+			var alignment = HeaderTextAlignment;
+			if (alignment == TextAlignment.Left)
+			{
+				Control.ClearValue(swc.DataGridColumn.HeaderStyleProperty);
+			}
+			else if (GridHandler != null)
+			{
+				var style = new sw.Style();
+				style.BasedOn = GridHandler.Control.ColumnHeaderStyle;
+				style.TargetType = typeof(swc.Primitives.DataGridColumnHeader);
+				style.Setters.Add(new sw.Setter(swc.Primitives.DataGridColumnHeader.HorizontalContentAlignmentProperty, alignment.ToWpf()));
+				Control.HeaderStyle = style;
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -280,6 +280,20 @@ namespace Eto.Wpf.Forms.Controls
 			HandleEvent(Eto.Forms.Control.MouseUpEvent);
 
 			Control.Loaded += Control_Loaded;
+
+			// Listen to changes of the column header style so we can apply column styles appropriately for alignment
+			Widget.Properties.Set(swc.DataGrid.ColumnHeaderStyleProperty, PropertyChangeNotifier.Register(swc.DataGrid.ColumnHeaderStyleProperty, Control_ColumnHeaderStyleChanged, Control));
+		}
+
+		private void Control_ColumnHeaderStyleChanged(object sender, EventArgs e)
+		{
+			foreach (var col in Widget.Columns)
+			{
+				if (col.Handler is IGridColumnHandler columnHandler)
+				{
+					columnHandler.SetHeaderStyle();
+				}
+			}
 		}
 
 		private void Control_Loaded(object sender, RoutedEventArgs e)
@@ -301,14 +315,14 @@ namespace Eto.Wpf.Forms.Controls
 			public override void AddItem(GridColumn item)
 			{
 				var colhandler = (GridColumnHandler)item.Handler;
-				colhandler.GridHandler = Handler;
+				colhandler.Setup(Handler);
 				Handler.Control.Columns.Add(colhandler.Control);
 			}
 
 			public override void InsertItem(int index, GridColumn item)
 			{
 				var colhandler = (GridColumnHandler)item.Handler;
-				colhandler.GridHandler = Handler;
+				colhandler.Setup(Handler);
 				Handler.Control.Columns.Insert(index, colhandler.Control);
 			}
 


### PR DESCRIPTION
This allows styles to be inherited when aligning text.  Any style applied to a DataGridColumn directly will still be wiped out, but then if you're doing that you'll set your alignment there anyway.