### PR TITLE
Add ability to print controls

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -262,7 +262,7 @@ namespace Eto.GtkSharp.Forms.Controls
 						var columnIndex = GetColumnOfItem(e.Column);
 						var item = GetItem(e.Path);
 						var column = columnIndex == -1 ? null : Widget.Columns[columnIndex];
-						Callback.OnCellClick(Widget, new GridCellMouseEventArgs(column, rowIndex, columnIndex, item, Mouse.Buttons, Keyboard.Modifiers, PointFromScreen(Mouse.Position)));
+						Callback.OnCellDoubleClick(Widget, new GridCellMouseEventArgs(column, rowIndex, columnIndex, item, Mouse.Buttons, Keyboard.Modifiers, PointFromScreen(Mouse.Position)));
 					};
 					break;
 				case Grid.SelectionChangedEvent:

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -996,5 +996,10 @@ namespace Eto.GtkSharp.Forms
 				Widget.VisualParent?.GetGtkControlHandler()?.InvalidateMeasure();
 			}
 		}
+
+		public void Print()
+		{
+			// ContainerControl.Print
+		}
 	}
 }

--- a/src/Eto.Gtk/Forms/Printing/PrintDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/Printing/PrintDialogHandler.cs
@@ -6,11 +6,6 @@ namespace Eto.GtkSharp.Forms.Printing
 	{
 		PrintSettings settings;
 
-		public PrintDialogHandler()
-		{
-			AllowPageRange = true;
-		}
-
 		public PrintDocument Document { get; set; }
 
 		public class CustomOptions : Gtk.VBox
@@ -27,14 +22,15 @@ namespace Eto.GtkSharp.Forms.Printing
 
 		public DialogResult ShowDialog(Window parent)
 		{
-			var parentWindow = parent != null ? (Gtk.Window)parent.ControlObject : null;
+			var parentWindow = parent?.ControlObject as Gtk.Window;
 			Control = new Gtk.PrintUnixDialog(string.Empty, parentWindow);
 
-			if (parent != null)
+			if (parentWindow != null)
 			{
-				Control.TransientFor = ((Gtk.Window)parent.ControlObject);
+				Control.TransientFor = parentWindow;
 				Control.Modal = true;
 			}
+
 
 			const Gtk.PrintCapabilities caps = Gtk.PrintCapabilities.Preview
 					| Gtk.PrintCapabilities.Collate
@@ -59,37 +55,39 @@ namespace Eto.GtkSharp.Forms.Printing
 			NativeMethods.gtk_print_unix_dialog_set_embed_page_setup(Control.Handle, true);
 
 			Control.ManualCapabilities = caps;
-			Control.ShowAll ();
-			var response = (Gtk.ResponseType)Control.Run ();
-			Control.Hide ();
+			Control.ShowAll();
+			var response = (Gtk.ResponseType)Control.Run();
+			Control.Hide();
 			Control.Unrealize();
 
 			printSettingsHandler.Set(Control.PrintSettings, Control.PageSetup, customOptions.SelectionOnly.Active);
-			if (response == Gtk.ResponseType.Apply) {
+			if (Document != null)
+				Document.PrintSettings = PrintSettings;
+
+			if (response == Gtk.ResponseType.Apply)
+			{
 				printSettingsHandler.ShowPreview = true;
+				(Document?.Handler as PrintDocumentHandler)?.Print(parentWindow);
 				return DialogResult.Ok;
 			}
+			if (response == Gtk.ResponseType.Ok)
+			{
+				(Document?.Handler as PrintDocumentHandler)?.Print(parentWindow);
+			}
 
-			return response.ToEto ();
+			return response.ToEto();
 		}
-		public PrintSettings PrintSettings {
-			get {
-				if (settings == null) settings = new PrintSettings();
-				return settings;
-			}
-			set {
-				settings = value;
-			}
+		
+		public PrintSettings PrintSettings
+		{
+			get => settings ?? (settings = new PrintSettings());
+			set => settings = value;
 		}
 
 		// not supported in gtk
-		public bool AllowPageRange {
-			get; set;
-		}
+		public bool AllowPageRange { get; set; } = true;
 
-		public bool AllowSelection {
-			get; set;
-		}
+		public bool AllowSelection { get; set; }
 	}
 }
 

--- a/src/Eto.Gtk/Forms/Printing/PrintDocumentHandler.cs
+++ b/src/Eto.Gtk/Forms/Printing/PrintDocumentHandler.cs
@@ -7,49 +7,123 @@ namespace Eto.GtkSharp.Forms.Printing
 {
 	public class PrintDocumentHandler : WidgetHandler<Gtk.PrintOperation, PrintDocument, PrintDocument.ICallback>, PrintDocument.IHandler
 	{
-		PrintSettings settings;
+		PrintSettings _settings;
+		Control _control;
+		SizeF _preferredSize;
+		Gtk.Widget _oldParent;
+#if GTK3
+		Gtk.OffscreenWindow _offscreenWindow;
+#endif
 
 		public PrintDocumentHandler()
 		{
 			Control = new Gtk.PrintOperation();
+			Control.BeginPrint += Control_BeginPrint;
+			Control.EndPrint += Control_EndPrint;
+			Control.DrawPage += Control_DrawPage;
 		}
 
-		public void Print()
+		private void Control_EndPrint(object o, Gtk.EndPrintArgs args)
+		{
+			Callback.OnPrinted(Widget, EventArgs.Empty);
+			if (_oldParent != null && _control != null)
+			{
+				var gtkWidget = _control.GetContainerWidget();
+				gtkWidget.Parent = _oldParent;
+				_oldParent = null;
+			}
+		}
+
+		private void Control_BeginPrint(object o, Gtk.BeginPrintArgs args)
+		{
+			if (_control != null && PageCount == -1)
+			{
+				var paperHeight = args.Context.Height;
+				var paperWidth = args.Context.Width;
+
+				_preferredSize = _control.GetPreferredSize();
+#if GTK3				
+				// to draw the widget using Cairo, we need to use an offscreen window
+				var gtkWidget = _control.GetContainerWidget();
+				_oldParent = gtkWidget.Parent;
+				_offscreenWindow = new Gtk.OffscreenWindow();
+				_offscreenWindow.Child = gtkWidget;
+
+				_offscreenWindow.SetSizeRequest((int)Math.Max(_preferredSize.Width, paperWidth), (int)Math.Max(_preferredSize.Height, paperHeight));
+				_offscreenWindow.ShowAll();
+#endif
+				
+				PageCount = (int)Math.Ceiling(_preferredSize.Height / paperHeight);
+			}
+			Callback.OnPrinting(Widget, EventArgs.Empty);
+		}
+
+		internal void Print(Gtk.Window parentWindow)
 		{
 			var settingsHandler = (PrintSettingsHandler)PrintSettings.Handler;
+
 			Control.PrintSettings = settingsHandler.Control;
 			if (settingsHandler.ShowPreview)
-				Control.Run(Gtk.PrintOperationAction.Preview, null);
+			{
+				Control.Run(Gtk.PrintOperationAction.Preview, parentWindow);
+			}
 			else
-				Control.Run(Gtk.PrintOperationAction.Print, null);
+			{
+				Control.Run(Gtk.PrintOperationAction.PrintDialog, parentWindow);
+			}
 		}
+
+		public void Create()
+		{
+		}
+
+		public void Create(Control control)
+		{
+			_control = control;
+		}
+
+		public void Print() => Print(null);
 
 		public override void AttachEvent(string id)
 		{
 			switch (id)
 			{
 				case PrintDocument.PrintingEvent:
-					Control.BeginPrint += (o, args) => Callback.OnPrinting(Widget, EventArgs.Empty);
-					break;
 				case PrintDocument.PrintedEvent:
-					Control.EndPrint += (o, args) => Callback.OnPrinted(Widget, EventArgs.Empty);
-					break;
-
 				case PrintDocument.PrintPageEvent:
-					Control.DrawPage += (o, args) =>
-					{
-						using (var graphics = new Graphics(new GraphicsHandler(args.Context.CairoContext, args.Context.CreatePangoContext())))
-						{
-							var width = args.Context.Width; //.PageSetup.GetPageWidth(Gtk.Unit.Points);
-							var height = args.Context.Height; //.PageSetup.GetPageHeight(Gtk.Unit.Points);
-							var e = new PrintPageEventArgs(graphics, new SizeF((float)width, (float)height), args.PageNr);
-							Callback.OnPrintPage(Widget, e);
-						}
-					};
+					// handled intrinsically
 					break;
 				default:
 					base.AttachEvent(id);
 					break;
+			}
+		}
+
+		private void Control_DrawPage(object o, Gtk.DrawPageArgs args)
+		{
+			var width = args.Context.Width;
+			var height = args.Context.Height;
+			var pageNumber = args.PageNr;
+
+			var context = args.Context.CairoContext;
+
+			if (_control != null)
+			{
+				context.Save();
+				context.Rectangle(new Cairo.Rectangle(0, 0, width, height));
+				context.Clip();
+				var ctl = _control.GetContainerWidget();
+				context.Translate(0, -pageNumber * height);
+#if !GTK2
+				ctl.Draw(context);
+#endif
+				context.Restore();
+			}
+
+			using (var graphics = new Graphics(new GraphicsHandler(context, args.Context.CreatePangoContext())))
+			{
+				var e = new PrintPageEventArgs(graphics, new SizeF((float)width, (float)height), pageNumber);
+				Callback.OnPrintPage(Widget, e);
 			}
 		}
 
@@ -63,15 +137,15 @@ namespace Eto.GtkSharp.Forms.Printing
 		{
 			get
 			{
-				if (settings == null)
-					settings = Control.PrintSettings.ToEto(Control.DefaultPageSetup, false);
-				return settings;
+				if (_settings == null)
+					_settings = Control.PrintSettings.ToEto(Control.DefaultPageSetup, false);
+				return _settings;
 			}
 			set
 			{
-				settings = value;
-				Control.DefaultPageSetup = settings.ToGtkPageSetup();
-				Control.PrintSettings = settings.ToGtkPrintSettings();
+				_settings = value;
+				Control.DefaultPageSetup = _settings.ToGtkPageSetup();
+				Control.PrintSettings = _settings.ToGtkPrintSettings();
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Printing/PrintPreviewDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/Printing/PrintPreviewDialogHandler.cs
@@ -1,0 +1,32 @@
+using Eto.Forms;
+
+namespace Eto.GtkSharp.Forms.Printing
+{
+	public class PrintPreviewDialogHandler : WidgetHandler<object, PrintPreviewDialog>, PrintPreviewDialog.IHandler
+	{
+		PrintSettings settings;
+
+		public PrintDocument Document { get; set; }
+
+		public DialogResult ShowDialog(Window parent)
+		{
+			var parentWindow = parent?.ControlObject as Gtk.Window;
+
+			var printSettingsHandler = (PrintSettingsHandler)PrintSettings.Handler;
+
+			Document.PrintSettings = PrintSettings;
+
+			printSettingsHandler.ShowPreview = true;
+			((PrintDocumentHandler)Document.Handler).Print(parentWindow);
+			return DialogResult.Ok;
+		}
+		
+		public PrintSettings PrintSettings
+		{
+			get => settings ?? (settings = new PrintSettings());
+			set => settings = value;
+		}
+
+	}
+}
+

--- a/src/Eto.Gtk/Platform.cs
+++ b/src/Eto.Gtk/Platform.cs
@@ -188,6 +188,7 @@ namespace Eto.GtkSharp
 			
 			// Forms.Printing
 			p.Add<PrintDialog.IHandler>(() => new PrintDialogHandler());
+			p.Add<PrintPreviewDialog.IHandler>(() => new PrintPreviewDialogHandler());
 			p.Add<PrintDocument.IHandler>(() => new PrintDocumentHandler());
 			p.Add<PrintSettings.IHandler>(() => new PrintSettingsHandler());
 			

--- a/src/Eto.Mac/Eto.XamMac2.csproj
+++ b/src/Eto.Mac/Eto.XamMac2.csproj
@@ -8,6 +8,7 @@
     <DefineConstants>$(DefineConstants);OSX;DESKTOP;XAMMAC;XAMMAC2;UNIFIED</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefaultItemExcludes>build\*</DefaultItemExcludes>
+    <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1040,6 +1040,12 @@ namespace Eto.Mac.Forms
 				}
 			}
 		}
+		
+		public void Print()
+		{
+			PrintSettingsHandler.SetDefaults(NSPrintInfo.SharedPrintInfo);
+			ContainerControl.Print(ContainerControl);
+		}
 
 		public virtual Cursor CurrentCursor
 		{
@@ -1069,15 +1075,6 @@ namespace Eto.Mac.Forms
 			set { ContentControl.ToolTip = value ?? string.Empty; }
 		}
 
-		public void Print(PrintSettings settings)
-		{
-			var op = NSPrintOperation.FromView(EventControl);
-			if (settings != null)
-				op.PrintInfo = ((PrintSettingsHandler)settings.Handler).Control;
-			op.ShowsPrintPanel = false;
-			op.RunOperation();
-		}
-
 		public virtual void OnPreLoad(EventArgs e)
 		{
 		}
@@ -1088,6 +1085,10 @@ namespace Eto.Mac.Forms
 			{
 				// adding dynamically or loading without a parent (e.g. embedding into a native app)
 				AsyncQueue.Add(FireOnShown);
+			}
+			if (Widget.IsAttached)
+			{
+				SetAlignmentFrameSize(GetPreferredSize(SizeF.PositiveInfinity).ToNS());
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Printing/PrintDialogHandler.cs
+++ b/src/Eto.Mac/Forms/Printing/PrintDialogHandler.cs
@@ -16,7 +16,7 @@ using MonoMac.CoreAnimation;
 
 namespace Eto.Mac.Forms.Printing
 {
-	public class PrintDialogHandler : WidgetHandler<NSPrintPanel, PrintDialog>, PrintDialog.IHandler
+	public class PrintDialogHandler : WidgetHandler<NSPrintPanel, CommonDialog>, PrintDialog.IHandler, PrintPreviewDialog.IHandler
 	{
 		PrintSettings settings;
 

--- a/src/Eto.Mac/Forms/Printing/PrintDocumentHandler.cs
+++ b/src/Eto.Mac/Forms/Printing/PrintDocumentHandler.cs
@@ -32,9 +32,28 @@ using CGPoint = System.Drawing.PointF;
 
 namespace Eto.Mac.Forms.Printing
 {
-	public class PrintDocumentHandler : WidgetHandler<PrintDocumentHandler.PrintView, PrintDocument, PrintDocument.ICallback>, PrintDocument.IHandler
+	public class PrintDocumentHandler : WidgetHandler<NSView, PrintDocument, PrintDocument.ICallback>, PrintDocument.IHandler
 	{
 		PrintSettings printSettings;
+		int? _pageCount;
+		private Control _control;
+
+		public class DrawnPrintView : PrintView
+		{
+			public override CGRect RectForPage(nint pageNumber)
+			{
+				var operation = NSPrintOperation.CurrentOperation;
+				if (Frame.Size != operation.PrintInfo.PaperSize)
+					SetFrameSize(operation.PrintInfo.PaperSize);
+				return new CGRect(new CGPoint(0, 0), operation.PrintInfo.PaperSize);
+				//return this.Frame;
+			}
+			public override bool KnowsPageRange(ref NSRange aRange)
+			{
+				aRange = new NSRange(1, Handler.PageCount);
+				return true;
+			}
+		} 
 
 		[Register("PrintView")]
 		public class PrintView : NSView
@@ -61,19 +80,8 @@ namespace Eto.Mac.Forms.Printing
 				set => handler = new WeakReference(value);
 			}
 
-			public override string PrintJobTitle
-			{
-				get { return Handler.Name ?? string.Empty; }
-			}
+			public override string PrintJobTitle => Handler.Name ?? string.Empty;
 
-			public override CGRect RectForPage(nint pageNumber)
-			{
-				var operation = NSPrintOperation.CurrentOperation;
-				if (Frame.Size != operation.PrintInfo.PaperSize)
-					SetFrameSize(operation.PrintInfo.PaperSize);
-				return new CGRect(new CGPoint(0, 0), operation.PrintInfo.PaperSize);
-				//return this.Frame;
-			}
 
 			static readonly IntPtr selCurrentContext = Selector.GetHandle("currentContext");
 			static readonly IntPtr classNSGraphicsContext = Class.GetHandle("NSGraphicsContext");
@@ -85,35 +93,24 @@ namespace Eto.Mac.Forms.Printing
 				var context = Messaging.GetNSObject<NSGraphicsContext>(Messaging.IntPtr_objc_msgSend(classNSGraphicsContext, selCurrentContext));
 				// this causes monomac to hang for some reason:
 				//var context = NSGraphicsContext.CurrentContext;
+				base.DrawRect(dirtyRect);
+				var height = Frame.Height;
+				var pageRect = RectForPage(operation.CurrentPage);
 
-				using (var graphics = new Graphics(new GraphicsHandler(this, context, (float)Frame.Height, IsFlipped)))
+				using (var graphics = new Graphics(new GraphicsHandler(this, context, (float)height, IsFlipped)))
 				{
-					Handler.Callback.OnPrintPage(Handler.Widget, new PrintPageEventArgs(graphics, operation.PrintInfo.PaperSize.ToEto(), (int)operation.CurrentPage - 1));
+					graphics.TranslateTransform((float)pageRect.X, (float)(height-pageRect.Y-pageRect.Height));
+					Handler.Callback.OnPrintPage(Handler.Widget, new PrintPageEventArgs(graphics, operation.PrintInfo.ImageablePageBounds.Size.ToEto(), (int)operation.CurrentPage - 1));
 				}
 			}
-
-			public override bool KnowsPageRange(ref NSRange aRange)
+			
+			public virtual void PrepareForPrint(NSPrintOperation operation)
 			{
-				aRange = new NSRange(1, Handler.PageCount);
-				return true;
 			}
+
 		}
 
-		protected override PrintView CreateControl()
-		{
-			return new PrintView();
-		}
-
-		protected override void Initialize()
-		{
-			Control.Handler = this;
-			base.Initialize();
-		}
-
-		public void Print()
-		{
-			Print(false, null, null);
-		}
+		public void Print() => Print(false, null, null);
 
 		class SheetHelper : NSObject
 		{
@@ -123,7 +120,7 @@ namespace Eto.Mac.Forms.Printing
 			public void PrintOperationDidRun(IntPtr printOperation, bool success, IntPtr contextInfo)
 			{
 				Success = success;
-				NSApplication.SharedApplication.StopModalWithCode(success ? 1 : 0); 
+				NSApplication.SharedApplication.StopModalWithCode(success ? 1 : 0);
 			}
 		}
 
@@ -132,6 +129,11 @@ namespace Eto.Mac.Forms.Printing
 			var op = NSPrintOperation.FromView(Control);
 			if (printSettings != null)
 				op.PrintInfo = printSettings.ToNS();
+			else
+				PrintSettingsHandler.SetDefaults(op.PrintInfo);
+				
+			(Control as PrintView)?.PrepareForPrint(op);
+			
 			if (panel != null)
 				op.PrintPanel = panel;
 			op.ShowsPrintPanel = showPanel;
@@ -148,7 +150,29 @@ namespace Eto.Mac.Forms.Printing
 
 		public string Name { get; set; }
 
-		public int PageCount { get; set; }
+		public int PageCount
+		{
+			get => _pageCount ?? (_pageCount = CalculatePageCount()).Value;
+			set => _pageCount = value;
+		}
+
+		int CalculatePageCount()
+		{
+			if (_control == null)
+				return 0;
+
+			var printInfo = printSettings.ToNS();
+			if (printInfo == null)
+			{
+				printInfo = new NSPrintInfo();
+				PrintSettingsHandler.SetDefaults(printInfo);
+			}
+
+			// todo: calculate if width is greater than one page??
+			var preferredSize = _control.GetPreferredSize();
+			var paperSize = printInfo.ImageablePageBounds.Size;
+			return (int)Math.Ceiling(preferredSize.Height / paperSize.Height);
+		}
 
 		public PrintSettings PrintSettings
 		{
@@ -175,6 +199,83 @@ namespace Eto.Mac.Forms.Printing
 					base.AttachEvent(id);
 					break;
 			}
+		}
+
+		public void Create()
+		{
+			Control = new DrawnPrintView { Handler = this };
+		}
+
+		public class ChildPrintView : PrintView
+		{
+			Control _child;
+			NSView _subView;
+			SizeF _preferredSize;
+			int _numPages;
+			public ChildPrintView(Control child)
+			{
+				_child = child;
+				_preferredSize = _child.GetPreferredSize();
+				SetFrameSize(_preferredSize.ToNS());
+				_subView = child.GetContainerView();
+				_subView.Frame = Bounds;
+				_subView.AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
+				_subView.TranslatesAutoresizingMaskIntoConstraints = true;
+				AddSubview(_subView);
+			}
+			
+			public override void PrepareForPrint(NSPrintOperation operation)
+			{
+				base.PrepareForPrint(operation);
+				
+				var paperSize = operation.PrintInfo.ImageablePageBounds.Size;
+				var size = Frame.Size;
+				// todo: take into account if width > page size and multiply number of pages as needed.
+				
+				_numPages = (int)Math.Ceiling(_preferredSize.Height / paperSize.Height);
+				
+				size.Width = (nfloat)Math.Max(size.Width, paperSize.Width);
+				size.Height = (nfloat)Math.Max(size.Height, paperSize.Height);
+				
+				SetFrameSize(size);
+				UpdateConstraintsForSubtreeIfNeeded();
+			}
+
+			public override CGRect RectForPage(nint pageNumber)
+			{
+				var operation = NSPrintOperation.CurrentOperation;
+				var paperSize = operation.PrintInfo.ImageablePageBounds.Size;
+				var size = Frame.Size;
+				size.Width = (nfloat)Math.Min(size.Width, paperSize.Width);
+				size.Height = (nfloat)Math.Min(size.Height, paperSize.Height);
+				var location = new CGPoint(0, 0);
+				location.Y = (nfloat)Math.Max(0, _preferredSize.Height - paperSize.Height * pageNumber);
+				return new CGRect(location, size);
+			}
+
+			public override bool KnowsPageRange(ref NSRange aRange)
+			{
+				aRange = new NSRange(1, _numPages);
+				return true;
+			}
+
+		}
+		
+		bool _dispose = true;
+
+		protected override bool DisposeControl => _dispose;
+
+		public void Create(Control control)
+		{
+			_control = control;
+			
+			if (_control.Loaded || _control.Parent != null)
+			{
+				Control = _control.GetContainerView();
+				_dispose = false;
+			}
+			else
+				Control = new ChildPrintView(control) { Handler = this };
 		}
 	}
 }

--- a/src/Eto.Mac/Forms/Printing/PrintSettingsHandler.cs
+++ b/src/Eto.Mac/Forms/Printing/PrintSettingsHandler.cs
@@ -43,7 +43,21 @@ namespace Eto.Mac.Forms.Printing
 
 		protected override NSPrintInfo CreateControl()
 		{
-			return new NSPrintInfo();
+			var info = new NSPrintInfo();
+			SetDefaults(info);
+			return info;
+		}
+		
+		internal static void SetDefaults(NSPrintInfo info)
+		{
+			if (info == null)
+				return;
+			info.TopMargin = 0;
+			info.BottomMargin = 0;
+			info.LeftMargin = 0;
+			info.RightMargin = 0;
+			info.VerticallyCentered = false;
+			info.HorizontallyCentered = false;
 		}
 
 		public int Copies

--- a/src/Eto.Mac/MacHelpers.cs
+++ b/src/Eto.Mac/MacHelpers.cs
@@ -49,9 +49,6 @@ namespace Eto.Forms
 			if (attach && !control.Loaded)
 			{
 				control.AttachNative();
-				var macView = control.GetMacViewHandler();
-
-				macView?.SetAlignmentFrameSize(control.GetPreferredSize(SizeF.PositiveInfinity).ToNS());
 			}
 			return control.GetContainerView();
 		}

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -256,6 +256,7 @@ namespace Eto.Mac
 
 			// Forms.Printing
 			p.Add<PrintDialog.IHandler>(() => new PrintDialogHandler());
