### PR TITLE
Add Window.AutoSize property

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/LabelHandler.cs
@@ -199,6 +199,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				Control.ResetWidth();
 				Control.TextWithMnemonic = value.ToPlatformMnemonic();
+				InvalidateMeasure();
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/EtoControls.cs
+++ b/src/Eto.Gtk/Forms/EtoControls.cs
@@ -175,4 +175,89 @@ namespace Eto.GtkSharp.Forms
 
     }
     
+    public partial class EtoVBox : Gtk.VBox
+    {
+        WeakReference _handler;
+        public IGtkControl Handler
+        {
+            get => _handler?.Target as IGtkControl;
+            set => _handler = new WeakReference(value);
+        }
+        
+#if GTK3        
+        protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)
+        {
+            base.OnGetPreferredWidth(out minimum_width, out natural_width);
+            var h = Handler;
+            if (h != null)
+            {
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Width > 0)
+                    natural_width = userPreferredSize.Width;
+
+                minimum_width = Math.Min(natural_width, minimum_width);
+            }
+        }
+        
+        protected override void OnGetPreferredWidthForHeight(int height, out int minimum_width, out int natural_width)
+        {
+            base.OnGetPreferredWidthForHeight(height, out minimum_width, out natural_width);
+            var h = Handler;
+            if (h != null)
+            {
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Width > 0)
+                    natural_width = userPreferredSize.Width;
+
+                minimum_width = Math.Min(natural_width, minimum_width);
+            }
+        }
+
+        protected override void OnGetPreferredHeight(out int minimum_height, out int natural_height)
+        {
+            base.OnGetPreferredHeight(out minimum_height, out natural_height);
+            var h = Handler;
+            if (h != null)
+            {
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Height > 0)
+                    natural_height = userPreferredSize.Height;
+
+                minimum_height = Math.Min(natural_height, minimum_height);
+            }
+        }
+        
+        protected override void OnAdjustSizeAllocation(Gtk.Orientation orientation, out int minimum_size, out int natural_size, out int allocated_pos, out int allocated_size)
+        {
+            base.OnAdjustSizeAllocation(orientation, out minimum_size, out natural_size, out allocated_pos, out allocated_size);
+            var h = Handler;
+            if (h != null)
+            {
+                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.UserPreferredSize.Width : h.UserPreferredSize.Height;
+
+                if (preferredSize > 0)
+                    natural_size = preferredSize;
+
+                minimum_size = Math.Min(natural_size, minimum_size);
+            }
+        }
+
+        protected override void OnAdjustSizeRequest(Gtk.Orientation orientation, out int minimum_size, out int natural_size)
+        {
+            base.OnAdjustSizeRequest(orientation, out minimum_size, out natural_size);
+            var h = Handler;
+            if (h != null)
+            {
+                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.UserPreferredSize.Width : h.UserPreferredSize.Height;
+
+                if (preferredSize > 0)
+                    natural_size = preferredSize;
+
+                minimum_size = Math.Min(natural_size, minimum_size);
+            }
+        }
+#endif
+
+    }
+    
 }

