### PR TITLE
Add Splitter.PositionChanging event

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,6 +90,12 @@ jobs:
         mono-version: latest
         xamarin-mac-version: latest
         xcode-version: latest
+    
+    # See https://github.com/actions/virtual-environments/issues/2790
+    - name: Fix issue with latest macos image
+      run: |
+        curl -o xamarinmac.pkg 'https://bosstoragemirror.blob.core.windows.net/wrench/xcode12.4/a4c70e7d04e3904d17aa60f6d640eb048081c757/4477741/package/notarized/xamarin.mac-7.4.0.10.pkg'
+        sudo installer -pkg xamarinmac.pkg -target /
 
     - name: Import code signing certificate
       if: github.event_name != 'pull_request'

--- a/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -123,6 +123,7 @@ namespace Eto.Mac.Forms.Controls
 			switch (id)
 			{
 				case Splitter.PositionChangedEvent:
+				case Splitter.PositionChangingEvent:
 					// handled by delegate
 					break;
 				default:
@@ -293,6 +294,12 @@ namespace Eto.Mac.Forms.Controls
 					proposedPosition = (nfloat)Math.Min(totalSize, proposedPosition);
 				}
 
+				var args = new SplitterPositionChangingEventArgs((int)Math.Round(proposedPosition));
+				h.Callback.OnPositionChanging(h.Widget, args);
+				if (args.Cancel)
+					return h.Position;
+
+
 				return (nfloat)Math.Round(proposedPosition);
 			}
 			
@@ -318,6 +325,7 @@ namespace Eto.Mac.Forms.Controls
 					h.Callback.OnPositionChanged(h.Widget, EventArgs.Empty);
 				}
 			}
+
 		}
 		// stupid hack for OSX 10.5 so that mouse down/drag/up events fire in children properly..
 		public class EtoSplitView : NSSplitView, IMacControl
@@ -639,6 +647,7 @@ namespace Eto.Mac.Forms.Controls
 		{
 			base.InvalidateMeasure();
 			Control.NeedsLayout = true;
+			UpdatePosition();
 		}
 
 		void UpdatePosition()

--- a/src/Eto.Wpf/Forms/Controls/ExpanderHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ExpanderHandler.cs
@@ -75,7 +75,7 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
-		void HandleIsExpandedChanged(object sender, EventArgs e)
+		void HandleIsExpandedChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
 		{
 			Callback.OnExpandedChanged(Widget, EventArgs.Empty);
 		}

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -282,10 +282,10 @@ namespace Eto.Wpf.Forms.Controls
 			Control.Loaded += Control_Loaded;
 
 			// Listen to changes of the column header style so we can apply column styles appropriately for alignment
-			Widget.Properties.Set(swc.DataGrid.ColumnHeaderStyleProperty, PropertyChangeNotifier.Register(swc.DataGrid.ColumnHeaderStyleProperty, Control_ColumnHeaderStyleChanged, Control));
+			AttachPropertyChanged(swc.DataGrid.ColumnHeaderStyleProperty, Control_ColumnHeaderStyleChanged, Control);
 		}
 
-		private void Control_ColumnHeaderStyleChanged(object sender, EventArgs e)
+		private void Control_ColumnHeaderStyleChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
 		{
 			foreach (var col in Widget.Columns)
 			{

--- a/src/Eto.Wpf/Forms/Controls/ToggleButtonHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ToggleButtonHandler.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-using wf = System.Windows;
+using sw = System.Windows;
 using swc = System.Windows.Controls;
 using swcp = System.Windows.Controls.Primitives;
 
@@ -15,7 +15,7 @@ namespace Eto.Wpf.Forms.Controls
 	{
 		public IWpfFrameworkElement Handler { get; set; }
 
-		protected override wf.Size MeasureOverride(wf.Size constraint)
+		protected override sw.Size MeasureOverride(sw.Size constraint)
 		{
 			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
 		}
@@ -46,7 +46,7 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
-		private void OnCheckedChanged(object sender, EventArgs e)
+		private void OnCheckedChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
 		{
 			Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 		}

--- a/src/Eto.Wpf/Forms/FontDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/FontDialogHandler.cs
@@ -40,7 +40,7 @@ namespace Eto.Wpf.Forms
 			}
 		}
 
-		private void FontChanged(object sender, EventArgs e)
+		private void FontChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
 		{
 			if (DisableFontChanged > 0)
 				return;

--- a/src/Eto.Wpf/Forms/Menu/CheckMenuItemHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/CheckMenuItemHandler.cs
@@ -37,7 +37,7 @@ namespace Eto.Wpf.Forms.Menu
 			}
 		}
 