+			p.Add<PrintPreviewDialog.IHandler>(() => new PrintDialogHandler());
 			p.Add<PrintDocument.IHandler>(() => new PrintDocumentHandler());
 			p.Add<PrintSettings.IHandler>(() => new PrintSettingsHandler());
 

--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -628,5 +628,7 @@ namespace Eto.WinForms.Forms
 		{
 			return Size;
 		}
+
+		public void Print() => throw new NotImplementedException();
 	}
 }

--- a/src/Eto.WinForms/Forms/Printing/PrintDialogHandler.cs
+++ b/src/Eto.WinForms/Forms/Printing/PrintDialogHandler.cs
@@ -6,45 +6,47 @@ namespace Eto.WinForms.Forms.Printing
 {
 	public class PrintDialogHandler : WidgetHandler<swf.PrintDialog, PrintDialog>, PrintDialog.IHandler
 	{
-		PrintSettings printSettings;
+		PrintSettings _printSettings;
 
-		public PrintDialogHandler ()
+		public PrintDialogHandler()
 		{
-			Control = new swf.PrintDialog {
+			Control = new swf.PrintDialog
+			{
 				UseEXDialog = true,
 				AllowSomePages = true,
-				PrinterSettings = PrintSettingsHandler.DefaultSettings ()
+				PrinterSettings = PrintSettingsHandler.DefaultSettings()
 			};
 		}
 
 		public PrintDocument Document { get; set; }
 
-		public DialogResult ShowDialog (Window parent)
+		public DialogResult ShowDialog(Window parent)
 		{
 			swf.DialogResult result;
 
-			Control.PrinterSettings = printSettings.ToSD ();
+			Control.PrinterSettings = _printSettings.ToSD();
 
 			if (parent != null)
-				result = Control.ShowDialog (((IWindowHandler)parent.Handler).Win32Window);
+				result = Control.ShowDialog(((IWindowHandler)parent.Handler).Win32Window);
 			else
-				result = Control.ShowDialog ();
+				result = Control.ShowDialog();
 
-			return result.ToEto ();
+			if (result == swf.DialogResult.OK && Document != null)
+			{
+				Document.PrintSettings = _printSettings;
+				Document.Print();
+			}
+
+			return result.ToEto();
 		}
 
 		public PrintSettings PrintSettings
 		{
-			get
-			{
-				if (printSettings == null)
-					printSettings = Control.PrinterSettings.ToEto();
-				return printSettings;
-			}
+			get => _printSettings ?? (_printSettings = Control.PrinterSettings.ToEto());
 			set
 			{
-				printSettings = value;
-				Control.PrinterSettings = value.ToSD ();
+				_printSettings = value;
+				Control.PrinterSettings = value.ToSD();
 			}
 		}
 

--- a/src/Eto.WinForms/Forms/Printing/PrintDocumentHandler.cs
+++ b/src/Eto.WinForms/Forms/Printing/PrintDocumentHandler.cs
@@ -1,22 +1,51 @@
 using swf = System.Windows.Forms;
 using sdp = System.Drawing.Printing;
+using sd = System.Drawing;
 using Eto.Forms;
 using Eto.Drawing;
-using Eto.WinForms.Drawing;
+using System;
 
 namespace Eto.WinForms.Forms.Printing
 {
 	public class PrintDocumentHandler : WidgetHandler<sdp.PrintDocument, PrintDocument, PrintDocument.ICallback>, PrintDocument.IHandler
 	{
-		int currentPage;
+		int _currentPage;
+		int? _pageCount;
+		Control _control;
+		sd.Bitmap _controlBitmap;
 		PrintSettings printSettings;
+		SizeF _preferredSize;
 
 		public PrintDocumentHandler()
 		{
 			Control = new sdp.PrintDocument
 			{
-				PrinterSettings = new sdp.PrinterSettings { MinimumPage = 1, MaximumPage = 1, FromPage = 1, ToPage = 1 }
+				PrinterSettings = PrintSettingsHandler.DefaultSettings()
 			};
+		}
+
+		public void Create()
+		{
+		}
+
+		public void Create(Control control)
+		{
+			_control = control;
+		}
+
+		protected override void Initialize()
+		{
+			base.Initialize();
+			Control.BeginPrint += Control_BeginPrint;
+			Control.PrintPage += HandlePrintPage;
+			Control.EndPrint += Control_EndPrint;
+		}
+
+		private void Control_EndPrint(object sender, sdp.PrintEventArgs e)
+		{
+			_controlBitmap?.Dispose();
+			_controlBitmap = null;
+			Callback.OnPrinted(Widget, e);
 		}
 
 		public void Print()
@@ -29,17 +58,9 @@ namespace Eto.WinForms.Forms.Printing
 			switch (id)
 			{
 				case PrintDocument.PrintingEvent:
-					Control.BeginPrint += (sender, e) =>
-					{
-						currentPage = 0;
-						Callback.OnPrinting(Widget, e);
-					};
-					break;
-				case PrintDocument.PrintedEvent:
-					Control.EndPrint += (sender, e) => Callback.OnPrinted(Widget, e);
-					break;
 				case PrintDocument.PrintPageEvent:
-					Control.PrintPage += HandlePrintPage;
+				case PrintDocument.PrintedEvent:
+					// handled intrinsically
 					break;
 				default:
 					base.AttachEvent(id);
@@ -47,14 +68,66 @@ namespace Eto.WinForms.Forms.Printing
 			}
 		}
 
+		private void Control_BeginPrint(object sender, sdp.PrintEventArgs e)
+		{
+			_currentPage = 0;
+			Callback.OnPrinting(Widget, e);
+			
+			_preferredSize = _control?.GetPreferredSize() ?? SizeF.Empty;
+		}
+
 		protected virtual void HandlePrintPage(object sender, sdp.PrintPageEventArgs e)
 		{
 			using (var graphics = e.Graphics.ToEto(false))
 			{
-				var args = new PrintPageEventArgs(graphics, e.PageBounds.Size.ToEto(), currentPage);
+				var bounds = e.MarginBounds;
+				var container = _control.GetContainerControl();
+				if (container != null)
+				{
+					container.SuspendLayout();
+					container.Width = (int)Math.Max(bounds.Width, _preferredSize.Width);
+					container.Height = (int)Math.Max(bounds.Height, _preferredSize.Height);
+					container.ResumeLayout();
+					
+					// create an offscreen bitmap to paint to
+					var bitmapSize = bounds.Size;
+					if (_controlBitmap == null || _controlBitmap.Size != bitmapSize)
+					{
+						_controlBitmap?.Dispose();
+						_controlBitmap = new sd.Bitmap(bitmapSize.Width, bitmapSize.Height, sd.Imaging.PixelFormat.Format32bppArgb);
+					}
+					
+					// setup a graphics object to paint to
+					sd.Graphics g = sd.Graphics.FromImage(_controlBitmap);
+					var hdc = g.GetHdc();
+					
+					// set the offset for the current page
+					var y = _currentPage * bounds.Height;
+					var oldOffset = new Win32.POINT();
+					Win32.OffsetWindowOrgEx(hdc, 0, y, ref oldOffset);
+					
+					// send the WM_PRINT message
+					Win32.SendMessage(
+						container.Handle,
+						Win32.WM.PRINT,
+						hdc,
+						(IntPtr)(Win32.PRF.CHILDREN | Win32.PRF.CLIENT | Win32.PRF.ERASEBKGND | Win32.PRF.NONCLIENT));
+					
+					// restore offset
+					Win32.OffsetWindowOrgEx(hdc, oldOffset.x, oldOffset.y, ref oldOffset);
+					
+					g.ReleaseHdc(hdc);
+					g.Dispose();
+					
+					// draw the image to the print graphics context
+					e.Graphics.DrawImage(_controlBitmap, bounds);
+				}
+
+				graphics.TranslateTransform(bounds.Left, bounds.Top);
+				var args = new PrintPageEventArgs(graphics, bounds.Size.ToEto(), _currentPage);
 				Callback.OnPrintPage(Widget, args);
-				currentPage++;
-				e.HasMorePages = currentPage < PageCount;
+				_currentPage++;
+				e.HasMorePages = _currentPage < PageCount;
 			}
 		}
 
@@ -66,8 +139,19 @@ namespace Eto.WinForms.Forms.Printing
 
 		public int PageCount
 		{
-			get;
-			set;
+			get => _pageCount ?? (_pageCount = GetPageCount()).Value;
+			set => _pageCount = value;
+		}
+
+		private int GetPageCount()
+		{
+			if (_control == null)
+				return 0;
+
+			var size = Control.DefaultPageSettings.Bounds.Size.ToEto();
+
+			var preferred = _control.GetPreferredSize();
+			return (int)Math.Ceiling(preferred.Height / size.Height);
 		}
 
 		public PrintSettings PrintSettings
@@ -83,6 +167,16 @@ namespace Eto.WinForms.Forms.Printing
 				printSettings = value;
 				Control.PrinterSettings = value.ToSD();
 			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && _controlBitmap != null)
+			{
+				_controlBitmap.Dispose();
+				_controlBitmap = null;
+			}
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/src/Eto.WinForms/Forms/Printing/PrintPreviewDialogHandler.cs
+++ b/src/Eto.WinForms/Forms/Printing/PrintPreviewDialogHandler.cs
@@ -1,0 +1,80 @@
+using swf = System.Windows.Forms;
+using sdp = System.Drawing.Printing;
+using sd = System.Drawing;
+using Eto.Forms;
+using System;
+using System.Linq;
+
+namespace Eto.WinForms.Forms.Printing
+{
+	public class PrintPreviewDialogHandler : WidgetHandler<swf.PrintPreviewDialog, PrintPreviewDialog>, PrintPreviewDialog.IHandler
+	{
+		PrintSettings _printSettings;
+
+		public PrintPreviewDialogHandler()
+		{
+			Control = new swf.PrintPreviewDialog();
+			Control.ClientSize = new sd.Size(800, 600);
+
+			ReplacePrintButton();
+		}
+
+		private void ReplacePrintButton()
+		{
+			var toolStrip = Control.Controls.OfType<swf.ToolStrip>().FirstOrDefault();
+			if (toolStrip == null)
+				return;
+
+			var oldPrintButton = toolStrip.Items.OfType<swf.ToolStripButton>().FirstOrDefault(r => r.Name == "printToolStripButton");
+			if (oldPrintButton == null)
+				return;
+				
+			var printButton = new swf.ToolStripButton();
+			printButton.Image = toolStrip.ImageList.Images[oldPrintButton.ImageIndex];
+			printButton.DisplayStyle = swf.ToolStripItemDisplayStyle.Image;
+			printButton.Click += printButton_Click;
+			toolStrip.Items.RemoveAt(0);
+			toolStrip.Items.Insert(0, printButton);
+		}
+
+		private void printButton_Click(object sender, EventArgs e)
+		{
+			var printDialog = new swf.PrintDialog();
+			printDialog.Document = Control.Document;
+
+			if (printDialog.ShowDialog() == swf.DialogResult.OK)
+			{
+				Control.Document.PrinterSettings = printDialog.PrinterSettings;
+				Control.Document.Print();
+			}
+		}
+
+		public PrintDocument Document { get; set; }
+		public PrintSettings PrintSettings
+		{
+			get => _printSettings ?? (_printSettings = Document?.PrintSettings ?? new PrintSettings());
+			set => _printSettings = value;
+		}
+
+		public DialogResult ShowDialog(Window parent)
+		{
+			swf.DialogResult result;
+			Control.Document = PrintDocumentHandler.GetControl(Document);
+
+			if (parent != null)
+				result = Control.ShowDialog(((IWindowHandler)parent.Handler).Win32Window);
+			else
+				result = Control.ShowDialog();
+
+			if (result == swf.DialogResult.OK && Document != null)
+			{
+				if (_printSettings != null)
+					Document.PrintSettings = _printSettings;
+				Document.Print();
+			}
+
+			return result.ToEto();
+		}
+
+	}
+}

--- a/src/Eto.WinForms/Forms/Printing/PrintSettingsHandler.cs
+++ b/src/Eto.WinForms/Forms/Printing/PrintSettingsHandler.cs
@@ -13,7 +13,9 @@ namespace Eto.WinForms.Forms.Printing
 
 		public static sdp.PrinterSettings DefaultSettings()
 		{
-			return new sdp.PrinterSettings { MinimumPage = 1, MaximumPage = 1, FromPage = 1, ToPage = 1, Copies = 1, Collate = true };
+			var settings = new sdp.PrinterSettings { MinimumPage = 1, MaximumPage = 1, FromPage = 1, ToPage = 1, Copies = 1, Collate = true };
+			settings.DefaultPageSettings.Margins = new sdp.Margins(0, 0, 0, 0);
+			return settings;
 		}
 
 		public PrintSettingsHandler()

--- a/src/Eto.WinForms/Forms/WindowsControl.cs
+++ b/src/Eto.WinForms/Forms/WindowsControl.cs
@@ -1005,5 +1005,10 @@ namespace Eto.WinForms.Forms
 		}
 
 		public Window GetNativeParentWindow() => ContainerControl.FindForm().ToEtoWindow();
+
+		public void Print()
+		{
+			
+		}
 	}
 }

