### PR TITLE
Use Assembly.GetCallingAssembly() directly in .NET Standard 2.0+

### DIFF
--- a/src/Eto/Drawing/Bitmap.cs
+++ b/src/Eto/Drawing/Bitmap.cs
@@ -7,6 +7,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Diagnostics;
 using sc = System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Eto.Drawing
 {
@@ -89,14 +90,13 @@ namespace Eto.Drawing
 		/// <param name="resourceName">Name of the resource in the caller's assembly to load. E.g. "MyProject.SomeFolder.YourFile.extension"</param>
 		/// <param name="assembly">Assembly to load the resource from, or null to use the caller's assembly</param>
 		/// <returns>A new instance of a Bitmap loaded from the specified resource</returns>
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static Bitmap FromResource(string resourceName, Assembly assembly = null)
 		{
 
 			if (assembly == null)
 			{
-#if NETSTANDARD
-				if (TypeHelper.GetCallingAssembly == null)
-					throw new ArgumentNullException("assembly", string.Format(CultureInfo.CurrentCulture, "This platform doesn't support Assembly.GetCallingAssembly(), so you must pass the assembly directly"));
+#if NETSTANDARD1_0
 				assembly = (Assembly)TypeHelper.GetCallingAssembly.Invoke(null, null);
 #else
 				assembly = Assembly.GetCallingAssembly();

--- a/src/Eto/Drawing/Icon.cs
+++ b/src/Eto/Drawing/Icon.cs
@@ -6,6 +6,7 @@ using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
 using sc = System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Eto.Drawing
 {
@@ -102,11 +103,12 @@ namespace Eto.Drawing
 		/// <param name="assembly">Assembly to load the resource from</param>
 		/// <param name="resourceName">Fully qualified name of the resource to load. E.g. "MyProject.SomeFolder.YourFile.extension"</param>
 		/// <returns>A new instance of an Icon loaded with the contents of the specified resource</returns>
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static Icon FromResource(string resourceName, Assembly assembly = null)
 		{
 			if (assembly == null)
 			{
-				#if NETSTANDARD
+				#if NETSTANDARD1_0
 				assembly = (Assembly)TypeHelper.GetCallingAssembly.Invoke(null, null);
 				#else
 				assembly = Assembly.GetCallingAssembly();

--- a/src/Eto/Drawing/IconFrame.cs
+++ b/src/Eto/Drawing/IconFrame.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Diagnostics;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Eto.Drawing
 {
@@ -129,13 +130,12 @@ namespace Eto.Drawing
 		/// <param name="scale">Scale of logical to physical pixels.</param>
 		/// <param name="resourceName">Name of the embedded resource to load.</param>
 		/// <param name="assembly">Assembly to load the embedded resource from, or null to use the calling assembly.</param>
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static IconFrame FromResource(float scale, string resourceName, Assembly assembly = null)
 		{
 			if (assembly == null)
 			{
-				#if NETSTANDARD
-				if (TypeHelper.GetCallingAssembly == null)
-					throw new ArgumentNullException("assembly", string.Format(CultureInfo.CurrentCulture, "This platform doesn't support Assembly.GetCallingAssembly(), so you must pass the assembly directly"));
+				#if NETSTANDARD1_0
                 assembly = (Assembly)TypeHelper.GetCallingAssembly.Invoke(null, null);
 				#else
 				assembly = Assembly.GetCallingAssembly();

--- a/src/Eto/Forms/AboutDialog.cs
+++ b/src/Eto/Forms/AboutDialog.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Eto.Drawing;
 
 namespace Eto.Forms
@@ -15,7 +16,13 @@ namespace Eto.Forms
 		/// <summary>
 		/// Initializes a new instance of the <see cref="T:Eto.Forms.AboutDialog"/> class.
 		/// </summary>
-		public AboutDialog() : this(TypeHelper.GetCallingAssembly?.Invoke(null, null) as Assembly)
+		[MethodImpl(MethodImplOptions.NoInlining)]
+		public AboutDialog() 
+#if NETSTANDARD1_0
+			: this(TypeHelper.GetCallingAssembly?.Invoke(null, null) as Assembly)
+#else
+			: this(Assembly.GetCallingAssembly())
+#endif
 		{
 		}
 

--- a/src/Eto/Forms/Cursor.cs
+++ b/src/Eto/Forms/Cursor.cs
@@ -2,6 +2,7 @@ using System;
 using System.Globalization;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using Eto.Drawing;
 
 namespace Eto.Forms
@@ -145,14 +146,13 @@ namespace Eto.Forms
 		/// <param name="resourceName">Name of the resource in the caller's assembly to load. E.g. "MyProject.SomeFolder.YourFile.cur"</param>
 		/// <param name="assembly">Assembly to load the cursor from, or null to use the caller's assembly</param>
 		/// <returns>A new instance of a Cursor loaded from the specified resource</returns>
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static Cursor FromResource(string resourceName, Assembly assembly = null)
 		{
 
 			if (assembly == null)
 			{
-#if NETSTANDARD
-				if (TypeHelper.GetCallingAssembly == null)
-					throw new ArgumentNullException(nameof(assembly), string.Format(CultureInfo.CurrentCulture, "This platform doesn't support Assembly.GetCallingAssembly(), so you must pass the assembly directly"));
+#if NETSTANDARD1_0
 				assembly = (Assembly)TypeHelper.GetCallingAssembly.Invoke(null, null);
 #else
 				assembly = Assembly.GetCallingAssembly();

--- a/src/Eto/TypeHelper.cs
+++ b/src/Eto/TypeHelper.cs
@@ -13,9 +13,9 @@ namespace Eto
 	/// </summary>
 	static class TypeHelper
 	{
-#if NETSTANDARD
+#if NETSTANDARD1_0
 		static MethodInfo getCallingAssembly = typeof(Assembly).GetTypeInfo().GetDeclaredMethod("GetCallingAssembly");
-		
+
 		static TypeHelper()
 		{
 			var detectType = Type.GetType("Eto.PlatformDetect, Eto.Gtk", false);
@@ -23,10 +23,10 @@ namespace Eto
 				getCallingAssembly = detectType.GetRuntimeMethod("GetCallingAssembly", new Type[] { });
 		}
 
-		public static MethodInfo GetCallingAssembly { get { return getCallingAssembly; } }
+		public static MethodInfo GetCallingAssembly => getCallingAssembly ?? throw new ArgumentNullException("assembly", "This platform doesn't support Assembly.GetCallingAssembly(), so you must pass the assembly directly");
 #endif
 
-				public static Assembly GetAssembly(this Type type)
+		public static Assembly GetAssembly(this Type type)
 		{
 #if NETSTANDARD1_0
 			return type.GetTypeInfo().Assembly;
@@ -114,7 +114,7 @@ namespace Eto
 #else
 
 		public static T GetCustomAttribute<T>(this Type type, bool inherit)
-			where T: Attribute
+			where T : Attribute
 		{
 			return (T)type.GetCustomAttributes(typeof(T), inherit).FirstOrDefault();
 		}

--- a/src/Shared/EmbeddedAssemblyLoader.cs
+++ b/src/Shared/EmbeddedAssemblyLoader.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 
 namespace Eto
 {
@@ -38,6 +39,7 @@ namespace Eto
 		/// <param name="assembly">Assembly to load the embedded assemblies from, or null to use the calling assembly</param>
 		/// <param name="domain">Application domain to load the assemblies in, or null to use the current app domain</param>
 		/// <returns>A new instance of an EmbeddedAssemblyLoader, registered for the specified namespace and assembly</returns>
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public static EmbeddedAssemblyLoader Register(string resourceNamespace, Assembly assembly = null, AppDomain domain = null)
 		{
 			assembly = assembly ?? Assembly.GetCallingAssembly();
@@ -51,6 +53,7 @@ namespace Eto
 		/// </summary>
 		/// <param name="resourceNamespace">Namespace of where the embedded assemblies should be loaded</param>
 		/// <param name="assembly">Assembly to load the embedded assemblies from, or null to use the calling assembly</param>
+		[MethodImpl(MethodImplOptions.NoInlining)]
 		public EmbeddedAssemblyLoader(string resourceNamespace, Assembly assembly = null)
 		{
 			Assembly = assembly ?? Assembly.GetCallingAssembly();


### PR DESCRIPTION
Fixes issues getting the correct calling assembly on .NET 5+ in some cases.

Also added `NoInlining` so that the caller assembly is always correct, in case the runtime decides to inline the `FromResource` method.