### PR TITLE
Mac: Fix WebView.DocumentLoading and OpenNewWindow events on macOS 10.14 and lower

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -49,7 +49,7 @@
 		},
 		{
 			"label": "build-mac64",
-			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.Mac64.csproj",
+			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} \"${workspaceFolder}/test/Eto.Test.Mac/Eto.Test.Mac64.csproj\"",
 			"type": "shell",
 			"group": "build",
 			"problemMatcher": "$msCompile",


### PR DESCRIPTION
This was a regression introduced in 2.5.9 when switching to use WKWebView.  One of the delegate api's used is only supported beginning macOS 10.15 (Big Sur).