### PR TITLE
Mac: Fix some Tree/GridView issues

### DIFF
--- a/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
@@ -186,7 +186,7 @@ namespace Eto.Mac.Forms.Cells
 			public override void DrawRect(CGRect dirtyRect)
 			{
 				var nscontext = NSGraphicsContext.CurrentContext;
-				var isFirstResponder = Window.FirstResponder == this;
+				var isFirstResponder = Window?.FirstResponder == this;
 
 				if (DrawsBackground)
 				{

--- a/src/Eto.Mac/Forms/Cells/ProgressCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ProgressCellHandler.cs
@@ -112,6 +112,7 @@ namespace Eto.Mac.Forms.Cells
 				view = new NSLevelIndicator();
 				view.Identifier = tableColumn.Identifier;
 				view.Cell = new EtoCell { MinValue = 0, MaxValue = 1 };
+				view.Enabled = false;
 				view.Cell.LevelIndicatorStyle = NSLevelIndicatorStyle.ContinuousCapacity;
 			}
 			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -743,6 +743,39 @@ namespace Eto.Mac.Forms.Controls
 				}
 			}
 		}
+		
+		protected virtual bool HandleMouseEvent(NSEvent theEvent)
+		{
+			var args = MacConversions.GetMouseEvent(this, theEvent, false);
+			if (theEvent.ClickCount >= 2)
+			{
+				Callback.OnMouseDoubleClick(Widget, args);
+				if (args.Handled)
+					return false;
+			}
+			else
+			{
+				Callback.OnMouseDown(Widget, args);
+				if (args.Handled)
+					return true;
+			}
+
+			var point = Control.ConvertPointFromView(theEvent.LocationInWindow, null);
+
+			var rowIndex = (int)Control.GetRow(point);
+			if (rowIndex >= 0)
+			{
+				var columnIndex = (int)Control.GetColumn(point);
+				var item = GetItem(rowIndex);
+				var column = columnIndex == -1 || columnIndex > Widget.Columns.Count ? null : Widget.Columns[columnIndex];
+				var cellArgs = MacConversions.CreateCellMouseEventArgs(column, ContainerControl, rowIndex, columnIndex, item, theEvent);
+				if (theEvent.ClickCount >= 2)
+					Callback.OnCellDoubleClick(Widget, cellArgs);
+				else
+					Callback.OnCellClick(Widget, cellArgs);
+			}
+			return false;
+		}
 	}
 }
 

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -71,7 +71,7 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void RightMouseDown(NSEvent theEvent)
 			{
-				if (HandleMouseEvent(theEvent))
+				if (Handler?.HandleMouseEvent(theEvent) == true)
 					return;
 				base.RightMouseDown(theEvent);
 				Handler?.TriggerMouseCallback();
@@ -79,7 +79,7 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void OtherMouseDown(NSEvent theEvent)
 			{
-				if (HandleMouseEvent(theEvent))
+				if (Handler?.HandleMouseEvent(theEvent) == true)
 					return;
 				base.OtherMouseDown(theEvent);
 				Handler?.TriggerMouseCallback();
@@ -87,56 +87,19 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void MouseDown(NSEvent theEvent)
 			{
-				if (HandleMouseEvent(theEvent))
-					return;
-
 				var h = Handler;
 				if (h == null)
 				{
 					base.MouseDown(theEvent);
 					return;
 				}
+				if (h.HandleMouseEvent(theEvent))
+					return;
+
 				h.IsMouseDragging = true;
 				base.MouseDown(theEvent);
 				h.IsMouseDragging = false;
 				h.TriggerMouseCallback();
-			}
-
-			bool HandleMouseEvent(NSEvent theEvent)
-			{
-				var handler = Handler;
-				if (handler != null)
-				{
-					var args = MacConversions.GetMouseEvent(handler, theEvent, false);
-					if (theEvent.ClickCount >= 2)
-					{
-						handler.Callback.OnMouseDoubleClick(handler.Widget, args);
-						if (args.Handled)
-							return false;
-					}
-					else
-					{
-						handler.Callback.OnMouseDown(handler.Widget, args);
-						if (args.Handled)
-							return true;
-					}
-
-					var point = ConvertPointFromView(theEvent.LocationInWindow, null);
-
-					int rowIndex;
-					if ((rowIndex = (int)GetRow(point)) >= 0)
-					{
-						int columnIndex = (int)GetColumn(point);
-						var item = handler.GetItem(rowIndex);
-						var column = columnIndex == -1 || columnIndex > handler.Widget.Columns.Count ? null : handler.Widget.Columns[columnIndex];
-						var cellArgs = MacConversions.CreateCellMouseEventArgs(column, handler.ContainerControl, rowIndex, columnIndex, item, theEvent);
-						if (theEvent.ClickCount >= 2)
-							handler.Callback.OnCellDoubleClick(handler.Widget, cellArgs);
-						else
-							handler.Callback.OnCellClick(handler.Widget, cellArgs);
-					}
-				}
-				return false;
 			}
 
 			public EtoTableView(GridViewHandler handler)

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -604,42 +604,37 @@ namespace Eto.Mac.Forms.Controls
 				return Handler?.DragInfo?.AllowedOperation ?? NSDragOperation.None;
 			}
 
+			public override void RightMouseDown(NSEvent theEvent)
+			{
+				if (Handler?.HandleMouseEvent(theEvent) == true)
+					return;
+				base.RightMouseDown(theEvent);
+				Handler?.TriggerMouseCallback();
+			}
+
+			public override void OtherMouseDown(NSEvent theEvent)
+			{
+				if (Handler?.HandleMouseEvent(theEvent) == true)
+					return;
+				base.OtherMouseDown(theEvent);
+				Handler?.TriggerMouseCallback();
+			}
+
 			public override void MouseDown(NSEvent theEvent)
 			{
-				var handler = Handler;
-				if (handler != null)
+				var h = Handler;
+				if (h == null)
 				{
-					var args = MacConversions.GetMouseEvent(handler, theEvent, false);
-					if (theEvent.ClickCount >= 2)
-						handler.Callback.OnMouseDoubleClick(handler.Widget, args);
-					else
-						handler.Callback.OnMouseDown(handler.Widget, args);
-					if (args.Handled)
-						return;
-
-					var point = ConvertPointFromView(theEvent.LocationInWindow, null);
-					int rowIndex = (int)GetRow(point);
-					if (rowIndex >= 0)
-					{
-						int columnIndex = (int)GetColumn(point);
-						var item = handler.GetItem(rowIndex);
-						var column = columnIndex == -1 || columnIndex > handler.Widget.Columns.Count ? null : handler.Widget.Columns[columnIndex];
-						var cellArgs = MacConversions.CreateCellMouseEventArgs(column, handler.ContainerControl, rowIndex, columnIndex, item, theEvent);
-						if (theEvent.ClickCount >= 2)
-							handler.Callback.OnCellDoubleClick(handler.Widget, cellArgs);
-						else
-							handler.Callback.OnCellClick(handler.Widget, cellArgs);
-					}
-					handler.IsMouseDragging = true;
 					base.MouseDown(theEvent);
-					handler.IsMouseDragging = false;
-
-					// NSOutlineView uses an event loop and MouseUp() does not get called
-					handler.TriggerMouseCallback();
-
 					return;
 				}
+				if (h.HandleMouseEvent(theEvent) == true)
+					return;
+
+				h.IsMouseDragging = true;
 				base.MouseDown(theEvent);
+				h.IsMouseDragging = false;
+				h.TriggerMouseCallback();
 			}
 
 			public EtoOutlineView(TreeGridViewHandler handler)


### PR DESCRIPTION
- DrawableCell can crash in Catalina if Window is null
- ProgressCell now allows you to select the row when clicked
- Share mouse logic between GridView and TreeGridView