### PR TITLE
Mac: Fix expander animation and sizing

### DIFF
--- a/test/Eto.Test/Sections/Controls/ExpanderSection.cs
+++ b/test/Eto.Test/Sections/Controls/ExpanderSection.cs
@@ -15,7 +15,7 @@ namespace Eto.Test.Sections.Controls
 			var expander = new Expander
 			{
 				Header = "Test Header",
-				Content = new Panel {  Size = new Size(200, 200), BackgroundColor = Colors.Blue }
+				Content = new Panel { Size = new Size(200, 200), BackgroundColor = Colors.Blue }
 			};
 
 			expandedCheckBox.CheckedBinding.Bind(expander, e => e.Expanded);
@@ -26,12 +26,17 @@ namespace Eto.Test.Sections.Controls
 			var expander2 = new Expander
 			{
 				Header = new StackLayout
-				{ 
-					Orientation = Orientation.Horizontal, 
+				{
+					Orientation = Orientation.Horizontal,
 					Items = { "Test Expanded with custom header", new TextBox() }
 				},
 				Expanded = true,
-				Content = new Panel { Size = new Size(300, 200), BackgroundColor = Colors.Blue }
+				Content = new Panel
+				{
+					Size = new Size(300, 200),
+					BackgroundColor = Colors.Blue,
+					Content = new TableLayout("Top", null, "Bottom")
+				}
 			};
 
 			LogEvents(expander2);


### PR DESCRIPTION
The animation did not work as intended where it should fold down, and it didn't invalidate the measuring of the container view which should reposition it after animated.
Fixes #1710

Before:
![Kapture 2022-01-30 at 14 36 55](https://user-images.githubusercontent.com/367446/151720827-221ba003-c64b-4b45-9aa5-282f42eb21c3.gif)


After:
![Kapture 2022-01-30 at 14 32 42](https://user-images.githubusercontent.com/367446/151720681-b475cc41-8587-45b5-bbaf-72db2e376b5c.gif)
