### PR TITLE
Fix some unit tests

### DIFF
--- a/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
@@ -48,6 +48,8 @@ namespace Eto.Mac.Forms.Controls
 		protected override NSButtonType DefaultButtonType => NSButtonType.MomentaryPushIn;
 
 		protected override Size DefaultMinimumSize => new Size(MinimumWidth, originalSize.Height);
+		
+		public static Size DefaultButtonSize => originalSize;
 
 		static ButtonHandler()
 		{

--- a/src/Eto.Wpf/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/SplitterHandler.cs
@@ -192,18 +192,18 @@ namespace Eto.Wpf.Forms.Controls
 			}
 			else if (fixedPanel == SplitterFixedPanel.Panel1)
 			{
-				var size1 = panel1.GetPreferredSize();
+				var size1 = panel1?.GetPreferredSize() ?? SizeF.Empty;
 				SetRelative(orientation == Orientation.Horizontal ? size1.Width : size1.Height);
 			}
 			else if (fixedPanel == SplitterFixedPanel.Panel2)
 			{
-				var size2 = panel2.GetPreferredSize();
+				var size2 = panel2?.GetPreferredSize() ?? SizeF.Empty;
 				SetRelative(orientation == Orientation.Horizontal ? size2.Width : size2.Height);
 			}
 			else
 			{
-				var size1 = panel1.GetPreferredSize();
-				var size2 = panel2.GetPreferredSize();
+				var size1 = panel1?.GetPreferredSize() ?? SizeF.Empty;
+				var size2 = panel2?.GetPreferredSize() ?? SizeF.Empty;
 				SetRelative(orientation == Orientation.Horizontal
 					? size1.Width / (double)(size1.Width + size2.Width)
 					: size1.Height / (double)(size1.Height + size2.Height));

--- a/src/Eto/Forms/Binding/IndirectChildBinding.cs
+++ b/src/Eto/Forms/Binding/IndirectChildBinding.cs
@@ -95,6 +95,12 @@ namespace Eto.Forms
 			{
 				var childItem = _parent.GetValue(dataItem);
 				_child.SetValue(childItem, value);
+				
+				// if this is an object binding, check to see if we are a boxed struct
+				var isStruct = typeof(TParent) == typeof(object) && childItem?.GetType().GetTypeInfo().IsValueType == true;
+				if (isStruct)
+					_parent.SetValue(dataItem, childItem);
+					
 			}
 		}
 	}

--- a/test/Eto.Test.Mac/UnitTests/ButtonTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/ButtonTests.cs
@@ -6,6 +6,7 @@ using Eto.Test.UnitTests;
 using NUnit.Framework;
 using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
+using Eto.Mac;
 #if XAMMAC2
 using AppKit;
 using CoreGraphics;
@@ -39,10 +40,13 @@ namespace Eto.Test.Mac.UnitTests
 
 				var handler = button?.Handler as ButtonHandler;
 				Assert.IsNotNull(handler, "#1.1");
-
+				
+				// big sur changed default height from 21 to 22.
+				var defaultButtonHeight = ButtonHandler.DefaultButtonSize.Height;
+				
 				var b = new EtoButton(NSButtonType.MomentaryPushIn);
 				var originalSize = b.GetAlignmentRectForFrame(new CGRect(CGPoint.Empty, b.FittingSize)).Size;
-				Assert.AreEqual(21, originalSize.Height, "#2.1");
+				Assert.AreEqual(defaultButtonHeight, originalSize.Height, "#2.1");
 
 				var preferred = handler.GetPreferredSize(SizeF.PositiveInfinity);
 				Assert.AreEqual(originalSize.Height, preferred.Height, "#2.1");
@@ -53,31 +57,31 @@ namespace Eto.Test.Mac.UnitTests
 					try
 					{
 						// need to use invokes to wait for the layout pass to complete
-						panel.Size = new Size(-1, 22);
+						panel.Size = new Size(-1, defaultButtonHeight + 1);
 						await Task.Delay(1000);
 						await Application.Instance.InvokeAsync(() =>
 						{
 							Assert.AreEqual(NSBezelStyle.RegularSquare, handler.Control.BezelStyle, "#3.1");
-							Assert.AreEqual(22, handler.Widget.Height, "#3.2");
+							Assert.AreEqual(defaultButtonHeight + 1, handler.Widget.Height, "#3.2");
 						});
 						panel.Size = new Size(-1, -1);
 						await Application.Instance.InvokeAsync(() =>
 						{
 							Assert.AreEqual(NSBezelStyle.Rounded, handler.Control.BezelStyle, "#4.1");
-							Assert.AreEqual(21, handler.Widget.Height, "#4.2");
+							Assert.AreEqual(defaultButtonHeight, handler.Widget.Height, "#4.2");
 						});
-						panel.Size = new Size(-1, 20);
+						panel.Size = new Size(-1, defaultButtonHeight - 1);
 						await Task.Delay(1000);
 						await Application.Instance.InvokeAsync(() =>
 						{
 							Assert.AreEqual(NSBezelStyle.SmallSquare, handler.Control.BezelStyle, "#5.1");
-							Assert.AreEqual(20, handler.Widget.Height, "#5.2");
+							Assert.AreEqual(defaultButtonHeight - 1, handler.Widget.Height, "#5.2");
 						});
 						panel.Size = new Size(-1, -1);
 						await Application.Instance.InvokeAsync(() =>
 						{
 							Assert.AreEqual(NSBezelStyle.Rounded, handler.Control.BezelStyle, "#6.1");
-							Assert.AreEqual(21, handler.Widget.Height, "#6.2");
+							Assert.AreEqual(defaultButtonHeight, handler.Widget.Height, "#6.2");
 						});
 
 					}

--- a/test/Eto.Test/UnitTests/Drawing/GraphicsOffsetModeTests.cs
+++ b/test/Eto.Test/UnitTests/Drawing/GraphicsOffsetModeTests.cs
@@ -72,7 +72,7 @@ namespace Eto.Test.UnitTests.Drawing
 			}
 		}
 
-		[Test]
+		[ManualTest, Test]
 		public void TestEdgeFillMisalignment()
 		{
 			using (var small = Chequer(20))
@@ -108,7 +108,7 @@ namespace Eto.Test.UnitTests.Drawing
 			}
 		}
 
-		[Test]
+		[ManualTest, Test]
 		public void TestPlugIcon()
 		{
 			var polygon = new PointF[]

--- a/test/Eto.Test/UnitTests/Forms/WindowTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/WindowTests.cs
@@ -74,6 +74,7 @@ namespace Eto.Test.UnitTests.Forms
 		}
 
 
+		[ManualTest]
 		[TestCase(true, true, true, false)]
 		[TestCase(true, true, false, true)]
 		[TestCase(true, false, true, false)]


### PR DESCRIPTION
Mac: ButtonTests.ButtonNaturalSizeShouldBeConsistent on Big Sur
Wpf: Splitter NRE when a panel is null
ChildBindingTests.IndirectBindingStructPropertiesShouldWork now works by detecting the struct type properly for object bindings
Properly mark some tests as manual