--- a/src/Eto.Gtk/Forms/EtoControls.tt
+++ b/src/Eto.Gtk/Forms/EtoControls.tt
@@ -12,7 +12,7 @@ using Eto.Drawing;
 namespace Eto.GtkSharp.Forms
 {
 <#
-var controls = new[] { "Fixed", "EventBox" };
+var controls = new[] { "Fixed", "EventBox", "VBox" };
 
 foreach (var control in controls)
 {

--- a/src/Eto.Gtk/Forms/FormHandler.cs
+++ b/src/Eto.Gtk/Forms/FormHandler.cs
@@ -3,49 +3,6 @@ using System.Threading.Tasks;
 
 namespace Eto.GtkSharp.Forms
 {
-	public class EtoWindow : Gtk.Window
-	{
-		public IGtkWindow Handler { get; set; }
-		public EtoWindow(Gtk.WindowType type) : base(type)
-		{
-		}
-
-#if GTK3
-		protected override void OnGetPreferredHeightForWidth(int width, out int minimum_height, out int natural_height)
-		{
-			base.OnGetPreferredHeightForWidth(width, out minimum_height, out natural_height);
-			var size = Handler.UserPreferredSize;
-			if (size.Height > 0)
-				natural_height = size.Height;
-		}
-
-		protected override void OnGetPreferredWidthForHeight(int height, out int minimum_width, out int natural_width)
-		{
-
-			base.OnGetPreferredWidthForHeight(height, out minimum_width, out natural_width);
-			var size = Handler.UserPreferredSize;
-			if (size.Width > 0)
-				natural_width = size.Width;
-		}
-
-		protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)
-		{
-			base.OnGetPreferredWidth(out minimum_width, out natural_width);
-			var size = Handler.UserPreferredSize;
-			if (size.Width > 0)
-				natural_width = size.Width;
-		}
-
-		protected override void OnGetPreferredHeight(out int minimum_height, out int natural_height)
-		{
-			base.OnGetPreferredHeight(out minimum_height, out natural_height);
-			var size = Handler.UserPreferredSize;
-			if (size.Height > 0)
-				natural_height = size.Height;
-		}
-#endif
-	}
-
 	public class FormHandler : GtkWindow<Gtk.Window, Form, Form.ICallback>, Form.IHandler
 	{
 		public FormHandler(Gtk.Window window)
@@ -55,35 +12,22 @@ namespace Eto.GtkSharp.Forms
 
 		public FormHandler()
 		{
-			Control = new EtoWindow(Gtk.WindowType.Toplevel) { Handler = this };
+			Control = new Gtk.Window(Gtk.WindowType.Toplevel);
 #if GTK2
 			Control.AllowGrow = true;
-#else
-			Control.Resizable = true;
 #endif
+			Resizable = true;
 			Control.SetPosition(Gtk.WindowPosition.Center);
 
-			var vbox = new Gtk.VBox();
+			var vbox = new EtoVBox { Handler = this };
 			vbox.PackStart(WindowActionControl, false, true, 0);
 			vbox.PackStart(WindowContentControl, true, true, 0);
 			Control.Child = vbox;
 		}
 
-		#if NET40
-		public void Show ()
-		{
-			Control.Child.ShowAll ();
-			if (ShowActivated || !Control.AcceptFocus)
-				Control.Show ();
-			else {
-				Control.AcceptFocus = false;
-				Control.Show ();
-				Control.AcceptFocus = true;
-			}
-		}
-		#else
 		public async void Show()
 		{
+			DisableAutoSizeUpdate++;
 			Control.Child.ShowAll();
 			if (ShowActivated || !Control.AcceptFocus)
 				Control.Show();
@@ -94,8 +38,8 @@ namespace Eto.GtkSharp.Forms
 				await Task.Delay(1); // why???  Only way I can get it to work properly on ubuntu 16.04
 				Control.AcceptFocus = CanFocus; // in case user changes it right after this call, but should be true
 			}
+			DisableAutoSizeUpdate--;
 		}
-		#endif
 
 		static object ShowActivated_Key = new object();
 

--- a/src/Eto.Gtk/Forms/GtkPanel.cs
+++ b/src/Eto.Gtk/Forms/GtkPanel.cs
@@ -115,7 +115,7 @@ namespace Eto.GtkSharp.Forms
 			get { return content; }
 			set
 			{
-				if (content != value)
+				if (!ReferenceEquals(content, value))
 				{
 					if (content != null)
 						alignment.Remove(content.GetContainerWidget());
@@ -128,6 +128,7 @@ namespace Eto.GtkSharp.Forms
 						widget.ShowAll();
 						alignment.Child = widget;
 					}
+					InvalidateMeasure();					
 				}
 			}
 		}

--- a/src/Eto.Gtk/Forms/PixelLayoutHandler.cs
+++ b/src/Eto.Gtk/Forms/PixelLayoutHandler.cs
@@ -44,6 +44,7 @@ namespace Eto.GtkSharp.Forms
 #endif
 			Control.Put(widget, x, y);
 			ctl.CurrentLocation = new Point(x, y);
+			InvalidateMeasure();
 		}
 
 		public void Move(Control child, int x, int y)
