### PR TITLE
Wpf: Fix DropDown.SelectedIndexChanged before control is loaded

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
@@ -15,6 +15,7 @@ using System.Collections.Specialized;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	
 	public class DropDownHandler : DropDownHandler<EtoComboBox, DropDown, DropDown.ICallback>
 	{
 		internal static readonly object AllowVirtualization_Key = new object();
@@ -23,35 +24,11 @@ namespace Eto.Wpf.Forms.Controls
 
 	public class EtoComboBox : swc.ComboBox, IEtoWpfControl
 	{
-		int? selected;
-
-		public EtoComboBox()
-		{
-			Loaded += ComboBoxEx_Loaded;
-		}
-
 		public bool IsVirtualizing
 		{
 			get => swc.VirtualizingPanel.GetIsVirtualizing(this);
 			set => swc.VirtualizingPanel.SetIsVirtualizing(this, value);
 		}
-
-		public override void OnApplyTemplate()
-		{
-			base.OnApplyTemplate();
-
-			if (!IsLoaded)
-			{
-				var lastSelected = SelectedIndex;
-				if (lastSelected != -1)
-				{
-					selected = lastSelected;
-					SelectedIndex = -1;
-				}
-			}
-		}
-
-		internal void SetSelected(int? index) => selected = index;
 
 		public swc.Primitives.Popup Popup => GetTemplateChild("PART_Popup") as swc.Primitives.Popup;
 
@@ -70,12 +47,6 @@ namespace Eto.Wpf.Forms.Controls
 
 		public IWpfFrameworkElement Handler { get; set; }
 
-		protected override void OnSelectionChanged(swc.SelectionChangedEventArgs e)
-		{
-			if (selected == null)
-				base.OnSelectionChanged(e);
-		}
-
 		protected override void OnItemsChanged(System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
 			base.OnItemsChanged(e);
@@ -83,13 +54,6 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				InvalidateMeasure();
 			}
-		}
-
-		void ComboBoxEx_Loaded(object sender, sw.RoutedEventArgs e)
-		{
-			if (selected == null) return;
-			SelectedIndex = selected.Value;
-			selected = null;
 		}
 
 		sw.Size FindMaxSize(sw.Size constraint)
@@ -225,13 +189,8 @@ namespace Eto.Wpf.Forms.Controls
 
 		public int SelectedIndex
 		{
-			get { return Control.SelectedIndex; }
-			set 
-			{
-				Control.SelectedIndex = value;
-				if (!Control.IsLoaded)
-					Control.SetSelected(value);
-			}
+			get => Control.SelectedIndex;
+			set => Control.SelectedIndex = value;
 		}
 
 		protected virtual swc.Border BorderControl => Control.FindChild<swc.Border>();

--- a/test/Eto.Test.Wpf/UnitTests/DropDownTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/DropDownTests.cs
@@ -1,0 +1,41 @@
+using Eto.Forms;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+
+namespace Eto.Test.Wpf.UnitTests
+{
+	[TestFixture]
+    public class DropDownTests : TestBase
+    {
+		[Test, InvokeOnUI]
+		public void DropDownInElementHostShouldHaveCorrectInitialValue()
+		{
+			var dropDown = new DropDown();
+			dropDown.DataStore = new [] { "Item 1", "Item 2", "Item 3" };
+			
+			var content = TableLayout.AutoSized(dropDown);
+			
+			// forces template to be applied to WPF controls
+			var native = content.ToNative(false);
+			native.Measure(new System.Windows.Size(double.PositiveInfinity, double.PositiveInfinity));
+
+			// now set selected index now that template has applied
+			dropDown.SelectedIndex = 1;
+			
+			// check that the index is correct when it is shown
+			int? dropDownIndex = null;
+			
+			var dlg = new Dialog();
+			dlg.ClientSize = new Drawing.Size(200, 200);
+			dlg.Content = content;
+			dlg.Shown += (sender, e) => {
+				dropDownIndex = dropDown.SelectedIndex;	
+				dlg.Close();
+			};
+			dlg.ShowModal(Application.Instance.MainForm);
+			
+			Assert.AreEqual(1, dropDownIndex);
+		}
+        
+    }
+}

--- a/test/Eto.Test/UnitTests/Forms/Controls/ListControlTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ListControlTests.cs
@@ -72,5 +72,25 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				};
 			});
 		}
+		
+		[Test, InvokeOnUI]
+		public void ChangingSelectedIndexMultipleTimesBeforeLoadShouldTriggerChanged()
+		{
+			var list = new T();
+			int changed = 0;
+			list.SelectedIndexChanged += (sender, e) => changed++;
+			list.DataStore = new [] { "Item 1", "Item 2", "Item 3" };
+			
+			Assert.AreEqual(0, changed, "1.1 - Setting data store should not fire selected index");
+			Assert.AreEqual(-1, list.SelectedIndex, "1.2");
+			
+			list.SelectedIndex = 0;
+			Assert.AreEqual(1, changed, "2.1 - Setting selected index should trigger event");
+			Assert.AreEqual(0, list.SelectedIndex, "2.2");
+			
+			list.SelectedIndex = 1;
+			Assert.AreEqual(2, changed, "3.1 - Setting selected index again should trigger event again");
+			Assert.AreEqual(1, list.SelectedIndex, "3.2");
+		}
 	}
 }


### PR DESCRIPTION
- Removes the ancient hack where it deferred setting the selected index until it is loaded
- Added tests to ensure the correct functionality when the control isn't loaded and also when setting the index between where the template is applied and it is loaded.