### PR TITLE
Only use newer api's for .NET 6 or later

### DIFF
--- a/src/Eto.Mac/Drawing/FontFamilyHandler.cs
+++ b/src/Eto.Mac/Drawing/FontFamilyHandler.cs
@@ -34,7 +34,7 @@ namespace Eto.Mac.Drawing
 				// faceName cannot be null.  Use this when it is fixed in xammac/monomac:
 				// return NSFontManager.SharedFontManager.LocalizedNameForFamily(MacName, null);
 				var facePtr = IntPtr.Zero;
-#if XAMMAC
+#if XAMMAC && NET6_0_OR_GREATER
 				var familyPtr = CFString.CreateNative(MacName);
 				var result = CFString.FromHandle(Messaging.IntPtr_objc_msgSend_IntPtr_IntPtr(NSFontManager.SharedFontManager.Handle, sel_LocalizedNameForFamilyFace, familyPtr, facePtr));
 				CFString.ReleaseNative(familyPtr);

--- a/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
@@ -457,7 +457,7 @@ namespace Eto.Mac.Forms.Controls
 				if (h != null && h.NeedsFormat)
 				{
 					double result;
-#if XAMMAC2
+#if XAMMAC && NET6_0_OR_GREATER
 					var str = CFString.FromHandle(strPtr);
 #else
 					var str = NSString.FromHandle(strPtr);

--- a/src/Eto.Mac/MacExtensions.cs
+++ b/src/Eto.Mac/MacExtensions.cs
@@ -87,7 +87,7 @@ namespace Eto.Mac
 		// replacementString should allow nulls
 		public static bool ShouldChangeTextNew(this NSTextView textView, NSRange affectedCharRange, string replacementString)
 		{
-#if XAMMAC2
+#if XAMMAC && NET6_0_OR_GREATER
 			IntPtr intPtr = replacementString != null ? CFString.CreateNative(replacementString) : IntPtr.Zero;
 			bool result;
 			result = Messaging.bool_objc_msgSend_NSRange_IntPtr(textView.Handle, selShouldChangeTextInRangeReplacementString_Handle, affectedCharRange, intPtr);


### PR DESCRIPTION
This allows us to support older versions of Xamarin.Mac.