### PR TITLE
More WebView2 initialization goodness

### DIFF
--- a/src/Eto/WidgetHandler.cs
+++ b/src/Eto/WidgetHandler.cs
@@ -129,6 +129,20 @@ namespace Eto
 		void Widget.IHandler.Initialize()
 		{
 			Initialize();
+			OnInitializeComplete();
+		}
+		
+		/// <summary>
+		/// Called after initialization is complete
+		/// </summary>
+		/// <remarks>
+		/// Override this to perform any logic after the handler is fully initialized, but before
+		/// returning from the construction of the widget.
+		/// 
+		/// This by default applies the any styles for the handler.
+		/// </remarks>
+		protected virtual void OnInitializeComplete()
+		{
 			// apply styles after the handler is fully initialized.
 			Style.Provider?.ApplyDefault(this);
 		}


### PR DESCRIPTION
- Allow WebView2 environment to be set via style
- Add global callback to get environment on demand vs. having to set it directly
- Added WidgetHandler.OnInitializeComplete() to be able to perform tasks after a widget is initialized, so we can do things after styles are applied.