### PR TITLE
Mac: CellClick/CellDoubleClick should respect Handled property

### DIFF
--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -773,6 +773,8 @@ namespace Eto.Mac.Forms.Controls
 					Callback.OnCellDoubleClick(Widget, cellArgs);
 				else
 					Callback.OnCellClick(Widget, cellArgs);
+				
+				return cellArgs.Handled;
 			}
 			return false;
 		}

--- a/test/Eto.Test/Sections/UnitTestPanel.cs
+++ b/test/Eto.Test/Sections/UnitTestPanel.cs
@@ -1158,8 +1158,8 @@ namespace Eto.Test.Sections
 					ImageBinding = Binding.Property((UnitTestItem m) => m.Image)
 				}
 			});
-
-			tree.Activated += (sender, e) =>
+			
+			void RunSelectedTest()
 			{
 				if (runner.IsRunning)
 					return;
@@ -1171,6 +1171,21 @@ namespace Eto.Test.Sections
 					{
 						RunTests(filter);
 					}
+				}
+			}
+
+			tree.CellDoubleClick += (sender, e) =>
+			{
+				RunSelectedTest();
+				e.Handled = true;
+			};
+			
+			tree.KeyDown += (sender, e) =>
+			{
+				if (e.KeyData == Keys.Enter)
+				{
+					RunSelectedTest();
+					e.Handled = true;
 				}
 			};
 


### PR DESCRIPTION
Also fix UnitTestPanel so double clicking a test won't be done in an event tracking loop.

This caused problems with tests such as `ApplicationTests.RunIterationShouldAllowBlocking`. Since it was draining the event loop in that test, it would get stuck in the TreeGridView mouse event as AppKit is waiting for the MouseUp but never getting it.  Afterwards all other clicks would be run one event behind and mess up all UI interaction.