### PR TITLE
Mac: Support using transparent background colors for most controls

### DIFF
--- a/src/Eto.Mac/ColorizeView.cs
+++ b/src/Eto.Mac/ColorizeView.cs
@@ -34,7 +34,6 @@ namespace Eto.Mac
 	class ColorizeView : IDisposable
 	{
 		NSImage _image;
-		CGSize? _realSize;
 
 		public Color Color { get; set; }
 
@@ -43,7 +42,7 @@ namespace Eto.Mac
 
 		public static void Create(ref ColorizeView colorize, Color? color)
 		{
-			if (color == null || color.Value.A <= 0)
+			if (color == null)
 			{
 				colorize?.Dispose();
 				colorize = null;
@@ -60,9 +59,9 @@ namespace Eto.Mac
 			var size = controlView.Frame.Size;
 			if (size.Width <= 0 || size.Height <= 0)
 			{
-				_realSize = null;
 				return;
 			}
+			
 			if (_image == null || size != _image.Size)
 			{
 				if (_image != null)
@@ -71,24 +70,19 @@ namespace Eto.Mac
 				_image = new NSImage(size);
 			}
 
-			if (supportsConvertSizeToBacking)
-				_realSize = controlView.ConvertSizeToBacking(size);
-			else
-				_realSize = controlView.ConvertSizeToBase(size);
-
 			_image.LockFocusFlipped(!controlView.IsFlipped);
 			NSGraphicsContext.CurrentContext.GraphicsPort.ClearRect(new CGRect(CGPoint.Empty, size));
 		}
 
 		public void End()
 		{
-			if (_image == null || _realSize == null)
+			if (_image == null)
 				return;
 
 			_image.UnlockFocus();
 
-			var ciImage = CIImage.FromCGImage(_image.CGImage);
-
+			var cgImage = _image.CGImage;
+			var ciImage = CIImage.FromCGImage(cgImage);
 
 #pragma warning disable CS0618 // Image => InputImage in Xamarin.Mac 6.6
 			var filter2 = new CIColorControls();
@@ -96,7 +90,7 @@ namespace Eto.Mac
 			filter2.Image = ciImage;
 			filter2.Saturation = 0.0f;
 			ciImage = (CIImage)filter2.ValueForKey(CIOutputImage);
-
+			
 			var filter3 = new CIColorMatrix();
 			filter3.SetDefaults();
 			filter3.Image = ciImage;
@@ -109,13 +103,21 @@ namespace Eto.Mac
 				filter3.RVector = new CIVector(0, components[0], 0);
 				filter3.GVector = new CIVector(components[1], 0, 0);
 				filter3.BVector = new CIVector(0, 0, components[2]);
-				filter3.AVector = new CIVector(0, 0, 0, cgColor.Alpha);
 			}
+			else if (components.Length >= 1)
+			{
+				// grayscale
+				filter3.RVector = new CIVector(0, components[0], 0);
+				filter3.GVector = new CIVector(components[0], 0, 0);
+				filter3.BVector = new CIVector(0, 0, components[0]);
+			}
+			
+			filter3.AVector = new CIVector(0, 0, 0, cgColor.Alpha);
 			ciImage = (CIImage)filter3.ValueForKey(CIOutputImage);
 
 			// create separate context so we can force using the software renderer, which is more than fast enough for this
 			var ciContext = CIContext.FromContext(NSGraphicsContext.CurrentContext.GraphicsPort, new CIContextOptions { UseSoftwareRenderer = true });
-			ciContext.DrawImage(ciImage, new CGRect(CGPoint.Empty, _image.Size), new CGRect(CGPoint.Empty, _realSize.Value));
+			ciContext.DrawImage(ciImage, new CGRect(CGPoint.Empty, _image.Size), new CGRect(0, 0, cgImage.Width, cgImage.Height));
 
 			ciImage.Dispose();
 			ciContext.Dispose();

--- a/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
@@ -59,7 +59,7 @@ namespace Eto.Mac.Forms.Controls
 		}
 	}
 
