### PR TITLE
Add NumericStepper.Wrap

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
@@ -117,7 +117,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			get { return !Control.IsEditable; }
 			set
 			{
-				Control.IsEditable = !value; 
+				Control.IsEditable = !value;
 				SetIncrement();
 			}
 		}
@@ -130,20 +130,20 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public double MaxValue
 		{
-			get { return Control.Adjustment.Upper == double.MaxValue ? double.PositiveInfinity : Control.Adjustment.Upper; }
+			get => Control.Adjustment.Upper;
 			set
-			{ 
-				Control.Adjustment.Upper = double.IsPositiveInfinity(value) ? double.MaxValue : value; 
+			{
+				Control.Adjustment.Upper = double.IsPositiveInfinity(value) ? double.MaxValue : value;
 				Value = Value;
 			}
 		}
 
 		public double MinValue
 		{
-			get { return Control.Adjustment.Lower == double.MinValue ? double.NegativeInfinity : Control.Adjustment.Lower; }
+			get => Control.Adjustment.Lower;
 			set
 			{
-				Control.Adjustment.Lower = double.IsNegativeInfinity(value) ? double.MinValue : value; 
+				Control.Adjustment.Lower = double.IsNegativeInfinity(value) ? double.MinValue : value;
 				Value = Value;
 			}
 		}
@@ -170,7 +170,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			get { return Widget.Properties.Get<int>(DecimalPlaces_Key); }
 			set
-			{ 
+			{
 				Widget.Properties.Set(DecimalPlaces_Key, value, () =>
 				{
 					MaximumDecimalPlaces = Math.Max(value, MaximumDecimalPlaces);
@@ -224,7 +224,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				{
 					DecimalPlaces = Math.Min(value, DecimalPlaces);
 					UpdateRequiredDigits();
-				}); 
+				});
 			}
 		}
 
@@ -255,12 +255,14 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public string FormatString
 		{
-			get { return Widget.Properties.Get<string>(FormatString_Key); }
-			set {
+			get => Widget.Properties.Get<string>(FormatString_Key);
+			set
+			{
 				// ensure format is valid first, GTK crashes if the formating throws in the Output event, even if caught while setting this
 				if (!string.IsNullOrEmpty(value))
 					0.0.ToString(value);
-				Widget.Properties.Set(FormatString_Key, value, UpdateFormat);
+				if (Widget.Properties.TrySet(FormatString_Key, value))
+					UpdateFormat();
 			}
 		}
 
@@ -268,7 +270,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			_formatString = null;
 			// GTK doesn't remember the value if the format changes as it tries to parse the old text with the new format
-			Control.Value = Control.Value; 
+			Control.Value = Control.Value;
 
 			// update to the new text
 			Control.Update();
@@ -278,8 +280,18 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public CultureInfo CultureInfo
 		{
-			get { return Widget.Properties.Get(CultureInfo_Key, CultureInfo.CurrentCulture); }
-			set { Widget.Properties.Set(CultureInfo_Key, value, UpdateFormat, CultureInfo.CurrentCulture); }
+			get => Widget.Properties.Get(CultureInfo_Key, CultureInfo.CurrentCulture);
+			set
+			{
+				if (Widget.Properties.TrySet(CultureInfo_Key, value, CultureInfo.CurrentCulture))
+					UpdateFormat();
+			}
+		}
+
+		public bool Wrap
+		{
+			get => Control.Wrap;
+			set => Control.Wrap = value;
 		}
 	}
 }

--- a/src/Eto.WinForms/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/NumericStepperHandler.cs
@@ -139,15 +139,11 @@ namespace Eto.WinForms.Forms.Controls
 			Control = new EtoNumericUpDown
 			{
 				Handler = this,
-				Maximum = decimal.MaxValue,
-				Minimum = decimal.MinValue,
+				Maximum = DoubleToDecimal(double.MaxValue),
+				Minimum = DoubleToDecimal(double.MinValue),
 				Width = 80
 			};