--- a/src/Eto.WinForms/Platform.cs
+++ b/src/Eto.WinForms/Platform.cs
@@ -132,6 +132,7 @@ namespace Eto.WinForms
 			
 			// Forms.Printing
 			p.Add<PrintDialog.IHandler>(() => new PrintDialogHandler());
+			p.Add<PrintPreviewDialog.IHandler>(() => new PrintPreviewDialogHandler());
 			p.Add<PrintDocument.IHandler>(() => new PrintDocumentHandler());
 			p.Add<PrintSettings.IHandler>(() => new PrintSettingsHandler());
 			

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -75,6 +75,16 @@ namespace Eto
 			SHOWDEFAULT = 10,
 			FORCEMINIMIZE = 11
 		}
+		
+		[Flags]
+		public enum PRF
+		{
+			CHECKVISIBLE = 0x00000001,
+        	NONCLIENT = 0x00000002,
+        	CLIENT = 0x00000004,
+        	ERASEBKGND = 0x00000008,
+        	CHILDREN = 0x00000010
+		}
 
 
 		public static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
@@ -175,7 +185,8 @@ namespace Eto
 
 			DPICHANGED = 0x02E0,
 			NCCREATE = 0x0081,
-			NCLBUTTONDOWN = 0x00A1
+			NCLBUTTONDOWN = 0x00A1,
+			PRINT = 0x0317
 		}
 		
 		public enum HT
