### PR TITLE
Add styles for converting Colors

### DIFF
--- a/src/Eto/Drawing/BitmapData.cs
+++ b/src/Eto/Drawing/BitmapData.cs
@@ -100,7 +100,7 @@ namespace Eto.Drawing
 		/// Each platform can have a different pixel format, and this allows you to abstract 
 		/// setting the data directly.
 		/// 
-		/// The ARGB value can be easily retrieved using <see cref="Color.ToArgb"/>.
+		/// The ARGB value can be easily retrieved using <see cref="Color.ToArgb()"/>.
 		/// 
 		/// For non-alpha bitmaps, the alpha component will be ignored
 		/// </remarks>

--- a/src/Eto/Drawing/ColorConverter.cs
+++ b/src/Eto/Drawing/ColorConverter.cs
@@ -9,9 +9,9 @@ namespace Eto.Drawing
 	/// Converts instances of other types to and from a <see cref="Color"/>.
 	/// </summary>
 	/// <remarks>
-	/// This only supports converting from a string supported by the <see cref="Color.TryParse"/> method.
+	/// This only supports converting from a string supported by the <see cref="Color.TryParse(string, out Color)"/> method.
 	/// 
-	/// When converting to a string, it converts to a Hex format via <see cref="Color.ToHex"/>
+	/// When converting to a string, it converts to a Hex format via <see cref="Color.ToHex(bool)"/>
 	/// </remarks>
 	/// <copyright>(c) 2014 by Curtis Wensley</copyright>
 	/// <license type="BSD-3">See LICENSE for full terms</license>
@@ -81,9 +81,9 @@ namespace Eto.Drawing
 	/// Converts instances of other types to and from a <see cref="Color"/>.
 	/// </summary>
 	/// <remarks>
-	/// This only supports converting from a string supported by the <see cref="Color.TryParse"/> method.
+	/// This only supports converting from a string supported by the <see cref="Color.TryParse(string, out Color)"/> method.
 	/// 
-	/// When converting to a string, it converts to a Hex format via <see cref="Color.ToHex"/>
+	/// When converting to a string, it converts to a Hex format via <see cref="Color.ToHex(bool)"/>
 	/// </remarks>
 	/// <copyright>(c) 2014 by Curtis Wensley</copyright>
 	/// <license type="BSD-3">See LICENSE for full terms</license>

--- a/src/Eto/Drawing/Palette.cs
+++ b/src/Eto/Drawing/Palette.cs
@@ -13,7 +13,7 @@ namespace Eto.Drawing
 	/// Typically used for <see cref="IndexedBitmap"/> or other purposes where a collection of colors is needed.
 	/// 
 	/// This class keeps a cache of 32-bit ARGB values for each element in the collection for faster retrieval. These
-	/// values are generated using <see cref="Color.ToArgb"/>.
+	/// values are generated using <see cref="Color.ToArgb()"/>.
 	/// </remarks>
 	/// <copyright>(c) 2014 by Curtis Wensley</copyright>
 	/// <license type="BSD-3">See LICENSE for full terms</license>

--- a/test/Eto.Test/UnitTests/Drawing/ColorTests.cs
+++ b/test/Eto.Test/UnitTests/Drawing/ColorTests.cs
@@ -98,5 +98,102 @@ namespace Eto.Test.UnitTests.Drawing
 			Assert.AreNotEqual(double.NaN, hsb.Y, "#4. Y is NaN");
 			Assert.AreNotEqual(double.NaN, hsb.K, "#4. K is NaN");
 		}