-			Control.ValueChanged += (sender, e) =>
-			{
-				UpdateRequiredDigits();
-				Callback.OnValueChanged(Widget, EventArgs.Empty);
-			};
+			Control.ValueChanged += Control_ValueChanged;
 			Control.LostFocus += (sender, e) =>
 			{
 				// ensure value is always shown
@@ -157,6 +153,31 @@ namespace Eto.WinForms.Forms.Controls
 					Control.UpdateText();
 				}
 			};
+		}
+		
+		int valueChanging;
+		double? lastValue;
+
+		private void Control_ValueChanged(object sender, EventArgs e)
+		{
+			if (valueChanging > 0)
+				return;
+			valueChanging++;
+			var val = Value;
+			if (Wrap)
+			{
+				if (val < MinValue)
+					Value = val = MaxValue;
+				else if (val > MaxValue)
+					Value = val = MinValue;
+			}
+			UpdateRequiredDigits();
+			valueChanging--;
+			if (val != lastValue)
+			{
+				lastValue = val;
+				Callback.OnValueChanged(Widget, EventArgs.Empty);
+			}
 		}
 
 		public override void OnUnLoad(EventArgs e)
@@ -176,27 +197,42 @@ namespace Eto.WinForms.Forms.Controls
 			get { return HasFormatString ? (double)Control.Value : Math.Round((double)Control.Value, MaximumDecimalPlaces); }
 			set
 			{
-				var val = Math.Max((double)Control.Minimum, Math.Min((double)Control.Maximum, value));
-				Control.Value = (decimal)val;
+				var val = Math.Max(MinValue, Math.Min(MaxValue, value));
+				Control.Value = DoubleToDecimal(val);
 			}
 		}
 
+		static readonly object MinValue_Key = new object();
+		static readonly object MaxValue_Key = new object();
+
 		public double MinValue
 		{
-			get { return Control.Minimum == decimal.MinValue ? double.NegativeInfinity : (double)Control.Minimum; }
-			set { Control.Minimum = double.IsNegativeInfinity(value) ? decimal.MinValue : (decimal)value; }
+			get => Widget.Properties.Get<double>(MinValue_Key, double.MinValue);
+			set
+			{
+				if (Widget.Properties.TrySet(MinValue_Key, value, double.MinValue))
+					SetMinMaxValues();
+			}
 		}
 
 		public double MaxValue
 		{
-			get { return Control.Maximum == decimal.MaxValue ? double.PositiveInfinity : (double)Control.Maximum; }
-			set { Control.Maximum = double.IsPositiveInfinity(value) ? decimal.MaxValue : (decimal)value; }
+			get => Widget.Properties.Get<double>(MaxValue_Key, double.MaxValue);
+			set
+			{
+				if (Widget.Properties.TrySet(MaxValue_Key, value, double.MaxValue))
+					SetMinMaxValues();
+			}
 		}
 
 		public double Increment
 		{
 			get { return (double)Control.Increment; }
-			set { Control.Increment = (decimal)value; }
+			set
+			{
+				Control.Increment = (decimal)value;
+				SetMinMaxValues();
+			}
 		}
 
 		static readonly object MaximumDecimalPlaces_Key = new object();
@@ -206,11 +242,11 @@ namespace Eto.WinForms.Forms.Controls
 			get { return Widget.Properties.Get<int>(MaximumDecimalPlaces_Key); }
 			set
 			{
-				Widget.Properties.Set(MaximumDecimalPlaces_Key, value, () =>
+				if (Widget.Properties.TrySet(MaximumDecimalPlaces_Key, value))
 				{
 					DecimalPlaces = Math.Min(DecimalPlaces, value);
 					UpdateRequiredDigits();
-				});
+				};
 			}
 		}
 
