### PR TITLE
Add Splitter.PositionChangeStarted/Completed events, and fix WPF events and sizing

### DIFF
--- a/src/Eto.WinForms/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/SplitterHandler.cs
@@ -128,12 +128,13 @@ namespace Eto.WinForms.Forms.Controls
 				SetInitialPosition();
 				SetFixedPanel();
 			};
-			Control.SplitterMoved += (sender, e) => CheckSplitterPos();
+			Control.SplitterMoved += (sender, e) => CheckSplitterPos(true);
 		}
 
 		int splitterMoving;
 		int lastPosition;
-		private void CheckSplitterPos()
+		
+		private void CheckSplitterPos(bool userMoved)
 		{
 			if (splitterMoving > 0)
 				return;
@@ -155,6 +156,10 @@ namespace Eto.WinForms.Forms.Controls
 				newPosition = panel1MinimumSize;
 			
 			position = lastPosition;
+			
+			if (userMoved)
+				Callback.OnPositionChangeStarted(Widget, EventArgs.Empty);
+			
 			var args = new SplitterPositionChangingEventArgs(newPosition);
 			Callback.OnPositionChanging(Widget, args);
 			position = null;
@@ -176,6 +181,9 @@ namespace Eto.WinForms.Forms.Controls
 				Control.SplitterDistance = newPosition;
 			}
 			lastPosition = newPosition;
+			
+			if (userMoved)
+				Callback.OnPositionChangeCompleted(Widget, EventArgs.Empty);
 				
 			splitterMoving--;
 		}
@@ -186,6 +194,8 @@ namespace Eto.WinForms.Forms.Controls
 			{
 				case Splitter.PositionChangedEvent:
 				case Splitter.PositionChangingEvent:
+				case Splitter.PositionChangeStartedEvent:
+				case Splitter.PositionChangeCompletedEvent:
 					break;
 				default:
 					base.AttachEvent(id);
@@ -529,7 +539,7 @@ namespace Eto.WinForms.Forms.Controls
 			set
 			{
 				panel1MinimumSize = value;
-				CheckSplitterPos();
+				CheckSplitterPos(false);
 			}
 		}
 
@@ -539,7 +549,7 @@ namespace Eto.WinForms.Forms.Controls
 			set
 			{
 				panel2MinimumSize = value;
-				CheckSplitterPos();
+				CheckSplitterPos(false);
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -1024,10 +1024,10 @@ namespace Eto.Wpf.Forms
 			return WinFormsHelpers.ToEtoWindow(handle);
 		}
 
-		protected void AttachPropertyChanged(sw.DependencyProperty property, EventHandler<sw.DependencyPropertyChangedEventArgs> handler, sw.DependencyObject control = null)
+		protected void AttachPropertyChanged(sw.DependencyProperty property, EventHandler<sw.DependencyPropertyChangedEventArgs> handler, sw.DependencyObject control = null, object key = null)
 		{
 			control = control ?? Control;
-			Widget.Properties.Set(property, PropertyChangeNotifier.Register(property, handler, control));
+			Widget.Properties.Set(key ?? property, PropertyChangeNotifier.Register(property, handler, control));
 		}
 
 		public void Print()

--- a/src/Eto/Forms/Controls/Splitter.cs
+++ b/src/Eto/Forms/Controls/Splitter.cs
@@ -125,10 +125,48 @@ namespace Eto.Forms
 		/// Raises the <see cref="PositionChanging"/> event.
 		/// </summary>
 		/// <param name="e">Event arguments.</param>
-		protected virtual void OnPositionChanging(SplitterPositionChangingEventArgs e)
+		protected virtual void OnPositionChanging(SplitterPositionChangingEventArgs e) => Properties.TriggerEvent(PositionChangingEvent, this, e);
+
+		/// <summary>
+		/// Identifier for the <see cref="PositionChangeStarted"/> event
+		/// </summary>
+		public const string PositionChangeStartedEvent = "Splitter.PositionChangeStarted";
+
+		/// <summary>
+		/// Raised when the user starts moving the splitter.
+		/// </summary>
+		public event EventHandler<EventArgs> PositionChangeStarted
 		{
-			Properties.TriggerEvent(PositionChangingEvent, this, e);
+			add { Properties.AddHandlerEvent(PositionChangeStartedEvent, value); }
+			remove { Properties.RemoveEvent(PositionChangeStartedEvent, value); }
 		}