@@ -60,6 +61,7 @@ namespace Eto.GtkSharp.Forms
 
 				ctl.CurrentLocation = new Point(x, y);
 			}
+			InvalidateMeasure();
 		}
 
 		public void Remove(Control child)
@@ -69,6 +71,7 @@ namespace Eto.GtkSharp.Forms
 #else
 			Control.Remove(child.GetContainerWidget());
 #endif
+			InvalidateMeasure();
 		}
 
 		public void Update()

--- a/src/Eto.Gtk/Forms/TableLayoutHandler.gtk3.cs
+++ b/src/Eto.Gtk/Forms/TableLayoutHandler.gtk3.cs
@@ -51,6 +51,7 @@ namespace Eto.GtkSharp.Forms
 			{
 				var widget = child.GetContainerWidget();
 				widget.ShowAll();
+				InvalidateMeasure();
 			}
 		}
 
@@ -137,6 +138,7 @@ namespace Eto.GtkSharp.Forms
 				SetExpand(widget, x, y);
 				Control.Attach(widget, x, y, 1, 1);
 				widget.ShowAll();
+				InvalidateMeasure();
 				return true;
 			}
 			else
@@ -150,6 +152,7 @@ namespace Eto.GtkSharp.Forms
 				SetExpand(blankWidget, x, y);
 				Control.Attach(blankWidget, x, y, 1, 1);
 			}
+			InvalidateMeasure();
 			return false;
 		}
 
@@ -168,6 +171,8 @@ namespace Eto.GtkSharp.Forms
 						var blankWidget = blank[y, x] = new Gtk.VBox();
 						SetExpand(blankWidget, x, y);
 						Control.Attach(blankWidget, x, y, 1, 1);
+
+						InvalidateMeasure();
 						return;
 					}
 				}
@@ -190,6 +195,7 @@ namespace Eto.GtkSharp.Forms
 			}
 			widget.Hexpand = columnScale[x] || x == lastColumnScale;
 			widget.Vexpand = rowScale[y] || y == lastRowScale;
+			InvalidateMeasure();
 		}
 
 		public void SetRowScale(int row, bool scale)
@@ -202,6 +208,7 @@ namespace Eto.GtkSharp.Forms
 			{
 				SetExpandRow(rowScale.Length - 1);
 			}
+			InvalidateMeasure();
 		}
 
 		public bool GetRowScale(int row) => rowScale[row];

--- a/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
@@ -86,7 +86,7 @@ namespace Eto.Mac.Forms.Controls
 	public interface IButtonHandler
 	{
 		bool SetBezel(Size size);
-		bool AutoSize { get; }
+		bool IsAutoSized { get; }
 		Size MinimumSize { get; }
 		int DisableSetBezel { get; set; }
 		void TriggerSizeChanged();
@@ -113,7 +113,7 @@ namespace Eto.Mac.Forms.Controls
 			}
 			h.DisableSetBezel++;
 			base.SizeToFit();
-			if (h.AutoSize)
+			if (h.IsAutoSized)
 			{
 				var size = Frame.Size;
 				var minSize = h.MinimumSize;
@@ -389,6 +389,8 @@ namespace Eto.Mac.Forms.Controls
 		}
 
 		public int DisableSetBezel { get; set; }
+
+		public bool IsAutoSized => UserPreferredSize.Width == -1 || UserPreferredSize.Height == -1;
 
 		public void TriggerSizeChanged()
 		{

--- a/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
@@ -43,12 +43,6 @@ namespace Eto.Mac.Forms.Controls
 			Control = nativeControl;
 		}
 
