### PR TITLE
Add SubMenuItem

### DIFF
--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.cs
@@ -44,9 +44,9 @@ namespace EtoApp.1
 				Items =
 				{
 					// File submenu
-					new ButtonMenuItem { Text = "&File", Items = { clickMe } },
-					// new ButtonMenuItem { Text = "&Edit", Items = { /* commands/items */ } },
-					// new ButtonMenuItem { Text = "&View", Items = { /* commands/items */ } },
+					new SubMenuItem { Text = "&File", Items = { clickMe } },
+					// new SubMenuItem { Text = "&Edit", Items = { /* commands/items */ } },
+					// new SubMenuItem { Text = "&View", Items = { /* commands/items */ } },
 				},
 				ApplicationItems =
 				{

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.eto.cs
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.eto.cs
@@ -41,9 +41,9 @@ namespace EtoApp.1
 				Items =
 				{
 					// File submenu
-					new ButtonMenuItem { Text = "&File", Items = { clickMe } },
-					// new ButtonMenuItem { Text = "&Edit", Items = { /* commands/items */ } },
-					// new ButtonMenuItem { Text = "&View", Items = { /* commands/items */ } },
+					new SubMenuItem { Text = "&File", Items = { clickMe } },
+					// new SubMenuItem { Text = "&Edit", Items = { /* commands/items */ } },
+					// new SubMenuItem { Text = "&View", Items = { /* commands/items */ } },
 				},
 				ApplicationItems =
 				{

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.jeto
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.jeto
@@ -15,7 +15,7 @@
 	"Menu": {
 		"Items": [
 			{ 
-				"$type": "ButtonMenuItem",
+				"$type": "SubMenuItem",
 				"Text": "&File",
 				"Items": [
 					{ "$type": "ButtonMenuItem", "Text": "Click Me!", "Click": "HandleClickMe" }

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.xeto
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.xeto
@@ -15,9 +15,9 @@
 <!--#if(IsForm)-->
 	<Form.Menu>
 		<MenuBar>
-			<ButtonMenuItem Text="F&amp;ile">
+			<SubMenuItem Text="F&amp;ile">
 				<ButtonMenuItem Text="Click Me!" Click="HandleClickMe" />
-			</ButtonMenuItem>
+			</SubMenuItem>
 			<MenuBar.ApplicationItems>
 				<ButtonMenuItem Text="Preferences.." Shortcut="{On Control+O, Mac=Application+Comma}" />
 			</MenuBar.ApplicationItems>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.jeto
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.jeto
@@ -15,7 +15,7 @@
 	"Menu": {
 		"Items": [
 			{ 
-				"$type": "ButtonMenuItem",
+				"$type": "SubMenuItem",
 				"Text": "&File",
 				"Items": [
 					{ "$type": "ButtonMenuItem", "Text": "Click Me!", "Click": "HandleClickMe" }

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.xeto
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/MainForm.xeto
@@ -15,9 +15,9 @@
 <!--#if(IsForm)-->
 	<Form.Menu>
 		<MenuBar>
-			<ButtonMenuItem Text="F&amp;ile">
+			<SubMenuItem Text="F&amp;ile">
 				<ButtonMenuItem Text="Click Me!" Click="HandleClickMe" />
-			</ButtonMenuItem>
+			</SubMenuItem>
 			<MenuBar.ApplicationItems>
 				<ButtonMenuItem Text="Preferences.." Shortcut="{On Control+O, Mac=Application+Comma}" />
 			</MenuBar.ApplicationItems>

--- a/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.cs
+++ b/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.cs
@@ -44,9 +44,9 @@ namespace EtoApp.1
 				Items =
 				{
 					// File submenu
-					new ButtonMenuItem { Text = "&File", Items = { clickMe } },
-					// new ButtonMenuItem { Text = "&Edit", Items = { /* commands/items */ } },
-					// new ButtonMenuItem { Text = "&View", Items = { /* commands/items */ } },
+					new SubMenuItem { Text = "&File", Items = { clickMe } },
+					// new SubMenuItem { Text = "&Edit", Items = { /* commands/items */ } },
+					// new SubMenuItem { Text = "&View", Items = { /* commands/items */ } },
 				},
 				ApplicationItems =
 				{

--- a/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.eto.cs
+++ b/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.eto.cs
@@ -41,9 +41,9 @@ namespace EtoApp.1
 				Items =
 				{
 					// File submenu
-					new ButtonMenuItem { Text = "&File", Items = { clickMe } },
-					// new ButtonMenuItem { Text = "&Edit", Items = { /* commands/items */ } },
-					// new ButtonMenuItem { Text = "&View", Items = { /* commands/items */ } },
+					new SubMenuItem { Text = "&File", Items = { clickMe } },
+					// new SubMenuItem { Text = "&Edit", Items = { /* commands/items */ } },
+					// new SubMenuItem { Text = "&View", Items = { /* commands/items */ } },
 				},
 				ApplicationItems =
 				{

--- a/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.jeto
+++ b/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.jeto
@@ -15,7 +15,7 @@
 	"Menu": {
 		"Items": [
 			{ 
-				"$type": "ButtonMenuItem",
+				"$type": "SubMenuItem",
 				"Text": "&File",
 				"Items": [
 					{ "$type": "ButtonMenuItem", "Text": "Click Me!", "Click": "HandleClickMe" }

--- a/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.xeto
+++ b/src/Addins/Eto.Forms.Templates/content/File-CSharp/MainForm.xeto
@@ -15,9 +15,9 @@
 <!--#if(IsForm)-->
 	<Form.Menu>
 		<MenuBar>
-			<ButtonMenuItem Text="F&amp;ile">
+			<SubMenuItem Text="F&amp;ile">
 				<ButtonMenuItem Text="Click Me!" Click="HandleClickMe" />
-			</ButtonMenuItem>
+			</SubMenuItem>
 			<MenuBar.ApplicationItems>
 				<ButtonMenuItem Text="Preferences.." Shortcut="{On Control+O, Mac=Application+Comma}" />
 			</MenuBar.ApplicationItems>

--- a/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.jeto
+++ b/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.jeto
@@ -15,7 +15,7 @@
 	"Menu": {
 		"Items": [
 			{ 
-				"$type": "ButtonMenuItem",
+				"$type": "SubMenuItem",
 				"Text": "&File",
 				"Items": [
 					{ "$type": "ButtonMenuItem", "Text": "Click Me!", "Click": "HandleClickMe" }

--- a/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.xeto
+++ b/src/Addins/Eto.Forms.Templates/content/File-FSharp/MainForm.xeto
@@ -15,9 +15,9 @@
 <!--#if(IsForm)-->
 	<Form.Menu>
 		<MenuBar>
-			<ButtonMenuItem Text="F&amp;ile">
+			<SubMenuItem Text="F&amp;ile">
 				<ButtonMenuItem Text="Click Me!" Click="HandleClickMe" />
-			</ButtonMenuItem>
+			</SubMenuItem>
 			<MenuBar.ApplicationItems>
 				<ButtonMenuItem Text="Preferences.." Shortcut="{On Control+O, Mac=Application+Comma}" />
 			</MenuBar.ApplicationItems>

--- a/src/Eto.Gtk/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/src/Eto.Gtk/Forms/Menu/ButtonMenuItemHandler.cs
@@ -5,12 +5,20 @@ using Eto.GtkSharp.Forms.Controls;
 
 namespace Eto.GtkSharp.Forms.Menu
 {
-	public class ButtonMenuItemHandler : MenuActionItemHandler<Gtk.ImageMenuItem, ButtonMenuItem, ButtonMenuItem.ICallback>, ButtonMenuItem.IHandler
+	public class ButtonMenuItemHandler : ButtonMenuItemHandler<ButtonMenuItem, ButtonMenuItem.ICallback>
+	{
+	}
+
+	public class ButtonMenuItemHandler<TWidget, TCallback> : MenuActionItemHandler<Gtk.ImageMenuItem, TWidget, TCallback>, ButtonMenuItem.IHandler
+		where TWidget: ButtonMenuItem
+		where TCallback: ButtonMenuItem.ICallback
 	{
 		string tooltip;
 		Keys shortcut;
 		Image image;
 		readonly Gtk.AccelLabel label;
+
+		protected Gtk.Menu Submenu => Control.Submenu as Gtk.Menu;
 
 		public ButtonMenuItemHandler()
 		{
@@ -29,16 +37,13 @@ namespace Eto.GtkSharp.Forms.Menu
 			Control.Activated += Connector.HandleActivated;
 		}
 
-		protected new ButtonMenuItemConnector Connector { get { return (ButtonMenuItemConnector)base.Connector; } }
+		protected new ButtonMenuItemConnector Connector => (ButtonMenuItemConnector)base.Connector;
 
-		protected override WeakConnector CreateConnector()
-		{
-			return new ButtonMenuItemConnector();
-		}
+		protected override WeakConnector CreateConnector() => new ButtonMenuItemConnector();
 
 		protected class ButtonMenuItemConnector : WeakConnector
 		{
-			public new ButtonMenuItemHandler Handler { get { return (ButtonMenuItemHandler)base.Handler; } }
+			public new ButtonMenuItemHandler<TWidget, TCallback> Handler => (ButtonMenuItemHandler<TWidget, TCallback>)base.Handler;
 
 			public void HandleActivated(object sender, EventArgs e)
 			{
@@ -101,17 +106,18 @@ namespace Eto.GtkSharp.Forms.Menu
 			}
 		}
 
-		public void AddMenu(int index, MenuItem item)
+		public virtual void AddMenu(int index, MenuItem item)
 		{
-			if (Control.Submenu == null) Control.Submenu = new Gtk.Menu();
-			((Gtk.Menu)Control.Submenu).Insert((Gtk.Widget)item.ControlObject, index);
+			var menu = Submenu;
+			if (menu == null) Control.Submenu = menu = new Gtk.Menu();
+			menu.Insert((Gtk.Widget)item.ControlObject, index);
 			SetChildAccelGroup(item);
 		}
 
-		public void RemoveMenu(MenuItem item)
+		public virtual void RemoveMenu(MenuItem item)
 		{
-			if (Control.Submenu == null) return;
-			var menu = (Gtk.Menu)Control.Submenu;
+			var menu = Submenu;
+			if (menu == null) return;
 			menu.Remove((Gtk.Widget)item.ControlObject);
 			if (menu.Children.Length == 0)
 			{
@@ -119,7 +125,7 @@ namespace Eto.GtkSharp.Forms.Menu
 			}
 		}
 
-		public void Clear()
+		public virtual void Clear()
 		{
 			Control.Submenu = null;
 		}

--- a/src/Eto.Gtk/Forms/Menu/SubMenuItemHandler.cs
+++ b/src/Eto.Gtk/Forms/Menu/SubMenuItemHandler.cs
@@ -1,0 +1,62 @@
+using System;
+using Eto.Forms;
+
+namespace Eto.GtkSharp.Forms.Menu
+{
+	public class SubMenuItemHandler : ButtonMenuItemHandler<SubMenuItem, SubMenuItem.ICallback>, SubMenuItem.IHandler
+	{
+		public SubMenuItemHandler()
+		{
+			Control.Submenu = new Gtk.Menu();
+		}
+
+		public override void RemoveMenu(MenuItem item) => Submenu.Remove((Gtk.Widget)item.ControlObject);
+
+		public override void Clear() => Submenu.RemoveAllChildren();
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case SubMenuItem.OpeningEvent:
+					Submenu.Shown += Connector.HandleMenuOpening;
+					break;
+				case SubMenuItem.ClosingEvent:
+					HandleEvent(SubMenuItem.ClosedEvent);
+					break;
+				case SubMenuItem.ClosedEvent:
+					Control.Deselected += Connector.HandleMenuClosed;
+					Control.Hidden += Connector.HandleMenuClosed;
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		protected new SubMenuItemConnector Connector => (SubMenuItemConnector)base.Connector;
+
+		protected override WeakConnector CreateConnector() => new SubMenuItemConnector();
+
+		protected class SubMenuItemConnector : ButtonMenuItemConnector
+		{
+			public new SubMenuItemHandler Handler => (SubMenuItemHandler)base.Handler;
+
+			public void HandleMenuOpening(object sender, EventArgs e)
+			{
+				Handler?.Callback.OnOpening(Handler.Widget, EventArgs.Empty);
+			}
+
+			public void HandleMenuClosed(object sender, EventArgs e)
+			{
+				var h = Handler;
+				if (h == null)
+					return;
+				// before menuitem click is processed
+				h.Callback.OnClosing(h.Widget, EventArgs.Empty);
+				// call OnClosed after menuitem click is processed
+				Application.Instance.AsyncInvoke(() => h.Callback.OnClosed(h.Widget, EventArgs.Empty));
+			}
+		}
+	}
+}

--- a/src/Eto.Gtk/Platform.cs
+++ b/src/Eto.Gtk/Platform.cs
@@ -184,6 +184,7 @@ namespace Eto.GtkSharp
 			p.Add<MenuBar.IHandler>(() => new MenuBarHandler());
 			p.Add<RadioMenuItem.IHandler>(() => new RadioMenuItemHandler());
 			p.Add<SeparatorMenuItem.IHandler>(() => new SeparatorMenuItemHandler());
+			p.Add<SubMenuItem.IHandler>(() => new SubMenuItemHandler());
 			
 			// Forms.Printing
 			p.Add<PrintDialog.IHandler>(() => new PrintDialogHandler());

--- a/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
@@ -18,7 +18,13 @@ using MonoMac.CoreAnimation;
 
 namespace Eto.Mac.Forms.Menu
 {
-	public class ButtonMenuItemHandler : MenuHandler<NSMenuItem, ButtonMenuItem, ButtonMenuItem.ICallback>, ButtonMenuItem.IHandler, IMenuActionHandler
+	public class ButtonMenuItemHandler : ButtonMenuItemHandler<ButtonMenuItem, ButtonMenuItem.ICallback>
+	{
+	}
+
+	public class ButtonMenuItemHandler<TWidget, TCallback> : MenuHandler<NSMenuItem, TWidget, TCallback>, ButtonMenuItem.IHandler, IMenuActionHandler
+		where TWidget: MenuItem
+		where TCallback: MenuItem.ICallback
 	{
 		Image image;
 		string text;
@@ -110,9 +116,8 @@ namespace Eto.Mac.Forms.Menu
 			Control.Image = ShowImage ? image.ToNS(16) : null;
 		}
 
-		MenuItem IMenuActionHandler.Widget
-		{
-			get { return Widget; }
-		}
+		MenuItem IMenuActionHandler.Widget => Widget;
+
+		MenuItem.ICallback IMenuActionHandler.Callback => Callback;
 	}
 }

--- a/src/Eto.Mac/Forms/Menu/MenuHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/MenuHandler.cs
@@ -42,7 +42,7 @@ namespace Eto.Mac.Forms.Menu
 		where TCallback : Eto.Forms.Menu.ICallback
 	{
 
-		public void EnsureSubMenu()
+		public virtual void EnsureSubMenu()
 		{
 			if (!Control.HasSubmenu)
 			{

--- a/src/Eto.Mac/Forms/Menu/SubMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/SubMenuItemHandler.cs
@@ -1,0 +1,97 @@
+using System;
+using Eto.Forms;
+#if XAMMAC2
+using AppKit;
+using Foundation;
+using CoreGraphics;
+using ObjCRuntime;
+using CoreAnimation;
+#else
+using MonoMac.AppKit;
+using MonoMac.Foundation;
+using MonoMac.CoreGraphics;
+using MonoMac.ObjCRuntime;
+using MonoMac.CoreAnimation;
+#endif
+
+namespace Eto.Mac.Forms.Menu
+{
+	class EtoSubMenuDelegate : NSMenuDelegate
+	{
+		WeakReference handler;
+		public SubMenuItemHandler Handler
+		{
+			get { return (SubMenuItemHandler)handler.Target; }
+			set { handler = new WeakReference(value); }
+		}
+
+		public override void MenuWillHighlightItem(NSMenu menu, NSMenuItem item)
+		{
+		}
+
+		public override void MenuWillOpen(NSMenu menu)
+		{
+			Handler?.OnOpening();
+		}
+
+		public override void MenuDidClose(NSMenu menu)
+		{
+			var h = Handler;
+			if (h == null)
+				return;
+			h.OnClosing();
+
+			Application.Instance.AsyncInvoke(() => h.OnClosed());
+		}
+	}
+
+	public class SubMenuItemHandler : ButtonMenuItemHandler<SubMenuItem, SubMenuItem.ICallback>, SubMenuItem.IHandler
+	{
+		protected override void Initialize()
+		{
+			base.Initialize();
+			EnsureSubMenu();
+			Control.Submenu.Delegate = new EtoSubMenuDelegate { Handler = this };
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case SubMenuItem.OpeningEvent:
+				case SubMenuItem.ClosingEvent:
+				case SubMenuItem.ClosedEvent:
+					// handled intrinsically by delegate
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		public virtual void OnClosed()
+		{
+			Callback.OnClosed(Widget, EventArgs.Empty);
+		}
+
+		public virtual void OnClosing()
+		{
+			Callback.OnClosing(Widget, EventArgs.Empty);
+		}
+
+		public virtual void OnOpening()
+		{
+			Callback.OnOpening(Widget, EventArgs.Empty);
+		}
+
+		public override void RemoveMenu(MenuItem item)
+		{
+			Control.Submenu.RemoveItem((NSMenuItem)item.ControlObject);
+		}
+
+		public override void Clear()
+		{
+			Control.Submenu.RemoveAllItems();
+		}
+	}
+}

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -252,6 +252,7 @@ namespace Eto.Mac
 			p.Add<MenuBar.IHandler>(() => new MenuBarHandler());
 			p.Add<RadioMenuItem.IHandler>(() => new RadioMenuItemHandler());
 			p.Add<SeparatorMenuItem.IHandler>(() => new SeparatorMenuItemHandler());
+			p.Add<SubMenuItem.IHandler>(() => new SubMenuItemHandler());
 
 			// Forms.Printing
 			p.Add<PrintDialog.IHandler>(() => new PrintDialogHandler());

--- a/src/Eto.WinForms/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/src/Eto.WinForms/Forms/Menu/ButtonMenuItemHandler.cs
@@ -1,25 +1,31 @@
 using System;
 using System.Linq;
 using SD = System.Drawing;
-using SWF = System.Windows.Forms;
+using swf = System.Windows.Forms;
 using Eto.Drawing;
 using Eto.Forms;
 
 namespace Eto.WinForms.Forms.Menu
 {
-	public class ButtonMenuItemHandler : MenuItemHandler<SWF.ToolStripMenuItem, ButtonMenuItem, ButtonMenuItem.ICallback>, ButtonMenuItem.IHandler
+	public class ButtonMenuItemHandler : ButtonMenuItemHandler<ButtonMenuItem, ButtonMenuItem.ICallback>
+	{
+	}
+
+	public class ButtonMenuItemHandler<TWidget, TCallback> : MenuItemHandler<swf.ToolStripMenuItem, TWidget, TCallback>, ButtonMenuItem.IHandler
+		where TWidget: ButtonMenuItem
+		where TCallback: ButtonMenuItem.ICallback
 	{
 		Image image;
 		int imageSize = 16;
-		bool openedHandled;
 
 		public ButtonMenuItemHandler()
 		{
-			Control = new SWF.ToolStripMenuItem();
+			Control = new swf.ToolStripMenuItem();
 			Control.Click += (sender, e) => Callback.OnClick(Widget, EventArgs.Empty);
+			Control.DropDownOpening += HandleDropDownOpened;
 		}
 
-		void HandleDropDownOpened(object sender, EventArgs e)
+		protected virtual void HandleDropDownOpened(object sender, EventArgs e)
 		{
 			foreach (var item in Widget.Items)
 			{
@@ -49,22 +55,17 @@ namespace Eto.WinForms.Forms.Menu
 			}
 		}
 
-		public void AddMenu(int index, MenuItem item)
+		public virtual void AddMenu(int index, MenuItem item)
 		{
-			Control.DropDownItems.Insert(index, (SWF.ToolStripItem)item.ControlObject);
-			if (!openedHandled)
-			{
-				Control.DropDownOpening += HandleDropDownOpened;
-				openedHandled = true;
-			}
+			Control.DropDownItems.Insert(index, (swf.ToolStripItem)item.ControlObject);
 		}
 
-		public void RemoveMenu(MenuItem item)
+		public virtual void RemoveMenu(MenuItem item)
 		{
-			Control.DropDownItems.Remove((SWF.ToolStripItem)item.ControlObject);
+			Control.DropDownItems.Remove((swf.ToolStripItem)item.ControlObject);
 		}
 
-		public void Clear()
+		public virtual void Clear()
 		{
 			Control.DropDownItems.Clear();
 		}

--- a/src/Eto.WinForms/Forms/Menu/SubMenuItemHandler.cs
+++ b/src/Eto.WinForms/Forms/Menu/SubMenuItemHandler.cs
@@ -1,0 +1,77 @@
+using swf = System.Windows.Forms;
+using Eto.Forms;
+using System;
+
+namespace Eto.WinForms.Forms.Menu
+{
+	public class SubMenuItemHandler : ButtonMenuItemHandler<SubMenuItem, SubMenuItem.ICallback>, SubMenuItem.IHandler
+	{
+		swf.ToolStripMenuItem hiddenItem;
+
+		public SubMenuItemHandler()
+		{
+			hiddenItem = new swf.ToolStripMenuItem();
+			Control.DropDownItems.Add(hiddenItem);
+		}
+
+		public override void AddMenu(int index, MenuItem item)
+		{
+			if (hiddenItem != null)
+			{
+				Control.DropDownItems.Remove(hiddenItem);
+				hiddenItem = null;
+			}
+			base.AddMenu(index, item);
+		}
+
+		public override void RemoveMenu(MenuItem item)
+		{
+			base.RemoveMenu(item);
+			if (Control.DropDownItems.Count == 0)
+			{
+				hiddenItem = hiddenItem ?? new swf.ToolStripMenuItem();
+				Control.DropDownItems.Add(hiddenItem);
+			}
+		}
+
+		public override void Clear()
+		{
+			base.Clear();
+			hiddenItem = hiddenItem ?? new swf.ToolStripMenuItem();
+			Control.DropDownItems.Add(hiddenItem);
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case SubMenuItem.OpeningEvent:
+					// handled with HandleDropDownOpened
+					break;
+				case SubMenuItem.ClosingEvent:
+					HandleEvent(SubMenuItem.ClosingEvent);
+					break;
+				case SubMenuItem.ClosedEvent:
+					Control.DropDownClosed += Control_DropDownClosed;
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		private void Control_DropDownClosed(object sender, EventArgs e)
+		{
+			// actually happens before the item is clicked
+			Callback.OnClosing(Widget, EventArgs.Empty);
+			Application.Instance.AsyncInvoke(() => Callback.OnClosed(Widget, EventArgs.Empty));
+		}
+
+		protected override void HandleDropDownOpened(object sender, EventArgs e)
+		{
+			Callback.OnOpening(Widget, EventArgs.Empty);
+
+			base.HandleDropDownOpened(sender, e);
+		}
+	}
+}

--- a/src/Eto.WinForms/Platform.cs
+++ b/src/Eto.WinForms/Platform.cs
@@ -128,6 +128,7 @@ namespace Eto.WinForms
 			p.Add<MenuBar.IHandler>(() => new MenuBarHandler());
 			p.Add<RadioMenuItem.IHandler>(() => new RadioMenuItemHandler());
 			p.Add<SeparatorMenuItem.IHandler>(() => new SeparatorMenuItemHandler());
+			p.Add<SubMenuItem.IHandler>(() => new SubMenuItemHandler());
 			
 			// Forms.Printing
 			p.Add<PrintDialog.IHandler>(() => new PrintDialogHandler());

--- a/src/Eto.Wpf/Forms/Menu/SubMenuItemHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/SubMenuItemHandler.cs
@@ -1,0 +1,86 @@
+using Eto.Forms;
+using swc = System.Windows.Controls;
+using swm = System.Windows.Media;
+using swi = System.Windows.Input;
+using System.Windows;
+using System;
+
+namespace Eto.Wpf.Forms.Menu
+{
+	public class SubMenuItemHandler : MenuItemHandler<swc.MenuItem, SubMenuItem, SubMenuItem.ICallback>, SubMenuItem.IHandler
+	{
+		swc.MenuItem hiddenItem;
+		public SubMenuItemHandler()
+		{
+			Control = new swc.MenuItem();
+
+			hiddenItem = new swc.MenuItem();
+			Control.Items.Add(hiddenItem);
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case SubMenuItem.OpeningEvent:
+					// handled with HandleContextMenuOpening
+					break;
+				case SubMenuItem.ClosedEvent:
+					Control.SubmenuClosed += Control_SubmenuClosed;
+					break;
+				case SubMenuItem.ClosingEvent:
+					// wpf's Closed event fires after, so look at IsSubmenuOpen property changes instead
+					Widget.Properties.Set(swc.MenuItem.IsSubmenuOpenProperty, PropertyChangeNotifier.Register(swc.MenuItem.IsSubmenuOpenProperty, HandleIsOpenChanged, Control));
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		private void HandleIsOpenChanged(object sender, DependencyPropertyChangedEventArgs e)
+		{
+			if (!Control.IsSubmenuOpen)
+				Callback.OnClosing(Widget, EventArgs.Empty);
+		}
+
+		private void Control_SubmenuClosed(object sender, RoutedEventArgs e)
+		{
+			Callback.OnClosed(Widget, EventArgs.Empty);
+		}
+
+		protected override void HandleContextMenuOpening(object sender, RoutedEventArgs e)
+		{
+			Callback.OnOpening(Widget, EventArgs.Empty);
+			base.HandleContextMenuOpening(sender, e);
+		}
+
+		public override void AddMenu(int index, MenuItem item)
+		{
+			if (hiddenItem != null)
+			{
+				Control.Items.Remove(hiddenItem);
+				hiddenItem = null;
+			}
+			base.AddMenu(index, item);
+		}
+
+		public override void RemoveMenu(MenuItem item)
+		{
+			base.RemoveMenu(item);
+
+			if (Control.Items.Count == 0)
+			{
+				hiddenItem = hiddenItem ?? new swc.MenuItem();
+				Control.Items.Add(hiddenItem);
+			}
+		}
+
+		public override void Clear()
+		{
+			base.Clear();
+			hiddenItem = hiddenItem ?? new swc.MenuItem();
+			Control.Items.Add(hiddenItem);
+		}
+	}
+}

--- a/src/Eto.Wpf/Platform.cs
+++ b/src/Eto.Wpf/Platform.cs
@@ -147,6 +147,7 @@ namespace Eto.Wpf
 			p.Add<MenuBar.IHandler>(() => new MenuBarHandler());
 			p.Add<RadioMenuItem.IHandler>(() => new RadioMenuItemHandler());
 			p.Add<SeparatorMenuItem.IHandler>(() => new SeparatorMenuItemHandler());
+			p.Add<SubMenuItem.IHandler>(() => new SubMenuItemHandler());
 
 			// Forms.Printing
 			p.Add<PrintDialog.IHandler>(() => new PrintDialogHandler());

--- a/src/Eto/Forms/Menu/ButtonMenuItem.cs
+++ b/src/Eto/Forms/Menu/ButtonMenuItem.cs
@@ -1,7 +1,7 @@
 using System;
 using Eto.Drawing;
 using System.Collections.Generic;
-using System.Linq;
+using System.ComponentModel;
 
 namespace Eto.Forms
 {
@@ -16,13 +16,13 @@ namespace Eto.Forms
 	{
 		MenuItemCollection items;
 
-		new IHandler Handler { get { return (IHandler)base.Handler; } }
+		new IHandler Handler => (IHandler)base.Handler;
 
 		/// <summary>
 		/// Gets the collection of menu items.
 		/// </summary>
 		/// <value>The items.</value>
-		public MenuItemCollection Items { get { return items ?? (items = new MenuItemCollection(Handler, this)); } }
+		public MenuItemCollection Items => items ?? (items = new MenuItemCollection(Handler, this));
 
 		/// <summary>
 		/// Gets a value indicating whether this sub menu should trim its child menu items when loaded onto a form
@@ -74,6 +74,7 @@ namespace Eto.Forms
 			set { Handler.Image = value; }
 		}
 
+		[Obsolete]
 		IEnumerable<BindableWidget> IBindableWidgetContainer.Children => Items;
 
 		/// <summary>
@@ -83,8 +84,14 @@ namespace Eto.Forms
 		internal protected override void OnLoad(EventArgs e)
 		{
 			base.OnLoad(e);
-			foreach (var item in Items)
-				item.OnLoad(e);
+			if (items != null)
+			{
+				for (int i = 0; i < items.Count; i++)
+				{
+					MenuItem item = items[i];
+					item.OnLoad(e);
+				}
+			}
 		}
 
 		/// <summary>
@@ -94,8 +101,14 @@ namespace Eto.Forms
 		internal protected override void OnUnLoad(EventArgs e)
 		{
 			base.OnUnLoad(e);
-			foreach (var item in Items)
-				item.OnUnLoad(e);
+			if (items != null)
+			{
+				for (int i = 0; i < items.Count; i++)
+				{
+					MenuItem item = items[i];
+					item.OnUnLoad(e);
+				}
+			}
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/Menu/ContextMenu.cs
+++ b/src/Eto/Forms/Menu/ContextMenu.cs
@@ -44,6 +44,13 @@ namespace Eto.Forms
 		/// <value><c>true</c> to trim the child menu items; otherwise, <c>false</c>.</value>
 		public bool Trim { get; set; }
 
+		static ContextMenu()
+		{
+			RegisterEvent<ContextMenu>(c => c.OnOpening(null), OpeningEvent);
+			RegisterEvent<ContextMenu>(c => c.OnClosing(null), ClosingEvent);
+			RegisterEvent<ContextMenu>(c => c.OnClosed(null), ClosedEvent);
+		}
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Eto.Forms.ContextMenu"/> class.
 		/// </summary>

--- a/src/Eto/Forms/Menu/MenuItemCollection.cs
+++ b/src/Eto/Forms/Menu/MenuItemCollection.cs
@@ -176,15 +176,16 @@ namespace Eto.Forms
 
 			var matchText = convert(submenuText);
 
-			bool match(ButtonMenuItem r) => convert(r.Text) == matchText;
+			bool match(MenuItem r) => convert(r.Text) == matchText;
 
 			var submenu = this.OfType<ButtonMenuItem>().FirstOrDefault(match);
 
 			if (submenu == null && create)
 			{
-				submenu = new ButtonMenuItem { Text = submenuText, Order = order, Trim = true };
+				submenu = new SubMenuItem { Text = submenuText, Order = order, Trim = true };
 				Add(submenu);
 			}
+
 			return submenu;
 		}
 

--- a/src/Eto/Forms/Menu/SubMenuItem.cs
+++ b/src/Eto/Forms/Menu/SubMenuItem.cs
@@ -1,0 +1,182 @@
+using System;
+using Eto.Drawing;
+using System.Collections.Generic;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Menu item for a submenu
+	/// </summary>
+	/// <remarks>
+	/// This will always show as a submenu, even when no items have been added.
+	/// The <see cref="SubMenuItem.Opening" /> can be used to populate or modify the submenu before it opens.
+	/// </remarks>
+	[ContentProperty("Items")]
+	[Handler(typeof(SubMenuItem.IHandler))]
+	public class SubMenuItem : ButtonMenuItem, ISubmenu, IBindableWidgetContainer
+	{
+		new IHandler Handler => (IHandler)base.Handler;
+
+		/// <summary>
+		/// Event identifier for handlers when attaching the <see cref="SubMenuItem.Opening"/> event.
+		/// </summary>
+		public const string OpeningEvent = "SubMenuItem.Opening";
+
+		/// <summary>
+		/// Occurs when the sub menu is opening, before it is shown.
+		/// </summary>
+		public event EventHandler<EventArgs> Opening
+		{
+			add { Properties.AddHandlerEvent(OpeningEvent, value); }
+			remove { Properties.RemoveEvent(OpeningEvent, value); }
+		}
+
+		/// <summary>
+		/// Raises the <see cref="SubMenuItem.Opening"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnOpening(EventArgs e)
+		{
+			Properties.TriggerEvent(OpeningEvent, this, e);
+		}
+
+		/// <summary>
+		/// Event identifier for handlers when attaching the <see cref="Closed"/> event.
+		/// </summary>
+		public const string ClosedEvent = "SubMenuItem.Closed";
+
+		/// <summary>
+		/// Occurs when the sub menu is closed/dismissed, after the menu item has been selected and its click 
+		/// event is triggered.
+		/// </summary>
+		public event EventHandler<EventArgs> Closed
+		{
+			add { Properties.AddHandlerEvent(ClosedEvent, value); }
+			remove { Properties.RemoveEvent(ClosedEvent, value); }
+		}
+
+		/// <summary>
+		/// Raises the <see cref="Closed"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnClosed(EventArgs e)
+		{
+			Properties.TriggerEvent(ClosedEvent, this, e);
+		}
+
+		/// <summary>
+		/// Event identifier for handlers when attaching the <see cref="Closing"/> event.
+		/// </summary>
+		public const string ClosingEvent = "SubMenuItem.Closing";
+
+		/// <summary>
+		/// Occurs before the sub menu is closed/dismissed when the user clicks an item, but before the menu item's
+		/// click event is triggered.
+		/// </summary>
+		public event EventHandler<EventArgs> Closing
+		{
+			add { Properties.AddHandlerEvent(ClosingEvent, value); }
+			remove { Properties.RemoveEvent(ClosingEvent, value); }
+		}
+
+		/// <summary>
+		/// Raises the <see cref="Closing"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnClosing(EventArgs e)
+		{
+			Properties.TriggerEvent(ClosingEvent, this, e);
+		}
+
+		static SubMenuItem()
+		{
+			RegisterEvent<SubMenuItem>(c => c.OnOpening(null), OpeningEvent);
+			RegisterEvent<SubMenuItem>(c => c.OnClosing(null), ClosingEvent);
+			RegisterEvent<SubMenuItem>(c => c.OnClosed(null), ClosedEvent);
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.SubMenuItem"/> class.
+		/// </summary>
+		public SubMenuItem()
+		{
+		}
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="Eto.Forms.SubMenuItem"/> class with the specified <paramref name="items" />.
+		/// </summary>
+		public SubMenuItem(params MenuItem[] items)
+		{
+			Items.AddRange(items);
+		}
+
+		static readonly object callback = new Callback();
+
+		/// <summary>
+		/// Gets an instance of an object used to perform callbacks to the widget from handler implementations
+		/// </summary>
+		/// <returns>The callback instance to use for this widget</returns>
+		protected override object GetCallback() => callback;
+
+		/// <summary>
+		/// Callback interface for instances of <see cref="SubMenuItem"/>
+		/// </summary>
+		public new interface ICallback : ButtonMenuItem.ICallback
+		{
+			/// <summary>
+			/// Raises the <see cref="SubMenuItem.Opening"/> event.
+			/// </summary>
+			void OnOpening(SubMenuItem widget, EventArgs e);
+
+			/// <summary>
+			/// Raises the <see cref="Closed"/> event.
+			/// </summary>
+			void OnClosed(SubMenuItem widget, EventArgs e);
+
+			/// <summary>
+			/// Raises the <see cref="Closing"/> event.
+			/// </summary>
+			void OnClosing(SubMenuItem widget, EventArgs e);
+		}
+
+		/// <summary>
+		/// Callback implementation for handlers of the <see cref="SubMenuItem"/>
+		/// </summary>
+		protected new class Callback : ButtonMenuItem.Callback, ICallback
+		{
+			/// <summary>
+			/// Raises the <see cref="Opening"/> event.
+			/// </summary>
+			public void OnOpening(SubMenuItem widget, EventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnOpening(e);
+			}
+
+			/// <summary>
+			/// Raises the <see cref="Closed"/> event.
+			/// </summary>
+			public void OnClosed(SubMenuItem widget, EventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnClosed(e);
+			}
+
+			/// <summary>
+			/// Raises the <see cref="Closing"/> event.
+			/// </summary>
+			public void OnClosing(SubMenuItem widget, EventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnClosing(e);
+			}
+		}
+
+		/// <summary>
+		/// Handler interface for the <see cref="SubMenuItem"/>.
+		/// </summary>
+		public new interface IHandler : ButtonMenuItem.IHandler
+		{
+		}
+	}
+}

--- a/test/Eto.Test.Wpf/UnitTests/MenuBarTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/MenuBarTests.cs
@@ -22,7 +22,7 @@ namespace Eto.Test.Wpf.UnitTests
 				var form = new Form();
 				form.Menu = new MenuBar();
 
-				var file = new ButtonMenuItem { Text = "File" };
+				var file = new SubMenuItem { Text = "File" };
 
 				var command = new Command { MenuText = "Click Me!" };
 				command.Shortcut = Keys.Control | Keys.N;

--- a/test/Eto.Test/MainForm.cs
+++ b/test/Eto.Test/MainForm.cs
@@ -229,15 +229,15 @@ namespace Eto.Test
 					throw new InvalidOperationException("This is the exception message");
 				};
 
-				var subMenu = new ButtonMenuItem { Text = "Sub Menu" };
+				var subMenu = new SubMenuItem { Text = "Sub Menu" };
 				subMenu.Items.Add(new ButtonMenuItem { Text = "Item 1" });
 				subMenu.Items.Add(new ButtonMenuItem { Text = "Item 2" });
 				subMenu.Items.Add(new ButtonMenuItem { Text = "Item 3" });
 
-				var file = new ButtonMenuItem { Text = "&File", Items = { saveSettingsItem, fileCommand, crashCommand } };
-				var edit = new ButtonMenuItem { Text = "&Edit", Items = { editCommand, subMenu } };
-                var view = new ButtonMenuItem { Text = "&View", Items = { viewCommand } };
-				var window = new ButtonMenuItem { Text = "&Window", Order = 1000, Items = { windowCommand } };
+				var file = new SubMenuItem { Text = "&File", Items = { saveSettingsItem, fileCommand, crashCommand } };
+				var edit = new SubMenuItem { Text = "&Edit", Items = { editCommand, subMenu } };
+                var view = new SubMenuItem { Text = "&View", Items = { viewCommand } };
+				var window = new SubMenuItem { Text = "&Window", Order = 1000, Items = { windowCommand } };
 
 				if (Platform.Supports<CheckMenuItem>())
 				{

--- a/test/Eto.Test/Sections/Behaviors/ContextMenuSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ContextMenuSection.cs
@@ -104,6 +104,25 @@ namespace Eto.Test.Sections.Behaviors
 			subMenu.Items.Add(new ButtonMenuItem { Text = "Item 6", Shortcut = Keys.I });
 			subMenu.Items.Add(new ButtonMenuItem { Text = "Disabled Item 2", Enabled = false });
 
+
+			var dynamicSubMenu = new SubMenuItem { Text = "Dynamic Sub Menu" };
+			dynamicSubMenu.Opening += (sender, e) => {
+				Log.Write(dynamicSubMenu, "Opening");
+				dynamicSubMenu.Items.Add(new ButtonMenuItem { Text = "Dynamic Item 1" });
+				dynamicSubMenu.Items.Add(new ButtonMenuItem { Text = "Dynamic Item 2" });
+				dynamicSubMenu.Items.Add(new ButtonMenuItem { Text = "Dynamic Item 3", Enabled = false });
+				LogEvents(dynamicSubMenu);
+			};
+			dynamicSubMenu.Closing += (sender, e) => {
+				Log.Write(dynamicSubMenu, "Closing");
+			};
+			dynamicSubMenu.Closed += (sender, e) => {
+				Log.Write(dynamicSubMenu, "Closed");
+				dynamicSubMenu.Items.Clear();
+			};
+
+			_menu.Items.Add(dynamicSubMenu);
+
 			_menu.Items.AddSeparator();
 			RadioMenuItem radioController;
 			_menu.Items.Add(radioController = new RadioMenuItem { Text = "Radio 1" });


### PR DESCRIPTION
This adds the ability to create a submenu that is _always_ a submenu even with no items without resorting to hacks like adding a dummy item.

You can then use Opening/Closing/Closed events to update the list of items dynamically.