### PR TITLE
Mac: Fix WebView crash when subscribing to DocumentTitleChanged event

### DIFF
--- a/src/Eto.Mac/Forms/Controls/WKWebViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/WKWebViewHandler.cs
@@ -35,6 +35,14 @@ namespace Eto.Mac.Forms.Controls
 
 		public class EtoNavigationDelegate : wk.WKNavigationDelegate
 		{
+			public EtoNavigationDelegate()
+			{
+			}
+			public EtoNavigationDelegate(IntPtr handle)
+				: base(handle)
+			{
+			}
+			
 			WeakReference handler;
 			public WKWebViewHandler Handler { get => handler?.Target as WKWebViewHandler; set => handler = new WeakReference(value); }
 
@@ -89,6 +97,7 @@ namespace Eto.Mac.Forms.Controls
 			}
 
 		}
+		
 
 		protected override void Initialize()
 		{
@@ -110,7 +119,11 @@ namespace Eto.Mac.Forms.Controls
 				Handler = handler;
 				UIDelegate = new EtoUIDelegate { Handler = handler };
 			}
-
+			
+			public EtoWebView(IntPtr handle)
+				: base(handle)
+			{
+			}
 		}
 
 		class PromptDialog : Dialog<bool>

--- a/src/Eto.Mac/Messaging.cs
+++ b/src/Eto.Mac/Messaging.cs
@@ -42,6 +42,7 @@ namespace Eto.Mac
 {
 	public static class Messaging
 	{
+		const string LIBOBJC_DYLIB = "/usr/lib/libobjc.dylib";
 		public static readonly IntPtr AppKitHandle = Dlfcn.dlopen("/System/Library/Frameworks/AppKit.framework/AppKit", 0);
 
 		public static readonly IntPtr CoreTextHandle = Dlfcn.dlopen("/System/Library/Frameworks/ApplicationServices.framework/Frameworks/CoreText.framework/CoreText", 0);
@@ -52,95 +53,98 @@ namespace Eto.Mac
 			return Runtime.GetNSObject<T>(ptr);
 		}
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern IntPtr IntPtr_objc_msgSendSuper_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern bool bool_objc_msgSendSuper_IntPtr_IntPtr_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2, IntPtr arg3);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern void void_objc_msgSendSuper_SizeF(IntPtr receiver, IntPtr selector, CGSize arg1);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern nfloat nfloat_objc_msgSendSuper_nint(IntPtr receiver, IntPtr selector, nint segment);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern bool bool_objc_msgSendSuper(IntPtr receiver, IntPtr selector);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern bool bool_objc_msgSendSuper_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern bool bool_objc_msgSendSuper_NSRange_IntPtr(IntPtr receiver, IntPtr sel, NSRange arg1, IntPtr arg2);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern void void_objc_msgSendSuper_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern void void_objc_msgSendSuper_CGRect(IntPtr receiver, IntPtr selector, CGRect arg1);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern void void_objc_msgSendSuper(IntPtr receiver, IntPtr selector);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern bool bool_objc_msgSend(IntPtr receiver, IntPtr selector);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern bool bool_objc_msgSend_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern bool bool_objc_msgSend_IntPtr_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern void void_objc_msgSend(IntPtr receiver, IntPtr selector);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern void void_objc_msgSend_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern void void_objc_msgSend_bool(IntPtr receiver, IntPtr selector, bool arg1);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern IntPtr IntPtr_objc_msgSend(IntPtr receiver, IntPtr selector);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern IntPtr IntPtr_objc_msgSend_nuint(IntPtr receiver, IntPtr selector, nuint arg1);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern nuint nuint_objc_msgSend(IntPtr receiver, IntPtr selector);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern void RectangleF_objc_msgSend_stret(out CGRect rect, IntPtr receiver, IntPtr selector);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend_stret")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend_stret")]
 		public static extern void RectangleF_objc_msgSend_stret_SizeF_int(out CGRect retval, IntPtr receiver, IntPtr selector, CGSize arg1, nint arg2);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern IntPtr IntPtr_objc_msgSend_nuint_IntPtr_IntPtr_bool(IntPtr receiver, IntPtr selector, nuint mask, IntPtr untilDate, IntPtr mode, bool dequeue);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern void void_objc_msgSend_NSRange_CGPoint(IntPtr receiver, IntPtr selector, NSRange arg1, CGPoint arg2);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern bool bool_objc_msgSend_NSRange_IntPtr(IntPtr receiver, IntPtr selector, NSRange arg1, IntPtr arg2);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern IntPtr IntPtr_objc_msgSend_IntPtr(IntPtr reciever, IntPtr selector, IntPtr arg1);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern IntPtr IntPtr_objc_msgSend_IntPtr_IntPtr(IntPtr reciever, IntPtr selector, IntPtr arg1, IntPtr arg2);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern IntPtr IntPtr_objc_msgSend_IntPtr_IntPtr_IntPtr(IntPtr reciever, IntPtr selector, IntPtr arg1, IntPtr arg2, IntPtr arg3);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSend")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
 		public static extern CGSize CGSize_objc_msgSend_CGSize_IntPtr_IntPtr_UInt64_UInt64_Int64(IntPtr receiver, IntPtr selector, CGSize arg1, IntPtr arg2, IntPtr arg3, ulong arg4, ulong arg5, long arg6);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern void void_objc_msgSendSuper_IntPtr_IntPtr_nuint_IntPtr_CGAffineTransform_IntPtr_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2, nuint arg3, IntPtr arg4, CGAffineTransform arg5, IntPtr arg6, IntPtr arg7);
 
-		[DllImport("/usr/lib/libobjc.dylib", EntryPoint = "objc_msgSendSuper")]
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern IntPtr IntPtr_objc_msgSendSuper_IntPtr_IntPtr_IntPtr_ref_CGPoint(IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2, IntPtr arg3, ref CGPoint arg4);
+		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
+		public extern static void void_objc_msgSend_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2);
+		
 	}
 }
 


### PR DESCRIPTION
Also fixes crash when it tries to recreate EtoNavigationDelegate/EtoWebView when loaded after it was destroyed.