-	public class EtoButtonCell : NSButtonCell
+	public class EtoButtonCell : NSButtonCell, IColorizeCell
 	{
 		ColorizeView colorize;
 		public Color? Color
@@ -207,19 +207,13 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		public override Color BackgroundColor
+		protected override Color DefaultBackgroundColor => ((EtoButtonCell)Control.Cell).Color ?? Control.Cell.BackgroundColor.ToEto();
+		
+		protected override void SetBackgroundColor(Color? color)
 		{
-			get
-			{
-				var cell = (EtoButtonCell)Control.Cell;
-				return cell.Color ?? Colors.Transparent;
-			}
-			set
-			{
-				var cell = (EtoButtonCell)Control.Cell;
-				cell.Color = value.A > 0 ? (Color?)value : null;
-				Control.SetNeedsDisplay();
-			}
+			var cell = (EtoButtonCell)Control.Cell;
+			cell.Color = color;
+			Control.SetNeedsDisplay();
 		}
 
 		public Image Image

--- a/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
@@ -76,7 +76,7 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		public class EtoCell : NSComboBoxCell
+		public class EtoCell : NSComboBoxCell, IColorizeCell
 		{
 			[Export("tableView:willDisplayCell:forTableColumn:row:")]
 			public void TableWillDisplayCellForTableColumn(NSTableView tableView, NSCell cell, NSTableColumn tableColumn, nint rowIndex)
@@ -94,6 +94,25 @@ namespace Eto.Mac.Forms.Controls
 					frame.Width = size.Width;
 					window.SetFrame(frame, true);
 				}
+			}
+
+			ColorizeView colorize;
+
+			public Color? Color
+			{
+				get => colorize?.Color;
+				set => ColorizeView.Create(ref colorize, value);
+			}
+
+			public override void DrawInteriorWithFrame(CGRect cellFrame, NSView inView)
+			{
+				colorize?.End();
+				base.DrawInteriorWithFrame(cellFrame, inView);
+			}
+			public override void DrawWithFrame(CGRect cellFrame, NSView inView)
+			{
+				colorize?.Begin(cellFrame, inView);
+				base.DrawWithFrame(cellFrame, inView);
 			}
 		}
 
