### PR TITLE
Wpf: Fix endless update cycles due to odd DPIs and wrapped labels

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/LabelHandler.cs
@@ -29,7 +29,7 @@ namespace Eto.Wpf.Forms.Controls
 	public class LabelHandler : WpfControl<swc.Label, Label, Label.ICallback>, Label.IHandler
 	{
 		readonly swc.AccessText accessText;
-		double? previousWidth;
+		double? previousDesiredHeight;
 		string text;
 
 		protected override void SetDecorations(sw.TextDecorationCollection decorations)
@@ -55,24 +55,26 @@ namespace Eto.Wpf.Forms.Controls
 			// not loaded? don't worry about it.
 			if (!Control.IsLoaded)
 				return;
-			var newWidth = Control.ActualWidth;
-			if (previousWidth == null)
+			var newDesiredHeight = Control.DesiredSize.Height;
+			if (previousDesiredHeight == null)
 			{
 				// don't update preferred sizes when called the first time.
 				// when there's many labels this causes a major slowdown
 				// the initial size should already have been taken care of by 
 				// the initial layout pass.
-				previousWidth = newWidth;
+				previousDesiredHeight = newDesiredHeight;
 				return;
 			}
-
+			
 			// ignore tiny changes as in some scales (e.g. 150%, 175%) it can cause an endless update cycle
-			if (Math.Abs(previousWidth.Value - newWidth) < 1)
+			// Is this needed any more?  We are now only comparing desired size vs. actual, which doesn't 
+			// appear to have this problem
+			if (Math.Abs(previousDesiredHeight.Value - newDesiredHeight) < 1)
 				return;
-			// update parents when the actual width has changed
-			// otherwise it won't shrink vertically when it gets wider
-			// when wrapped
-			previousWidth = newWidth;
+			
+			// update parents when the actual desired height has changed
+			// otherwise parent containers won't shrink vertically when it gets wider when wrapped
+			previousDesiredHeight = newDesiredHeight;
 			if (Wrap != WrapMode.None)
                 UpdatePreferredSize();
 		}


### PR DESCRIPTION
We now only re-jig the layout if the _desired height_ of a label is changed, vs. every time the width changes.  In odd DPI sizes (e.g. 150%, 175%) the actual width of a label can get sizes different than assigned by the layout, which causes it to cycle layouts constantly going back and forth between two very similar widths.

Checking the desired height gets around this problem by only updating the preferred size when the height actually changes, which is why we were doing this to begin with.  It is consequently more efficient and has fewer layout updates when resizing unless the number of lines in a label would actually change.