### PR TITLE
Application.RunIteration fixes

### DIFF
--- a/src/Eto.Gtk/Forms/ApplicationHandler.cs
+++ b/src/Eto.Gtk/Forms/ApplicationHandler.cs
@@ -54,7 +54,9 @@ namespace Eto.GtkSharp.Forms
 
 		public void RunIteration()
 		{
-			Gtk.Application.RunIteration();
+			var start = DateTime.Now;
+		    while (Gtk.Application.EventsPending() && (DateTime.Now - start).TotalMilliseconds < 100)
+				Gtk.Application.RunIteration();
 		}
 
 		public void Restart()

--- a/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
@@ -26,9 +26,13 @@ namespace Eto.Test.UnitTests.Forms
 			});
 		}
 
-		[Test]
-		public void RunIterationShouldAllowBlocking()
+		[TestCase(-1)]
+		[TestCase(10)]
+		[TestCase(1000)]
+		public void RunIterationShouldAllowBlocking(int delay)
 		{
+			int count = 0;
+			Label countLabel = null;
 			Form form = null;
 			bool running = true;
 			bool stopClicked = false;
@@ -43,16 +47,27 @@ namespace Eto.Test.UnitTests.Forms
 					running = false;
 					stopClicked = true;
 				};
+				
+				countLabel = new Label();
+				
+				var spinner = new Spinner { Enabled = false };
+				
+				var enableSpinnerCheck = new CheckBox { Text = "Enable spinner" };
+				enableSpinnerCheck.CheckedChanged += (sender, e) => {
+					spinner.Enabled = enableSpinnerCheck.Checked == true;
+				};
 
 				var layout = new DynamicLayout();
 
 				layout.Padding = 10;
 				layout.DefaultSpacing = new Size(4, 4);
-				layout.Add(new Label { Text = "The controls in this form should\nbe functional while test is running", TextAlignment = TextAlignment.Center });
+				layout.Add(new Label { Text = "The controls in this form should\nbe functional while test is running,\nand count should increase without moving the mouse.", TextAlignment = TextAlignment.Center });
 				layout.Add(new DropDown { DataStore = new[] { "Item 1", "Item 2", "Item 3" } });
 				layout.Add(new TextBox());
 				layout.Add(new DateTimePicker());
-				layout.AddCentered(new Spinner { Enabled = true });
+				layout.AddCentered(enableSpinnerCheck);
+				layout.AddCentered(spinner);
+				layout.AddCentered(countLabel);
 				layout.AddCentered(stopButton);
 
 				form.Content = layout;
@@ -65,6 +80,9 @@ namespace Eto.Test.UnitTests.Forms
 				do
 				{
 					Application.Instance.RunIteration();
+					if (delay > 0)
+						System.Threading.Thread.Sleep(delay);
+					countLabel.Text = $"Iteration Count: {count++}";
 				} while (running);
 				form.Close();
 			});


### PR DESCRIPTION
Ensure Application.RunIteration() flushes queue and returns when there are no events.

This allows you to use RunIteration() in a loop, keeping the UI functional while doing other work.  This is not a recommended approach (use async/await when you can!), however it is sometimes necessary.

This also fixes some issues with the WebView where it stalls on initial display until you move your mouse.