@@ -276,19 +295,6 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		public override Color BackgroundColor
-		{
-			get { return ((NSComboBoxCell)Control.Cell).BackgroundColor.ToEto(); }
-			set
-			{
-				if (value != BackgroundColor)
-				{
-					((NSComboBoxCell)Control.Cell).BackgroundColor = value.ToNSUI();
-					Control.SetNeedsDisplay();
-				}
-			}
-		}
-
 		public Color TextColor
 		{
 			get { return ((NSComboBoxCell)Control.Cell).TextColor.ToEto(); }
@@ -306,7 +312,7 @@ namespace Eto.Mac.Forms.Controls
 		{
 			get { return Control.StringValue; }
 			set
-			{ 
+			{
 				if (Text != value)
 				{
 					Control.StringValue = value ?? string.Empty;
@@ -327,7 +333,7 @@ namespace Eto.Mac.Forms.Controls
 		{
 			get { return !Control.Editable; }
 			set
-			{ 
+			{
 				Control.Editable = !value;
 				if (Control.Window != null)
 					Control.Window.MakeFirstResponder(null); // allows editing if currently focussed, so remove focus

--- a/src/Eto.Mac/Forms/Controls/DateTimePickerHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DateTimePickerHandler.cs
@@ -40,24 +40,25 @@ namespace Eto.Mac.Forms.Controls
 		{
 			public override void DrawRect(CGRect dirtyRect)
 			{
-				if (Handler.curValue != null)
+				var h = Handler;
+				if (h == null)
 				{
-					if (Cell.BackgroundStyle == NSBackgroundStyle.Dark && Cell.TextColor == NSColor.ControlText)
-					{
-						Cell.TextColor = NSColor.AlternateSelectedControlText;
-						base.DrawRect(dirtyRect);
-						Cell.TextColor = NSColor.ControlText;
-					}
-					else
-						base.DrawRect(dirtyRect);
+					base.DrawRect(dirtyRect);
+					return;
+				}
+
+				if (h.curValue != null)
+				{
+					base.DrawRect(dirtyRect);
 				}
 				else
 				{
 					// paint with no elements visible
-					var old = DatePickerElements;
-					DatePickerElements = 0;
+					// use transparent color so sizing is still correct.
+					var old = TextColor;
+					TextColor = NSColor.Clear;
 					base.DrawRect(dirtyRect);
-					DatePickerElements = old;
+					TextColor = old;
 				}
 			}
 
@@ -201,10 +202,12 @@ namespace Eto.Mac.Forms.Controls
 
 		protected override void SetBackgroundColor(Color? color)
 		{
+			// base.SetBackgroundColor(color);
 			if (color != null)
 			{
 				Control.BackgroundColor = color.Value.ToNSUI();
 				Control.DrawsBackground = color.Value.A > 0;
+				Control.WantsLayer = color.Value.A < 1;
 			}
 			else
 			{

--- a/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
@@ -67,7 +67,7 @@ namespace Eto.Mac.Forms.Controls
 
 		CollectionHandler collection;
 
-		public class EtoPopUpButtonCell : NSPopUpButtonCell
+		public class EtoPopUpButtonCell : NSPopUpButtonCell, IColorizeCell
 		{
 			NSDictionary textAttributes;
 			Color? textColor;
@@ -297,19 +297,6 @@ namespace Eto.Mac.Forms.Controls
 				{
 					Control.SelectItem(value);
 					Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
-				}
-			}
-		}
-
-		public override Color BackgroundColor
-		{
-			get { return ((EtoPopUpButtonCell)Control.Cell).Color ?? Colors.Transparent; }
-			set
-			{
-				if (value != BackgroundColor)
-				{
-					((EtoPopUpButtonCell)Control.Cell).Color = value;
-					Control.SetNeedsDisplay();
 				}
 			}
 		}

--- a/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
@@ -213,6 +213,7 @@ namespace Eto.Mac.Forms.Controls
 			Control.Delegate = new EtoDelegate { Handler = this };
 
 			scroll = new EtoScrollView { Handler = this };
+			scroll.DrawsBackground = false;
 			scroll.AutoresizesSubviews = true;
 			scroll.DocumentView = Control;
 			scroll.HasVerticalScroller = true;

--- a/src/Eto.Mac/Forms/Controls/MacControl.cs
+++ b/src/Eto.Mac/Forms/Controls/MacControl.cs
@@ -31,7 +31,7 @@ namespace Eto.Mac.Forms.Controls
 
 		protected override bool ControlEnabled
 		{
-			get => Control.Enabled; 
+			get => Control.Enabled;
 			set => Control.Enabled = value;
 		}
 
@@ -50,6 +50,9 @@ namespace Eto.Mac.Forms.Controls
 				};
 			}
 		}
+
+		protected override IColorizeCell ColorizeCell => Control.Cell as IColorizeCell;
+
 	}
 }
 

--- a/src/Eto.Mac/Forms/Controls/MacText.cs
+++ b/src/Eto.Mac/Forms/Controls/MacText.cs
@@ -44,22 +44,25 @@ namespace Eto.Mac.Forms.Controls
 
 		public Range<int>? InitialSelection { get; set; }
 
-		public override Color BackgroundColor
+		protected override Color DefaultBackgroundColor => Control.BackgroundColor.ToEto();
+
+		protected override bool UseColorizeCellWithAlphaOnly => true;
+
+		protected override void SetBackgroundColor(Color? color)
 		{
-			get { return Control.BackgroundColor.ToEto(); }
-			set
+			base.SetBackgroundColor(color);
+			var c = color ?? Colors.Transparent;
+			Control.BackgroundColor = c.ToNSUI();
+			Control.DrawsBackground = c.A > 0;
+			Control.WantsLayer = c.A < 1;
+			if (Widget.Loaded && HasFocus)
 			{
-				var color = value.ToNSUI();
-				Control.BackgroundColor = color;
-				Control.DrawsBackground = value.A > 0;
-				if (Widget.Loaded && HasFocus)
+				var editor = Control.CurrentEditor;
+				if (editor != null)
 				{
-					var editor = Control.CurrentEditor;
-					if (editor != null)
-					{
-						editor.BackgroundColor = color;
-						editor.DrawsBackground = value.A > 0;
-					}
+					var nscolor = c.ToNSUI();
+					editor.BackgroundColor = nscolor;
+					editor.DrawsBackground = c.A > 0;
 				}
 			}
 		}
@@ -102,7 +105,7 @@ namespace Eto.Mac.Forms.Controls
 			get { return Control.TextColor.ToEto(); }
 			set { Control.TextColor = value.ToNSUI(); }
 		}
-
+		
 		public int CaretIndex
 		{
 			get { return InitialSelection?.Start ?? (int?)Control.CurrentEditor?.SelectedRange.Location ?? LastSelection?.Start ?? 0; }

--- a/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
@@ -66,6 +66,7 @@ namespace Eto.Mac.Forms.Controls
 			}
 			public EtoTextField()
 			{
+				Cell = new EtoTextFieldCell();
 			}
 		}
 
@@ -139,10 +140,9 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		public override object EventObject
-		{
-			get { return Control.TextField; }
-		}
+		public override object EventObject => Control.TextField;
+		
+		protected override IColorizeCell ColorizeCell => Control.TextField.Cell as IColorizeCell;
 
 		public static NSNumberFormatter DefaultFormatter = new NSNumberFormatter
 		{
@@ -505,10 +505,26 @@ namespace Eto.Mac.Forms.Controls
 			set { TextField.TextColor = value.ToNSUI(); }
 		}
 
+		protected override bool UseColorizeCellWithAlphaOnly => true;
+
 		protected override void SetBackgroundColor(Color? color)
 		{
-			if (color != null)
-				TextField.BackgroundColor = color.Value.ToNSUI();
+			base.SetBackgroundColor(color);
+			var textField = Control.TextField;
+			var c = color ?? Colors.Transparent;
+			textField.BackgroundColor = c.ToNSUI();
+			textField.DrawsBackground = c.A > 0;
+			textField.WantsLayer = c.A < 1;
+			if (Widget.Loaded && HasFocus)
+			{
+				var editor = textField.CurrentEditor;
+				if (editor != null)
+				{
+					var nscolor = c.ToNSUI();
+					editor.BackgroundColor = nscolor;
+					editor.DrawsBackground = c.A > 0;
+				}
+			}
 		}
 
 		public override void AttachEvent(string id)
@@ -599,5 +615,6 @@ namespace Eto.Mac.Forms.Controls
 				});
 			}
 		}