@@ -478,5 +489,8 @@ namespace Eto
 				
 			return info.hwndFocus;
 		}
+		
+		[DllImport("gdi32.dll")]
+		public static extern bool OffsetWindowOrgEx(IntPtr hdc, int nXOffset, int nYOffset, ref POINT lpPoint);
 	}
 }

--- a/src/Eto.Wpf/Forms/Printing/PrintDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/Printing/PrintDialogHandler.cs
@@ -24,6 +24,7 @@ namespace Eto.Wpf.Forms.Printing
 			if (result == true)
 			{
 				settings.SetFromDialog(Control);
+				Document?.Print();
 				return DialogResult.Ok;
 			}
 			return DialogResult.Cancel;

--- a/src/Eto.Wpf/Forms/Printing/PrintDocumentHandler.cs
+++ b/src/Eto.Wpf/Forms/Printing/PrintDocumentHandler.cs
@@ -5,12 +5,18 @@ using swm = System.Windows.Media;
 using Eto.Forms;
 using Eto.Drawing;
 using Eto.Wpf.Drawing;
+using System;
+using System.Collections;
 
 namespace Eto.Wpf.Forms.Printing
 {
 	public class PrintDocumentHandler : WidgetHandler<PrintDocumentHandler.Paginator, PrintDocument, PrintDocument.ICallback>, PrintDocument.IHandler
 	{
-		public PrintDocumentHandler ()
+		Control _control;
+		int? _pageCount;
+		sw.Rect _imageableArea;
+
+		public PrintDocumentHandler()
 		{
 			Control = new Paginator { Handler = this };
 		}
@@ -19,19 +25,119 @@ namespace Eto.Wpf.Forms.Printing
 		{
 			public PrintDocumentHandler Handler { get; set; }
 
-			public int PageNumber { get; set; }
-
-			protected override void OnRender (swm.DrawingContext drawingContext)
+			int _pageNumber;
+			public int PageNumber
 			{
-				base.OnRender (drawingContext);
-				var rect = new Rectangle (new Size((int)Width, (int)Height));
-				var graphicsHandler = new GraphicsHandler (this, drawingContext, new sw.Rect (0, 0, Width, Height), rect);
+				get => _pageNumber;
+				set
+				{
+					_pageNumber = value;
+					InvalidateVisual();
+				}
+			}
+
+			protected override void OnRender(swm.DrawingContext drawingContext)
+			{
+				base.OnRender(drawingContext);
+				var rect = new Rectangle(new Size((int)ActualWidth, (int)ActualHeight));
+				var graphicsHandler = new GraphicsHandler(this, drawingContext, new sw.Rect(0, 0, ActualWidth, ActualHeight), rect);
 				var graphics = new Graphics(graphicsHandler);
 				// needed to set size properly for some reason.. ??
-				graphics.DrawRectangle (new Pen(Colors.Transparent), rect);
+				graphics.DrawRectangle(new Pen(Colors.Transparent), rect);
 
-				var args = new PrintPageEventArgs (graphics, rect.Size, PageNumber);
+				var args = new PrintPageEventArgs(graphics, rect.Size, PageNumber);
 				Handler.Callback.OnPrintPage(Handler.Widget, args);
+			}
+		}
+
+		class Combined : sw.FrameworkElement
+		{
+			Canvas _canvas;
+			sw.FrameworkElement _control;
+			public PrintDocumentHandler Handler { get; set; }
+			public Canvas Canvas
+			{
+				get => _canvas;
+				set
+				{
+					if (_canvas != value)
+					{
+						RemoveLogicalChild(_canvas);
+						RemoveVisualChild(_canvas);
+						_canvas = value;
+						AddLogicalChild(_canvas);
+						AddVisualChild(_canvas);
+						InvalidateMeasure();
+					}
+				}
+			}
+			public sw.FrameworkElement Control
+			{
+				get => _control;
+				set
+				{
+					if (_control != value)
+					{
+						RemoveLogicalChild(_control);
+						RemoveVisualChild(_control);
+						_control = value;
+						AddLogicalChild(_control);
+						AddVisualChild(_control);
+						InvalidateMeasure();
+					}
+				}
+			}
+
+			protected override int VisualChildrenCount => 2;
+
+			protected override swm.Visual GetVisualChild(int index)
+			{
+				if (index == 0)
+					return Canvas;
+				if (index == 1)
+					return Control;
+				throw new ArgumentOutOfRangeException(nameof(index));
+			}
+
+			protected override IEnumerator LogicalChildren
+			{
+				get
+				{
+					yield return Canvas;
+					yield return Control;
+				}
+			}
+
+			int _pageNumber;
+			public int PageNumber
+			{
+				get => _pageNumber;
+				set
+				{
+					_pageNumber = value;
+					Canvas.PageNumber = value;
+					InvalidateArrange();
+				}
+			}
+
+
+			protected override sw.Size ArrangeOverride(sw.Size finalSize)
+			{
+				var finalRect = new sw.Rect(new sw.Point(), finalSize);
+				Canvas?.Arrange(finalRect);
+
+				var desired = Control.DesiredSize;
+				var rect = new sw.Rect(0, 0, Math.Max(finalSize.Width, desired.Width), Math.Max(finalSize.Height, desired.Height));
+				rect.Y -= PageNumber * Handler._imageableArea.Height;
+				Control?.Arrange(rect);
+				return finalSize;
+			}
+
+			protected override sw.Size MeasureOverride(sw.Size availableSize)
+			{
+				Canvas?.Measure(availableSize);
+				Control?.Measure(new sw.Size(availableSize.Width, double.PositiveInfinity));
+				return availableSize;
 			}
 		}
 
@@ -39,73 +145,131 @@ namespace Eto.Wpf.Forms.Printing
 		{
 			public PrintDocumentHandler Handler { get; set; }
 
-			public override swd.DocumentPage GetPage (int pageNumber)
+			public override swd.DocumentPage GetPage(int pageNumber)
 			{
-				var page = new Canvas { 
-					Handler = Handler,
+				return Handler.GetPage(pageNumber);
+			}
+
+			public override bool IsPageCountValid => true;
+			public override int PageCount => Handler.PageCount;
+
+			public override sw.Size PageSize { get; set; }
+
+			public override swd.IDocumentPaginatorSource Source => null;
+		}
+		
+		private swd.DocumentPage GetPage(int pageNumber)
+		{
+			sw.UIElement page;
+			bool measure = true;
+			if (_control != null)
+			{
+				var control = _control.GetContainerControl();
+				
+					
+				if (control.Parent is Combined parentCombined)
+				{
+					parentCombined.PageNumber = pageNumber;
+					page = parentCombined;
+				}
+				else if (control.Parent == null)
+				{
+					var combined = new Combined
+					{
+						Handler = this,
+						Width = _imageableArea.Width,
+						Height = _imageableArea.Height,
+						Control = control,
+						Canvas = new Canvas { Handler = this }
+					};
+					
+					// force all children to load
+					combined.Measure(new sw.Size(double.PositiveInfinity, double.PositiveInfinity));
+					combined.Arrange(new sw.Rect(combined.DesiredSize));
+					// set the scale after the control is loaded
+					// note we need to do the additional measure/arrange below so controls get to the right spot.
+					_control?.GetWpfFrameworkElement()?.SetScale(true, true);
+					page = combined;
+				}
+				else
+				{
+					page = control;
+					measure = false;
+				}
+			}
+			else
+			{
+				page = new Canvas
+				{
+					Handler = this,
 					PageNumber = pageNumber,
-					Width = ImageableArea.Width,
-					Height = ImageableArea.Height
+					Width = _imageableArea.Width,
+					Height = _imageableArea.Height
 				};
-
-				page.Measure (ImageableArea.Size);
-				page.Arrange (ImageableArea);
-
-				return new swd.DocumentPage(page);
 			}
-
-			public override bool IsPageCountValid
+			
+			if (measure)
 			{
-				get { return true; }
+				page.Measure(_imageableArea.Size);
+				page.Arrange(_imageableArea);
 			}
-
-			public override int PageCount
-			{
-				get { return Handler.PageCount; }
-			}
-
-			public override sw.Size PageSize
-			{
-				get; set;
-			}
-			public sw.Rect ImageableArea
-			{
-				get;
-				set;
-			}
-
-			public override swd.IDocumentPaginatorSource Source
-			{
-				get { return null; }
-			}
+			
+			return new swd.DocumentPage(page);
 		}
 
-		public void Print ()
+		public void Print()
 		{
-			var print = new swc.PrintDialog ();
+			var print = new swc.PrintDialog();
 			print.SetEtoSettings(PrintSettings);
 
-			Control.PageSize = new sw.Size (print.PrintableAreaWidth, print.PrintableAreaHeight);
+
+			Control.PageSize = new sw.Size(print.PrintableAreaWidth, print.PrintableAreaHeight);
 			var printCapabilities = print.PrintQueue.GetPrintCapabilities(print.PrintTicket);
 			var ia = printCapabilities.PageImageableArea;
-			Control.ImageableArea = new sw.Rect(ia.OriginWidth, ia.OriginHeight, ia.ExtentWidth, ia.ExtentHeight);
-			//printCapabilities.PageImageableArea.OriginWidth, printCapabilities.PageImageableArea.OriginHeight
+			_imageableArea = new sw.Rect(ia.OriginWidth, ia.OriginHeight, ia.ExtentWidth, ia.ExtentHeight);
+
 			print.PrintDocument(Control, Name);
 		}
-
-
-		public override void AttachEvent (string id)
+		
+		public sw.Xps.Packaging.XpsDocument GetPrintPreview(string tempFileName)
 		{
-			switch (id) {
-			case PrintDocument.PrintingEvent:
-			case PrintDocument.PrintedEvent:
-			case PrintDocument.PrintPageEvent:
-				// handled by paginator
-				break;
-			default:
-				base.AttachEvent (id);
-				break;
+			var print = new swc.PrintDialog();
+			print.SetEtoSettings(PrintSettings);
+
+			Control.PageSize = new sw.Size(print.PrintableAreaWidth, print.PrintableAreaHeight);
+			var printCapabilities = print.PrintQueue.GetPrintCapabilities(print.PrintTicket);
+			var ia = printCapabilities.PageImageableArea;
+			_imageableArea = new sw.Rect(ia.OriginWidth, ia.OriginHeight, ia.ExtentWidth, ia.ExtentHeight);
+
+			var xpsDocument = new sw.Xps.Packaging.XpsDocument(tempFileName, System.IO.FileAccess.ReadWrite);
+			var writer = sw.Xps.Packaging.XpsDocument.CreateXpsDocumentWriter(xpsDocument);
+			writer.WritingPrintTicketRequired += (sender, e) => e.CurrentPrintTicket = print.PrintTicket;
+			writer.Write(Control);
+			return xpsDocument;
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case PrintDocument.PrintingEvent:
+				case PrintDocument.PrintedEvent:
+				case PrintDocument.PrintPageEvent:
+					// handled by paginator
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
 			}
+		}
+
+		public void Create()
+		{
+		}
+
+		public void Create(Control control)
+		{
+			_control = control;
 		}
 
 		public string Name
@@ -113,11 +277,40 @@ namespace Eto.Wpf.Forms.Printing
 			get; set;
 		}
 
-		public int PageCount { get; set; }
+		public int PageCount
+		{
+			get => _pageCount ?? (_pageCount = GetPageCount()) ?? 0;
+			set => _pageCount = value;
+		}
 
+		int GetPageCount()
+		{
+			if (_control == null)
+				return 0;
+
+			var settings = PrintSettings.Handler as PrintSettingsHandler;
+
+			var printCapabilities = settings.PrintQueue.GetPrintCapabilities(settings.Control);
+			var ia = printCapabilities.PageImageableArea;
+
+			// var ctl = _control.GetContainerControl();
+			// ctl.Measure(WpfConversions.PositiveInfinitySize);
+			// var preferredSize = ctl.DesiredSize;
+
+			var preferredSize = _control.GetPreferredSize();
+			return (int)Math.Ceiling(preferredSize.Height / ia.ExtentHeight);
+		}
+
+		PrintSettings _printSettings;
 		public PrintSettings PrintSettings
 		{
-			get; set;
+			get
+			{
+				if (_printSettings == null)
+					_printSettings = new PrintSettings();
+				return _printSettings;
+			}
+			set => _printSettings = value;
 		}
 	}
 }

