### PR TITLE
Override incorrect dotnet paths in EtoSpecialFolders

### DIFF
--- a/src/Eto.Gtk/EtoEnvironmentHandler.cs
+++ b/src/Eto.Gtk/EtoEnvironmentHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using Eto;
+using System.Linq;
 using System.Reflection;
 using System.IO;
 using System.Diagnostics;
@@ -8,23 +9,20 @@ namespace Eto.GtkSharp
 {
 	public class EtoEnvironmentHandler : WidgetHandler<Widget>, EtoEnvironment.IHandler
 	{
-		static Environment.SpecialFolder Convert(EtoSpecialFolder folder)
-		{
-			switch (folder)
-			{
-				case EtoSpecialFolder.ApplicationSettings:
-					return Environment.SpecialFolder.ApplicationData;
-				case EtoSpecialFolder.Documents:
-					return Environment.SpecialFolder.MyDocuments;
-				default:
-					throw new NotSupportedException();
-			}
-		}
-
 		public string GetFolderPath(EtoSpecialFolder folder)
 		{
+			string homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 			switch (folder)
 			{
+				// Currently has a bug on dotnet where it returns the wrong path for Mac
+				// https://github.com/dotnet/runtime/issues/63214#issuecomment-1003414322
+				case EtoSpecialFolder.ApplicationSettings:
+					{
+						if (EtoEnvironment.Platform.IsMac)
+							return Path.Combine(homeDir, "Library", "Preferences");
+						else 
+							return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+					}
 				case EtoSpecialFolder.ApplicationResources:
 					return Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
 				case EtoSpecialFolder.EntryExecutable:
@@ -34,10 +32,98 @@ namespace Eto.GtkSharp
 							path = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
 						return path;
 					}
+				// Curently has a bug on dotnet, where it returns the wrong path for Linux+Mac
+				// See link above
+				case EtoSpecialFolder.Documents:
+					{
+						if (EtoEnvironment.Platform.IsLinux)
+							return GetXdgUserDirectory(homeDir, "XDG_DOCUMENTS_DIR", "Documents");
+						// Technically Mac would be solved by the Linux path as well, but it's cleaner
+						// and faster to just combine the paths on Mac rather than trying to resolve the xdg path
+						else if (EtoEnvironment.Platform.IsMac)
+							return Path.Combine(homeDir, "Documents");
+						else
+							return Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+					}
 				case EtoSpecialFolder.Downloads:
-					return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Downloads");
+					{
+						if (EtoEnvironment.Platform.IsLinux)
+							return GetXdgUserDirectory(homeDir, "XDG_DOWNLOAD_DIR", "Downloads");
+						else
+							return Path.Combine(homeDir, "Downloads");
+					}
 				default:
-					return Environment.GetFolderPath(Convert(folder));
+					throw new NotSupportedException();
+			}
+		}
+
+		/// <summary>
+		/// Tries to resolve <paramref name="xdgUserDir"/> and get its value.
+		/// </summary>
+		/// <param name="homeDir">Home directory of the user.</param>
+		/// <param name="xdgUserDir">The XDG user directory to get the value for.</param>
+		/// <param name="fallback">The fallback folder, which will be appended to <paramref name="homeDir"/>.</param>
+		/// <returns>The value of <paramref name="xdgUserDir"/> if it can be resolved, otherwise 
+		/// the combined Path of <paramref name="homeDir"/> and <paramref name="xdgUserDir"/></returns>
+		private static string GetXdgUserDirectory(string homeDir, string xdgUserDir, string fallback)
+		{
+			// If user has set a custom xdg env var, return that instead
+			string xdgEnvVar = Environment.GetEnvironmentVariable(xdgUserDir);
+			if (!String.IsNullOrEmpty(xdgEnvVar))
+				return xdgEnvVar;
+			
+			// Try to read XDG_CONFIG_HOME/users-dirs.dirs and get the variable from there
+			string userDirsPath = Path.Combine(GetXdgBaseDirectory(homeDir, "XDG_CONFIG_HOME"), "user-dirs.dirs");
+			try
+			{
+				// Find the line where the xdg user dir is mentioned and it's not commented out
+				string lineContent = File.ReadAllLines(userDirsPath).Where(l => l.Contains(xdgUserDir) && l[0] != '#').First();
+				// Get the path which is enclosed in '"'
+				int firstIndex = lineContent.IndexOf('"') + 1;
+				int secondIndex = lineContent.IndexOf('"', firstIndex);
+				lineContent = lineContent.Substring(firstIndex, secondIndex - firstIndex);
+
+				// If HOME is there, replace it
+				lineContent = lineContent.Replace("$HOME", homeDir);
+
+				// We have the Path now
+				return lineContent;
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine($"Error occured while trying to get XDG-USER-DIR \"{xdgUserDir}\": {ex}");
+			}
+
+			// Something failed while trying 
+			return Path.Combine(homeDir, fallback);
+		}
+
+		/// <summary>
+		/// Tries to resolve <paramref name="xdgBaseDir"/> and get its value.
+		/// </summary>
+		/// <param name="homeDir">Home directory of the user.</param>
+		/// <param name="xdgBaseDir">The XDG base directory to get the value for.</param>
+		/// <returns>The value of the Environment Variable <paramref name="xdgBaseDir"/>
+		/// otherwise the appropriate fallback will used.</returns>
+		private static string GetXdgBaseDirectory(string homeDir, string xdgBaseDir)
+		{
+			// If user has set a custom xdg env var, return that instead
+			string xdgEnvVar = Environment.GetEnvironmentVariable(xdgBaseDir);
+			if (!String.IsNullOrEmpty(xdgEnvVar))
+				return xdgEnvVar;
+
+			// Otherwise, return the fallback
+			switch (xdgBaseDir)
+			{
+				// We currently only need CONFIG. Can expand this later if needed.
+				case "XDG_CONFIG_HOME":
+					return Path.Combine(homeDir, ".config");
+				// xdg-user-dir returns HOME for everything that isn't defined
+				default:
+					{
+						Debug.WriteLine($"XDG-BASE-DIRECTORY {xdgBaseDir} not found!");
+						return homeDir;
+					}
 			}
 		}
 	}

