### PR TITLE
Wpf: a few minor optimizations

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -285,6 +285,7 @@ namespace Eto.Wpf.Forms.Controls
 				var oldText = Text;
 				CurrentText = null;
 				var newText = value ?? string.Empty;
+				TextBox.BeginChange();
 				if (newText != oldText)
 				{
 					var args = new TextChangingEventArgs(oldText, newText, false);
@@ -303,6 +304,7 @@ namespace Eto.Wpf.Forms.Controls
 					TextBox.SelectionStart = value.Length;
 					TextBox.SelectionLength = 0;
 				}
+				TextBox.EndChange();
 			}
 		}
 
@@ -345,8 +347,10 @@ namespace Eto.Wpf.Forms.Controls
 			set
 			{
 				CurrentSelection = null;
+				TextBox.BeginChange();
 				TextBox.SelectionStart = value.Start;
 				TextBox.SelectionLength = value.Length();
+				TextBox.EndChange();
 				if (!HasFocus)
 					initialSelection = true;
 			}

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -396,8 +396,11 @@ namespace Eto.Wpf.Forms
 			get { return ContainerControl.Visibility == sw.Visibility.Visible; }
 			set
 			{
-				ContainerControl.Visibility = (value) ? sw.Visibility.Visible : sw.Visibility.Collapsed;
-				UpdatePreferredSize();
+				if (value != Visible)
+				{
+					ContainerControl.Visibility = (value) ? sw.Visibility.Visible : sw.Visibility.Collapsed;
+					UpdatePreferredSize();
+				}
 			}
 		}
 


### PR DESCRIPTION
- TextBox.Text and Selection has a little less overhead by using BeginChange()/EndChange()
- Only update preferred size when Control.Visible is changed, vs. every time it is set.