-		void HandleIsCheckedChanged(object sender, EventArgs e)
+		void HandleIsCheckedChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
 		{
 			Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 		}

--- a/src/Eto.Wpf/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/ContextMenuHandler.cs
@@ -50,7 +50,7 @@ namespace Eto.Wpf.Forms.Menu
 			}
 		}
 
-		void HandleIsOpenChanged(object sender, EventArgs e)
+		void HandleIsOpenChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
 		{
 			if (!Control.IsOpen)
 				Callback.OnClosing(Widget, EventArgs.Empty);

--- a/src/Eto.Wpf/Forms/Menu/RadioMenuItemHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/RadioMenuItemHandler.cs
@@ -4,6 +4,7 @@ using Eto.Forms;
 using swc = System.Windows.Controls;
 using swm = System.Windows.Media;
 using swi = System.Windows.Input;
+using sw = System.Windows;
 using System.Linq;
 using System.ComponentModel;
 
@@ -77,7 +78,7 @@ namespace Eto.Wpf.Forms.Menu
 			}
 		}
 
-		void HandleIsCheckedChanged(object sender, EventArgs e)
+		void HandleIsCheckedChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
 		{
 			Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 		}

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -994,7 +994,7 @@ namespace Eto.Wpf.Forms
 			return WinFormsHelpers.ToEtoWindow(handle);
 		}
 