-		protected override void Initialize()
-		{
-			base.Initialize();
-			AutoSize = false;
-		}
-
 		public override SizeF GetPreferredSize(SizeF availableSize)
 		{
 			return Control.FittingSize.ToEto();

--- a/src/Eto.Mac/Forms/MacBase.cs
+++ b/src/Eto.Mac/Forms/MacBase.cs
@@ -37,10 +37,6 @@ namespace Eto.Mac.Forms
 
 		NSView FocusControl { get; }
 
-		bool AutoSize { get; }
-
-		// SizeF GetPreferredSize(SizeF availableSize);
-
 		void RecalculateKeyViewLoop(ref NSView last);
 
 		void InvalidateMeasure();

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -563,12 +563,6 @@ namespace Eto.Mac.Forms
 
 		public virtual IEnumerable<Control> VisualControls => Enumerable.Empty<Control>();
 
-		public virtual bool AutoSize
-		{
-			get { return Widget.Properties.Get<bool>(MacView.AutoSize_Key, true); }
-			protected set { Widget.Properties.Set(MacView.AutoSize_Key, value, true); }
-		}
-
 		protected virtual Size DefaultMinimumSize
 		{
 			get { return Size.Empty; }
@@ -592,8 +586,12 @@ namespace Eto.Mac.Forms
 			set
 			{
 				if (Widget.Properties.TrySet(MacView.UserPreferredSize_Key, value))
-					SetAutoSize();
+					OnUserPrefferedSizeChanged();
 			}
+		}
+
+		protected virtual void OnUserPrefferedSizeChanged()
+		{
 		}
 
 		public virtual Size Size
@@ -646,12 +644,6 @@ namespace Eto.Mac.Forms
 			set => Size = new Size(UserPreferredSize.Width, value);
 		}
 
-		protected virtual void SetAutoSize()
-		{
-			var userPreferredSize = UserPreferredSize;
-			AutoSize = userPreferredSize.Width == -1 || userPreferredSize.Height == -1;
-		}
-
 		protected Size? NaturalAvailableSize
 		{
 			get { return Widget.Properties.Get<Size?>(MacView.NaturalAvailableSize_Key); }
@@ -675,7 +667,7 @@ namespace Eto.Mac.Forms
 			NaturalSize = null;
 			NaturalSizeInfinity = null;
 
-			if (!Widget.Loaded)
+			if (!Widget.Loaded || Widget.IsSuspended)
 				return;
 
 			Widget.VisualParent.GetMacControl()?.InvalidateMeasure();
@@ -897,6 +889,7 @@ namespace Eto.Mac.Forms
 
 		public virtual void ResumeLayout()
 		{
+			InvalidateMeasure();
 		}
 
 

--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -598,6 +598,7 @@ namespace Eto.WinForms.Forms
 		}
 
 		public bool MovableByWindowBackground { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+		public bool AutoSize { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
 
 		public void DoDragDrop(DataObject data, DragEffects allowedAction, Image image, PointF offset)
 		{

--- a/src/Eto.WinForms/Forms/WindowHandler.cs
+++ b/src/Eto.WinForms/Forms/WindowHandler.cs
@@ -354,10 +354,7 @@ namespace Eto.WinForms.Forms
 
 		public Eto.Forms.ToolBar ToolBar
 		{
-			get
-			{
-				return toolBar;
-			}
+			get => toolBar;
 			set
 			{
 				toolbarHolder.SuspendLayout();
@@ -374,14 +371,11 @@ namespace Eto.WinForms.Forms
 			}
 		}
 
-		public void Close()
-		{
-			Control.Close();
-		}
+		public void Close() => Control.Close();
 
 		public Icon Icon
 		{
-			get { return icon; }
+			get => icon;
 			set
 			{
 				icon = value;
@@ -391,16 +385,13 @@ namespace Eto.WinForms.Forms
 
 		public string Title
 		{
-			get { return Control.Text; }
-			set { Control.Text = value; }
+			get => Control.Text;
+			set => Control.Text = value;
 		}
 
 		public new Point Location
 		{
-			get
-			{
-				return Control.Location.ToEto();
-			}
+			get => Control.Location.ToEto();
 			set
 			{
 				Control.Location = value.ToSD();
@@ -480,20 +471,14 @@ namespace Eto.WinForms.Forms
 			Control.Activate();
 		}
 
-		public void SendToBack()
-		{
-			Control.SendToBack();
-		}
+		public void SendToBack() => Control.SendToBack();
 
 		public virtual void SetOwner(Window owner)
 		{
 			Control.Owner = owner.ToSWF();
 		}
 
-		public Screen Screen
-		{
-			get { return swf.Screen.FromControl(Control).ToEto(); }
-		}
+		public Screen Screen => swf.Screen.FromControl(Control).ToEto();
 
 		public override bool Visible
 		{
@@ -509,11 +494,16 @@ namespace Eto.WinForms.Forms
 			}
 		}
 
-		public float LogicalPixelSize
+		public float LogicalPixelSize => 1f;
+
+		public bool AutoSize
 		{
-			get
+			get => Control.AutoSize;
+			set
 			{
-				return 1f;
+				// TODO: not quite working as intended yet on winforms, user can't resize after this is turned on..
+				Control.AutoSizeMode = swf.AutoSizeMode.GrowAndShrink;
+				Control.AutoSize = value;
 			}
 		}
 	}

--- a/src/Eto/Forms/Container.cs
+++ b/src/Eto/Forms/Container.cs
@@ -365,6 +365,7 @@ namespace Eto.Forms
 			{
 				throw new InvalidOperationException("Cannot assign a control as a child of itself.");
 			}
+			SuspendLayout();
 			if (Handler is IThemedControlHandler)
 			{
 				if (!ReferenceEquals(previousChild, null))
@@ -373,6 +374,7 @@ namespace Eto.Forms
 				if (!ReferenceEquals(child, null) && ReferenceEquals(child.LogicalParent, null))
 					SetLogicalParent(child);
 				assign();
+				ResumeLayout();
 				return;
 			}
 			if (!ReferenceEquals(previousChild, null) && !ReferenceEquals(previousChild, child))
@@ -415,10 +417,12 @@ namespace Eto.Forms
 						assign?.Invoke();
 						child.TriggerLoadComplete(EventArgs.Empty);
 					}
+					ResumeLayout();
 					return;
 				}
 			}
 			assign?.Invoke();
+			ResumeLayout();
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/Layout/StackLayout.cs
+++ b/src/Eto/Forms/Layout/StackLayout.cs
@@ -493,6 +493,7 @@ namespace Eto.Forms
 
 		void Create()
 		{
+			SuspendLayout();
 			var table = new TableLayout { IsVisualControl = true };
 			table.Spacing = new Size(Spacing, Spacing);
 
@@ -566,6 +567,7 @@ namespace Eto.Forms
 					throw new ArgumentOutOfRangeException();
 			}
 			Content = table;
+			ResumeLayout();
 			isCreated = true;
 		}
 

