### PR TITLE
Mac: Fix crash when aborting a change to a TextBoxCell

### DIFF
--- a/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
@@ -248,8 +248,12 @@ namespace Eto.Mac.Forms.Cells
 					ColumnHandler.DataViewHandler.OnCellEdited(ee);
 					control.ObjectValue = GetObjectValue(item);
 				};
+				bool isResigning = false;
 				view.TextField.ResignedFirstResponder += (sender, e) =>
 				{
+					if (isResigning)
+						return;
+					isResigning = true;
 					var control = (CellView)(sender as NSView)?.Superview;
 					var r = (int)control.Tag;
 					var item = getItem(control.Item, r);
@@ -257,6 +261,7 @@ namespace Eto.Mac.Forms.Cells
 
 					var ee = MacConversions.CreateCellEventArgs(ColumnHandler.Widget, tableView, r, col, item);
 					ColumnHandler.DataViewHandler.OnCellEdited(ee);
+					isResigning = false;
 				};
 				view.TextField.Bind(editableBinding, tableColumn, "editable", null);
 			}

--- a/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
@@ -192,8 +192,12 @@ namespace Eto.Mac.Forms.Cells
 					ColumnHandler.DataViewHandler.OnCellEdited(ee);
 					control.ObjectValue = GetObjectValue(item) ?? new NSString(string.Empty);
 				};
+				bool isResigning = false;
 				view.ResignedFirstResponder += (sender, e) =>
 				{
+					if (isResigning)
+						return;
+					isResigning = true;
 					var control = (CellView)sender;
 					var r = (int)control.Tag;
 					var item = getItem(control.Item, r);
@@ -201,6 +205,7 @@ namespace Eto.Mac.Forms.Cells
 
 					var ee = MacConversions.CreateCellEventArgs(ColumnHandler.Widget, tableView, r, col, item);
 					ColumnHandler.DataViewHandler.OnCellEdited(ee);
+					isResigning = false;
 				};
 				view.Bind(editableBinding, tableColumn, "editable", null);
 			}


### PR DESCRIPTION
A stack overflow was caused as reloading the data would cause another ResignFirstResponder event to occur.