### PR TITLE
Mac: Fix crash when there are null values for TextBoxCell or ImageTextCell

### DIFF
--- a/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
@@ -189,7 +189,7 @@ namespace Eto.Mac.Forms.Cells
 				{
 					var val = value as MacImageData;
 
-					TextField.ObjectValue = val?.Text ?? NSString.Empty;
+					TextField.ObjectValue = (NSString)(val?.Text ?? string.Empty);
 					Image = val?.Image;
 					_objectValue = value;
 				}

--- a/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
@@ -57,9 +57,10 @@ namespace Eto.Mac.Forms.Cells
 			if (Widget.Binding != null)
 			{
 				var val = Widget.Binding.GetValue(dataItem);
-				return val != null ? new NSString(Convert.ToString(val)) : NSString.Empty;
+				var ret = val != null ? Convert.ToString(val) : string.Empty;
+				return (NSString)ret;
 			}
-			return NSString.Empty;
+			return (NSString)string.Empty;
 		}
 
 		public override void SetObjectValue(object dataItem, NSObject value)


### PR DESCRIPTION
Need to avoid the use of NSString.Empty which is a single static instance which then gets disposed causing a crash.