-		protected void AttachPropertyChanged(sw.DependencyProperty property, EventHandler handler, sw.DependencyObject control = null)
+		protected void AttachPropertyChanged(sw.DependencyProperty property, EventHandler<sw.DependencyPropertyChangedEventArgs> handler, sw.DependencyObject control = null)
 		{
 			control = control ?? Control;
 			Widget.Properties.Set(property, PropertyChangeNotifier.Register(property, handler, control));

--- a/src/Eto.Wpf/PropertyChangeNotifier.cs
+++ b/src/Eto.Wpf/PropertyChangeNotifier.cs
@@ -15,9 +15,9 @@ namespace Eto.Wpf
 	{
 		WeakReference _propertySource;
 		sw.PropertyPath _property;
-		public event EventHandler ValueChanged;
+		public event EventHandler<sw.DependencyPropertyChangedEventArgs> ValueChanged;
 
-		public static PropertyChangeNotifier Register(sw.DependencyProperty property, EventHandler handler, sw.DependencyObject propertySource = null)
+		public static PropertyChangeNotifier Register(sw.DependencyProperty property, EventHandler<sw.DependencyPropertyChangedEventArgs> handler, sw.DependencyObject propertySource = null)
 		{
 			var notifier = new PropertyChangeNotifier(property);
 			if (propertySource != null)
@@ -61,7 +61,7 @@ namespace Eto.Wpf
 		private static void OnPropertyChanged(sw.DependencyObject d, sw.DependencyPropertyChangedEventArgs e)
 		{
 			var notifier = (PropertyChangeNotifier)d;
-			notifier.ValueChanged?.Invoke(notifier, EventArgs.Empty);
+			notifier.ValueChanged?.Invoke(notifier, e);
 		}
 
 		public object Value

--- a/src/Eto/Forms/Controls/Splitter.cs
+++ b/src/Eto/Forms/Controls/Splitter.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Eto.Forms
 {
@@ -20,6 +21,27 @@ namespace Eto.Forms
 		/// Both panels will resize along with the splitter's container.
 		/// </summary>
 		None
+	}
+
+	/// <summary>
+	/// Event arguments for the <see cref="Splitter.PositionChanging"/> event.
+	/// </summary>
+	public class SplitterPositionChangingEventArgs : CancelEventArgs
+	{
+		/// <summary>
+		/// The new position for the splitter
+		/// </summary>
+		/// <value></value>
+		public int NewPosition { get; }
+
+		/// <summary>
+		/// Initializes a new instance of the SplitterPositionChangingEventArgs class
+		/// </summary>
+		/// <param name="newPosition"></param>
+		public SplitterPositionChangingEventArgs(int newPosition)
+		{
+			NewPosition = newPosition;
+		}
 	}
 
 	/// <summary>
@@ -85,11 +107,35 @@ namespace Eto.Forms
 			Properties.TriggerEvent(PositionChangedEvent, this, e);
 		}
 
+		/// <summary>
+		/// Identifier for the <see cref="PositionChanging"/> event
+		/// </summary>
+		public const string PositionChangingEvent = "Splitter.PositionChanging";
+
+		/// <summary>
+		/// Raised when the user moves the splitter. Set <see cref="CancelEventArgs.Cancel" /> to true to abort the change.
+		/// </summary>
+		public event EventHandler<SplitterPositionChangingEventArgs> PositionChanging
+		{
+			add { Properties.AddHandlerEvent(PositionChangingEvent, value); }
+			remove { Properties.RemoveEvent(PositionChangingEvent, value); }
+		}
+
+		/// <summary>
+		/// Raises the <see cref="PositionChanging"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments.</param>
+		protected virtual void OnPositionChanging(SplitterPositionChangingEventArgs e)
+		{
+			Properties.TriggerEvent(PositionChangingEvent, this, e);
+		}
+
 		#endregion
 
 		static Splitter()
 		{
 			EventLookup.Register<Splitter>(c => c.OnPositionChanged(null), Splitter.PositionChangedEvent);
+			EventLookup.Register<Splitter>(c => c.OnPositionChanging(null), Splitter.PositionChangingEvent);
 		}
 
 		/// <summary>
@@ -232,6 +278,10 @@ namespace Eto.Forms
 			/// Raises the position changed event.
 			/// </summary>
 			void OnPositionChanged(Splitter widget, EventArgs e);
+			/// <summary>
+			/// Raises the position changing event.
+			/// </summary>
+			void OnPositionChanging(Splitter widget, SplitterPositionChangingEventArgs e);
 		}
 
 		/// <summary>
@@ -246,6 +296,14 @@ namespace Eto.Forms
 			{
 				using (widget.Platform.Context)
 					widget.OnPositionChanged(e);
+			}
+			/// <summary>
+			/// Raises the position changing event.
+			/// </summary>
+			public void OnPositionChanging(Splitter widget, SplitterPositionChangingEventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnPositionChanging(e);
 			}
 		}
 

