### PR TITLE
Wpf: Fix calling Window.LostFocus when focus changes within a window

### DIFF
--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -227,7 +227,11 @@ namespace Eto.Wpf.Forms
 					Control.Activated += (sender, e) => Callback.OnGotFocus(Widget, EventArgs.Empty);
 					break;
 				case Eto.Forms.Control.LostFocusEvent:
-					Control.LostKeyboardFocus += (sender, e) => Callback.OnLostFocus(Widget, EventArgs.Empty);
+					// LostKeyboardFocus is called for every child, only fire event when the form is no longer active
+					Control.LostKeyboardFocus += (sender, e) => {
+						if (!Control.IsActive)
+							Callback.OnLostFocus(Widget, EventArgs.Empty);
+					};
 					break;
 				case Window.LocationChangedEvent:
 					Control.LocationChanged += (sender, e) => Callback.OnLocationChanged(Widget, EventArgs.Empty);


### PR DESCRIPTION
Yet another follow up to #2131, which caused LostFocus to be called when a control loses focus within the window.