+
+		/// <summary>
+		/// Raises the <see cref="PositionChangeStarted"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments.</param>
+		protected virtual void OnPositionChangeStarted(EventArgs e) => Properties.TriggerEvent(PositionChangeStartedEvent, this, e);
+
+		/// <summary>
+		/// Identifier for the <see cref="PositionChangeCompleted"/> event
+		/// </summary>
+		public const string PositionChangeCompletedEvent = "Splitter.PositionChangeCompleted";
+
+		/// <summary>
+		/// Raised when the user starts finishes moving the splitter
+		/// </summary>
+		public event EventHandler<EventArgs> PositionChangeCompleted
+		{
+			add { Properties.AddHandlerEvent(PositionChangeCompletedEvent, value); }
+			remove { Properties.RemoveEvent(PositionChangeCompletedEvent, value); }
+		}
+
+		/// <summary>
+		/// Raises the <see cref="PositionChangeCompleted"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments.</param>
+		protected virtual void OnPositionChangeCompleted(EventArgs e) => Properties.TriggerEvent(PositionChangeCompletedEvent, this, e);
+
 
 		#endregion
 
@@ -136,6 +174,8 @@ namespace Eto.Forms
 		{
 			EventLookup.Register<Splitter>(c => c.OnPositionChanged(null), Splitter.PositionChangedEvent);
 			EventLookup.Register<Splitter>(c => c.OnPositionChanging(null), Splitter.PositionChangingEvent);
+			EventLookup.Register<Splitter>(c => c.OnPositionChangeStarted(null), Splitter.PositionChangingEvent);
+			EventLookup.Register<Splitter>(c => c.OnPositionChangeCompleted(null), Splitter.PositionChangingEvent);
 		}
 
 		/// <summary>
@@ -282,6 +322,14 @@ namespace Eto.Forms
 			/// Raises the position changing event.
 			/// </summary>
 			void OnPositionChanging(Splitter widget, SplitterPositionChangingEventArgs e);
+			/// <summary>
+			/// Raises the position change started event.
+			/// </summary>
+			void OnPositionChangeStarted(Splitter widget, EventArgs e);
+			/// <summary>
+			/// Raises the position change completed event.
+			/// </summary>
+			void OnPositionChangeCompleted(Splitter widget, EventArgs e);
 		}
 
 		/// <summary>
@@ -304,6 +352,22 @@ namespace Eto.Forms
 			{
 				using (widget.Platform.Context)
 					widget.OnPositionChanging(e);
+			}
+			/// <summary>
+			/// Raises the position change started event.
+			/// </summary>
+			public void OnPositionChangeStarted(Splitter widget, EventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnPositionChangeStarted(e);
+			}
+			/// <summary>
+			/// Raises the position change completed event.
+			/// </summary>
+			public void OnPositionChangeCompleted(Splitter widget, EventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnPositionChangeCompleted(e);
 			}
 		}
 

--- a/test/Eto.Test/Sections/Controls/SplitterSection.cs
+++ b/test/Eto.Test/Sections/Controls/SplitterSection.cs
@@ -130,17 +130,19 @@ namespace Eto.Test.Sections.Controls
 				{
 					using (Context)
 					{
+						var splitter = new Splitter
+						{
+							Panel1 = new TreeGridView { Size = new Size(100, 100) },
+							Panel2 = new GridView(),
+							Orientation = Orientation.Horizontal,
+							FixedPanel = SplitterFixedPanel.Panel1,
+							Position = 100,
+						};
+						LogEvents(splitter);
 						var newTabpage = new TabPage
 						{
 							Text = "test",
-							Content = new Splitter
-							{
-								Panel1 = new TreeGridView { Size = new Size(100, 100) },
-								Panel2 = new GridView(),
-								Orientation = Orientation.Horizontal,
-								FixedPanel = SplitterFixedPanel.Panel1,
-								Position = 100,
-							}
+							Content = splitter
 						};
 						tabcontrol.Pages.Add(newTabpage);
 						tabcontrol.SelectedPage = newTabpage;
@@ -248,6 +250,7 @@ namespace Eto.Test.Sections.Controls
 						Orientation = Orientation.Vertical,
 						Position = 200
 					};
+					LogEvents(p0_1);
 					// absolute position with height and second panel fixed (issue #309)
 					var p2_3 = new Splitter
 					{
@@ -258,6 +261,7 @@ namespace Eto.Test.Sections.Controls
 						//Position = 0,
 						Height = 205 // ~ RelativePosition=200
 					};
+					LogEvents(p2_3);
 					// ratio mode (60%)
 					var p4_5 = new Splitter
 					{
@@ -267,6 +271,7 @@ namespace Eto.Test.Sections.Controls
 						FixedPanel = SplitterFixedPanel.None,
 						RelativePosition = .6
 					};
+					LogEvents(p4_5);
 					// auto-size test
 					var p01_23 = new Splitter
 					{
@@ -274,6 +279,7 @@ namespace Eto.Test.Sections.Controls
 						Panel2 = p2_3,
 						Orientation = Orientation.Horizontal,
 					};
+					LogEvents(p01_23);
 					// relative position with second panel fixed
 					var p0123_45 = new Splitter
 					{
@@ -283,6 +289,7 @@ namespace Eto.Test.Sections.Controls
 						FixedPanel = SplitterFixedPanel.Panel2,
 						RelativePosition = 150
 					};
+					LogEvents(p0123_45);
 					return Root = p0123_45;
 				}
 			}
