### PR TITLE
Wpf: Prevent mouse capture when dialogs are shown in MouseDown

### DIFF
--- a/src/Eto.Wpf/Forms/ApplicationHandler.cs
+++ b/src/Eto.Wpf/Forms/ApplicationHandler.cs
@@ -192,6 +192,7 @@ namespace Eto.Wpf.Forms
 			var frame = new DispatcherFrame();
 			Dispatcher.CurrentDispatcher.BeginInvoke(DispatcherPriority.Background, new DispatcherOperationCallback(ExitFrame), frame);
 			Dispatcher.PushFrame(frame);
+			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 		}
 
 		static object ExitFrame(object f)

--- a/src/Eto.Wpf/Forms/ColorDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/ColorDialogHandler.cs
@@ -96,6 +96,7 @@ namespace Eto.Wpf.Forms
 				Control.WindowStartupLocation = sw.WindowStartupLocation.CenterOwner;
 			}
 			var result = Control.ShowDialog();
+			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 			if (result == true)
 			{
 				Callback.OnColorChanged(Widget, EventArgs.Empty);

--- a/src/Eto.Wpf/Forms/FontDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/FontDialogHandler.cs
@@ -105,6 +105,7 @@ namespace Eto.Wpf.Forms
 			var lastFont = Font;
 
 			var result = Control.ShowDialog();
+			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 
 			if (result != true)
 			{

--- a/src/Eto.Wpf/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/MessageBoxHandler.cs
@@ -31,6 +31,7 @@ namespace Eto.Wpf.Forms
 				var caption = Caption ?? ((parent != null && parent.ParentWindow != null) ? parent.ParentWindow.Title : null);
 				if (window != null) result = WpfMessageBox.Show(window, Text, caption, buttons, icon, defaultButton);
 				else result = WpfMessageBox.Show(Text, caption, buttons, icon, defaultButton);
+				WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 				return Convert(result);
 			}
 		}

--- a/src/Eto.Wpf/Forms/Printing/PrintDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/Printing/PrintDialogHandler.cs
@@ -21,6 +21,7 @@ namespace Eto.Wpf.Forms.Printing
 		{
 			Control.SetEtoSettings(settings);
 			var result = Control.ShowDialog();
+			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 			if (result == true)
 			{
 				settings.SetFromDialog(Control);

--- a/src/Eto.Wpf/Forms/Printing/PrintPreviewDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/Printing/PrintPreviewDialogHandler.cs
@@ -64,6 +64,7 @@ namespace Eto.Wpf.Forms.Printing
 					
 					Control.Document = fixedDocument;
 					Control.ShowDialog();
+					WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 				}
 			}
 			finally

--- a/src/Eto.Wpf/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/SelectFolderDialogHandler.cs
@@ -14,6 +14,7 @@ namespace Eto.Wpf.Forms
 		public DialogResult ShowDialog (Window parent)
 		{
 			var dr = Control.ShowDialog ();
+			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 			return dr == swf.DialogResult.OK ? DialogResult.Ok : DialogResult.Cancel;
 		}
 

--- a/src/Eto.Wpf/Forms/VistaSelectFolderDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/VistaSelectFolderDialogHandler.cs
@@ -37,6 +37,7 @@ namespace Eto.Wpf.Forms
 			// don't use WPF window, parent might be a HwndFormHandler
 			var wpfParent = parent?.NativeHandle;
 			var result = wpfParent != null ? Control.ShowDialog(wpfParent.Value) : Control.ShowDialog();
+			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 #endif
 			switch (result)
 			{

--- a/src/Eto.Wpf/Forms/WpfCommonDialog.cs
+++ b/src/Eto.Wpf/Forms/WpfCommonDialog.cs
@@ -18,6 +18,7 @@ namespace Eto.Wpf.Forms
 			else {
 				result = Control.ShowDialog ();
 			}
+			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 			return result != null && result.Value ? DialogResult.Ok : DialogResult.Cancel;
 		}
 	}

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -1037,6 +1037,7 @@ namespace Eto.Wpf.Forms
 			{
 				dlg.PrintVisual(ContainerControl, string.Empty);
 			}
+			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1903