### PR TITLE
Change LinuxTrayIndicatorHandler to use libayatana-appindicator3 instead of libappindicator3

### DIFF
--- a/src/Eto.Gtk/Forms/LinuxTrayIndicatorHandler.cs
+++ b/src/Eto.Gtk/Forms/LinuxTrayIndicatorHandler.cs
@@ -11,7 +11,7 @@ namespace Eto.GtkSharp.Forms
 {
 	public class LinuxTrayIndicatorHandler : WidgetHandler<GLib.Object, TrayIndicator, TrayIndicator.ICallback>, TrayIndicator.IHandler
 	{
-		const string libappindicator = "libappindicator3.so.1";
+		const string libappindicator = "libayatana-appindicator3.so.1";
 		Image image;
 		string imagePath;
 		ContextMenu menu;


### PR DESCRIPTION
The package that provides `libappindicator3.so.1` was [removed from Debian 11](https://www.debian.org/releases/bullseye/amd64/release-notes/ch-information.en.html#noteworthy-obsolete-packages). `libayatana-appindicator3.so.1` is a drop-in replacement for `libappindicator3.so.1` (as far as I can tell), so this should work, and as far as I've tested, it has. I'll admit I'm not very cognizant of other distros, so it might break compatibility there. All I know is that it works on my machine, and that's all I have time to test, so I encourage others to test it on other distros.