@@ -317,19 +324,23 @@ namespace Eto.Test.Sections.Controls
 					Panel2 = rightBottom,
 					Position = 200,
 				};
+				LogEvents(rightPane);
+
+				var mainPane = new Splitter
+				{
+					Orientation = Orientation.Horizontal,
+					FixedPanel = SplitterFixedPanel.Panel1,
+					BackgroundColor = Colors.Gray,
+					Position = 200,
+					Panel1 = leftPane,
+					Panel2 = rightPane
+				};
+				LogEvents(mainPane);
 
 				var form = new Form
 				{
 					Padding = new Padding(5),
-					Content = new Splitter
-					{
-						Orientation = Orientation.Horizontal,
-						FixedPanel = SplitterFixedPanel.Panel1,
-						BackgroundColor = Colors.Gray,
-						Position = 200,
-						Panel1 = leftPane,
-						Panel2 = rightPane
-					}
+					Content = mainPane
 				};
 				if (setSize)
 					form.Size = new Size(600, 400);
@@ -384,23 +395,27 @@ namespace Eto.Test.Sections.Controls
 					{
 						Position = 80
 					};
+					LogEvents(main);
 					var middle = new Splitter
 					{
 						FixedPanel = SplitterFixedPanel.Panel2,
 						Width = 200,
 						Position = 120 - main.SplitterWidth
 					};
+					LogEvents(middle);
 					var ltop = new Splitter
 					{
 						Orientation = Orientation.Vertical,
 						Position = 80
 					};
+					LogEvents(ltop);
 					var lbottom = new Splitter
 					{
 						Orientation = Orientation.Vertical,
 						FixedPanel = SplitterFixedPanel.Panel2,
 						RelativePosition = 80
 					};
+					LogEvents(lbottom);
 					var right = new Splitter
 					{
 						Orientation = Orientation.Vertical,
@@ -408,11 +423,13 @@ namespace Eto.Test.Sections.Controls
 						Height = 300 + main.SplitterWidth,
 						Position = 100 // ~33%
 					};
+					LogEvents(right);
 					var center = new Splitter
 					{
 						FixedPanel = SplitterFixedPanel.None,
 						RelativePosition = .4
 					};
+					LogEvents(center);
 					main.Panel1 = ltop;
 					main.Panel2 = middle;
 					ltop.Panel1 = makebox(ltop);
@@ -491,6 +508,7 @@ namespace Eto.Test.Sections.Controls
 						Panel1 = new Panel { Padding = 20, BackgroundColor = Colors.Red, Content = new Panel { BackgroundColor = Colors.White, Size = new Size(200, 400) } },
 						Panel2 = new Panel { Padding = 20, BackgroundColor = Colors.Blue, Content = new Panel { BackgroundColor = Colors.White, Size = new Size(200, 400) } }
 					};
+					LogEvents(splitter);
 
 					var showPanel1 = new CheckBox { Text = "Panel1.Visible" };
 					showPanel1.CheckedBinding.Bind(splitter.Panel1, r => r.Visible);
@@ -572,6 +590,14 @@ namespace Eto.Test.Sections.Controls
 			};
 
 			return control;
