### PR TITLE
Wpf: Only fire SizeChanged when resulting size changes

### DIFF
--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -471,9 +471,12 @@ namespace Eto.Wpf.Forms
 				case Eto.Forms.Control.SizeChangedEvent:
 					ContainerControl.SizeChanged += (sender, e) =>
 					{
-						if (e.NewSize != e.PreviousSize) // WPF calls this event even if it hasn't changed
+						// 
+						var size = e.NewSize.ToEtoSize();
+						var prev = e.PreviousSize.ToEtoSize();
+						if (size != prev) // WPF calls this event even if it hasn't changed
 						{
-							newSize = e.NewSize.ToEtoSize(); // so we can report this back in Control.Size
+							newSize = size; // so we can report this back in Control.Size
 							Callback.OnSizeChanged(Widget, EventArgs.Empty);
 							newSize = null;
 						}


### PR DESCRIPTION
In DPI settings like 150%, 225%, etc this can be called even when the size reported by Eto does not change.