### PR TITLE
Support using PropertyDescriptor with bindings

### DIFF
--- a/src/Eto/Forms/Binding/PropertyBinding.cs
+++ b/src/Eto/Forms/Binding/PropertyBinding.cs
@@ -4,6 +4,7 @@ using System.Globalization;
 using System.Reflection;
 using System.Linq;
 using System.Diagnostics;
+using sc = System.ComponentModel;
 
 namespace Eto.Forms
 {
@@ -20,12 +21,11 @@ namespace Eto.Forms
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	public class PropertyBinding<T> : IndirectBinding<T>
 	{
-#if NETSTANDARD
-		PropertyInfo descriptor;
 		Type declaringType;
-#else
+#if !NETSTANDARD1_0
 		PropertyDescriptor descriptor;
 #endif
+		PropertyInfo propInfo;
 		string property;
 
 		/// <summary>
@@ -37,7 +37,7 @@ namespace Eto.Forms
 			set
 			{
 				property = value;
-				descriptor = null;
+				Reset();
 			}
 		}
 
@@ -63,38 +63,71 @@ namespace Eto.Forms
 			this.Property = property;
 			this.IgnoreCase = ignoreCase;
 		}
-
-		void EnsureProperty(object dataItem)
+		
+#if !NETSTANDARD1_0
+		bool IsValid => descriptor != null || propInfo != null;
+		bool CanRead => descriptor != null || propInfo?.CanRead == true;
+		bool CanWrite => descriptor?.IsReadOnly == false || propInfo?.CanWrite == true;
+		void Reset()
 		{
-			if (dataItem == null)
-				return;
-
-			if (
-				// found previously, but incompatible type
-				(descriptor != null && !declaringType.IsInstanceOfType(dataItem))
-				// not found yet, and the type is different than last lookup
-				|| (descriptor == null || declaringType != dataItem.GetType())
-			)
-			{
-#if NETSTANDARD
-				var dataItemType = dataItem.GetType();
-				descriptor = null;
-				// iterate to find non-public properties or with different case
-				var comparison = IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
-				foreach (var prop in dataItemType.GetRuntimeProperties())
-				{
-					if (string.Equals(prop.Name, Property, comparison))
-					{
-						descriptor = prop;
-						break;
-					}
-				}
-				declaringType = descriptor?.DeclaringType ?? dataItemType;
+			descriptor = null;
+			propInfo = null;
+			declaringType = null;
+		}
 #else
-				descriptor = TypeDescriptor.GetProperties(dataItem).Find(Property, IgnoreCase);
-				declaringType = descriptor?.ComponentType ?? dataItemType;
+		bool IsValid => propInfo != null;
+		bool CanRead => propInfo?.CanRead == true;
+		bool CanWrite => propInfo?.CanWrite == true;
+		void Reset()
+		{
+			propInfo = null;
+			declaringType = null;
+		}
 #endif
+
+		bool EnsureProperty(object dataItem)
+		{
+			// no dataItem, so no way to get any value..
+			if (dataItem == null)
+				return false;
+
+			// ensure we are valid and the dataItem is an instance of the declaring type
+			if (IsValid && declaringType.IsInstanceOfType(dataItem))
+				return true;
+			
+			var dataItemType = dataItem.GetType();
+			
+			// if we tried with the same type last time, skip.
+			if (declaringType != null && declaringType == dataItemType)
+				return false;
+				
+
+#if !NETSTANDARD1_0
+			// use property descriptors first to support more scenarios
+			descriptor = sc.TypeDescriptor.GetProperties(dataItem).Find(Property, IgnoreCase);
+			if (descriptor != null)
+			{
+				declaringType = descriptor.ComponentType;
+				propInfo = null;
+				return true;
 			}
+#endif
+			
+			// iterate to find non-public properties or with different case
+			var comparison = IgnoreCase ? StringComparison.OrdinalIgnoreCase : StringComparison.Ordinal;
+			foreach (var prop in dataItemType.GetRuntimeProperties())
+			{
+				if (string.Equals(prop.Name, Property, comparison))
+				{
+					propInfo = prop;
+					declaringType = propInfo.DeclaringType;
+					return true;
+				}
+			}
+			
+			// not valid, but we remember the declaring type so we don't keep checking for the same type
+			declaringType = dataItemType;
+			return false;
 		}
 
 		/// <summary>
@@ -104,8 +137,7 @@ namespace Eto.Forms
 		/// <param name="dataItem">Data item to find the property.</param>
 		protected bool HasProperty(object dataItem)
 		{
-			EnsureProperty(dataItem);
-			return descriptor != null;
+			return EnsureProperty(dataItem);
 		}
 
 
@@ -116,15 +148,14 @@ namespace Eto.Forms
 		/// <returns>value of the property from the specified dataItem object</returns>
 		protected override T InternalGetValue(object dataItem)
 		{
-			EnsureProperty(dataItem);
-			if (descriptor != null && dataItem != null
-				#if NETSTANDARD
-				&& descriptor.CanRead
-				#endif
-				)
+			if (EnsureProperty(dataItem) && CanRead)
 			{
 				var propertyType = typeof(T);
-				object val = descriptor.GetValue(dataItem);
+#if !NETSTANDARD1_0
+				object val = descriptor != null ? descriptor.GetValue(dataItem) : propInfo.GetValue(dataItem);
+#else
+				object val = propInfo.GetValue(dataItem);
+#endif
 				if (val != null && !propertyType.IsInstanceOfType(val))
 				{
 					try
@@ -150,24 +181,19 @@ namespace Eto.Forms
 		/// <param name="value">value to set to the property of the specified dataItem object</param>
 		protected override void InternalSetValue(object dataItem, T value)
 		{
-			EnsureProperty(dataItem);
-			if (descriptor != null && dataItem != null
-				#if NETSTANDARD
-				&& descriptor.CanWrite
-				#else
-				&& !descriptor.IsReadOnly
-				#endif
-				)
+			if (EnsureProperty(dataItem) && CanWrite)
 			{
-				var propertyType = descriptor.PropertyType;
+#if !NETSTANDARD1_0
+				var propertyType = descriptor?.PropertyType ?? propInfo.PropertyType;
+#else
+				var propertyType = propInfo.PropertyType;
+#endif
 				object val = value;
 				if (val != null && !propertyType.IsInstanceOfType(val))
 				{
 					try
 					{
-#if NETSTANDARD
 						propertyType = Nullable.GetUnderlyingType(propertyType) ?? propertyType;
-#endif
 						val = System.Convert.ChangeType(value, propertyType, CultureInfo.InvariantCulture);
 					}
 					catch (Exception ex)
@@ -176,7 +202,14 @@ namespace Eto.Forms
 						val = propertyType.GetTypeInfo().IsValueType ? Activator.CreateInstance(propertyType) : null;
 					}
 				}
-				descriptor.SetValue(dataItem, val);
+#if !NETSTANDARD1_0
+				if (descriptor != null)
+					descriptor.SetValue(dataItem, val);
+				else if (propInfo != null)
+					propInfo.SetValue(dataItem, val);
+#else
+				propInfo.SetValue(dataItem, val);
+#endif
 			}
 		}
 

--- a/test/Eto.Test/UnitTests/Forms/Bindings/PropertyBindingTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Bindings/PropertyBindingTests.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using NUnit.Framework;
 using Eto.Forms;
+using System.Data;
+using System.ComponentModel;
+using System.Collections.Generic;
+using sc = System.ComponentModel;
 
 namespace Eto.Test.UnitTests.Forms.Bindings
 {
@@ -144,6 +148,108 @@ namespace Eto.Test.UnitTests.Forms.Bindings
 			Assert.AreEqual(1, changed);
 			Assert.AreEqual("some other value", binding.GetValue(item));
 			binding.RemoveValueChangedHandler(changeReference, valueChanged);
+		}
+
+		class MyCustomDescriptorClass : ICustomTypeDescriptor
+		{
+			Dictionary<object, object> _properties = new Dictionary<object, object> 
+			{
+				{ "FirstProperty", "Initial Value" },
+				{ "SecondProperty", true }
+			};
+			
+			PropertyDescriptorCollection _propertyDescriptorCollection;
+			
+			public string NonTypeDescriptorProperty { get; set; } = "Initial Other Value";
+			
+
+			AttributeCollection ICustomTypeDescriptor.GetAttributes() => sc.TypeDescriptor.GetAttributes(this);
+
+			string ICustomTypeDescriptor.GetClassName() => sc.TypeDescriptor.GetClassName(this);
+
+			string ICustomTypeDescriptor.GetComponentName() => sc.TypeDescriptor.GetComponentName(this);
+
+			System.ComponentModel.TypeConverter ICustomTypeDescriptor.GetConverter() => sc.TypeDescriptor.GetConverter(this);
+
+			EventDescriptor ICustomTypeDescriptor.GetDefaultEvent() => sc.TypeDescriptor.GetDefaultEvent(this);
+
+			PropertyDescriptor ICustomTypeDescriptor.GetDefaultProperty() => sc.TypeDescriptor.GetDefaultProperty(this);
+
+			object ICustomTypeDescriptor.GetEditor(Type editorBaseType) => sc.TypeDescriptor.GetEditor(this, editorBaseType);
+
+			EventDescriptorCollection ICustomTypeDescriptor.GetEvents() => sc.TypeDescriptor.GetEvents(this);
+
+			EventDescriptorCollection ICustomTypeDescriptor.GetEvents(Attribute[] attributes) => sc.TypeDescriptor.GetEvents(this, attributes);
+
+			PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties() => GetProperties(null);
+
+			PropertyDescriptorCollection ICustomTypeDescriptor.GetProperties(Attribute[] attributes) => GetProperties(attributes);
+
+			private PropertyDescriptorCollection GetProperties(Attribute[] attributes)
+			{
+				if (_propertyDescriptorCollection != null)
+					return _propertyDescriptorCollection;
+				var props = new List<PropertyDescriptor>();
+				props.Add(new MyPropertyDescriptor<string>("FirstProperty"));
+				props.Add(new MyPropertyDescriptor<bool>("SecondProperty"));
+				_propertyDescriptorCollection = new PropertyDescriptorCollection(props.ToArray());
+				return _propertyDescriptorCollection;
+			}
+
+			object ICustomTypeDescriptor.GetPropertyOwner(PropertyDescriptor pd) => this;
+
+			class MyPropertyDescriptor<T> : sc.PropertyDescriptor
+			{
+				public MyPropertyDescriptor(string name) : base(name, null)
+				{
+				}
+
+				public override Type ComponentType => typeof(MyCustomDescriptorClass);
+
+				public override bool IsReadOnly => false;
+
+				public override Type PropertyType => typeof(T);
+
+				public override bool CanResetValue(object component) => false;
+
+				public override object GetValue(object component) => ((MyCustomDescriptorClass)component)._properties[Name];
+
+				public override void ResetValue(object component)
+				{
+				}
+
+				public override void SetValue(object component, object value) => ((MyCustomDescriptorClass)component)._properties[Name] = value;
+
+				public override bool ShouldSerializeValue(object component) => false;
+			}
+		}
+
+		[Test]
+		public void PropertyBindingsShouldUseDescriptors()
+		{
+			var item = new MyCustomDescriptorClass();
+
+			var stringBinding = Eto.Forms.Binding.Property<string>("FirstProperty");
+			var boolBinding = Eto.Forms.Binding.Property<bool>("SecondProperty");
+			var invalidBinding = Eto.Forms.Binding.Property<string>("ThirdInvalidProperty");
+			var propertyInfoBinding = Eto.Forms.Binding.Property<string>("NonTypeDescriptorProperty");
+			
+			Assert.AreEqual("Initial Value", stringBinding.GetValue(item));
+			stringBinding.SetValue(item, "Some Value");
+			Assert.AreEqual("Some Value", stringBinding.GetValue(item));
+
+			Assert.AreEqual(true, boolBinding.GetValue(item));
+			boolBinding.SetValue(item, false);
+			Assert.AreEqual(false, boolBinding.GetValue(item));
+			
+			Assert.IsNull(invalidBinding.GetValue(item));
+			invalidBinding.SetValue(item, "something");
+			Assert.IsNull(invalidBinding.GetValue(item));
+			
+			// ensure properties can also be accessed without descriptors
+			Assert.AreEqual("Initial Other Value", propertyInfoBinding.GetValue(item));
+			propertyInfoBinding.SetValue(item, "Some Other Value");
+			Assert.AreEqual("Some Other Value", propertyInfoBinding.GetValue(item));
 		}
 	}
 }


### PR DESCRIPTION
only when using .NET Standard 2.0+

Also fix issue where it'd look up property each time if the declaring type didn't match the current type