@@ -221,11 +257,11 @@ namespace Eto.WinForms.Forms.Controls
 			get { return Widget.Properties.Get<int>(DecimalPlaces_Key); }
 			set
 			{
-				Widget.Properties.Set(DecimalPlaces_Key, value, () =>
+				if (Widget.Properties.TrySet(DecimalPlaces_Key, value))
 				{
 					MaximumDecimalPlaces = Math.Max(value, MaximumDecimalPlaces);
 					UpdateRequiredDigits();
-				});
+				};
 			}
 		}
 
@@ -280,6 +316,59 @@ namespace Eto.WinForms.Forms.Controls
 			}
 		}
 
+		static readonly object Wrap_Key = new object();
+
+		public bool Wrap
+		{
+			get => Widget.Properties.Get<bool>(Wrap_Key);
+			set
+			{
+				if (Widget.Properties.TrySet(Wrap_Key, value))
+					SetMinMaxValues();
+			}
+		}
+
+		void EnsureWithinRange()
+		{
+			var val = Value;
+			var newval = Math.Max(MinValue, Math.Min(MaxValue, val));
+			if (val != newval)
+				Control.Value = DoubleToDecimal(newval);
+		}
+
+		void SetMinMaxValues()
+		{
+			valueChanging++;
+			var val = Value;
+			var min = MinValue;
+			var max = MaxValue;
+			if (Wrap)
+			{
+				if (!double.IsNaN(min))
+					min -= Increment;
+				if (!double.IsNaN(max))
+					max += Increment;
+			}
+
+			Control.Minimum = DoubleToDecimal(min);
+			Control.Maximum = DoubleToDecimal(max);
+			UpdateRequiredDigits();
+			EnsureWithinRange();
+			if (val != Value)
+			{
+				Callback.OnValueChanged(Widget, EventArgs.Empty);
+			}
+			valueChanging--;
+		}
+		
+		decimal DoubleToDecimal(double value)
+		{
+			if (double.IsNegativeInfinity(value) || value < (double)decimal.MinValue)
+				return decimal.MinValue;
+			if (double.IsPositiveInfinity(value) || value > (double)decimal.MaxValue)
+				return decimal.MaxValue;
+			return (decimal)value;
+		}
 
 		void UpdateFormat()
 		{

--- a/src/Eto.Wpf/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/NumericStepperHandler.cs
@@ -7,6 +7,7 @@ using mwc = Xceed.Wpf.Toolkit;
 using System.Text;
 using System.Globalization;
 using System.Text.RegularExpressions;
+using System.Windows;
 
 namespace Eto.Wpf.Forms.Controls
 {
@@ -72,23 +73,52 @@ namespace Eto.Wpf.Forms.Controls
 				FormatString = "0",
 				Value = 0
 			};
-			Control.ValueChanged += (sender, e) =>
-			{
-				var val = Math.Max(MinValue, Math.Min(MaxValue, double.Parse((Control.Value ?? 0).ToString())));
-				Control.Value = val;
-				TriggerValueChanged();
-				var textBox = Control.TextBox;
-				if (val != Control.Value && textBox != null)
-				{
-					// callback set a different value, but it still shows just whatever the user typed in.
-					// possibly due to some async call in Xceed.Wpf.Toolkit.
-					// so, we set the text specifically.
-					textBox.Text = Control.Value.Value.ToString(Control.FormatString, Control.CultureInfo);
-					textBox.SelectionStart = textBox.Text.Length;
-					textBox.SelectionLength = 0;
-				}
-			};
+			Control.ValueChanged += Control_ValueChanged;
 			Control.Loaded += Control_Loaded;
+		}
+
+		static double GetPreciseValue(double value)
+		{
+			// prevent spinner from accumulating an inprecise value, which would eventually 
+			// show values like 1.0000000000001 or 1.999999999998
+			var str = value.ToString("G15");
+			if (double.TryParse(str, out var val))
+				return val;
+			else
+				return value;
+		}
+
+		int valueChanging;
+		private void Control_ValueChanged(object sender, RoutedPropertyChangedEventArgs<object> e)
+		{
+			if (valueChanging > 0)
+				return;
+			var val = GetPreciseValue(Control.Value ?? 0);
+
+			if (Wrap)
+			{
+				if (val < MinValue)
+					val = MaxValue;
+				else if (val > MaxValue)
+					val = MinValue;
+			}
+			val = Math.Max(MinValue, Math.Min(MaxValue, val));
+			valueChanging++;
+			Control.Value = val;
+			valueChanging--;
+			TriggerValueChanged();
+			var textBox = Control.TextBox;
+			if (val != Control.Value && textBox != null)
+			{
+				// callback set a different value, but it still shows just whatever the user typed in.
+				// possibly due to some async call in Xceed.Wpf.Toolkit.
+				// so, we set the text specifically.
+				valueChanging++;
+				textBox.Text = GetPreciseValue(Control.Value.Value).ToString(Control.FormatString, Control.CultureInfo);
+				textBox.SelectionStart = textBox.Text.Length;
+				textBox.SelectionLength = 0;
+				valueChanging--;
+			}
 		}
 
 		void Control_Loaded(object sender, sw.RoutedEventArgs e)
