### PR TITLE
Mac: Fix crash with ListBox when setting DataStore to empty

### DIFF
--- a/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
@@ -251,6 +251,12 @@ namespace Eto.Mac.Forms.Controls
 		{
 			public ListBoxHandler Handler { get; set; }
 
+			protected override void InitializeCollection()
+			{
+				Handler.Control.ReloadData();
+				Handler.InvalidateMeasure();
+			}
+
 			public override void AddRange(IEnumerable<object> items)
 			{
 				Handler.Control.ReloadData();

--- a/test/Eto.Test/UnitTests/Forms/Controls/ListControlTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ListControlTests.cs
@@ -13,7 +13,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 	}
 
 	public class ListControlTests<T> : TestBase
-		where T: ListControl, new()
+		where T : ListControl, new()
 	{
 		[ManualTest]
 		[TestCase(SetBindingMode.Before)]
@@ -48,6 +48,28 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				}
 				else
 					return dropDown;
+			});
+		}
+
+		[Test]
+		public void SettingDataStoreToNullAfterPopulatedShouldNotCrash()
+		{
+			Form(form =>
+			{
+				var list = new T();
+
+				list.DataStore = new[] { "Item 1", "Item 2", "Item 3" };
+				form.Content = list;
+
+				form.Shown += (sender, e) =>
+				{
+					Application.Instance.AsyncInvoke(() =>
+					{
+						list.DataStore = null;
+						list.Invalidate();
+						new UITimer((sender2, e2) => { form.Close(); }) { Interval = 1 }.Start();
+					});
+				};
 			});
 		}
 	}


### PR DESCRIPTION
If it had items then setting the DataStore to an empty or null collection would cause a crash.