+
+		[TestCase("#000", 255, 0, 0, 0)]
+		[TestCase("#123", 255, 17, 34, 51)]
+		[TestCase("#FFF", 255, 255, 255, 255)]
+		[TestCase("#000000", 255, 0, 0, 0)]
+		[TestCase("#123456", 255, 18, 52, 86)]
+		[TestCase("#FFFFFF", 255, 255, 255, 255)]
+		[TestCase("0, 0, 0", 255, 0, 0, 0)]
+		[TestCase("12, 34, 56", 255, 12, 34, 56)]
+		[TestCase("12 34 56", 255, 12, 34, 56)]
+		[TestCase("rgb(12, 34, 56)", 255, 12, 34, 56)]
+		[TestCase("255, 255, 255", 255, 255, 255, 255)]
+
+		[TestCase("#0000", 0, 0, 0, 0)]
+		[TestCase("#1234", 17, 34, 51, 68)]
+		[TestCase("#FFFF", 255, 255, 255, 255)]
+		[TestCase("#00000000", 0, 0, 0, 0)]
+		[TestCase("#12345678", 18, 52, 86, 120)]
+		[TestCase("#FFFFFFFF", 255, 255, 255, 255)]
+		[TestCase("0, 0, 0, 0", 0, 0, 0, 0)]
+		[TestCase("12, 34, 56, 78", 12, 34, 56, 78)]
+		[TestCase("12 34 56 78", 12, 34, 56, 78)]
+		[TestCase("255, 255, 255, 255", 255, 255, 255, 255)]
+		[TestCase("rgba(12,34,56,0.5)", 127, 12, 34, 56)]
+		[TestCase("rgba(50%,20%,100%,0.3)", 76, 127, 51, 255)]
+		[TestCase("rgba(50%,20.5%,100%,0.3)", 76, 127, 52, 255)]
+		[TestCase("0", 0, 0, 0, 0)]
+		[TestCase("4294967295", 255, 255, 255, 255)] // #FFFFFFFF
+		[TestCase("16777215", 0, 255, 255, 255)] // #FFFFFF
+		[TestCase("305419896", 18, 52, 86, 120)] // #12345678 A = 12
+
+		[TestCase("#0000", 255, 0, 0, 0, ColorStyles.ExcludeAlpha)]
+		[TestCase("#1234", 255, 34, 51, 68, ColorStyles.ExcludeAlpha)]
+		[TestCase("#00000000", 255, 0, 0, 0, ColorStyles.ExcludeAlpha)]
+		[TestCase("#12345678", 255, 52, 86, 120, ColorStyles.ExcludeAlpha)]
+		[TestCase("0, 0, 0, 0", 255, 0, 0, 0, ColorStyles.ExcludeAlpha)]
+		[TestCase("12, 34, 56, 78", 255, 34, 56, 78, ColorStyles.ExcludeAlpha)]
+		[TestCase("255, 255, 255, 255", 255, 255, 255, 255, ColorStyles.ExcludeAlpha)]
+		[TestCase("rgba(12,34,56,0.5)", 255, 12, 34, 56, ColorStyles.ExcludeAlpha)] // alpha always last
+		[TestCase("rgba(50%,20%,100%,0.3)", 255, 127, 51, 255, ColorStyles.ExcludeAlpha)]
+		[TestCase("rgba(50%,20.5%,100%,0.3)", 255, 127, 52, 255, ColorStyles.ExcludeAlpha)]
+		[TestCase("0", 255, 0, 0, 0, ColorStyles.ExcludeAlpha)]
+		[TestCase("4294967295", 255, 255, 255, 255, ColorStyles.ExcludeAlpha)] // #FFFFFFFF
+		[TestCase("16777215", 255, 255, 255, 255, ColorStyles.ExcludeAlpha)] // #FFFFFF
+		[TestCase("305419896", 255, 52, 86, 120, ColorStyles.ExcludeAlpha)] // #12345678 A = 12
+
+		[TestCase("#0000", 0, 0, 0, 0, ColorStyles.AlphaLast)]
+		[TestCase("#1234", 68, 17, 34, 51, ColorStyles.AlphaLast)]
+		[TestCase("#00000000", 0, 0, 0, 0, ColorStyles.AlphaLast)]
+		[TestCase("#12345678", 120, 18, 52, 86, ColorStyles.AlphaLast)]
+		[TestCase("0, 0, 0, 0", 0, 0, 0, 0, ColorStyles.AlphaLast)]
+		[TestCase("12, 34, 56, 78", 78, 12, 34, 56, ColorStyles.AlphaLast)]
+		[TestCase("255, 255, 255, 255", 255, 255, 255, 255, ColorStyles.AlphaLast)]
+		[TestCase("rgba(12,34,56,0.3)", 76, 12, 34, 56, ColorStyles.AlphaLast)]
+		[TestCase("rgba(50%,20%,100%,0.3)", 76, 127, 51, 255, ColorStyles.AlphaLast)]
+		[TestCase("rgba(50%,20.5%,100%,0.3)", 76, 127, 52, 255, ColorStyles.AlphaLast)]
+		[TestCase("0", 0, 0, 0, 0, ColorStyles.AlphaLast)]
+		[TestCase("4294967295", 255, 255, 255, 255, ColorStyles.AlphaLast)] // #FFFFFFFF
+		[TestCase("16777215", 255, 0, 255, 255, ColorStyles.AlphaLast)] // #FFFFFF
+		[TestCase("305419896", 120, 18, 52, 86, ColorStyles.AlphaLast)] // #12345678 A = 78
+		public void ColorShouldParse(string text, int a, int r, int g, int b, ColorStyles? style = null)
+		{
+			Color color;
+			var result = style == null ? Color.TryParse(text, out color) : Color.TryParse(text, out color, style.Value);
+			Assert.IsTrue(result, "#1 - Color could not be parsed from text");
+
+			Assert.AreEqual(a, color.Ab, "#2.1 - Alpha component is incorrect");
+			Assert.AreEqual(r, color.Rb, "#2.2 - Red component is incorrect");
+			Assert.AreEqual(g, color.Gb, "#2.3 - Green component is incorrect");
+			Assert.AreEqual(b, color.Bb, "#2.4 - Blue component is incorrect");
+		}
+
+		[TestCase("#0000", 0, 0, 0, 0, ColorStyles.ShortHex)]
+		[TestCase("#1234", 17, 34, 51, 68, ColorStyles.ShortHex)]
+		[TestCase("#FFFF", 255, 255, 255, 255, ColorStyles.ShortHex)]
+		[TestCase("#12345678", 18, 52, 86, 120, ColorStyles.ShortHex)]
+		[TestCase("#00000000", 0, 0, 0, 0)]
+		[TestCase("#12345678", 18, 52, 86, 120)]
+		[TestCase("#FFFFFFFF", 255, 255, 255, 255)]
+
+		[TestCase("#000", 255, 0, 0, 0, ColorStyles.ExcludeAlpha | ColorStyles.ShortHex)]
+		[TestCase("#234", 255, 34, 51, 68, ColorStyles.ExcludeAlpha | ColorStyles.ShortHex)]
+		[TestCase("#345678", 255, 52, 86, 120, ColorStyles.ExcludeAlpha | ColorStyles.ShortHex)]
+		[TestCase("#000000", 255, 0, 0, 0, ColorStyles.ExcludeAlpha)]
+		[TestCase("#345678", 255, 52, 86, 120, ColorStyles.ExcludeAlpha)]
+
+		[TestCase("#0000", 0, 0, 0, 0, ColorStyles.AlphaLast | ColorStyles.ShortHex)]
+		[TestCase("#1234", 68, 17, 34, 51, ColorStyles.AlphaLast | ColorStyles.ShortHex)]
+		[TestCase("#12345678", 120, 18, 52, 86, ColorStyles.AlphaLast | ColorStyles.ShortHex)]
+		[TestCase("#00000000", 0, 0, 0, 0, ColorStyles.AlphaLast)]
+		[TestCase("#12345678", 120, 18, 52, 86, ColorStyles.AlphaLast)]
+		public void ColorToHexShouldBeCorrect(string text, int a, int r, int g, int b, ColorStyles? style = null)
+		{
+			var color = Color.FromArgb(r, g, b, a);
+			var value = style != null ? color.ToHex(style.Value) : color.ToHex();
+			Assert.AreEqual(text, value, "#1 Hex value incorrect");
+		}
 	}
 }


### PR DESCRIPTION
- support short hex formats (e.g `#123` or `#1234`)
- parse css rgb() and rgba() formats
- support percentage values
- optionally omit alpha
- optionally parse alpha as last component