### PR TITLE
Fix memory leak for EtoLayoutManager

### DIFF
--- a/src/Eto.Mac/Drawing/FormattedTextHandler.cs
+++ b/src/Eto.Mac/Drawing/FormattedTextHandler.cs
@@ -256,6 +256,7 @@ namespace Eto.iOS.Drawing
 			Control.CurrentGraphics = graphics;
 			var ctx = graphics.Control;
 			Control.DrawGlyphs(new NSRange(0, (int)_text.Length), location.ToNS());
+			Control.CurrentGraphics = null;
 		}
 	}
 }


### PR DESCRIPTION
It fix the issue #2086.
If the CurrentGraphics of EtoLayoutManager is not cleared, it will create a native retain cycle and EtoLayoutManager is never released.