@@ -96,11 +126,27 @@ namespace Eto.Wpf.Forms.Controls
 			// ensure changed event fires when changing the text, not just when focus is lost
 			if (Control.TextBox != null)
 			{
-				Control.TextBox.TextChanged += (sender2, e2) => TriggerValueChanged();
+				Control.TextBox.TextChanged += TextBox_TextChanged;
 				if (Control.Spinner != null)
 					Control.Spinner.GotKeyboardFocus += (sender2, e2) => Control.TextBox?.Focus();
 				Control.Loaded -= Control_Loaded;
 			}
+		}
+
+		private void TextBox_TextChanged(object sender, swc.TextChangedEventArgs e)
+		{
+			if (valueChanging > 0)
+				return;
+				
+			var val = Value;
+			var newval = GetPreciseValue(val);
+			if (newval != val)
+			{
+				valueChanging++;
+				Control.Value = newval;
+				valueChanging--;
+			}
+			TriggerValueChanged();
 		}
 
 		void TriggerValueChanged()
@@ -129,23 +175,33 @@ namespace Eto.Wpf.Forms.Controls
 			set { Control.Value = Math.Max(MinValue, Math.Min(MaxValue, value)); }
 		}
 
+		static readonly object MinValue_Key = new object();
+
 		public double MinValue
 		{
-			get { return Control.Minimum ?? double.MinValue; }
+			get => Widget.Properties.Get(MinValue_Key, double.MinValue);
 			set
 			{
-				Control.Minimum = value;
-				Control.Value = Math.Max(value, Value);
+				if (Widget.Properties.TrySet(MinValue_Key, value, double.MinValue))
+				{
+					SetMinMaxValues();
+					Control.Value = Math.Max(value, Value);
+				}
 			}
 		}
 
+		static readonly object MaxValue_Key = new object();
+
 		public double MaxValue
 		{
-			get { return Control.Maximum ?? double.MaxValue; }
+			get => Widget.Properties.Get(MaxValue_Key, double.MaxValue);
 			set
 			{
-				Control.Maximum = value;
-				Control.Value = Math.Min(value, Value);
+				if (Widget.Properties.TrySet(MaxValue_Key, value, double.MaxValue))
+				{
+					SetMinMaxValues();
+					Control.Value = Math.Min(value, Value);
+				}
 			}
 		}
 
@@ -167,8 +223,12 @@ namespace Eto.Wpf.Forms.Controls
 
 		public double Increment
 		{
-			get { return Control.Increment ?? 1; }
-			set { Control.Increment = value; }
+			get => Control.Increment ?? 1;
+			set
+			{
+				Control.Increment = value;
+				SetMinMaxValues();
+			}
 		}
 
 		public override void Focus()
@@ -219,6 +279,33 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			get { return Control.CultureInfo; }
 			set { Control.CultureInfo = value; }
