### PR TITLE
Fix crash with StackLayout

### DIFF
--- a/src/Eto/Forms/Layout/StackLayout.cs
+++ b/src/Eto/Forms/Layout/StackLayout.cs
@@ -567,8 +567,8 @@ namespace Eto.Forms
 					throw new ArgumentOutOfRangeException();
 			}
 			Content = table;
-			ResumeLayout();
 			isCreated = true;
+			ResumeLayout();
 		}
 
 		internal override void InternalEnsureLayout()


### PR DESCRIPTION
Calling ResumeLayout before setting the isCreated flag could cause a stack overflow.