### PR TITLE
Fixing WebView2 detection mechanism

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/WebView2Handler.cs
+++ b/src/Eto.Wpf/Forms/Controls/WebView2Handler.cs
@@ -70,7 +70,7 @@ namespace Eto.Wpf.Forms.Controls
 #endif
 			try
 			{
-				var version = CoreWebView2Environment.GetAvailableBrowserVersionString();
+				var versionInfo = CoreWebView2Environment.GetAvailableBrowserVersionString();
 				return versionInfo != null;
 			}
 			catch (WebView2RuntimeNotFoundException)

--- a/src/Eto.Wpf/Forms/Controls/WebView2Handler.cs
+++ b/src/Eto.Wpf/Forms/Controls/WebView2Handler.cs
@@ -68,9 +68,15 @@ namespace Eto.Wpf.Forms.Controls
 #if TEST_INSTALL
 			return false;
 #endif
-			var versionInfo = CoreWebView2Environment.GetAvailableBrowserVersionString();
-			// If versionInfo is NULL, the WebView2 Runtime isn't currently installed on the client.
-			return versionInfo != null;
+			try
+			{
+				var version = CoreWebView2Environment.GetAvailableBrowserVersionString();
+				return versionInfo != null;
+			}
+			catch (WebView2RuntimeNotFoundException)
+			{
+				return false;
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
Actually I didn't do it quite right. We need to catch `WebView2RuntimeNotFoundException` when calling `GetAvailableBrowserVersionString`.

It doesn't seem to be documented anywhere but I don't think `GetAvailableBrowserVersionString` will ever return `null`. It's either version string or an exception.