### PR TITLE
Fix MessageBox themes in WPF apps without a custom manifest in .NET 5+

### DIFF
--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -131,6 +131,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
       <LastGenOutput>FontDialogResources.Designer.cs</LastGenOutput>
       <SubType>Designer</SubType>
     </EmbeddedResource>
+    <EmbeddedResource Include="XPThemes.manifest" />
   </ItemGroup>
 
   <!-- Automatically added by WindowsDesktop SDK -->

--- a/src/Eto.Wpf/Forms/EnableThemingInScope.cs
+++ b/src/Eto.Wpf/Forms/EnableThemingInScope.cs
@@ -28,7 +28,7 @@ namespace Eto.Wpf.Forms
 		IntPtr cookie;
 		static ACTCTX enableThemingActivationContext;
 		static IntPtr hActCtx;
-		static bool contextCreationSucceeded = false;
+		static bool? contextCreationSucceeded;
 
 		public EnableThemingInScope(bool enable)
 		{
@@ -72,47 +72,27 @@ namespace Eto.Wpf.Forms
 		{
 			lock (typeof(EnableThemingInScope))
 			{
-				if (!contextCreationSucceeded)
+				if (contextCreationSucceeded != null)
+					return contextCreationSucceeded.Value;
+					
+				// Use a custom manifest from resources and write it to a temp file
+				var manifestLoc = Path.GetTempFileName();
+				try
 				{
-					// Pull manifest from the .NET Framework install
-					// directory
-
-					string assemblyLoc = null;
-
-					FileIOPermission fiop = new FileIOPermission(PermissionState.None);
-					fiop.AllFiles = FileIOPermissionAccess.PathDiscovery;
-					fiop.Assert();
-					try
+					var stream = typeof(EnableThemingInScope).Assembly.GetManifestResourceStream("Eto.Wpf.XPThemes.manifest");
+					if (stream == null)
+						return false;
+						
+					using (var fs = File.Create(manifestLoc))
 					{
-						assemblyLoc = typeof(Object).Assembly.Location;
-					}
-					finally
-					{
-						CodeAccessPermission.RevertAssert();
+						stream.CopyTo(fs);
 					}
 
-					string manifestLoc = null;
-					string installDir = null;
-					if (assemblyLoc != null)
-					{
-						installDir = Path.GetDirectoryName(assemblyLoc);
-						const string manifestName = "XPThemes.manifest";
-						manifestLoc = Path.Combine(installDir, manifestName);
-					}
-
-					if (manifestLoc != null && installDir != null)
+					if (manifestLoc != null)
 					{
 						enableThemingActivationContext = new ACTCTX();
 						enableThemingActivationContext.cbSize = Marshal.SizeOf(typeof(ACTCTX));
 						enableThemingActivationContext.lpSource = manifestLoc;
-
-						// Set the lpAssemblyDirectory to the install
-						// directory to prevent Win32 Side by Side from
-						// looking for comctl32 in the application
-						// directory, which could cause a bogus dll to be
-						// placed there and open a security hole.
-						enableThemingActivationContext.lpAssemblyDirectory = installDir;
-						enableThemingActivationContext.dwFlags = ACTCTX_FLAG_ASSEMBLY_DIRECTORY_VALID;
 
 						// Note this will fail gracefully if file specified
 						// by manifestLoc doesn't exist.
@@ -120,10 +100,13 @@ namespace Eto.Wpf.Forms
 						contextCreationSucceeded = (hActCtx != new IntPtr(-1));
 					}
 				}
+				finally
+				{
+					if (File.Exists(manifestLoc))
+						File.Delete(manifestLoc);
+				}
 
-				// If we return false, we'll try again on the next call into
-				// EnsureActivateContextCreated(), which is fine.
-				return contextCreationSucceeded;
+				return contextCreationSucceeded.Value;
 			}
 		}
 

--- a/src/Eto.Wpf/XPThemes.manifest
+++ b/src/Eto.Wpf/XPThemes.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes" ?> 
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <description>Windows Forms Common Control manifest</description> 
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity type="win32" name="Microsoft.Windows.Common-Controls" version="6.0.0.0" processorArchitecture="*" publicKeyToken="6595b64144ccf1df" language="*" /> 
+    </dependentAssembly>
+  </dependency>
+</assembly>

--- a/test/Eto.Test.Wpf/app.manifest
+++ b/test/Eto.Test.Wpf/app.manifest
@@ -64,18 +64,4 @@
     </windowsSettings>
   </application>
 
-  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
-  <dependency>
-    <dependentAssembly>
-      <assemblyIdentity
-          type="win32"
-          name="Microsoft.Windows.Common-Controls"
-          version="6.0.0.0"
-          processorArchitecture="*"
-          publicKeyToken="6595b64144ccf1df"
-          language="*"
-        />
-    </dependentAssembly>
-  </dependency>
-  
 </assembly>


### PR DESCRIPTION
The previous implementation looked for XPTheme.manifest wherever mscorlib.dll was, instead we now embed the file in Eto.Wpf.dll and write it out when needed to enable visual styles.

Fixes #1851