### PR TITLE
Wpf: Fix issue autosizing a Drawable content with labels with constraints

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DrawableHandler.cs
@@ -83,16 +83,19 @@ namespace Eto.Wpf.Forms.Controls
 
 			protected override sw.Size MeasureOverride(sw.Size constraint)
 			{
+				return Handler.MeasureOverride(constraint, ContentMeasureOverride);
+			}
+
+			private sw.Size ContentMeasureOverride(sw.Size constraint)
+			{
+				var size = base.MeasureOverride(constraint);
 				var content = Handler.content;
-				if (content != null)
-				{
-					content.Measure(constraint);
-					return Handler.MeasureOverride(constraint, c => {
-						base.MeasureOverride(c);
-						return content.DesiredSize;
-						});
-				}
-				return Handler.MeasureOverride(constraint, base.MeasureOverride);
+				if (content == null)
+					return size;
+			
+				// content should be used to measure, if present		
+				content.Measure(constraint);
+				return content.DesiredSize;
 			}
 
 			protected override sw.Size ArrangeOverride(sw.Size arrangeSize)
@@ -139,7 +142,7 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
-		protected override bool NeedsPixelSizeNotifications {  get { return true; } }
+		protected override bool NeedsPixelSizeNotifications { get { return true; } }
 
 		public override void OnLoadComplete(EventArgs e)
 		{
@@ -182,7 +185,7 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			UpdateTiles(true);
 			Control.Loaded -= Control_Loaded; // only perform once
-        }
+		}
 
 		public virtual Graphics CreateGraphics()
 		{

--- a/test/Eto.Test/UnitTests/Forms/Controls/DrawableTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/DrawableTests.cs
@@ -5,30 +5,35 @@ using NUnit.Framework;
 namespace Eto.Test.UnitTests.Forms.Controls
 {
 	[TestFixture]
-    public class DrawableTests : TestBase
-    {
+	public class DrawableTests : TestBase
+	{
 		[Test, ManualTest]
 		public void DrawableWithCanFocusShouldGetFirstMouseDownOnInactiveWindow()
 		{
 			bool wasClicked = false;
 			bool gotFocusBeforeClick = false;
-			Form(form => {
-			
+			Form(form =>
+			{
+
 				var drawable = new Drawable();
 				var font = SystemFonts.Default();
-				drawable.Paint += (sender, e) => {
+				drawable.Paint += (sender, e) =>
+				{
 					e.Graphics.FillRectangle(Colors.Blue, 0, 0, drawable.Width, drawable.Height);
 					e.Graphics.DrawText(font, SystemColors.ControlText, 0, 0, "Clicking once on this control should close the form");
 				};
 				drawable.Size = new Size(350, 200);
 				drawable.CanFocus = true;
-				drawable.MouseDown += (sender, e) => {
+				drawable.MouseDown += (sender, e) =>
+				{
 					wasClicked = true;
 					form.Close();
 				};
 				form.Content = drawable;
-				form.GotFocus += (sender, e) => {
-					Application.Instance.AsyncInvoke(() => {
+				form.GotFocus += (sender, e) =>
+				{
+					Application.Instance.AsyncInvoke(() =>
+					{
 						if (!wasClicked)
 							gotFocusBeforeClick = true;
 					});
@@ -41,6 +46,37 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			Assert.IsTrue(wasClicked, "#1 Drawable didn't get clicked");
 			Assert.IsFalse(gotFocusBeforeClick, "#2 Form should not have got focus before MouseDown event");
 		}
-        
-    }
+
+		[Test]
+		public void DrawableWithWrappedLabelShouldAutoSizeToConstraints()
+		{
+			Form form = null;
+			Label labelThatShouldWrap = null;
+			Shown(f =>
+			{
+				form = f;
+				labelThatShouldWrap = new Label
+				{
+					Text = "This is some label that should wrap and show you the entire string including the period at the end."
+				};
+
+				var drawable = new Drawable
+				{
+					Content = labelThatShouldWrap
+				};
+
+				form.Content = drawable;
+				form.Width = 100;
+				form.WindowStyle = WindowStyle.Utility;
+			},
+			() =>
+			{
+				Assert.GreaterOrEqual(labelThatShouldWrap.Height, 20, "#1 - Label should have wrapped!");
+
+				Assert.AreEqual(100, form.Width, "#2 - Form width should be 100");
+			}
+			);
+		}
+
+	}
 }


### PR DESCRIPTION
Setting only the width of a form/dialog should allow the label to wrap and grow vertically to show all of its content.