### PR TITLE
Allow RadioButtonList.SelectedIndex to be set to -1

### DIFF
--- a/src/Eto/Forms/Controls/RadioButtonList.cs
+++ b/src/Eto/Forms/Controls/RadioButtonList.cs
@@ -202,7 +202,7 @@ namespace Eto.Forms
 			set
 			{
 				EnsureButtons();
-				SetSelected(buttons[value]);
+				SetSelected(value >= 0 && value < buttons.Count ? buttons[value] : null);
 			}
 		}
 

--- a/test/Eto.Test/Sections/Controls/RadioButtonListSection.cs
+++ b/test/Eto.Test/Sections/Controls/RadioButtonListSection.cs
@@ -34,11 +34,20 @@ namespace Eto.Test.Sections.Controls
 
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5) };
 			layout.Add(TableLayout.AutoSized(control));
-			layout.BeginVertical();
-			layout.AddRow(null, AddRowsButton(control), RemoveRowsButton(control), ClearButton(control), OrientationDropDown(control), TextColorControl(control), null);
-			layout.EndVertical();
+			layout.AddSeparateRow(null, AddRowsButton(control), RemoveRowsButton(control), ClearButton(control), OrientationDropDown(control), TextColorControl(control), null);
+			layout.AddSeparateRow(null, UnselectButton(control), null);
 
 			return layout;
+		}
+
+		Control UnselectButton(RadioButtonList list)
+		{
+			var control = new Button { Text = "Set SelectedIndex=-1" };
+			control.Click += delegate
+			{
+				list.SelectedIndex = -1;
+			};
+			return control;
 		}
 
 		Control AddRowsButton(RadioButtonList list)

--- a/test/Eto.Test/UnitTests/Forms/Controls/RadioButtonListTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/RadioButtonListTests.cs
@@ -1,0 +1,37 @@
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Controls
+{
+	[TestFixture]
+    public class RadioButtonListTests : TestBase
+    {
+		[Test]
+		public void ShouldBeAbleToUnselectAll()
+		{
+			Shown(form => {
+				var rbl = new RadioButtonList 
+				{
+					Items = { "Item 1", "Item 2", "Item 3" },
+					SelectedIndex = 1
+				};
+				Assert.AreEqual(1, rbl.SelectedIndex, "#1.1");
+				
+				return rbl;
+			}, rbl => {
+				Assert.AreEqual(1, rbl.SelectedIndex, "#2.1");
+				
+				
+				rbl.SelectedIndex = -1;
+				Assert.AreEqual(-1, rbl.SelectedIndex, "#3.1");
+				
+				rbl.SelectedKey = "Item 3";
+				Assert.AreEqual(2, rbl.SelectedIndex, "#3.1");
+
+				rbl.SelectedKey = null;
+				Assert.AreEqual(-1, rbl.SelectedIndex, "#3.1");
+			});
+		}
+        
+    }
+}


### PR DESCRIPTION
Before it'd just crash, but now if the value is outside the list of buttons it'll deselect them all gracefully.