### PR TITLE
Mac/Gtk: Only fire DropDown.SelectedIndexChanged when the index is different while setting DataStore

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DropDownHandler.cs
@@ -184,18 +184,21 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public IEnumerable<object> DataStore
 		{
-			get { return collection != null ? collection.Collection : null; }
+			get => collection?.Collection;
 			set
 			{
 				SuppressIndexChanged++;
 				var selected = Widget.SelectedValue;
+				var selectedIndex = SelectedIndex;
 				collection?.Unregister();
 				collection = new CollectionHandler { Handler = this };
 				collection.Register(value);
 				if (!ReferenceEquals(selected, null))
 				{
-					SelectedIndex = collection.IndexOf(selected);
-					Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
+					var newIndex = collection.IndexOf(selected);
+					SelectedIndex = newIndex;
+					if (newIndex != selectedIndex)
+						Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
 				}
 				SuppressIndexChanged--;
 			}

--- a/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DropDownHandler.cs
@@ -275,14 +275,17 @@ namespace Eto.Mac.Forms.Controls
 			set
 			{
 				var selected = Widget.SelectedValue;
+				var selectedIndex = SelectedIndex;
 				Control.SelectItem(-1);
 				collection?.Unregister();
 				collection = new CollectionHandler { Handler = this };
 				collection.Register(value);
 				if (!ReferenceEquals(selected, null))
 				{
-					Control.SelectItem(collection.IndexOf(selected));
-					Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
+					var newIndex = collection.IndexOf(selected);
+					Control.SelectItem(newIndex);
+					if (selectedIndex != newIndex)
+						Callback.OnSelectedIndexChanged(Widget, EventArgs.Empty);
 				}
 				InvalidateMeasure();
 			}

--- a/test/Eto.Test/UnitTests/Forms/Controls/DropDownTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/DropDownTests.cs
@@ -1,6 +1,8 @@
 using System;
 using NUnit.Framework;
 using Eto.Forms;
+using System.Collections.Generic;
+
 namespace Eto.Test.UnitTests.Forms.Controls
 {
 	[TestFixture]
@@ -140,6 +142,52 @@ namespace Eto.Test.UnitTests.Forms.Controls
 						null
 					}
 				};
+			});
+		}
+
+		[Test]
+		public void SelectedIndexShouldOnlyFireIfIndexChanges()
+		{
+			var list = new List<string> { "aaa", "bbb", "ccc" };
+			var selectedIndexChangedCount = 0;
+			Shown(form =>
+			{
+				var dropDown = new DropDown();
+				dropDown.SelectedIndexChanged += (sender, e) => selectedIndexChangedCount++;
+				dropDown.DataStore = list;
+				dropDown.SelectedIndex = 1;
+				Assert.AreEqual(1, selectedIndexChangedCount, "#1");
+				
+				form.Content = dropDown;
+				return dropDown;
+			}, dropDown =>
+			{
+				Assert.AreEqual(1, dropDown.SelectedIndex, "#2.1");
+				Assert.AreEqual("bbb", dropDown.SelectedValue, "#2.2");
+				Assert.AreEqual(1, selectedIndexChangedCount, "#2.3");
+				
+				// set to same list instance, should not fire a changed event
+				dropDown.DataStore = list;
+				Assert.AreEqual(1, dropDown.SelectedIndex, "#3.1");
+				Assert.AreEqual("bbb", dropDown.SelectedValue, "#3.2");
+				Assert.AreEqual(1, selectedIndexChangedCount, "#3.3");
+				
+				// set to new list instance with same index for selected item, should not fire a changed event
+				list = new List<string>(list);
+				list.Add("ddd");
+				Assert.AreEqual(1, dropDown.SelectedIndex, "#4.1");
+				Assert.AreEqual("bbb", dropDown.SelectedValue, "#4.2");
+				Assert.AreEqual(1, selectedIndexChangedCount, "#4.3");
+				
+				// create a copy and insert to make the index differnet, should now fire a changed event
+				list = new List<string>(list);
+				list.Insert(0, "ddd");
+				dropDown.DataStore = list;
+				
+				// now we should get a change event, since the index of the previously selected item is now different.
+				Assert.AreEqual(2, dropDown.SelectedIndex, "#5.1");
+				Assert.AreEqual("bbb", dropDown.SelectedValue, "#5.2");
+				Assert.AreEqual(2, selectedIndexChangedCount, "#5.3");
 			});
 		}
 


### PR DESCRIPTION
This makes Mac and Gtk fire the events in the same way as Wpf and WinForms.