### PR TITLE
Add check for UI thread when using UI controls.

### DIFF
--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -22,7 +22,18 @@ namespace Eto.Forms
 	[sc.TypeConverter(typeof(ControlConverter))]
 	public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInputSource, ICallbackSource
 	{
-		new IHandler Handler => (IHandler)base.Handler;
+		/// <summary>
+		/// Gets the handler for the widget, ensuring the current thread is the UI thread
+		/// </summary>
+		/// <value>The handler object for this control</value>
+		protected new IHandler Handler
+		{
+			get
+			{
+				Application.Instance?.EnsureUIThread();
+				return (IHandler)base.Handler;
+			}
+		}
 
 		/// <summary>
 		/// Gets a value indicating that the control is loaded onto a form, that is it has been created, added to a parent, and shown

--- a/src/Eto/Forms/MessageBox.cs
+++ b/src/Eto/Forms/MessageBox.cs
@@ -186,6 +186,7 @@ namespace Eto.Forms
 		/// <param name="defaultButton">Button to set focus to by default</param>
 		public static DialogResult Show(Control parent, string text, string caption, MessageBoxButtons buttons, MessageBoxType type = MessageBoxType.Information, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Default)
 		{
+			Application.Instance.EnsureUIThread();
 			var mb = Platform.Instance.Create<IHandler>();
 			mb.Text = text;
 			mb.Caption = caption;

--- a/test/Eto.Test/TestApplication.cs
+++ b/test/Eto.Test/TestApplication.cs
@@ -37,6 +37,7 @@ namespace Eto.Test
 			: base(platform)
 		{
 			TestAssemblies = DefaultTestAssemblies().ToList();
+			UIThreadCheckMode = UIThreadCheckMode.Error;
 			this.Name = "Test Application";
 			this.Style = "application";
 

--- a/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
@@ -89,5 +89,23 @@ namespace Eto.Test.UnitTests.Forms
 			
 			Assert.IsTrue(stopClicked, "#1 - Must press the stop button to close the form");
 		}
+		
+		[Test]
+		public void EnsureUIThreadShouldThrow()
+		{
+			Form form = null;
+			TextBox textBox = null;
+			var oldMode = Application.Instance.UIThreadCheckMode;
+			Application.Instance.UIThreadCheckMode = UIThreadCheckMode.Error;
+			Invoke(() => {
+				textBox = new TextBox();
+				form = new Form();
+			});
+			
+			Assert.Throws<UIThreadAccessException>(() => textBox.Text = "hello", "#1");
+			Assert.Throws<UIThreadAccessException>(() => form.Bounds = new Rectangle(0, 0, 100, 100), "#2");
+			
+			Application.Instance.UIThreadCheckMode = oldMode;
+		}
 	}
 }


### PR DESCRIPTION
This should make it easier to troubleshoot programming errors where UI code is accessed from background threads.  This includes showing message boxes in background threads, which only works on WPF or WinForms.

There are three modes for `Application.Instance.UIThreadCheckMode`

- `None`: Same as before, you won't be notified if you do something wrong things will just not work properly
- `Warning`: You'll get warnings written to the console via Trace.WriteLine, default when not debugging
- `Error`: An exception will be thrown, default when a debugger is attached

Fixes #2002