### PR TITLE
Mac: Show .NET stack trace when a native crash occurs

### DIFF
--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -197,6 +197,7 @@ namespace Eto.Mac.Forms
 		public static readonly object UseAlignmentFrame_Key = new object();
 		public static readonly IntPtr selSetDataProviderForTypes_Handle = Selector.GetHandle("setDataProvider:forTypes:");
 		public static readonly IntPtr selInitWithPasteboardWriter_Handle = Selector.GetHandle("initWithPasteboardWriter:");
+		public static readonly IntPtr selClass_Handle = Selector.GetHandle("class");
 		public const string FlagsChangedEvent = "MacView.FlagsChangedEvent";
 
 		// before 10.12, we have to call base.Layout() AFTER we do our layout otherwise it doesn't work correctly..
@@ -523,7 +524,8 @@ namespace Eto.Mac.Forms
 						return command.Enabled;
 				}
 			}
-			var objClass = ObjCExtensions.object_getClass(sender);
+
+			var objClass = Messaging.IntPtr_objc_msgSend(sender, MacView.selClass_Handle);
 
 			if (objClass == IntPtr.Zero)
 				return false;

--- a/test/Eto.Test.Mac/UnitTests/DrawableTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/DrawableTests.cs
@@ -1,0 +1,31 @@
+using Eto.Drawing;
+using Eto.Forms;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+
+namespace Eto.Test.Mac.UnitTests
+{
+	[TestFixture]
+    public class DrawableTests : TestBase
+    {
+		[ManualTest, Test]
+		public void MappingPlatformCommandShouldNotCrash() => ManualForm("Click the Edit > Cut menu item, it should not crash", form =>
+		{
+			form.Menu = new MenuBar();
+
+			var drawable = new Drawable();
+			drawable.Content = "I should have focus!";
+			drawable.Size = new Size(100, 100);
+			drawable.MapPlatformCommand("cut", new Command((sender, e) => MessageBox.Show("You clicked me! woo!")));
+			drawable.MapPlatformCommand("copy", null);
+
+			drawable.BackgroundColor = Colors.Green;
+			drawable.CanFocus = true;
+			drawable.Focus();
+
+			return drawable;
+
+		});
+        
+    }
+}


### PR DESCRIPTION
Mac: fix exception when not all platform commands are mapped for a control