### PR TITLE
RichTextArea and Binding performance improvements

### DIFF
--- a/src/Eto/Forms/Binding/BindingChangedEventArgs.cs
+++ b/src/Eto/Forms/Binding/BindingChangedEventArgs.cs
@@ -12,15 +12,24 @@ namespace Eto.Forms
 		/// <summary>
 		/// Gets the value that was set to the binding
 		/// </summary>
-		public object Value { get; private set; }
-		
+		public object Value => InternalValue;
+
+		internal virtual object InternalValue { get; set; }
+
+		/// <summary>
+		/// Initializes a new instance of the BindingChangedEventArgs with the specified value
+		/// </summary>
+		/// <param name="value">value that the binding was set to</param>
+		public BindingChangedEventArgs(object value)
+		{
+			this.InternalValue = value;
+		}
+
 		/// <summary>
 		/// Initializes a new instance of the BindingChangedEventArgs
 		/// </summary>
-		/// <param name="value">value that the binding was set to</param>
-		public BindingChangedEventArgs (object value)
+		internal BindingChangedEventArgs()
 		{
-			this.Value = value;
 		}
 	}
 }

--- a/src/Eto/Forms/Binding/BindingChangingEventArgs.cs
+++ b/src/Eto/Forms/Binding/BindingChangingEventArgs.cs
@@ -16,16 +16,29 @@ namespace Eto.Forms
 		/// <summary>
 		/// Proposed value to set to the binding
 		/// </summary>
-		public object Value { get; set; }
-		
+		public object Value
+		{
+			get => InternalValue;
+			set => InternalValue = value;
+		}
+
+		internal virtual object InternalValue { get; set; }
+
 		/// <summary>
-		/// Initializes a new instance of the BindingChangingEventArgs
+		/// Initializes a new instance of the BindingChangingEventArgs with the specifid value
 		/// </summary>
 		/// <param name="value"></param>
-		public BindingChangingEventArgs (object value)
+		public BindingChangingEventArgs(object value)
 		{
 			this.Value = value;
 		}
+
+		/// <summary>
+		/// Initializes a new instance of the BindingChangingEventArgs
+		/// </summary>
+		internal BindingChangingEventArgs()
+		{
+		}
 	}
-	
+
 }

--- a/src/Eto/Forms/Binding/ObjectBinding.cs
+++ b/src/Eto/Forms/Binding/ObjectBinding.cs
@@ -68,6 +68,35 @@ namespace Eto.Forms
 		bool dataValueChangedHandled;
 		T dataItem;
 
+		class ObjectBindingChangingEventArgs : BindingChangingEventArgs
+		{
+			ObjectBinding<T, TValue> _parent;
+			public ObjectBindingChangingEventArgs(ObjectBinding<T, TValue> parent)
+			{
+				_parent = parent;
+			}
+
+			internal override object InternalValue
+			{
+				get => _parent.DataValue;
+				set => _parent.DataValue = (TValue)value;
+			}
+		}
+
+		class ObjectBindingChangedEventArgs : BindingChangedEventArgs
+		{
+			ObjectBinding<T, TValue> _parent;
+			public ObjectBindingChangedEventArgs(ObjectBinding<T, TValue> parent)
+			{
+				_parent = parent;
+			}
+
+			internal override object InternalValue
+			{
+				get => _parent.DataValue;
+			}
+		}
+
 		/// <summary>
 		/// Gets the binding used to get/set the values from the <see cref="DataItem"/>
 		/// </summary>
@@ -161,12 +190,12 @@ namespace Eto.Forms
 			}
 			set
 			{
-				var args = new BindingChangingEventArgs(DataValue);
+				var args = new ObjectBindingChangingEventArgs(this);
 				OnChanging(args);
 				if (args.Cancel)
 					return;
 				InnerBinding.SetValue(DataItem, Equals(value, default(T)) ? SettingNullValue : value);
-				OnChanged(new BindingChangedEventArgs(DataValue));
+				OnChanged(new ObjectBindingChangedEventArgs(this));
 			}
 		}
 


### PR DESCRIPTION
- When loading a large RTF it can get really slow looking up win32 font names if they don't match the WPF source name, or if the font doesn't exist.
- When an object binding is changed, we now only retrieve the current value if actually requested for the Changing/Changed events. Additionally, the `Binding.Changing` and `Binding.Changed` events are rarely even used.