### PR TITLE
Wpf: Clip PixelLayout content to its bounds

### DIFF
--- a/src/Eto.Wpf/Forms/PixelLayoutHandler.cs
+++ b/src/Eto.Wpf/Forms/PixelLayoutHandler.cs
@@ -40,6 +40,7 @@ namespace Eto.Wpf.Forms
 			{
 				Handler = this,
 				SnapsToDevicePixels = true,
+				ClipToBounds = true
 			};
 		}
 


### PR DESCRIPTION
This fixes the issue mentioned in #1879, where the PixelLayout by default should clip its children to its bounds.