### PR TITLE
Wpf: PixelLayout now respects the desired and contained size

### DIFF
--- a/src/Eto.Wpf/Forms/PixelLayoutHandler.cs
+++ b/src/Eto.Wpf/Forms/PixelLayoutHandler.cs
@@ -10,7 +10,14 @@ namespace Eto.Wpf.Forms
 	{
 		public class EtoCanvas : swc.Canvas
 		{
+			public IWpfFrameworkElement Handler { get; set; }
+
 			protected override sw.Size MeasureOverride(sw.Size constraint)
+			{
+				return Handler?.MeasureOverride(constraint, MeasureChildren) ?? MeasureChildren(constraint);
+			}
+			
+			sw.Size MeasureChildren(sw.Size constraint)
 			{
 				var size = new sw.Size();
 				
@@ -23,7 +30,7 @@ namespace Eto.Wpf.Forms
 					if (size.Width < left) size.Width = left;
 					if (size.Height < top) size.Height = top;
 				}
-				return size;
+				return size.Min(constraint.InfinityIfNan());
 			}
 		}
 
@@ -31,7 +38,8 @@ namespace Eto.Wpf.Forms
 		{
 			Control = new EtoCanvas
 			{
-				SnapsToDevicePixels = true
+				Handler = this,
+				SnapsToDevicePixels = true,
 			};
 		}
 


### PR DESCRIPTION
Before, it would always size it based on the content so it wouldn't trigger size change events, etc.  Now you can properly use the SizeChanged event to update the position of controls when shrinking it beyond where those controls are.