### PR TITLE
Support building with net6.0-macos

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,6 +25,16 @@
         },
 		{
             "name": "Eto.Test.XamMac2",
+            "type": "coreclr",
+			"request": "launch",
+			"preLaunchTask": "build-xammac2",
+			"program": "${workspaceFolder}/artifacts/test/${config:var.configuration}/net6.0-macos/osx-x64/Eto.Test.XamMac2.app/Contents/MacOS/Eto.Test.XamMac2",
+            "args": [],
+            "console": "internalConsole",
+            "internalConsoleOptions": "openOnSessionStart"
+        },
+		{
+            "name": "Eto.Test.XamMac2 - mono",
             "type": "mono",
 			"request": "launch",
 			"preLaunchTask": "build-xammac2",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -29,7 +29,7 @@
 		},
 		{
 			"label": "build-templates",
-			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/src/Addins/Eto.Forms.Templates/Eto.Forms.Templates.csproj ; dotnet new -i ${workspaceFolder}/",
+			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/src/Addins/Eto.Forms.Templates/Eto.Forms.Templates.csproj",
 			"type": "shell",
 			"problemMatcher": "$msCompile",
 			"group": "build",

--- a/build/Build.proj
+++ b/build/Build.proj
@@ -190,7 +190,7 @@
 
     <!-- <RemoveDir Directories="$(NugetPackagesPath)"/> -->
 
-    <Exec Command='dotnet new nuget -o $(ArtifactsDir) &amp;&amp; dotnet nuget add source "./nuget/$(Configuration)" --name eto-local --configfile "$(NugetConfigPath)"'
+    <Exec Command='dotnet new nugetconfig -o $(ArtifactsDir) &amp;&amp; dotnet nuget add source "./nuget/$(Configuration)" --name eto-local --configfile "$(NugetConfigPath)"'
           Condition="!Exists('$(NugetConfigPath)')" />
   </Target>
   
@@ -200,6 +200,7 @@
     <RemoveDir Directories="$(ArtifactsDir)templates"/>
 
     <!-- install the current version of the templates -->
+    <Exec Command="dotnet new -u Eto.Forms.Templates" />
     <Exec Command="dotnet new -i $(PackageOutputPath)Eto.Forms.Templates.$(InformationalVersion).nupkg" />
   
     <!-- generate project templates -->
@@ -216,6 +217,7 @@
       <Combined Include="combined" Value="-c" />
       <Combined Include="separate" Value="" />
 
+      <Framework Include="net60" Value="net6.0" Condition="$([MSBuild]::VersionGreaterThanOrEquals($(NETCoreSdkVersion), '6.0'))" />
       <Framework Include="net50" Value="net5.0" />
       <Framework Include="net48" Value="net48" />
 

--- a/samples/XamarinMac/EmbedEtoInXamarinMac/Info.plist
+++ b/samples/XamarinMac/EmbedEtoInXamarinMac/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.10</string>
+	<string>10.14</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/samples/XamarinMac/EmbedXamarinMacInEto/Info.plist
+++ b/samples/XamarinMac/EmbedXamarinMacInEto/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.10</string>
+	<string>10.14</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/.template.config/template.json
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/.template.config/template.json
@@ -76,6 +76,10 @@
 			"replaces": "net5.0",
 			"choices": [
 				{
+					"choice": "net6.0",
+					"description": ".NET 6.0"
+				},
+				{
 					"choice": "net5.0",
 					"description": ".NET 5.0"
 				},

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/Info.plist
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>LSMinimumSystemVersion</key>
-    <string>10.12</string>
+    <string>10.14</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>NSHumanReadableCopyright</key>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.Mac/Info.plist
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.Mac/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>LSMinimumSystemVersion</key>
-    <string>10.12</string>
+    <string>10.14</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>NSHumanReadableCopyright</key>

--- a/src/Addins/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.XamMac/Info.plist
+++ b/src/Addins/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.XamMac/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.10</string>
+	<string>10.14</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/.template.config/template.json
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/.template.config/template.json
@@ -76,6 +76,10 @@
 			"replaces": "net5.0",
 			"choices": [
 				{
+					"choice": "net6.0",
+					"description": ".NET 6.0"
+				},
+				{
 					"choice": "net5.0",
 					"description": ".NET 5.0"
 				},

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/Info.plist
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/EtoApp.1/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>LSMinimumSystemVersion</key>
-    <string>10.12</string>
+    <string>10.14</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>NSHumanReadableCopyright</key>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/Separate/EtoApp.1.Mac/Info.plist
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/Separate/EtoApp.1.Mac/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>LSMinimumSystemVersion</key>
-    <string>10.12</string>
+    <string>10.14</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>NSHumanReadableCopyright</key>

--- a/src/Addins/Eto.Forms.Templates/content/App-FSharp/Separate/EtoApp.1.XamMac/Info.plist
+++ b/src/Addins/Eto.Forms.Templates/content/App-FSharp/Separate/EtoApp.1.XamMac/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.10</string>
+	<string>10.14</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/src/Addins/Eto.Forms.Templates/content/App-VisualBasic/.template.config/template.json
+++ b/src/Addins/Eto.Forms.Templates/content/App-VisualBasic/.template.config/template.json
@@ -76,6 +76,10 @@
 			"replaces": "net5.0",
 			"choices": [
 				{
+					"choice": "net6.0",
+					"description": ".NET 6.0"
+				},
+				{
 					"choice": "net5.0",
 					"description": ".NET 5.0"
 				},

--- a/src/Addins/Eto.Forms.Templates/content/App-VisualBasic/EtoApp.1/Info.plist
+++ b/src/Addins/Eto.Forms.Templates/content/App-VisualBasic/EtoApp.1/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>LSMinimumSystemVersion</key>
-    <string>10.12</string>
+    <string>10.14</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>NSHumanReadableCopyright</key>

--- a/src/Addins/Eto.Forms.Templates/content/App-VisualBasic/Separate/EtoApp.1.Mac/Info.plist
+++ b/src/Addins/Eto.Forms.Templates/content/App-VisualBasic/Separate/EtoApp.1.Mac/Info.plist
@@ -9,7 +9,7 @@
     <key>CFBundleShortVersionString</key>
     <string>1.0</string>
     <key>LSMinimumSystemVersion</key>
-    <string>10.12</string>
+    <string>10.14</string>
     <key>CFBundleDevelopmentRegion</key>
     <string>en</string>
     <key>NSHumanReadableCopyright</key>

--- a/src/Addins/Eto.Forms.Templates/content/App-VisualBasic/Separate/EtoApp.1.XamMac/Info.plist
+++ b/src/Addins/Eto.Forms.Templates/content/App-VisualBasic/Separate/EtoApp.1.XamMac/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.10</string>
+	<string>10.14</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/src/Eto.Mac/Eto.Mac64.csproj
+++ b/src/Eto.Mac/Eto.Mac64.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup>
     <PackageId>Eto.Platform.Mac64</PackageId>
     <Title>Eto.Forms - MonoMac 64-bit Platform</Title>
-    <Description>OS X Platform for the Eto.Forms UI Framework using the open-source MonoMac with 64-bit mono</Description>
+    <Description>OS X Platform for the Eto.Forms UI Framework using the open-source MonoMac</Description>
     <PackageTags>cross platform gui ui framework desktop monomac osx mac eto.forms</PackageTags>
     <PackageDescription>
 This is the 64-bit MonoMac platform for Eto.Forms UI Framework.

--- a/src/Eto.Mac/Eto.XamMac2.csproj
+++ b/src/Eto.Mac/Eto.XamMac2.csproj
@@ -2,10 +2,10 @@
 
   <PropertyGroup>
     <UseXamarinMac>True</UseXamarinMac>
-    <TargetFrameworks>net45</TargetFrameworks>
-    <TargetFrameworks Condition="$(HasXamarinMac) == 'True'">$(TargetFrameworks);xamarinmac20</TargetFrameworks>
+    <TargetFrameworks>net45;xamarinmac20</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::VersionGreaterThanOrEquals($(NETCoreSdkVersion), '6.0'))">$(TargetFrameworks);net6.0-macos</TargetFrameworks>
     <RootNamespace>Eto.Mac</RootNamespace>
-    <DefineConstants>$(DefineConstants);OSX;DESKTOP</DefineConstants>
+    <DefineConstants>$(DefineConstants);OSX;DESKTOP;XAMMAC;XAMMAC2;UNIFIED</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefaultItemExcludes>build\*</DefaultItemExcludes>
   </PropertyGroup>
@@ -13,7 +13,7 @@
   <PropertyGroup>
     <PackageId>Eto.Platform.XamMac2</PackageId>
     <Title>Eto.Forms - Xamarin.Mac (unified) Platform</Title>
-    <Description>OS X Platform for the Eto.Forms UI Framework using 64-bit Xamarin.Mac v2.0 (unified)</Description>
+    <Description>OS X Platform for the Eto.Forms UI Framework using Xamarin.Mac (unified)</Description>
     <PackageTags>cross platform gui ui framework desktop osx xamarin.mac mac eto.forms</PackageTags>
     <PackageDescription>
 This is the Xamarin.Mac2 (unified) platform for Eto.Forms UI Framework.
@@ -57,6 +57,6 @@ You do not need to use any of the classes of this assembly (unless customizing t
     <None Include="..\..\build\MSBuildTaskHelper.props" Pack="True" PackagePath="build" />
   </ItemGroup>
   
-  <Import Project="..\..\build\Xamarin.Mac.targets" />
+  <Import Project="..\..\build\Xamarin.Mac.targets" Condition="!$(TargetFramework.Contains('-macos'))" />
 
 </Project>

--- a/src/Eto.Mac/build/BundleDotNetCore.targets
+++ b/src/Eto.Mac/build/BundleDotNetCore.targets
@@ -67,7 +67,7 @@
   <!-- Bundle using a system shared runtime -->
   <Target Name="MacBuildAppBundleWithoutRuntime" AfterTargets="AfterBuild" Condition="($(MacBundleDotNet) != 'True' AND $(MacIsBuildingBundle) == 'True') OR ($(MacAutoPublishBundle) == 'False' AND $(MacIsBuildingBundle) != 'True')" DependsOnTargets="MacInitializeBundle;MacCollectExecutableFiles">
 
-    <Message Text="MacBuildAppBundleWithoutRuntime" Importance="high" /> 
+    <!-- <Message Text="MacBuildAppBundleWithoutRuntime" Importance="high" />  -->
     
     <!-- copy executable files -->
     <Copy SourceFiles="@(MacExecutableFiles)" DestinationFiles="@(MacExecutableFiles->'$(LauncherPath)%(TargetPath)')" />
@@ -82,8 +82,6 @@
       <LauncherFiles Include="$(PublishDir)**\*" />
       <LauncherFiles Remove="$(PublishDir)**\*.pdb" Condition="$(MacIncludeSymbols) != 'True'" />
     </ItemGroup>
-
-    <Message Text="MacPublishAppBundleForAutoPublish" Importance="high" /> 
     
     <!-- copy executable and all files which need to be in the same folder -->
     <Copy SourceFiles="@(LauncherFiles)" DestinationFolder="$(LauncherPath)%(LauncherFiles.RecursiveDir)" />
@@ -98,7 +96,7 @@
       <LauncherFiles Remove="$(PublishDir)**\*.pdb" Condition="$(MacIncludeSymbols) != 'True'" />
     </ItemGroup>
 
-    <Message Text="MacCopyPublishFiles: @(LauncherFiles)" Importance="high" /> 
+    <!-- <Message Text="MacCopyPublishFiles: @(LauncherFiles)" Importance="high" />  -->
     
     <!-- copy executable and all files which need to be in the same folder -->
     <Copy SourceFiles="@(LauncherFiles)" DestinationFolder="$(LauncherPath)%(LauncherFiles.RecursiveDir)" />
@@ -110,7 +108,7 @@
   <!-- Build bundle for published folder -->
   <Target Name="MacPublishAppBundle" AfterTargets="Publish" Condition="$(MacIsBuildingBundle) != 'True' AND $(MacAutoPublishBundle) == 'False'">
     
-    <Message Text="MacPublishAppBundle" Importance="high" /> 
+    <!-- <Message Text="MacPublishAppBundle" Importance="high" />  -->
 
     <MSBuild Projects="$(MSBuildProjectFullPath)" Targets="MacCopyPublishFiles"
              Properties="BaseOutputAppPath=$(PublishDir)" />

--- a/src/Eto.Mac/build/Mac.targets
+++ b/src/Eto.Mac/build/Mac.targets
@@ -20,8 +20,8 @@
     <!-- properties you can override in your project file -->
 
     <!-- Specify that the bundle should be created during build -->
-    <!-- Enabled by default only for exe's and if not using a specific project type (e.g. Xamarin.Mac) -->
-    <MacBuildBundle Condition="$(MacBuildBundle) == '' and $(ProjectTypeGuids) == '' and ( $(OutputType) == 'Exe' Or $(OutputType) == 'WinExe' )">True</MacBuildBundle>
+    <!-- Enabled by default only for exe's and if not using a specific project type (e.g. Xamarin.Mac, -macos tfm's) -->
+    <MacBuildBundle Condition="$(MacBuildBundle) == '' and $(ProjectTypeGuids) == '' and ( $(OutputType) == 'Exe' Or $(OutputType) == 'WinExe' ) and !$(TargetFramework.Contains('-macos'))">True</MacBuildBundle>
 
     <!-- Specifies the name of the .app bundle, usually the same as the project -->
     <MacBundleName Condition="$(MacBundleName) == '' AND $(OutputAppPath.TrimEnd('/').TrimEnd('\').EndsWith('.app')) == 'True'">$([System.IO.Path]::GetFileName($(OutputAppPath.TrimEnd('/').TrimEnd('\'))))</MacBundleName>
@@ -182,7 +182,7 @@
         AddStringProperty("NSPrincipalClass", "NSApplication");
         AddStringProperty("CFBundleName", MacBundleName);
         AddStringProperty("CFBundleExecutable", LauncherFile, true);
-        AddStringProperty("LSMinimumSystemVersion", "10.9");
+        AddStringProperty("LSMinimumSystemVersion", "10.14");
         if (!string.IsNullOrEmpty(MonoMinimumVersion)) {
           AddStringProperty("MonoMinimumVersion", MonoMinimumVersion);
         }

--- a/src/Eto/sdk/Sdk.props
+++ b/src/Eto/sdk/Sdk.props
@@ -2,7 +2,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003" ToolsVersion="15.0">
 
   <PropertyGroup>
-    <OutputType>WinExe</OutputType>
+    <OutputType>Exe</OutputType>
   </PropertyGroup>
 
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />

--- a/src/Eto/sdk/Sdk.targets
+++ b/src/Eto/sdk/Sdk.targets
@@ -4,7 +4,6 @@
     <BuildPlatform Condition="$(BuildPlatform) == 'WinForms'">Windows</BuildPlatform>
 
     <UseXamarinMac Condition="$(UseXamarinMac) == '' AND $(BuildPlatform) == 'XamMac2'">True</UseXamarinMac>
-    <RuntimeIdentifiers Condition="$(RuntimeIdentifiers) == ''">win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
   <PropertyGroup Condition="$(BuildPlatform) == '' ">
@@ -17,13 +16,34 @@
   </PropertyGroup>
 
 
-  <PropertyGroup Condition="$(TargetFramework) != ''">
-    <TargetFramework Condition="!$(TargetFramework.StartsWith('net4')) and !$(TargetFramework.EndsWith('-windows')) and ($(BuildPlatform) == 'Wpf' or $(BuildPlatform) == 'Windows')">$(TargetFramework)-windows</TargetFramework>
-    <TargetFramework Condition="$(BuildPlatform) == 'XamMac2' AND !$(TargetFramework.StartsWith('net4'))">xamarinmac20</TargetFramework>
+  <PropertyGroup>
+    <!-- Windows requires windows TFM suffix -->
+    <_TfmSuffix Condition="$(BuildPlatform) == 'Wpf' or $(BuildPlatform) == 'Windows'">-windows</_TfmSuffix>
+    <!-- Xamarin.Mac requires macos TFM suffix -->
+    <_TfmSuffix Condition="$(BuildPlatform) == 'XamMac2'">-macos</_TfmSuffix>
+
+    <OutputType Condition="$(OutputType) == 'Exe' and ($(BuildPlatform) == 'Wpf' or $(BuildPlatform) == 'Windows')">WinExe</OutputType>
   </PropertyGroup>
 
-  <PropertyGroup Condition="$(TargetFrameworks) != '' and !$(TargetFrameworks.Contains('-windows')) and ($(BuildPlatform) == 'Wpf' or $(BuildPlatform) == 'Windows')">
-    <TargetFrameworks Condition="$(TargetFrameworks.Contains('net5.0'))">$(TargetFrameworks.Replace('net5.0;', '').Replace(';net5.0', ''));net5.0-windows</TargetFrameworks>
+  <PropertyGroup Condition="$(TargetFramework) != '' and $(_TfmSuffix) != '' and !$(TargetFramework.Contains('-'))">
+    <!-- Add proper TargetFramework suffix -->
+    <TargetFramework Condition="!$(TargetFramework.StartsWith('net4')) and !$(TargetFramework.Contains($(_TfmSuffix)))">$(TargetFramework)$(_TfmSuffix)</TargetFramework>
+    <!-- Special case for Xamarin.Mac.  net5.0 is treated as xamarinmac20 -->
+    <TargetFramework Condition="$(BuildPlatform) == 'XamMac2' and $(TargetFramework) == 'net5.0-macos'">xamarinmac20</TargetFramework>
+  </PropertyGroup>
+
+  <!-- Fix up target frameworks for platform-specific tfm's -->
+  <PropertyGroup Condition="$(TargetFrameworks) != '' and !$(TargetFrameworks.Contains('-')) and $(_TfmSuffix) != ''">
+    <_CurrentFrameworks>$(TargetFrameworks)</_CurrentFrameworks>
+
+    <!-- We need to calculate each target framework individually, doing a replace on it as a whole string doesn't work.
+         Is there a better way? -->
+    <TargetFrameworks></TargetFrameworks>
+    <TargetFrameworks Condition="$(_CurrentFrameworks.Contains('net4'))">$(TargetFrameworks);$([System.Text.RegularExpressions.Regex]::Match($(_CurrentFrameworks), '(?&lt;=;|^)?(net4\d+)(?=;|$)'))</TargetFrameworks>
+    <TargetFrameworks Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(_CurrentFrameworks), '(?&lt;=;|^)?(net5\.\d)(?=;|$)')) AND $(BuildPlatform) != 'XamMac2'">$(TargetFrameworks);net5.0$(_TfmSuffix)</TargetFrameworks>
+    <!-- Special case for Xamarin.Mac.  net5.0 is treated as xamarinmac20 -->
+    <TargetFrameworks Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(_CurrentFrameworks), '(?&lt;=;|^)?(net5\.\d)(?=;|$)')) AND $(BuildPlatform) == 'XamMac2'">$(TargetFrameworks);xamarinmac20</TargetFrameworks>
+    <TargetFrameworks Condition="$([System.Text.RegularExpressions.Regex]::IsMatch($(_CurrentFrameworks), '(?&lt;=;|^)?(net6\.\d)(?=;|$)'))">$(TargetFrameworks);net6.0$(_TfmSuffix)</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
@@ -38,14 +58,16 @@
     <BaseIntermediateOutputPath Condition="$(BaseIntermediateOutputPath) == ''">obj\</BaseIntermediateOutputPath>
 
     <IntermediateOutputPath Condition="$(IntermediateOutputPath) == ''">$(BaseIntermediateOutputPath)</IntermediateOutputPath>
-    <IntermediateOutputPath>$(IntermediateOutputPath)$(BuildPlatform)\</IntermediateOutputPath>
+    <IntermediateOutputPath>$(IntermediateOutputPath)$(BuildPlatform)\$(Configuration)\</IntermediateOutputPath>
 
     <BaseOutputPath Condition="$(BaseOutputPath) == ''">bin\</BaseOutputPath>
     <OutputPath Condition="$(MacIsBuildingBundle) != 'True' and $(OutputPath) == ''">$(BaseOutputPath)</OutputPath>
-    <OutputPath Condition="$(MacIsBuildingBundle) != 'True'">$(OutputPath)$(BuildPlatform)\</OutputPath>
+    <OutputPath Condition="$(MacIsBuildingBundle) != 'True'">$(OutputPath)$(BuildPlatform)\$(Configuration)\</OutputPath>
+
+    <RuntimeIdentifiers Condition="$(RuntimeIdentifiers) == '' and !$(TargetFramework.Contains('-'))">win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
   </PropertyGroup>
 
-  <Import Project="Xamarin.Mac.targets" Condition="$(BuildPlatform) == 'XamMac2'" />
+  <Import Project="Xamarin.Mac.targets" Condition="$(BuildPlatform) == 'XamMac2' and !$(TargetFramework.Contains('-macos'))" />
 
   <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
 

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
@@ -4,12 +4,14 @@
     <UseXamarinMac>True</UseXamarinMac>
     <OutputType>Exe</OutputType>
     <TargetFrameworks>net472;xamarinmac20</TargetFrameworks>
+    <TargetFrameworks Condition="$([MSBuild]::VersionGreaterThanOrEquals($(NETCoreSdkVersion), '6.0'))">$(TargetFrameworks);net6.0-macos</TargetFrameworks>
     <RootNamespace>Eto.Test.Mac</RootNamespace>
     <EnableDefaultNoneItems>False</EnableDefaultNoneItems>
     <EnableDefaultContentItems>False</EnableDefaultContentItems>
     <CodeSigningKey>Mac Developer</CodeSigningKey>
     <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
     <MonoBundlingExtraArgs>--nowarn:2006 --nowarn:0176</MonoBundlingExtraArgs>
+    <DefineConstants>XAMMAC;XAMMAC2</DefineConstants>
   </PropertyGroup>
   
   <PropertyGroup Condition="$(TargetFramework) == 'xamarinmac20'">
@@ -46,6 +48,6 @@
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
 
-  <Import Project="..\..\build\Xamarin.Mac.targets" />
+  <Import Project="..\..\build\Xamarin.Mac.targets" Condition="!$(TargetFramework.Contains('-macos'))" />
 
 </Project>

--- a/test/Eto.Test.Mac/Info.plist
+++ b/test/Eto.Test.Mac/Info.plist
@@ -11,7 +11,7 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.9</string>
+	<string>10.14</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSRequiresAquaSystemAppearance</key>


### PR DESCRIPTION
- Will now build XamMac2 for net6.0-macos when using the .NET 6 sdk.
- Default minimum macOS is 10.14
- Add net6.0 to template creation (net5.0 is still default)