--- a/src/Eto.Wpf/Forms/Printing/PrintPreviewDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/Printing/PrintPreviewDialogHandler.cs
@@ -1,0 +1,80 @@
+using System;
+using System.IO;
+using Eto.Forms;
+using sw = System.Windows;
+using swc = System.Windows.Controls;
+
+namespace Eto.Wpf.Forms.Printing
+{
+	public class EtoPrintPreviewDialog : sw.Window
+	{
+		swc.DocumentViewer _documentViewer;
+		
+		public sw.Documents.IDocumentPaginatorSource Document
+		{
+			get => _documentViewer.Document;
+			set => _documentViewer.Document = value;
+		}
+		
+		public EtoPrintPreviewDialog()
+		{
+			_documentViewer = new swc.DocumentViewer();
+			Content = _documentViewer;
+			ShowInTaskbar = false;
+		}
+	}
+	
+	public class PrintPreviewDialogHandler : WidgetHandler<EtoPrintPreviewDialog, PrintPreviewDialog>, PrintPreviewDialog.IHandler
+	{
+		PrintSettings settings;
+		public PrintPreviewDialogHandler()
+		{
+			Control = new EtoPrintPreviewDialog();
+		}
+
+		protected override void Initialize()
+		{
+			base.Initialize();
+		}
+
+		public PrintDocument Document { get; set; }
+
+		public DialogResult ShowDialog(Window parent)
+		{
+			var print = new swc.PrintDialog();
+			print.SetEtoSettings(PrintSettings);
+			Control.Owner = parent?.ToNative();
+			
+			if (!string.IsNullOrEmpty(Document.Name))
+				Control.Title = string.Format(Application.Instance.Localize(Widget, "Print Preview - {0}"), Document.Name);
+			else
+				Control.Title = Application.Instance.Localize(Widget, "Print Preview");
+
+			var printCapabilities = print.PrintQueue.GetPrintCapabilities(print.PrintTicket);
+			var ia = printCapabilities.PageImageableArea;
+			var documentHandler = (PrintDocumentHandler)Document.Handler;
+			var tempFileName = Path.GetTempFileName();
+			try
+			{
+				using (var previewDocument = documentHandler.GetPrintPreview(tempFileName))
+				{
+					Control.Document = previewDocument.GetFixedDocumentSequence();
+					Control.ShowDialog();
+				}
+			}
+			finally
+			{
+				if (File.Exists(tempFileName))
+					File.Delete(tempFileName);
+			}
+
+			return DialogResult.Ok;
+		}
+
+		public PrintSettings PrintSettings
+		{
+			get => settings ?? (settings = new PrintSettings());
+			set => settings = value;
+		}
+	}
+}

