### PR TITLE
Mac: Use async to set contextmenu/print features when WebView loads.

### DIFF
--- a/src/Eto.Mac/Forms/Controls/WKWebViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/WKWebViewHandler.cs
@@ -379,12 +379,12 @@ namespace Eto.Mac.Forms.Controls
 			if (!BrowserContextMenuEnabled)
 			{
 				// no way to do this through code.. 
-				ExecuteScript("document.body.setAttribute('oncontextmenu', 'event.preventDefault();');");
+				var task = ExecuteScriptAsync("document.body.setAttribute('oncontextmenu', 'event.preventDefault();');");
 			}
 			if (EnablePrintRouting)
 			{
 				// no way to do this through code.. 
-				ExecuteScript(@"window.print = function () { window.location = 'eto:print'; };");
+				var task = ExecuteScriptAsync(@"window.print = function () { window.location = 'eto:print'; };");
 			}
 
 		}


### PR DESCRIPTION
No need to block on these calls