--- a/src/Eto/Forms/Window.cs
+++ b/src/Eto/Forms/Window.cs
@@ -272,7 +272,7 @@ namespace Eto.Forms
 		{
 			get { return Handler.ToolBar; }
 			set
-			{ 
+			{
 				var toolbar = Handler.ToolBar;
 				if (toolbar != null)
 				{
@@ -563,6 +563,19 @@ namespace Eto.Forms
 			set => Handler.MovableByWindowBackground = value;
 		}
 
+		/// <summary>
+		/// Gets or sets a value indicating that the window will automatically resize when its content changes
+		/// </summary>
+		/// <remarks>
+		/// Note that if you set both dimensions of the <see cref="Size"/> and/or <see cref="Container.ClientSize"/>, this will be set to false.
+		/// </remarks>
+		/// <value><c>true</c> to auto size the window when its content changes, <c>false</c> to only auto size when first created</value>
+		public bool AutoSize
+		{
+			get => Handler.AutoSize;
+			set => Handler.AutoSize = value;
+		}
+
 		#region Callback
 
 		static readonly object callback = new Callback();
@@ -823,6 +836,15 @@ namespace Eto.Forms
 			/// Gets or sets a value indicating that the window can be moved by click+dragging the window background
 			/// </summary>
 			bool MovableByWindowBackground { get; set; }
+
+			/// <summary>
+			/// Gets or sets a value indicating that the window will automatically resize when its content changes
+			/// </summary>
+			/// <remarks>
+			/// Note that if you set both dimensions of the <see cref="Size"/> and/or <see cref="Container.ClientSize"/>, this will be set to false.
+			/// </remarks>
+			/// <value><c>true</c> to auto size the window when its content changes, <c>false</c> to only auto size when first created</value>
+			bool AutoSize { get; set; }
 		}
 
 		#endregion

--- a/test/Eto.Test/Sections/Controls/LabelSection.cs
+++ b/test/Eto.Test/Sections/Controls/LabelSection.cs
@@ -127,10 +127,9 @@ namespace Eto.Test.Sections.Controls
 
 		Control WrapLabel()
 		{
-			const string text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
 			var label = new Label
 			{
-				Text = text
+				Text = Utility.LoremText
 			};
 
 			var wrapDropDown = new EnumDropDown<WrapMode>();

--- a/test/Eto.Test/Sections/Controls/RichTextAreaSection.cs
+++ b/test/Eto.Test/Sections/Controls/RichTextAreaSection.cs
@@ -10,9 +10,9 @@ namespace Eto.Test.Sections.Controls
 	[Section("Controls", typeof(RichTextArea))]
 	public class RichTextAreaSection : Panel
 	{
-		public static string LoremText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
-
 		public static string RtfString = "{\\rtf1\\ansi\\ansicpg1252\\cocoartf1343\\cocoasubrtf160\r\n{\\fonttbl\\f0\\fswiss\\fcharset0 Helvetica;}\r\n{\\colortbl;\\red255\\green255\\blue255;}\r\n\\margl1440\\margr1440\\vieww10800\\viewh8400\\viewkind0\r\n\\pard\\tx566\\tx1133\\tx1700\\tx2267\\tx2834\\tx3401\\tx3968\\tx4535\\tx5102\\tx5669\\tx6236\\tx6803\\pardirnatural\r\n\r\n\\f0\\fs24 \\cf0 This is some \r\n\\b bold\r\n\\b0 , \r\n\\i italic\r\n\\i0 , and \\ul underline\\ulnone  text! \\\r\n\\\r\n\\pard\\tx566\\tx1133\\tx1700\\tx2267\\tx2834\\tx3401\\tx3968\\tx4535\\tx5102\\tx5669\\tx6236\\tx6803\\pardirnatural\\qr\r\n\\cf0 Some other text}";
+
+		static string LastText = Utility.LoremText;
 
 		public RichTextAreaSection()
 		{
@@ -23,7 +23,7 @@ namespace Eto.Test.Sections.Controls
 			var buffer = richText.Buffer;
 
 			/**/
-			richText.Text = LoremText;
+			richText.Text = LastText;
 
 			var range = new Range<int>(6, 10);
 			buffer.SetFont(range, Fonts.Cursive(20, FontStyle.Bold, FontDecoration.Underline));
@@ -35,7 +35,7 @@ namespace Eto.Test.Sections.Controls
 			buffer.SetUnderline(new Range<int>(22, 25), true);
 			buffer.SetStrikethrough(new Range<int>(28, 38), true);
 
-			richText.CaretIndex = LoremText.Length - 1;
+			richText.CaretIndex = LastText.Length - 1;
 			/**/
 
 
@@ -114,7 +114,7 @@ namespace Eto.Test.Sections.Controls
 
 			var loadButton = new Button { Text = "Load" };
 			loadButton.Enabled = buffer.SupportedFormats.Contains(formatEnum.SelectedValue);
-			loadButton.Click += (sender, e) => buffer.Load(new MemoryStream(Encoding.UTF8.GetBytes(formatEnum.SelectedValue == RichTextAreaFormat.Rtf ? RtfString : LoremText)), formatEnum.SelectedValue);
+			loadButton.Click += (sender, e) => buffer.Load(new MemoryStream(Encoding.UTF8.GetBytes(formatEnum.SelectedValue == RichTextAreaFormat.Rtf ? RtfString : LastText)), formatEnum.SelectedValue);
 
 			var loadFileButton = new Button { Text = "Load File..." };
 			loadFileButton.Enabled = buffer.SupportedFormats.Contains(formatEnum.SelectedValue);
@@ -139,7 +139,7 @@ namespace Eto.Test.Sections.Controls
 				if (formatEnum.SelectedValue == RichTextAreaFormat.Rtf)
 					RtfString = Encoding.UTF8.GetString(stream.ToArray());
 				else
-					LoremText = Encoding.UTF8.GetString(stream.ToArray());
+					LastText = Encoding.UTF8.GetString(stream.ToArray());
 				Log.Write(richText, "Saved {0}:\n{1}", formatEnum.SelectedValue, new StreamReader(stream).ReadToEnd());
 			};
 

--- a/test/Eto.Test/Sections/Controls/TextAreaSection.cs
+++ b/test/Eto.Test/Sections/Controls/TextAreaSection.cs
@@ -15,7 +15,7 @@ namespace Eto.Test.Sections.Controls
 
 		Control Default()
 		{
-			var text = new TextArea { Text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum." };
+			var text = new TextArea { Text = Utility.LoremText };
 			LogEvents(text);
 
 			return new TableLayout

--- a/test/Eto.Test/Sections/Drawing/FormattedTextSection.cs
+++ b/test/Eto.Test/Sections/Drawing/FormattedTextSection.cs
@@ -15,7 +15,7 @@ namespace Eto.Test.Sections.Drawing
 
             var formattedText = new FormattedText
             {
-                Text = Sections.Controls.RichTextAreaSection.LoremText,
+                Text = Utility.LoremText,
                 MaximumSize = new SizeF(200, 100),
                 Wrap = FormattedTextWrapMode.Word,
                 Trimming = FormattedTextTrimming.CharacterEllipsis,

--- a/test/Eto.Test/Sections/UnitTestPanel.cs
+++ b/test/Eto.Test/Sections/UnitTestPanel.cs
@@ -1119,7 +1119,8 @@ namespace Eto.Test.Sections
 			timer.Interval = 0.5;
 			timer.Elapsed += (sender, e) => PerformSearch();
 
-			testCountLabel = new Label {
+			testCountLabel = new Label
+			{
 				VerticalAlignment = VerticalAlignment.Center
 			};
 
@@ -1527,18 +1528,18 @@ namespace Eto.Test.Sections
 			{
 				var map = new Dictionary<object, UnitTestItem>();
 				var tests = Runner.GetTests();
-		  // always show all categories
-		  var categories = AvailableCategories ?? Runner.GetCategories(TestFilter.Empty).OrderBy(r => r);
+				// always show all categories
+				var categories = AvailableCategories ?? Runner.GetCategories(TestFilter.Empty).OrderBy(r => r);
 				var totalTestCount = Runner.GetTestCount(filter);
 				var testSuites = tests.Select(suite => ToTree(suite.Assembly, suite, filter, map)).Where(r => r != null);
 				var treeData = new TreeGridItem(testSuites);
 				Application.Instance.AsyncInvoke(() =>
-		  {
-				  AvailableCategories = categories;
-				  testCountLabel.Text = $"{totalTestCount} Tests";
-				  testMap = map;
-				  tree.DataStore = treeData;
-			  });
+				{
+					  AvailableCategories = categories;
+					  testCountLabel.Text = $"{totalTestCount} Tests";
+					  testMap = map;
+					  tree.DataStore = treeData;
+				  });
 			});
 		}
 

--- a/test/Eto.Test/Utility.cs
+++ b/test/Eto.Test/Utility.cs
@@ -1,0 +1,29 @@
+using System.Text;
+
+namespace Eto.Test
+{
+	public static class Utility
+	{
+		public static string LoremText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+		public static string GenerateLoremText(int length)
+		{
+			var words = LoremText.Split(' ');
+			var sb = new StringBuilder();
+			var loremIndex = 0;
+			for (int i = 0; i < length; i++)
+			{
+				if (loremIndex >= words.Length)
+				{
+					loremIndex = 0;
+					sb.AppendLine();
+				}
+				if (i > 0)
+					sb.Append(" ");
+				sb.Append(words[loremIndex++]);
+			}
+			return sb.ToString();
+		}
+		
+	}
+}


### PR DESCRIPTION
Some behaviours to note:
- If you set only Width _or_ Height of a window it will use that and autosize the unset dimension.
- When the window is resizable and the user resizes it, AutoSize will be turned off
- Setting AutoSize after it has been turned off autosizes it again
- Setting both Width and Height of a form effectively disables AutoSize logic.

Fixes #1591