--- a/src/Eto.Wpf/Forms/WpfContainer.cs
+++ b/src/Eto.Wpf/Forms/WpfContainer.cs
@@ -82,5 +82,7 @@ namespace Eto.Wpf.Forms
 		}
 
 		public override IEnumerable<Control> VisualControls => Widget.Controls;
+		
+		protected override void SetDefaultScale() => SetScale(true, true);
 	}
 }

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -260,7 +260,7 @@ namespace Eto.Wpf.Forms
 			// ideally, this should be removed, but may require overriding ArrangeOverride on all controls as well.
 			// see the ControlTests.ControlsShouldHaveSaneDefaultWidths unit test for repro of the issue.
 			var defaultSize = DefaultSize.ZeroIfNan();
-			if (XScale && Control.IsLoaded)
+			if (XScale && Widget.Loaded)
 			{
 				ContainerControl.Width = double.NaN;
 				ContainerControl.MinWidth = 0;
@@ -276,7 +276,7 @@ namespace Eto.Wpf.Forms
 				ContainerControl.MinWidth = Math.Max(0, double.IsNaN(UserPreferredSize.Width) ? defaultSize.Width : UserPreferredSize.Width);
 			}
 
-			if (YScale && Control.IsLoaded)
+			if (YScale && Widget.Loaded)
 			{
 				ContainerControl.Height = double.NaN;
 				ContainerControl.MinHeight = 0;
@@ -302,14 +302,14 @@ namespace Eto.Wpf.Forms
 		public SizeF GetPreferredSize(SizeF availableSize)
 		{
 			var size = availableSize.ToWpf();
-			if (ContainerControl.Parent == null && !(ContainerControl is swc.Panel))
+			if (ContainerControl.Parent == null && !(ContainerControl is swc.Panel) && !(ContainerControl is swc.Border))
 			{
 				// what the?!? some controls don't measure correctly when not in a container..
-				var p = new swc.DockPanel();
-				p.Children.Add(ContainerControl);
+				var p = new swc.Border();
+				p.Child = ContainerControl;
 				p.Measure(size);
 				var result = p.DesiredSize.ToEto();
-				p.Children.Remove(ContainerControl);
+				p.Child = null;
 				return result;
 			}
 			ContainerControl.Measure(size);
@@ -840,7 +840,13 @@ namespace Eto.Wpf.Forms
 
 		public virtual void OnLoad(EventArgs e)
 		{
+			if (Widget.IsAttached)
+			{
+				SetDefaultScale();
+			}
 		}
+		
+		protected virtual void SetDefaultScale() => SetScale(true, true);
 
 		void Control_Loaded(object sender, sw.RoutedEventArgs e)
 		{
@@ -1021,6 +1027,15 @@ namespace Eto.Wpf.Forms
 		{
 			control = control ?? Control;
 			Widget.Properties.Set(property, PropertyChangeNotifier.Register(property, handler, control));
+		}
+
+		public void Print()
+		{
+			var dlg = new swc.PrintDialog();
+			if (dlg.ShowDialog() == true)
+			{
+				dlg.PrintVisual(ContainerControl, string.Empty);
+			}
 		}
 	}
 }

--- a/src/Eto.Wpf/Platform.cs
+++ b/src/Eto.Wpf/Platform.cs
@@ -151,6 +151,7 @@ namespace Eto.Wpf
 
 			// Forms.Printing
 			p.Add<PrintDialog.IHandler>(() => new PrintDialogHandler());
+			p.Add<PrintPreviewDialog.IHandler>(() => new PrintPreviewDialogHandler());
 			p.Add<PrintDocument.IHandler>(() => new PrintDocumentHandler());
 			p.Add<PrintSettings.IHandler>(() => new PrintSettingsHandler());
 

--- a/src/Eto.Wpf/WpfExtensions.cs
+++ b/src/Eto.Wpf/WpfExtensions.cs
@@ -316,6 +316,30 @@ namespace Eto.Wpf
 			return new sw.Size(Math.Max(0, size1.Width - size2.Width), Math.Max(0, size1.Height - size2.Height));
 		}
 
