### PR TITLE
TextBox.AutoSelectMode fixes

### DIFF
--- a/src/Eto.Mac/Forms/Controls/SearchBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SearchBoxHandler.cs
@@ -63,6 +63,18 @@ namespace Eto.Mac.Forms.Controls
 				Cell.Wraps = false;
 				Cell.UsesSingleLineMode = true;
 			}
+			
+			[Export("textViewDidChangeSelection:")]
+			public void TextViewDidChangeSelection(NSNotification notification)
+			{
+				var h = Handler;
+				if (h != null)
+				{
+					var textView = (NSTextView)notification.Object;
+					h.SetLastSelection(textView.SelectedRange.ToEto());
+				}
+			}
+			
 		}
 
 		public override bool HasFocus
@@ -120,6 +132,14 @@ namespace Eto.Mac.Forms.Controls
 			{
 				handler.Callback.OnTextChanged(handler.Widget, EventArgs.Empty);
 			}
+		}
+		
+		protected override bool SelectAllOnMouseDown(MouseEventArgs e)
+		{
+			var cancelRect = Control.Cell.CancelButtonRectForBounds(Control.Bounds).ToEto();
+			if (!cancelRect.Contains(e.Location))
+				return base.SelectAllOnMouseDown(e);
+			return false;
 		}
 
 		public bool ReadOnly

--- a/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
@@ -81,6 +81,11 @@ namespace Eto.Mac.Forms.Controls
 	{
 		ColorizeView colorize;
 
+		public EtoTextFieldCell()
+		{
+			StringValue = string.Empty;
+		}
+
 		public Color? Color 
 		{ 
 			get => colorize?.Color;

--- a/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -104,7 +104,7 @@ namespace Eto.Wpf.Forms.Controls
 				initialSelection = false;
 				return;
 			}
-			if (AutoSelectMode == AutoSelectMode.OnFocus)
+			if (AutoSelectMode == AutoSelectMode.OnFocus || AutoSelectMode == AutoSelectMode.Always)
 				TextBox.SelectAll();
 		}
 

--- a/test/Eto.Test/Sections/Controls/TextBoxSection.cs
+++ b/test/Eto.Test/Sections/Controls/TextBoxSection.cs
@@ -4,11 +4,21 @@ using Eto.Drawing;
 namespace Eto.Test.Sections.Controls
 {
 	[Section("Controls", typeof(TextBox))]
-	public class TextBoxSection : Scrollable
+	public class TextBoxSection : TextBoxSection<TextBox>
+	{
+	}
+	
+	[Section("Controls", typeof(SearchBox))]
+	public class SearchBoxSection : TextBoxSection<SearchBox>
+	{
+	}
+	
+	public class TextBoxSection<T> : Scrollable
+		where T: TextBox, new()
 	{
 		public TextBoxSection()
 		{
-			var textBox = new TextBox();
+			var textBox = new T();
 			LogEvents(textBox);
 
 			var placeholderText = new TextBox();
@@ -53,7 +63,7 @@ namespace Eto.Test.Sections.Controls
 
 		Control DifferentSize()
 		{
-			var control = new TextBox { Text = "Different Size (300x50)", Size = new Size(300, 50) };
+			var control = new T { Text = "Different Size (300x50)", Size = new Size(300, 50) };
 			LogEvents(control);
 			return control;
 		}


### PR DESCRIPTION
Mac: Allow user to change cursor or select different text when the control has focus
Mac: Fix SearchBox clear button when in AutoSelectMode.Always
Mac: SearchBox should remember selection when set to AutoSelectMode.Never
Wpf: AutoSelectMode.Always should select all when the control gets focus