--- a/src/Eto.Gtk/EtoEnvironmentHandler.cs
+++ b/src/Eto.Gtk/EtoEnvironmentHandler.cs
@@ -9,6 +9,25 @@ namespace Eto.GtkSharp
 {
 	public class EtoEnvironmentHandler : WidgetHandler<Widget>, EtoEnvironment.IHandler
 	{
+
+		/// <summary>
+		/// Determines if <see cref="GetFolderPath"/> should return XDG Folders or the legacy ones.
+		/// </summary>
+		/// <remarks>This changes the return values of:
+		/// <list type="bullet">
+		/// <item><see cref="EtoSpecialFolder.ApplicationSettings"/> for Mac. If this is set to <c>true</c>,
+		/// it will return "~/Library/Application Support". Otherwise it will return "~/.config/".</item>
+		/// <item><see cref="EtoSpecialFolder.Documents"/> for Mac and Linux. If this is set to <c>true</c>,
+		/// it will return the user's documents folder for Mac and Linux. For Linux, $XDG_DOCUMENTS_DIR
+		/// is used for determining the folder, with "~/Documents" as a fallback should it not be set.<br/>
+		/// If this is set to <c>false</c>, it will return the home folder for both Mac and Linux.</item>
+		/// <item><see cref="EtoSpecialFolder.Downloads"/> for Mac and Linux. If this is set to <c>true</c>,
+		/// it will return the user's download folder for Mac and Linux. For Linux, $XDG_DOWNLOADS_DIR
+		/// is used for determining the folder, with "~/Downloads" as a fallback should it not be set. <br/>
+		/// If this is set to <c>false</c>, it will return "~/Downloads" for both Mac and Linux.</item>
+		/// </list></remarks>
+		public static bool UseXDG = true;
+
 		public string GetFolderPath(EtoSpecialFolder folder)
 		{
 			string homeDir = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
@@ -17,53 +36,49 @@ namespace Eto.GtkSharp
 				// Currently has a bug on dotnet where it returns the wrong path for Mac
 				// https://github.com/dotnet/runtime/issues/63214#issuecomment-1003414322
 				case EtoSpecialFolder.ApplicationSettings:
-					{
-						if (EtoEnvironment.Platform.IsMac)
-							return Path.Combine(homeDir, "Library", "Preferences");
-						else 
-							return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
-					}
+					if (UseXDG && EtoEnvironment.Platform.IsMac)
+						return Path.Combine(homeDir, "Library", "Application Support");
+					return Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+
 				case EtoSpecialFolder.ApplicationResources:
 					return Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+
 				case EtoSpecialFolder.EntryExecutable:
-					{
-						var path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-						if (string.IsNullOrEmpty(path))
-							path = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
-						return path;
-					}
-				// Curently has a bug on dotnet, where it returns the wrong path for Linux+Mac
+					var path = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+					if (String.IsNullOrEmpty(path))
+						path = Path.GetDirectoryName(Process.GetCurrentProcess().MainModule.FileName);
+					return path;
+
+				// Currently has a bug on dotnet, where it returns the wrong path for Linux+Mac
 				// See link above
 				case EtoSpecialFolder.Documents:
-					{
-						if (EtoEnvironment.Platform.IsLinux)
-							return GetXdgUserDirectory(homeDir, "XDG_DOCUMENTS_DIR", "Documents");
-						// Technically Mac would be solved by the Linux path as well, but it's cleaner
-						// and faster to just combine the paths on Mac rather than trying to resolve the xdg path
-						else if (EtoEnvironment.Platform.IsMac)
-							return Path.Combine(homeDir, "Documents");
-						else
-							return Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
-					}
+					if (UseXDG && EtoEnvironment.Platform.IsMac)
+						return Path.Combine(homeDir, "Documents");
+					if (UseXDG && EtoEnvironment.Platform.IsLinux)
+						return GetXdgUserDirectory(homeDir, "XDG_DOCUMENTS_DIR", "Documents");
+					return Environment.GetFolderPath(Environment.SpecialFolder.MyDocuments);
+
 				case EtoSpecialFolder.Downloads:
-					{
-						if (EtoEnvironment.Platform.IsLinux)
-							return GetXdgUserDirectory(homeDir, "XDG_DOWNLOAD_DIR", "Downloads");
-						else
-							return Path.Combine(homeDir, "Downloads");
-					}
+					if (UseXDG && EtoEnvironment.Platform.IsLinux)
+						return GetXdgUserDirectory(homeDir, "XDG_DOWNLOAD_DIR", "Downloads");
+
+					// This technically doesn't return the proper download path for Windows on UseXDG, but it's not really a priority to implement.
+					// If someone wants to implement this to call SHGetFolderPath on Windows, feel free to PR.
+					return Path.Combine(homeDir, "Downloads");
+
 				default:
 					throw new NotSupportedException();
 			}
 		}
 
 		/// <summary>
-		/// Tries to resolve <paramref name="xdgUserDir"/> and get its value.
+		/// Tries to resolve <paramref name="xdgUserDir"/> and get its value. <br/>
+		/// See this for more documentation: https://www.freedesktop.org/wiki/Software/xdg-user-dirs/
 		/// </summary>
 		/// <param name="homeDir">Home directory of the user.</param>
 		/// <param name="xdgUserDir">The XDG user directory to get the value for.</param>
 		/// <param name="fallback">The fallback folder, which will be appended to <paramref name="homeDir"/>.</param>
-		/// <returns>The value of <paramref name="xdgUserDir"/> if it can be resolved, otherwise 
+		/// <returns>The value of <paramref name="xdgUserDir"/> if it can be resolved, otherwise
 		/// the combined Path of <paramref name="homeDir"/> and <paramref name="xdgUserDir"/></returns>
 		private static string GetXdgUserDirectory(string homeDir, string xdgUserDir, string fallback)
 		{
@@ -71,13 +86,14 @@ namespace Eto.GtkSharp
 			string xdgEnvVar = Environment.GetEnvironmentVariable(xdgUserDir);
 			if (!String.IsNullOrEmpty(xdgEnvVar))
 				return xdgEnvVar;
-			
+
 			// Try to read XDG_CONFIG_HOME/users-dirs.dirs and get the variable from there
 			string userDirsPath = Path.Combine(GetXdgBaseDirectory(homeDir, "XDG_CONFIG_HOME"), "user-dirs.dirs");
 			try
 			{
 				// Find the line where the xdg user dir is mentioned and it's not commented out
-				string lineContent = File.ReadAllLines(userDirsPath).Where(l => l.Contains(xdgUserDir) && l[0] != '#').First();
+				string lineContent = File.ReadAllLines(userDirsPath).First(l => l.Contains(xdgUserDir) && (l[0] != '#'));
+
 				// Get the path which is enclosed in '"'
 				int firstIndex = lineContent.IndexOf('"') + 1;
 				int secondIndex = lineContent.IndexOf('"', firstIndex);
@@ -86,20 +102,24 @@ namespace Eto.GtkSharp
 				// If HOME is there, replace it
 				lineContent = lineContent.Replace("$HOME", homeDir);
 
-				// We have the Path now
+				// Per xdg-specification, if a user dir is set to home it's marked as disabled, which means we use the fallback.
+				if (lineContent == homeDir)
+					return Path.Combine(homeDir, fallback);
+
+				// We have the path now
 				return lineContent;
 			}
+			// If we get an error trying to read the file, if the user dir doesn't exist or anything else, we use the fallback.
 			catch (Exception ex)
 			{
 				Debug.WriteLine($"Error occured while trying to get XDG-USER-DIR \"{xdgUserDir}\": {ex}");
 			}
-
-			// Something failed while trying 
 			return Path.Combine(homeDir, fallback);
 		}
 
 		/// <summary>
-		/// Tries to resolve <paramref name="xdgBaseDir"/> and get its value.
+		/// Tries to resolve <paramref name="xdgBaseDir"/> and get its value. <br/>
+		/// See this for more documentation: https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html
 		/// </summary>
 		/// <param name="homeDir">Home directory of the user.</param>
 		/// <param name="xdgBaseDir">The XDG base directory to get the value for.</param>
@@ -120,10 +140,8 @@ namespace Eto.GtkSharp
 					return Path.Combine(homeDir, ".config");
 				// xdg-user-dir returns HOME for everything that isn't defined
 				default:
-					{
-						Debug.WriteLine($"XDG-BASE-DIRECTORY {xdgBaseDir} not found!");
-						return homeDir;
-					}
+					Debug.WriteLine($"XDG-BASE-DIRECTORY {xdgBaseDir} not found!");
+					return homeDir;
 			}
 		}
 	}

