### PR TITLE
Wpf: Close window when disposed

### DIFF
--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -914,5 +914,14 @@ namespace Eto.Wpf.Forms
 				return scale;
 			}
 		}
+		
+		protected override void Dispose(bool disposing)
+		{
+			// close the window when disposing from Eto explicitly
+			if (disposing)
+				Close();
+				
+			base.Dispose(disposing);
+		}
 	}
 }


### PR DESCRIPTION
If you created a window then disposed, it would stay around forever due to WPF keeping a reference to it.  We need to close explicitly when disposing so that it gets cleaned up.