+		
 	}
 }

--- a/src/Eto.Mac/Forms/Controls/PasswordBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/PasswordBoxHandler.cs
@@ -61,6 +61,7 @@ namespace Eto.Mac.Forms.Controls
 
 			public EtoSecureTextField()
 			{
+				Cell = new EtoTextFieldCell();
 				Bezeled = true;
 				Editable = true;
 				Selectable = true;

--- a/src/Eto.Mac/Forms/Controls/SegmentedButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SegmentedButtonHandler.cs
@@ -221,18 +221,11 @@ namespace Eto.Mac.Forms.Controls
 			{
 				colorize?.Begin(cellFrame, inView);
 				base.DrawWithFrame(cellFrame, inView);
-				colorize?.End();
 			}
 
 			public override void DrawInteriorWithFrame(CGRect cellFrame, NSView inView)
 			{
-				if (colorize != null)
-				{
-					var context = NSGraphicsContext.CurrentContext.GraphicsPort;
-					var frame = inView.Frame;
-					context.TranslateCTM(0, frame.Height + cellFrame.Y - (frame.Height - cellFrame.Y - cellFrame.Height) + 1);
-					context.ScaleCTM(1, -1);
-				}
+				colorize?.End();
 				base.DrawInteriorWithFrame(cellFrame, inView);
 			}
 		}

--- a/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
@@ -71,6 +71,33 @@ namespace Eto.Mac.Forms.Controls
 			return null;
 		}
 	}
+	
+	public interface IColorizeCell
+	{
+		Color? Color { get; set; }
+	}
+	
+	public class EtoTextFieldCell : NSTextFieldCell, IColorizeCell
+	{
+		ColorizeView colorize;
+
+		public Color? Color 
+		{ 
+			get => colorize?.Color;
+			set => ColorizeView.Create(ref colorize, value);
+		}
+
+		public override void DrawInteriorWithFrame(CGRect cellFrame, NSView inView)
+		{
+			colorize?.End();
+			base.DrawInteriorWithFrame(cellFrame, inView);
+		}
+		public override void DrawWithFrame(CGRect cellFrame, NSView inView)
+		{
+			colorize?.Begin(cellFrame, inView);
+			base.DrawWithFrame(cellFrame, inView);
+		}
+	}
 
 	public class EtoTextField : NSTextField, IMacControl, ITextBoxWithMaxLength
 	{
@@ -80,7 +107,7 @@ namespace Eto.Mac.Forms.Controls
 		ITextBoxWithMaxLength MaxLengthHandler => WeakHandler.Target as ITextBoxWithMaxLength;
 
 		public int MaxLength { get { return MaxLengthHandler?.MaxLength ?? 0; } }
-
+		
 		public EtoTextField(IntPtr handle)
 			: base(handle)	
 		{
@@ -90,6 +117,7 @@ namespace Eto.Mac.Forms.Controls
 
 		public EtoTextField()
 		{
+			Cell = new EtoTextFieldCell();
 			Bezeled = true;
 			Editable = true;
 			Selectable = true;

--- a/test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
+++ b/test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
@@ -21,6 +21,7 @@ namespace Eto.Test.Sections.Behaviors
 			layout.BeginHorizontal();
 			layout.Add(null);
 			layout.Add(TextAreaControl());
+			layout.Add(RichTextAreaControl());
 			if (Platform.Supports<ListBox>())
 				layout.Add(ListBoxControl());
 			layout.Add(PanelControl());
@@ -91,6 +92,13 @@ namespace Eto.Test.Sections.Behaviors
 		Control TextAreaControl()
 		{
 			var control = new TextArea { Text = "TextArea" };
+			LogEvents(control);
+			return control;
+		}
+
+		Control RichTextAreaControl()
+		{
+			var control = new RichTextArea { Text = "RichTextArea" };
 			LogEvents(control);
 			return control;
 		}


### PR DESCRIPTION
- SegmentedButton no longer colourizes the button text with the background color
- Properly colourize with grayscale colors

Still a problem with DateTimePicker in Light mode, but I couldn't find a way around that