### PR TITLE
Wpf: Release mouse capture before MouseUp event is called.

### DIFF
--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -785,13 +785,14 @@ namespace Eto.Wpf.Forms
 		protected virtual void HandleMouseUp(object sender, swi.MouseButtonEventArgs e)
 		{
 			var args = e.ToEto(ContainerControl, swi.MouseButtonState.Released);
-			Callback.OnMouseUp(Widget, args);
-			e.Handled = args.Handled;
-			if ((isMouseCaptured || args.Handled) && Control.IsMouseCaptured)
+			if (isMouseCaptured && Control.IsMouseCaptured)
 			{
 				Control.ReleaseMouseCapture();
 				isMouseCaptured = false;
 			}
+
+			Callback.OnMouseUp(Widget, args);
+			e.Handled = args.Handled;
 		}
 
 		void HandleMouseDoubleClick(object sender, swi.MouseButtonEventArgs e)


### PR DESCRIPTION
This fixes logic in the MouseUp event that may require interaction with other controls via some form of modal call. 