+		public static sw.Point Add(this sw.Point point, sw.Point point2)
+		{
+			return new sw.Point(point.X + point2.X, point.Y + point2.Y);
+		}
+		
+		public static sw.Point Add(this sw.Point point, sw.Size size2)
+		{
+			return new sw.Point(point.X + size2.Width, point.Y + size2.Height);
+		}
+
+		public static sw.Point Subtract(this sw.Point point, sw.Point point2)
+		{
+			return new sw.Point(point.X - point2.X, point.Y - point2.Y);
+		}
+		public static sw.Point Subtract(this sw.Point point, sw.Size size2)
+		{
+			return new sw.Point(point.X - size2.Width, point.Y - size2.Height);
+		}
+
+		public static sw.Point Divide(this sw.Point point, double factor)
+		{
+			return new sw.Point(point.X / factor, point.Y / factor);
+		}
+
 		public static void AddKeyBindings(this swi.InputBindingCollection bindings, swc.ItemCollection items)
 		{
 			foreach (var item in items.OfType<sw.UIElement>())

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -966,13 +966,13 @@ namespace Eto.Forms
 		static readonly object IsAttached_Key = new object();
 
 		/// <summary>
-		/// Gets or sets a value indicating this control has been attached to a native container
+		/// Gets a value indicating this control has been attached to a native container
 		/// </summary>
 		/// <seealso cref="AttachNative"/>
-		bool IsAttached
+		public bool IsAttached
 		{
 			get => Properties.Get<bool>(IsAttached_Key);
-			set => Properties.Set(IsAttached_Key, value);
+			private set => Properties.Set(IsAttached_Key, value);
 		}
 
 		/// <summary>
@@ -1005,7 +1005,7 @@ namespace Eto.Forms
 		void PostAttach()
 		{
 			// if the control is disposed before we get here Handler will be null, so omit calling OnLoadComplete
-			if (!IsDisposed && Handler != null)
+			if (!IsDisposed && Handler != null && Loaded)
 				OnLoadComplete(EventArgs.Empty);
 		}
 
@@ -1369,7 +1369,19 @@ namespace Eto.Forms
 		/// <param name="widget">Widget to style.</param>
 		/// <param name="style">Style of the widget to apply.</param>
 		protected virtual void ApplyStyles(object widget, string style) => Parent?.ApplyStyles(widget, Style);
-
+		
+		/// <summary>
+		/// Shows a print dialog to print the specified control
+		/// </summary>
+		public void Print()
+		{
+			using (var doc = new PrintDocument(this))
+			{
+				var dlg = new PrintDialog();
+				dlg.ShowDialog(this, doc);
+			}
+		}
+		
 
 		/// <summary>
 		/// Handles the disposal of this control

--- a/src/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/src/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -464,6 +464,9 @@ namespace Eto.Forms
 		/// <returns>The parent window, or null if it is not currently on a window</returns>
 		public Window GetNativeParentWindow() => Control.ParentWindow;
 
+		/// <inheritdoc />
+		public void Print() => Control.Print();
+
 		#endregion
 
 	}