--- a/src/Eto/EtoEnvironment.cs
+++ b/src/Eto/EtoEnvironment.cs
@@ -14,7 +14,7 @@ namespace Eto
 		/// <remarks>
 		/// This will return a different folder, depending on the platform: <br/>
 		///   OS X:    ~/Library/Preferences/ <br/>
-		///   Windows: %APPDATA% ([User's Home]/Appdata/Roaming <br/>
+		///   Windows: %APPDATA% [User's Home]/Appdata/Roaming <br/>
 		///   Linux:   ~/.config <br/>
 		/// </remarks>
 		ApplicationSettings,
@@ -41,10 +41,14 @@ namespace Eto
 		/// the location of the assembly can no longer be found as it is loaded from memory.
 		/// </remarks>
 		EntryExecutable,
-		
+
 		/// <summary>
 		/// Gets the user's downloads folder
 		/// </summary>
+		/// <remarks>
+		/// Note that for GTK on Windows, this will *always* return "[User's Home]/Downloads",
+		/// regardless of what the user's actual download path is.
+		/// </remarks>
 		Downloads
 	}
 

--- a/src/Eto/EtoEnvironment.cs
+++ b/src/Eto/EtoEnvironment.cs
@@ -12,10 +12,10 @@ namespace Eto
 		/// Application settings folder to store settings or data
 		/// </summary>
 		/// <remarks>