+		}
+
+		static readonly object Wrap_Key = new object();
+
+		public bool Wrap
+		{
+			get => Widget.Properties.Get<bool>(Wrap_Key);
+			set
+			{
+				if (Widget.Properties.TrySet(Wrap_Key, value))
+					SetMinMaxValues();
+			}
+		}
+
+		void SetMinMaxValues()
+		{
+			var min = MinValue;
+			var max = MaxValue;
+			if (Wrap)
+			{
+				if (!double.IsNaN(min))
+					min -= Increment;
+				if (!double.IsNaN(max))
+					max += Increment;
+			}
+			Control.Minimum = min;
+			Control.Maximum = max;
 		}
 
 		void UpdateRequiredDigits()

--- a/src/Eto/Forms/Controls/NumericStepper.cs
+++ b/src/Eto/Forms/Controls/NumericStepper.cs
@@ -207,6 +207,16 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// A value indicating whether to wrap the value after the user steps past the min or max value
+		/// </summary>
+		/// <value><c>true</c> to wrap the value when stepping past its bounds, <c>false</c> to stop</value>
+		public bool Wrap
+		{
+			get => Handler.Wrap;
+			set => Handler.Wrap = value;
+		}
+
+		/// <summary>
 		/// Gets the binding for the <see cref="Value"/> property.
 		/// </summary>
 		/// <value>The value binding.</value>
@@ -215,10 +225,10 @@ namespace Eto.Forms
 			get
 			{
 				return new BindableBinding<NumericStepper, double>(
-					this, 
-					c => c.Value, 
-					(c, v) => c.Value = v, 
-					(c, h) => c.ValueChanged += h, 
+					this,
+					c => c.Value,
+					(c, v) => c.Value = v,
+					(c, h) => c.ValueChanged += h,
 					(c, h) => c.ValueChanged -= h
 				)
 				{
@@ -366,6 +376,12 @@ namespace Eto.Forms
 			/// for the thousands separator, decimal separator, and currency symbol.
 			/// </remarks>
 			CultureInfo CultureInfo { get; set; }
+			
+			/// <summary>
+			/// A value indicating whether to wrap the value after the user steps past the min or max value
+			/// </summary>
+			/// <value><c>true</c> to wrap the value when stepping past its bounds, <c>false</c> to stop</value>
+			bool Wrap { get; set; }
 		}
 	}
 }

--- a/test/Eto.Test/Sections/Controls/NumericStepperSection.cs
+++ b/test/Eto.Test/Sections/Controls/NumericStepperSection.cs
@@ -29,7 +29,7 @@ namespace Eto.Test.Sections.Controls
 			var chkMinValue = new CheckBox { Text = "MinValue" };
 			chkMinValue.CheckedBinding.Convert(r => r == true ? DualBindingMode.OneWayToSource : DualBindingMode.Manual).Bind(minBinding, m => m.Mode);
 			chkMinValue.CheckedBinding.Bind(minValue, m => m.Enabled);
-			chkMinValue.CheckedBinding.Convert(r => r == false ? double.NegativeInfinity : minValue.Value).Bind(numeric, m => m.MinValue);
+			chkMinValue.CheckedBinding.Convert(r => r == false ? double.MinValue : minValue.Value).Bind(numeric, m => m.MinValue);
 
 			var maxValue = new NumericStepper { Enabled = false, Value = 1000 };
 			var maxBinding = maxValue.ValueBinding.Bind(numeric, (n) => n.MaxValue, DualBindingMode.Manual);
@@ -37,7 +37,7 @@ namespace Eto.Test.Sections.Controls
 			var chkMaxValue = new CheckBox { Text = "MaxValue" };
 			chkMaxValue.CheckedBinding.Convert(r => r == true ? DualBindingMode.OneWayToSource : DualBindingMode.Manual).Bind(maxBinding, m => m.Mode);
 			chkMaxValue.CheckedBinding.Bind(maxValue, m => m.Enabled);
