### PR TITLE
Mac: Fix intermittent crash resizing images

### DIFF
--- a/src/Eto.Mac/Messaging.cs
+++ b/src/Eto.Mac/Messaging.cs
@@ -142,9 +142,13 @@ namespace Eto.Mac
 
 		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern IntPtr IntPtr_objc_msgSendSuper_IntPtr_IntPtr_IntPtr_ref_CGPoint(IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2, IntPtr arg3, ref CGPoint arg4);
-		[DllImport (LIBOBJC_DYLIB, EntryPoint="objc_msgSend")]
-		public extern static void void_objc_msgSend_IntPtr_IntPtr (IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2);
-		
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		public extern static void void_objc_msgSend_IntPtr_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1, IntPtr arg2);
+
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSend")]
+		[return: MarshalAs(UnmanagedType.I1)]
+		public static extern bool bool_objc_msgSend_CGRect_CGRect_UIntPtr_nfloat_bool_IntPtr(IntPtr receiver, IntPtr selector, CGRect arg1, CGRect arg2, UIntPtr arg3, nfloat arg4, [MarshalAs(UnmanagedType.I1)] bool arg5, IntPtr arg6);
+
 	}
 }
 

--- a/src/Eto.Mac/NSImageExtensions.cs
+++ b/src/Eto.Mac/NSImageExtensions.cs
@@ -50,8 +50,9 @@ namespace Eto.Mac
 			return newimage;
 		}
 
-		// remove when XamMac supports null for draw hint dictionary
-		static NSDictionary DrawHints = new NSDictionary();
+#if XAMMAC
+		static IntPtr selDrawInRect_FromRect_Operation_Fraction_RespectFlipped_Hints_Handle = Selector.GetHandle("drawInRect:fromRect:operation:fraction:respectFlipped:hints:");
+#endif
 
 		public static NSImageRep Resize(this NSImageRep image, CGSize newsize, ImageInterpolation interpolation = ImageInterpolation.Default, CGSize? imageSize = null)
 		{
@@ -62,7 +63,12 @@ namespace Eto.Mac
 			NSGraphicsContext.GlobalSaveGraphicsState();
 			NSGraphicsContext.CurrentContext = graphics;
 			graphics.GraphicsPort.InterpolationQuality = interpolation.ToCG();
-			image.DrawInRect(new CGRect(CGPoint.Empty, newrep.Size), CGRect.Empty, NSCompositingOperation.SourceOver, 1f, true, DrawHints);
+#if XAMMAC
+			// Xamarin.Mac doesn't allow null for hints, remove this when it does.
+			Messaging.bool_objc_msgSend_CGRect_CGRect_UIntPtr_nfloat_bool_IntPtr(image.Handle, selDrawInRect_FromRect_Operation_Fraction_RespectFlipped_Hints_Handle, new CGRect(CGPoint.Empty, newrep.Size), CGRect.Empty, (UIntPtr)(ulong)NSCompositingOperation.SourceOver, 1f, true, IntPtr.Zero);
+#else
+			image.DrawInRect(new CGRect(CGPoint.Empty, newrep.Size), CGRect.Empty, NSCompositingOperation.SourceOver, 1f, true, null);
+#endif
 			NSGraphicsContext.GlobalRestoreGraphicsState();
 			return newrep;
 		}


### PR DESCRIPTION
The supposed long-lived DrawHints dictionary can sometimes get disposed for reasons unknown, so just omit it completely.