### PR TITLE
Gtk: Fix TextStepper ValidDirection

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/TextStepperHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextStepperHandler.cs
@@ -10,12 +10,8 @@ namespace Eto.GtkSharp.Forms.Controls
 {
 	public class TextStepperHandler : TextBoxHandler<Gtk.SpinButton, TextStepper, TextStepper.ICallback>, TextStepper.IHandler
 	{
-		#if GTK2
 		static Gtk.Adjustment DefaultAdjustment = new Gtk.Adjustment(0, 0, 2, 1, 1, 0);
-		#else
-		// in gtk3 the upper adjustment is not inclusive?? ugh
-		static Gtk.Adjustment DefaultAdjustment = new Gtk.Adjustment(0, 0, 3, 1, 1, 0);
-		#endif
+
 		int disableNotification;
 
 		public TextStepperHandler()


### PR DESCRIPTION
Buttons wouldn't properly enable/disable with latest Gtk+

Apparently my last comments about Gtk3 having non-inclusive upper bound is at least now incorrect.