### PR TITLE
Wpf: Set FloatingForm.Visible properly after calling Show()

### DIFF
--- a/src/Eto.Wpf/Forms/FloatingFormHandler.cs
+++ b/src/Eto.Wpf/Forms/FloatingFormHandler.cs
@@ -45,9 +45,15 @@ namespace Eto.Wpf.Forms
 			get => Widget.Properties.Get<bool>(Visible_Key, true);
 			set
 			{
-				if (Widget.Properties.TrySet(Visible_Key, value, true))
-					SetVisibility();
+				Widget.Properties.Set(Visible_Key, value, true);
+				SetVisibility();
 			}
+		}
+		
+		public override void Show()
+		{
+			Widget.Properties.Set(Visible_Key, true, true);
+			base.Show();
 		}
 		
 		void SetVisibility()


### PR DESCRIPTION
If you set FloatingForm.Visible = false then subsequently set Show() it wouldn't update the Visible state of the FloatingForm, causing it to always be hidden.