--- a/test/Eto.Test/TestApplication.cs
+++ b/test/Eto.Test/TestApplication.cs
@@ -9,78 +9,6 @@ using System.Reflection;
 
 namespace Eto.Test
 {
-
-	class TestForm : Form
-	{
-     	public TestForm()
-        {
-            Title = "GM Kickout";
-			Menu = new MenuBar();
-            MinimumSize = new Size(200, 200);
-            Size = new Size(600, 300);
-            var root  = new DynamicLayout();
-            root.BackgroundColor = Colors.White;
-
-            var header = new DynamicLayout();
-            header.Height = 70;
-            header.BackgroundColor = Color.FromRgb(0x008080);
-
-            root.Add(header);
-
-            var content = new DynamicLayout();
-            content.Padding = new Padding(0, 20, 0, 0);
-           
-
-            var layout1 = CreateMainContentItem("Content Editor", "Edit the Content files of the project.", null);
-            content.Add(layout1);
-            root.Add(content);
-	    Content = root;
-
-            Focus();
-	}
-        public static DynamicLayout CreateMainContentItem(string title, string description, Action click)
-        {
-            DynamicLayout layout = new DynamicLayout();
-            
-            StackLayout stackLayout = new StackLayout();
-            stackLayout.Orientation = Orientation.Vertical;
-            stackLayout.Padding = new Padding(0, 10);
-            stackLayout.HorizontalContentAlignment = HorizontalAlignment.Center;
-            stackLayout.MouseEnter += ((e, o) =>
-            {
-                stackLayout.BackgroundColor = Color.FromRgb(0xdfdfdf);
-            });
-            stackLayout.MouseDown += ((e, o) =>
-            {
-                stackLayout.BackgroundColor = Color.FromRgb(0x008080);
-                if(click != null)
-                click();
-            });
-            stackLayout.MouseLeave += ((e, o) =>
-            {
-                stackLayout.BackgroundColor = SystemColors.ControlBackground;
-            });
-
-            Label titleLbl = new Label();
-            titleLbl.TextColor = Color.FromRgb(0xf88379);
-            titleLbl.Font = new Font(SystemFont.Label, 20f);
-            titleLbl.Text = title;
-
-            Label descriptionLbl = new Label();
-            descriptionLbl.Font = new Font(SystemFont.Label);
-            descriptionLbl.Text = description;
-
-            stackLayout.Items.Add(titleLbl);
-            stackLayout.Items.Add(descriptionLbl);
-
-            StackLayout dummy = new StackLayout();
-            layout.Add(stackLayout);
-            layout.Add(dummy);
-
-            return layout;
-        }		
-	}
-	
 	public class TestApplication : Application
 	{
 		static Settings settings;
@@ -121,7 +49,6 @@ namespace Eto.Test
 		protected override void OnInitialized(EventArgs e)
 		{
 			MainForm = new MainForm(TestSections.Get(TestAssemblies));
-			// MainForm = new TestForm();
 
 			base.OnInitialized(e);
 

--- a/test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
@@ -399,5 +399,45 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				return tabs;
 			});
 		}
+
+		[Test, ManualTest]
+		public void SplitterChangingShouldAllowRestrictingWithoutArtifacts()
+		{
+			int? outOfBounds = null;
+			ManualForm("Splitter should be restricted between 100 and 200, and start at 300", form => {
+            	form.ClientSize = new Size(600, 300);
+				var splitter = new Splitter {
+
+					Panel1 = new Panel { BackgroundColor = Colors.Blue, Size = new Size(300, 200) },
+					Panel2 = new Panel { BackgroundColor = Colors.Red, Size = new Size(300, 200) }
+				};
+
+				splitter.PositionChanging += (sender, e) => {
+					System.Diagnostics.Debug.WriteLine($"PositionChanging, Position {splitter.Position}, NewPosition: {e.NewPosition}");
+					if (e.NewPosition < 100)
+					{
+						splitter.Position = 100;
+						e.Cancel = true;
+					}
+					if (e.NewPosition > 200)
+					{
+						splitter.Position = 200;
+						e.Cancel = true;
+					}
+				};
+				splitter.PositionChanged += (sender, e) => {
+					var position = splitter.Position;
+					System.Diagnostics.Debug.WriteLine($"PositionChanged, Position: {position}");
+					if (position > 200 || position < 100)
+					{
+						outOfBounds = position;
+						form.Close();
+					}
+				};
+
+		    	return splitter;
+			});
+			Assert.IsNull(outOfBounds, $"#1 - Position went out of bounds 100-200, was {outOfBounds}");
+		}
 	}
 }


### PR DESCRIPTION
PositionChanging can be used to add custom logic to restrict the splitter position.
Gtk: Fix setting Splitter panels to null where it should collapse the panel
Wpf: Protect against crash when calling Window.Close() while window is already closing
Update SplitterSection > Test Hiding so it cycles through all transitions instead of randomly