--- a/src/Eto/Forms/Printing/PrintDialog.cs
+++ b/src/Eto/Forms/Printing/PrintDialog.cs
@@ -9,7 +9,7 @@ namespace Eto.Forms
 	[Handler(typeof(PrintDialog.IHandler))]
 	public class PrintDialog : CommonDialog
 	{
-		new IHandler Handler { get { return (IHandler)base.Handler; } }
+		new IHandler Handler => (IHandler)base.Handler;
 
 		/// <summary>
 		/// Gets or sets the print settings the print dialog is modifying.
@@ -54,14 +54,12 @@ namespace Eto.Forms
 		/// <param name="document">Document to print.</param>
 		public DialogResult ShowDialog(Control parent, PrintDocument document)
 		{
+			document.OnBeforePrint();
 			PrintSettings = document.PrintSettings;
 			PrintSettings.MaximumPageRange = new Range<int>(1, document.PageCount);
 			Handler.Document = document;
 			var result = ShowDialog(parent);
-			if (result == DialogResult.Ok)
-			{
-				document.Print();
-			}
+			document.OnAfterPrint();
 			return result;
 		}
 

--- a/src/Eto/Forms/Printing/PrintPreviewDialog.cs
+++ b/src/Eto/Forms/Printing/PrintPreviewDialog.cs
@@ -1,0 +1,77 @@
+using System.ComponentModel;
+using System;
+
+namespace Eto.Forms
+{
+	/// <summary>
+	/// Dialog to show a print preview dialog which the user can print from
+	/// </summary>
+	[Handler(typeof(PrintPreviewDialog.IHandler))]
+	public class PrintPreviewDialog : CommonDialog
+	{
+		new IHandler Handler => (IHandler)base.Handler;
+		
+		
+		/// <summary>
+		/// Gets the document the preview dialog is presenting
+		/// </summary>
+		/// <value></value>
+		public PrintDocument Document { get; }
+		
+		/// <summary>
+		/// Initializes a new instance of the PrintPreviewDialog for the specified <paramref name="document"/>.
+		/// </summary>
+		/// <param name="document">Print document to preview</param>
+		public PrintPreviewDialog(PrintDocument document)
+		{
+			Document = document ?? throw new ArgumentNullException(nameof(document));
+		}
+
+		/// <summary>
+		/// Gets or sets the print settings the print dialog is modifying.
+		/// </summary>
+		/// <value>The print settings.</value>
+		public PrintSettings PrintSettings
+		{
+			get { return Handler.PrintSettings; }
+			set { Handler.PrintSettings = value; }
+		}
+
+		/// <summary>
+		/// Shows the print preview dialog with the specified <paramref name="parent"/>
+		/// </summary>
+		/// <param name="parent">Parent window</param>
+		/// <returns>The dialog resultP</returns>
+		public override DialogResult ShowDialog(Window parent)
+		{
+			Document.OnBeforePrint();
+			PrintSettings = Document.PrintSettings;
+			PrintSettings.MaximumPageRange = new Range<int>(1, Document.PageCount);
+			Handler.Document = Document;
+			var result = base.ShowDialog(parent);
+			Document.OnAfterPrint();
+			return result;
+		}
+
+		/// <summary>
+		/// Handler for the <see cref="PrintPreviewDialog"/>.
+		/// </summary>
+		public new interface IHandler : CommonDialog.IHandler
+		{
+			/// <summary>
+			/// Gets or sets the document that is being printed.
+			/// </summary>
+			/// <value>The document to print.</value>
+			PrintDocument Document { get; set; }
+
+			/// <summary>
+			/// Gets or sets the print settings the print dialog is modifying.
+			/// </summary>
+			/// <remarks>
+			/// This should always return an instance, and is not required to be set by the user.
+			/// </remarks>
+			/// <value>The print settings.</value>
+			PrintSettings PrintSettings { get; set; }
+		}
+	}
+}

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
@@ -12,6 +12,8 @@
     <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
     <MonoBundlingExtraArgs>--nowarn:2006 --nowarn:0176</MonoBundlingExtraArgs>
     <DefineConstants>XAMMAC;XAMMAC2</DefineConstants>
+    <SupportedOSPlatformVersion>10.15</SupportedOSPlatformVersion>
+    <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
   
   <PropertyGroup Condition="$(TargetFramework) == 'xamarinmac20'">

--- a/test/Eto.Test.Mac/Info.plist
+++ b/test/Eto.Test.Mac/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.14</string>
+	<string>10.15</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSRequiresAquaSystemAppearance</key>

--- a/test/Eto.Test/Sections/Printing/PrintDialogSection.cs
+++ b/test/Eto.Test/Sections/Printing/PrintDialogSection.cs
@@ -87,10 +87,11 @@ namespace Eto.Test.Sections.Printing
 			return control;
 		}
 
-		PrintDocument GetPrintDocument()
+		public static PrintDocument GetPrintDocument(PrintSettings settings)
 		{
 			var document = new PrintDocument();
-			document.PrintSettings = settings;
+			if (settings != null)
+				document.PrintSettings = settings;
 			var font = Fonts.Serif(16);
 			var printTime = DateTime.Now;
 			document.PrintPage += (sender, e) =>
@@ -99,7 +100,7 @@ namespace Eto.Test.Sections.Printing
 
 				// draw a border around the printable area
 				var rect = new Rectangle(pageSize);
-				rect.Inflate(-1, -1);
+				// rect.Inflate(-1, -1);
 				e.Graphics.DrawRectangle(Pens.Silver, rect);
 
 				// draw title
@@ -139,7 +140,7 @@ namespace Eto.Test.Sections.Printing
 
 			control.Click += delegate
 			{
-				var document = GetPrintDocument();
+				var document = GetPrintDocument(settings);
 				document.Print();
 			};
 
@@ -152,7 +153,7 @@ namespace Eto.Test.Sections.Printing
 
 			control.Click += delegate
 			{
-				var document = GetPrintDocument();
+				var document = GetPrintDocument(settings);
 				var dialog = CreatePrintDialog();
 				dialog.ShowDialog(this, document);
 				DataContext = settings = document.PrintSettings;

--- a/test/Eto.Test/UnitTests/Forms/PrintingTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/PrintingTests.cs
@@ -1,0 +1,101 @@
+using Eto.Drawing;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms
+{
+	[TestFixture]
+	public class PrintingTests : TestBase
+	{
+		[TestCase(10)]
+		[TestCase(1000)]
+		[InvokeOnUI]
+		public void PrintControl(int count)
+		{
+			var ctl = new TableLayout
+			{
+				Rows = {
+					new TableRow(new Label { Text = "Hello"}),
+					new TextBox { Text = "Some Text"},
+				}
+			};
+
+			for (int i = 0; i < count; i++)
+			{
+				ctl.Rows.Add(new Label { Text = "Row " + i });
+			}
+
+			ctl.Rows.Add(new TableRow { ScaleHeight = true });
+			ctl.Rows.Add(new Label { Text = "Bottom" });
+
+			ctl.Print();
+		}
+
+		[TestCase(10)]
+		[TestCase(1000)]
+		[InvokeOnUI]
+		public void PrintControlPreview(int count)
+		{
+			var ctl = new TableLayout
+			{
+				Rows = {
+					new TableRow(new Label { Text = "Hello"}),
+					new TextBox { Text = "Some Text"}
+				}
+			};
+
+			for (int i = 0; i < count; i++)
+			{
+				ctl.Rows.Add(new Label { Text = "Row " + i });
+			}
+
+			ctl.Rows.Add(new TableRow { ScaleHeight = true });
+			ctl.Rows.Add(new Label { Text = "Bottom" });
+			
+			var doc = new PrintDocument(ctl);
+			doc.PrintPage += (sender, e) =>
+			{
+				// add page number to top right of page
+				var text = $"Page {e.CurrentPage}";
+				var textSize = e.Graphics.MeasureString(SystemFonts.Default(), text);
+				e.Graphics.DrawText(SystemFonts.Default(), Colors.Black, e.PageSize.Width - textSize.Width, 0, text);
+			};
+
+			var dlg = new PrintPreviewDialog(doc);
+			dlg.ShowDialog(null);
+
+			doc.Dispose();
+		}
+		
+		[Test]
+		[InvokeOnUI]
+		public void PrintPreviewWithGraphics()
+		{
+			var settings = new PrintSettings();
+			var doc = Sections.Printing.PrintDialogSection.GetPrintDocument(settings);
+			var dlg = new PrintPreviewDialog(doc);
+			dlg.ShowDialog(null);
+			doc.Dispose();
+		}
+		
+		[Test]
+		[InvokeOnUI]
+		public void PrintWithGraphics()
+		{
+			var settings = new PrintSettings();
+			var doc = Sections.Printing.PrintDialogSection.GetPrintDocument(settings);
+			var dlg = new PrintDialog();
+			dlg.ShowDialog(null, doc);
+			doc.Dispose();
+		}
+		
+		[Test]
+		[InvokeOnUI]
+		public void PrintDialogWithoutDocument()
+		{
+			var settings = new PrintSettings();
+			var dlg = new PrintDialog();
+			dlg.ShowDialog(null);
+		}
+	}
+}


### PR DESCRIPTION
This will add the ability to print controls directly vs. having to use the Graphics object, which can make things much easier for simple printing tasks.  This should allow for pagination if the control cannot fit on a single page.

Also adds a PrintPreviewDialog which fixes #969.  On Mac it simply shows the same print dialog as it includes a preview already.