-		/// This will return a different folder, depending on the platform:
-		///   OS X:    ~/Library/Application Settings/[Name Of Application]
-		///   Windows: [User's Home]/AppSettings
-		///   Linux:   ~/.config
+		/// This will return a different folder, depending on the platform: <br/>
+		///   OS X:    ~/Library/Preferences/ <br/>
+		///   Windows: %APPDATA% ([User's Home]/Appdata/Roaming <br/>
+		///   Linux:   ~/.config <br/>
 		/// </remarks>
 		ApplicationSettings,
 
@@ -23,7 +23,7 @@ namespace Eto
 		/// The application resources.path
 		/// </summary>
 		/// <remarks>
-		/// In OS X, this will be the .app bunldle's resource path.  Other platforms
+		/// In OS X, this will be the .app bundle's resource path.  Other platforms
 		/// will typically return the same path as the current executable file
 		/// </remarks>
 		ApplicationResources,

--- a/src/Eto/EtoEnvironment.cs
+++ b/src/Eto/EtoEnvironment.cs
@@ -13,7 +13,7 @@ namespace Eto
 		/// </summary>
 		/// <remarks>
 		/// This will return a different folder, depending on the platform: <br/>
-		///   OS X:    ~/Library/Preferences/ <br/>
+		///   OS X:    ~/Library/Application Support/ <br/>
 		///   Windows: %APPDATA% [User's Home]/Appdata/Roaming <br/>
 		///   Linux:   ~/.config <br/>
 		/// </remarks>
@@ -24,7 +24,7 @@ namespace Eto
 		/// </summary>
 		/// <remarks>
 		/// In OS X, this will be the .app bundle's resource path.  Other platforms
-		/// will typically return the same path as the current executable file
+		/// will typically return the same path as the current executable file.
 		/// </remarks>
 		ApplicationResources,
 


### PR DESCRIPTION
- Use XDG_DOWNLOAD_DIR on Linux for EtoSpecialFolder.Downloads (Fix #2096) and the hardcoded download path for everything else.
- Use XDG_DOCUMENT_DIR on Linux for EtoSpecialFolder.Documents and the harcoded download folder for Mac
- Return XDG_CONFIG_HOME for EtoSpecialFolder.ApplicationSettings on Linux and HOME/Library/Preferences for Mac
- update some documentation

Note:
You *can* apparently rename core user folders in windows, and windows does update them somewhere in the registry. Thus, for EtoSpecialFolder.Downloads it would be more accurate to fetch the downloads folder from the registry.
The exact key is in `HKEY_CURRENT_USER\SOFTWARE\Microsoft\Windows\CurrentVersion\Explorer\Shell Folders\{374DE290-123F-4565-9164-39C4925E467B}`, however there's also a really neat warning with `!Do not use this registry key -    Use the SHGetFolderPath or SHGetKnownFolderPath function instead` 🙃 