-			chkMaxValue.CheckedBinding.Convert(r => r == false ? double.PositiveInfinity : maxValue.Value).Bind(numeric, m => m.MaxValue);
+			chkMaxValue.CheckedBinding.Convert(r => r == false ? double.MaxValue : maxValue.Value).Bind(numeric, m => m.MaxValue);
 
 			var decimalPlaces = new NumericStepper { MaxValue = 15, MinValue = 0 };
 			var decimalBinding = decimalPlaces.ValueBinding.Convert(r => (int)r, r => r).Bind(numeric, n => n.DecimalPlaces);
@@ -59,10 +59,14 @@ namespace Eto.Test.Sections.Controls
 
 			var cultureDropDown = new CultureDropDown();
 			cultureDropDown.SelectedValueBinding.Bind(numeric, c => c.CultureInfo);
+			
+			var wrap = new CheckBox { Text = "Wrap" };
+			wrap.CheckedBinding.Bind(numeric, n => n.Wrap);
+			
 
 			var increment = new NumericStepper { MaximumDecimalPlaces = 15 };
 			increment.ValueBinding.Bind(numeric, n => n.Increment);
-
+			
 			var options1 = new StackLayout
 			{
 				Spacing = 5,
@@ -71,7 +75,8 @@ namespace Eto.Test.Sections.Controls
 				Items =
 				{
 					enabled,
-					readOnly
+					readOnly,
+					wrap
 				}
 			};
 			var options2 = new StackLayout

--- a/test/Eto.Test/UnitTests/Forms/Controls/NumericStepperTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/NumericStepperTests.cs
@@ -21,8 +21,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				int valueChanged = 0;
 				numeric.ValueChanged += (sender, e) => valueChanged++;
 
-				Assert.AreEqual(double.NegativeInfinity, numeric.MinValue, "MinValue should be double.NegativeInfinity");
-				Assert.AreEqual(double.PositiveInfinity, numeric.MaxValue, "MaxValue should be double.PositiveInfinity");
+				Assert.AreEqual(double.MinValue, numeric.MinValue, "MinValue should be double.MinValue");
+				Assert.AreEqual(double.MaxValue, numeric.MaxValue, "MaxValue should be double.MaxValue");
 				Assert.AreEqual(0, numeric.Value, "initial value should be 0");
 
 				Assert.AreEqual(0, valueChanged, "ValueChanged event should not fire when setting to default values");
@@ -45,12 +45,12 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				Assert.AreEqual(1000, numeric.MaxValue, "MaxValue should return the same value as set");
 				Assert.AreEqual(++currentValueChanged, valueChanged, "ValueChanged event should fire when changing the MinValue");
 
-				numeric.MinValue = double.NegativeInfinity;
-				numeric.MaxValue = double.PositiveInfinity;
+				numeric.MinValue = double.MinValue;
+				numeric.MaxValue = double.MaxValue;
 				numeric.Value = 0;
 
-				Assert.AreEqual(double.NegativeInfinity, numeric.MinValue, "MinValue should be double.NegativeInfinity");
-				Assert.AreEqual(double.PositiveInfinity, numeric.MaxValue, "MaxValue should be double.PositiveInfinity");
+				Assert.AreEqual(double.MinValue, numeric.MinValue, "MinValue should be double.MinValue");
+				Assert.AreEqual(double.MaxValue, numeric.MaxValue, "MaxValue should be double.MaxValue");
 				Assert.AreEqual(0, numeric.Value, "Value should be back to 0");
 
 				Assert.AreEqual(++currentValueChanged, valueChanged, "ValueChanged event should fire when changing the MinValue");


### PR DESCRIPTION
- Min/MaxValue now default to double.Min/MaxValue instead of Negative/PositiveInfinity
- Wrapping is turned off by default on macOS to be more consistent, and since the default MaxValue is double.MaxValue, it does not make much sense to have it on unless you set your own MaxValue
- Wrapping added to WinForms/WPF by making the min/max values one increment bigger