### PR TITLE
Wpf: Fix crash when closing a Dialog

### DIFF
--- a/src/Eto.Wpf/Forms/FormHandler.cs
+++ b/src/Eto.Wpf/Forms/FormHandler.cs
@@ -56,6 +56,13 @@ namespace Eto.Wpf.Forms
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 		}
 
+		protected override void InternalClose()
+		{
+			// Clear owner so WPF doesn't change the z-order of the parent when closing
+			SetOwner(null);
+			Control.Close();
+		}
+
 		public bool ShowActivated
 		{
 			get { return Control.ShowActivated; }

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -400,6 +400,8 @@ namespace Eto.Wpf.Forms
 				toolBarHolder.Content = toolBar != null ? toolBar.ControlObject : null;
 			}
 		}
+		
+		protected virtual void InternalClose() => Control.Close();
 
 		public void Close()
 		{
@@ -408,9 +410,7 @@ namespace Eto.Wpf.Forms
 				// prevent crash if we call this more than once..
 				if (!IsClosing)
 				{
-					// Clear owner so WPF doesn't change the z-order of the parent when closing
-					SetOwner(null);
-					Control.Close();
+					InternalClose();
 				}
 			}
 			else


### PR DESCRIPTION
This was a regression introduced in #2131, calling Dialog.Close() causes the following exception:

```
System.InvalidOperationException: 'Cannot set Owner property after Dialog is shown.'
[External Code]	
Eto.Wpf.dll!Eto.Wpf.Forms.WpfWindow<System.Windows.Window, Eto.Forms.Dialog, Eto.Forms.Window.ICallback>.SetOwner(Eto.Forms.Window owner) Line 897	C#
Eto.Wpf.dll!Eto.Wpf.Forms.WpfWindow<System.Windows.Window, Eto.Forms.Dialog, Eto.Forms.Window.ICallback>.Close() Line 412	C#
Eto.dll!Eto.Forms.Window.Close() Line 327	C#
ZooClient.dll!ZooClient.ClientManager._PerformCloudZooTask.AnonymousMethod__5() Line 1952	C#
[External Code]	
Eto.Wpf.dll!Eto.Wpf.Forms.DialogHandler.ShowModal() Line 62	C#
Eto.dll!Eto.Forms.Dialog.ShowModal() Line 225	C#
Eto.dll!Eto.Forms.Dialog.ShowModal(Eto.Forms.Control owner) Line 207	C#
Eto.dll!Eto.Forms.Dialog<bool>.ShowModal(Eto.Forms.Control owner) Line 87	C#
```

