### PR TITLE
Revert removal of setting WS_CHILD style when Form.CanFocus is false

### DIFF
--- a/src/Eto.Wpf/Forms/FormHandler.cs
+++ b/src/Eto.Wpf/Forms/FormHandler.cs
@@ -69,6 +69,7 @@ namespace Eto.Wpf.Forms
 			{
 				Control.Focusable = value;
 				SetStyleEx(Win32.WS_EX.NOACTIVATE, !value);
+				SetStyle(Win32.WS.CHILD, !value);
 			}
 		}
 	}


### PR DESCRIPTION
This causes the form to still get focus when clicked on, making other controls lose focus.