### PR TITLE
Wpf: Fix clicking on items in the GridView when MouseUp occurs on blank space

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -92,7 +92,7 @@ jobs:
       with:
         mono-version: latest
         xamarin-mac-version: latest
-        xcode-version: 13.1
+        xcode-version: latest
     
     - name: Import code signing certificate
       if: github.event_name != 'pull_request'

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
@@ -16,8 +16,8 @@
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
   
-  <PropertyGroup Condition="$(TargetFramework) == 'xamarinmac20'">
-    <LinkMode Condition="$(Configuration) == 'Release'">Platform</LinkMode>
+  <PropertyGroup Condition="$(TargetFramework) == 'xamarinmac20' or $(TargetFramework) == 'net6.0-macos'">
+    <LinkMode Condition="$(Configuration) == 'Release'">SdkOnly</LinkMode>
   </PropertyGroup>
   
   <ItemGroup>


### PR DESCRIPTION
If you click on an item which then changes the layout so that your mouse up occurs on a blank space then it deselects it again.