### PR TITLE
Wpf: Fix issue closing windows during the LostFocus event

### DIFF
--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -227,7 +227,7 @@ namespace Eto.Wpf.Forms
 					Control.Activated += (sender, e) => Callback.OnGotFocus(Widget, EventArgs.Empty);
 					break;
 				case Eto.Forms.Control.LostFocusEvent:
-					Control.Deactivated += (sender, e) => Callback.OnLostFocus(Widget, EventArgs.Empty);
+					Control.LostKeyboardFocus += (sender, e) => Callback.OnLostFocus(Widget, EventArgs.Empty);
 					break;
 				case Window.LocationChangedEvent:
 					Control.LocationChanged += (sender, e) => Callback.OnLocationChanged(Widget, EventArgs.Empty);
@@ -407,7 +407,11 @@ namespace Eto.Wpf.Forms
 			{
 				// prevent crash if we call this more than once..
 				if (!IsClosing)
+				{
+					// Clear owner so WPF doesn't change the z-order of the parent when closing
+					SetOwner(null);
 					Control.Close();
+				}
 			}
 			else
 				Visible = false;

--- a/test/Eto.Test/UnitTests/Forms/WindowTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/WindowTests.cs
@@ -28,18 +28,21 @@ namespace Eto.Test.UnitTests.Forms
 				var rightPanel = new StackLayout { Orientation = Orientation.Horizontal };
 
 				var autoSize = new CheckBox { Text = "AutoSize", Checked = window.AutoSize };
-				autoSize.CheckedChanged += (sender, e) => {
+				autoSize.CheckedChanged += (sender, e) =>
+				{
 					window.AutoSize = autoSize.Checked == true;
 				};
 
 				var addBottomButton = new Button { Text = "Add bottom control" };
-				addBottomButton.Click += (sender, e) => {
+				addBottomButton.Click += (sender, e) =>
+				{
 					bottomPanel.Items.Add(new Panel { Size = new Size(20, 20) });
 					autoSize.Checked = window.AutoSize;
 				};
 
 				var addRightButton = new Button { Text = "Add right control" };
-				addRightButton.Click += (sender, e) => {
+				addRightButton.Click += (sender, e) =>
+				{
 					rightPanel.Items.Add(new Panel { Size = new Size(20, 20) });
 					autoSize.Checked = window.AutoSize;
 				};
@@ -120,7 +123,8 @@ namespace Eto.Test.UnitTests.Forms
 						window.Height = 150;
 				}
 
-				label.MouseDown += (sender, e) => {
+				label.MouseDown += (sender, e) =>
+				{
 					label.Text = infoText + Utility.GenerateLoremText(new Random().Next(200));
 				};
 
@@ -252,23 +256,52 @@ namespace Eto.Test.UnitTests.Forms
 				return layout;
 			});
 		}
-		
+
 		[Test, ManualTest]
 		public void WindowFromPointShouldReturnWindowUnderPoint()
 		{
 			ManualForm("Move your mouse, it should show the title of the window under the mouse pointer",
-			form => {
+			form =>
+			{
 				var content = new Panel { MinimumSize = new Size(100, 100) };
 				var timer = new UITimer { Interval = 0.5 };
-				timer.Elapsed += (sender, e) => {
+				timer.Elapsed += (sender, e) =>
+				{
 					var window = Window.FromPoint(Mouse.Position);
 					content.Content = $"Window: {window?.Title}";
 				};
 				timer.Start();
-				form.Closed += (sender, e) => {
-					timer.Stop();	
+				form.Closed += (sender, e) =>
+				{
+					timer.Stop();
 				};
 				form.Title = "Test Form";
+				return content;
+			}
+			);
+		}
+
+		[Test, ManualTest]
+		public void WindowShouldCloseOnLostFocusWithoutHidingParent()
+		{
+			ManualForm("Click on this window after the child is shown,\nthe form and the main form should not go behind other windows",
+			form =>
+			{
+				var content = new Panel { MinimumSize = new Size(100, 100) };
+				form.Shown += (sender, e) =>
+				{
+					var childForm = new Form
+					{
+						Title = "Child Form",
+						ClientSize = new Size(100, 100),
+						Owner = form
+					};
+					childForm.MouseDown += (s2, e2) => childForm.Close();
+					childForm.LostFocus += (s2, e2) => childForm.Close();
+					childForm.Show();
+				};
+				form.Title = "Test Form";
+				form.Owner = Application.Instance.MainForm;
 				return content;
 			}
 			);


### PR DESCRIPTION
This would cause parent windows to be moved behind other applications when the child form is closed.