### PR TITLE
Mac: Fix Application.RunIteration()

### DIFF
--- a/src/Eto.Mac/Forms/ApplicationHandler.cs
+++ b/src/Eto.Mac/Forms/ApplicationHandler.cs
@@ -188,9 +188,9 @@ namespace Eto.Mac.Forms
 
 		public void RunIteration()
 		{
-#pragma warning disable 0618 // for some reason we get a warning (error in Release) here even though we aren't using an obsolete api.
-			NSApplication.SharedApplication.NextEvent(NSEventMask.AnyEvent, NSDate.DistantFuture, NSRunLoop.NSDefaultRunLoopMode, true);
-#pragma warning restore 0618
+			var evt = NSApplication.SharedApplication.NextEvent(NSEventMask.AnyEvent, NSDate.DistantFuture, NSRunLoop.NSDefaultRunLoopMode, true);
+			// need to actually send the event
+			NSApplication.SharedApplication.SendEvent(evt);
 		}
 
 		public void Attach(object context)

--- a/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
@@ -1,4 +1,5 @@
 using System;
+using Eto.Drawing;
 using Eto.Forms;
 using NUnit.Framework;
 
@@ -23,6 +24,52 @@ namespace Eto.Test.UnitTests.Forms
 			{
 				_ = new Application(Platform.Instance);
 			});
+		}
+
+		[Test]
+		public void RunIterationShouldAllowBlocking()
+		{
+			Form form = null;
+			bool running = true;
+			bool stopClicked = false;
+			Application.Instance.Invoke(() =>
+			{
+				form = new Form();
+				form.Closed += (sender, e) => running = false;
+
+				var stopButton = new Button { Text = "Stop" };
+				stopButton.Click += (sender, e) =>
+				{
+					running = false;
+					stopClicked = true;
+				};
+
+				var layout = new DynamicLayout();
+
+				layout.Padding = 10;
+				layout.DefaultSpacing = new Size(4, 4);
+				layout.Add(new Label { Text = "The controls in this form should\nbe functional while test is running", TextAlignment = TextAlignment.Center });
+				layout.Add(new DropDown { DataStore = new[] { "Item 1", "Item 2", "Item 3" } });
+				layout.Add(new TextBox());
+				layout.Add(new DateTimePicker());
+				layout.AddCentered(new Spinner { Enabled = true });
+				layout.AddCentered(stopButton);
+
+				form.Content = layout;
+			});
+
+			Application.Instance.Invoke(() =>
+			{
+				form.Owner = Application.Instance.MainForm;
+				form.Show();
+				do
+				{
+					Application.Instance.RunIteration();
+				} while (running);
+				form.Close();
+			});
+			
+			Assert.IsTrue(stopClicked, "#1 - Must press the stop button to close the form");
 		}
 	}
 }


### PR DESCRIPTION
On Mac, Application.RunIteration() did not work correctly in that it would not actually execute the event that it removed from the run loop.