+		}
+
+		static void LogEvents(Splitter splitter)
+		{
+			splitter.PositionChanged += (sender, e) => Log.Write(sender, $"PositionChanged: {splitter.Position}");
+			splitter.PositionChanging += (sender, e) => Log.Write(sender, $"PositionChanging: New: {e.NewPosition}, Current: {splitter.Position}");
+			splitter.PositionChangeStarted += (sender, e) => Log.Write(sender, $"PositionChangeStarted");
+			splitter.PositionChangeCompleted += (sender, e) => Log.Write(sender, $"PositionChangeCompleted");
 		}
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
@@ -41,7 +41,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					{
 						BackgroundColor = Colors.Black
 					}
-				}, 
+				},
 				it =>
 				{
 					Assert.AreEqual(50, it.Position, "Fix: {0}; {1} [replay={2}]", fix, orient, replay);
@@ -149,6 +149,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			Shown(
 				form =>
 				{
+					form.WindowStyle = WindowStyle.Utility;
 					// +====test 1====+ 
 					// |        |     | 
 					// | tested |     |   Tested splitter is placed inside two other splitters
@@ -238,7 +239,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 						}
 					};
 					return it;
-				}, 
+				},
 				it =>
 				{
 					Assert.AreEqual(40, it.Position, "{0}; {1}", fix, orient);
@@ -259,8 +260,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					var it = new Splitter()
 					{
 						Orientation = orient,
-						FixedPanel	= fix,
-						Position	= 50,
+						FixedPanel = fix,
+						Position = 50,
 						Panel1 = new Panel
 						{
 							BackgroundColor = Colors.White
@@ -293,10 +294,10 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			{
 				var posLabel = new Label();
 				var label = new Label
-				{ 
+				{
 					Text = "Drag the splitter right",
 					TextAlignment = TextAlignment.Center,
-					VerticalAlignment = VerticalAlignment.Center 
+					VerticalAlignment = VerticalAlignment.Center
 				};
 				int stage = 0;
 				var splitter = new Splitter
@@ -404,15 +405,18 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		public void SplitterChangingShouldAllowRestrictingWithoutArtifacts()
 		{
 			int? outOfBounds = null;
-			ManualForm("Splitter should be restricted between 100 and 200, and start at 300", form => {
-            	form.ClientSize = new Size(600, 300);
-				var splitter = new Splitter {
+			ManualForm("Splitter should be restricted between 100 and 200, and start at 300", form =>
+			{
+				form.ClientSize = new Size(600, 300);
+				var splitter = new Splitter
+				{
 
 					Panel1 = new Panel { BackgroundColor = Colors.Blue, Size = new Size(300, 200) },
 					Panel2 = new Panel { BackgroundColor = Colors.Red, Size = new Size(300, 200) }
 				};
 
-				splitter.PositionChanging += (sender, e) => {
+				splitter.PositionChanging += (sender, e) =>
+				{
 					System.Diagnostics.Debug.WriteLine($"PositionChanging, Position {splitter.Position}, NewPosition: {e.NewPosition}");
 					if (e.NewPosition < 100)
 					{
@@ -425,7 +429,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 						e.Cancel = true;
 					}
 				};
-				splitter.PositionChanged += (sender, e) => {
+				splitter.PositionChanged += (sender, e) =>
+				{
 					var position = splitter.Position;
 					System.Diagnostics.Debug.WriteLine($"PositionChanged, Position: {position}");
 					if (position > 200 || position < 100)
@@ -435,26 +440,28 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					}
 				};
 
-		    	return splitter;
+				return splitter;
 			});
 			Assert.IsNull(outOfBounds, $"#1 - Position went out of bounds 100-200, was {outOfBounds}");
 		}
-		
+
 		[TestCase(Orientation.Horizontal)]
 		[TestCase(Orientation.Vertical)]
 		public void ZeroRelativePositionShouldNotCrash(Orientation orientation)
 		{
-			Shown(form => {
-				return new Splitter 
+			Shown(form =>
+			{
+				return new Splitter
 				{
 					Orientation = orientation,
-					Panel1 = new Panel { Size = new Size(200, 200)},
-					Panel2 = new Panel { Size = new Size(200, 200)},
+					Panel1 = new Panel { Size = new Size(200, 200) },
+					Panel2 = new Panel { Size = new Size(200, 200) },
 					FixedPanel = SplitterFixedPanel.None,
 					RelativePosition = 0
 				};
 			},
-			c => {
+			c =>
+			{
 				// if we got here it was successful
 			});
 		}


### PR DESCRIPTION
- Allows you to perform logic or change state while a user moves the splitter
- Wpf: Fixes issues triggering events when fixed panel is set, and fixes the initial size of the control. Fixes #1676