### PR TITLE
Mac: Add ability to draw NSImage via Graphics when it is a template

### DIFF
--- a/src/Eto.Mac/Drawing/BitmapHandler.cs
+++ b/src/Eto.Mac/Drawing/BitmapHandler.cs
@@ -260,6 +260,12 @@ namespace Eto.Mac.Drawing
 
 		public override void DrawImage(GraphicsHandler graphics, RectangleF source, RectangleF destination)
 		{
+			if (Control.Template)
+			{
+				DrawTemplateImage(graphics, source, destination);
+				return;
+			}
+			
 			var sourceRect = new CGRect(source.X, (float)Control.Size.Height - source.Y - source.Height, source.Width, source.Height);
 			var destRect = destination.ToNS();
 			if (alpha)

--- a/src/Eto.Mac/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Mac/Drawing/GraphicsHandler.cs
@@ -92,6 +92,8 @@ namespace Eto.iOS.Drawing
 		public NSView DisplayView { get; private set; }
 
 		static readonly object PixelOffsetMode_Key = new object();
+		
+		public NSGraphicsContext GraphicsContext => graphicsContext;
 
 		public PixelOffsetMode PixelOffsetMode
 		{

--- a/src/Eto.Mac/Drawing/IconHandler.cs
+++ b/src/Eto.Mac/Drawing/IconHandler.cs
@@ -111,6 +111,12 @@ namespace Eto.Mac.Drawing
 
 		public override void DrawImage(GraphicsHandler graphics, RectangleF source, RectangleF destination)
 		{
+			if (Control.Template)
+			{
+				DrawTemplateImage(graphics, source, destination);
+				return;
+			}
+
 			var sourceRect = new CGRect(source.X, (float)Control.Size.Height - source.Y - source.Height, source.Width, source.Height);
 			var destRect = destination.ToNS();
 			Control.Draw(destRect, sourceRect, NSCompositingOperation.SourceOver, 1, true, null);

--- a/src/Eto.Mac/Forms/MacControlExtensions.cs
+++ b/src/Eto.Mac/Forms/MacControlExtensions.cs
@@ -121,6 +121,21 @@ namespace Eto.Mac.Forms
 				view.SetFrameOrigin(new CGPoint((nfloat)(superFrame.Width - size.Width) / 2, (nfloat)(superFrame.Height - size.Height) / 2));
 			}
 		}
+		
+		public static bool HasDarkTheme(this NSView view)
+		{
+			if (!MacVersion.IsAtLeast(10, 14))
+				return false;
+				
+			var appearance = view?.EffectiveAppearance ?? NSAppearance.CurrentAppearance;
+			
+			var name = appearance.Name;
+			
+			if (name == NSAppearance.NameDarkAqua || name == NSAppearance.NameAccessibilityHighContrastDarkAqua)
+				return true;
+				
+			return false;
+		}
 	}
 }
 

--- a/test/Eto.Test.Mac/UnitTests/BitmapTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/BitmapTests.cs
@@ -1,0 +1,69 @@
+using Eto.Drawing;
+using Eto.Forms;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+
+#if XAMMAC2
+using AppKit;
+using CoreGraphics;
+#else
+using MonoMac.AppKit;
+using MonoMac.CoreGraphics;
+#endif
+
+namespace Eto.Test.Mac.UnitTests
+{
+	[TestFixture]
+    public class BitmapTests : TestBase
+    {
+		[TestCase(null)]
+		[TestCase("Blue")]
+		[TestCase("White")]
+		[TestCase("Black")]
+		[ManualTest]
+        public void TemplateImagesShouldDrawCorrectly(string color)
+		{
+			ManualForm("Both images should be the same in both light and dark mode",
+			form => {
+				
+				Color? backgroundColor = color != null ? Color.Parse(color) : (Color?)null;
+				var bmp = new Bitmap(200, 200, PixelFormat.Format32bppRgba);
+				var img = bmp.ControlObject as NSImage;
+				img.Template = true;
+				using (var g = new Graphics(bmp))
+				{
+					g.PixelOffsetMode = PixelOffsetMode.Half;
+					g.FillRectangle(new Color(Colors.Black, .5f), 39, 39, 120, 120);
+
+					g.DrawRectangle(Colors.Red, 4.5f, 4.5f, 191, 191);
+					g.FillRectangle(Colors.Red, 49, 49, 100, 100);
+
+
+					g.DrawRectangle(Colors.Black, 0.5f, 0.5f, 199, 199);
+					g.FillRectangle(Colors.Black, 59, 59, 80, 80);
+					
+				}
+				
+				var drawable = new Drawable { Size = bmp.Size };
+				drawable.Paint += (sender, e) => {
+					if (backgroundColor != null)
+						e.Graphics.Clear(backgroundColor.Value);
+					e.Graphics.DrawImage(bmp, 0, 0);
+					// e.Graphics.DrawImage(bmp, 50, 50, 100, 100);
+					// e.Graphics.DrawImage(bmp, new RectangleF(99, 99, 100, 100), new Rectangle(0, 0, 200, 200));
+				};
+				
+				var imageView = new ImageView();
+				imageView.Image = bmp;
+				if (backgroundColor != null)
+					imageView.BackgroundColor = backgroundColor.Value;
+				
+				var content = new DynamicLayout();
+				content.AddRow(drawable, imageView, null);
+				content.AddSpace();
+				return content;	
+			}
+			);
+		}
+    }
+}


### PR DESCRIPTION
This allows you to draw a template-based NSImage either by loading a "*Template" image using `NSImage.FromNamed()`, or when setting its `Template` property to true.  This makes it easier to use images that work on both dark and light mode on macOS, without having to make a separate image for each.