### PR TITLE
Wpf/WinForms: Fix more window active issues.

### DIFF
--- a/src/Eto.WinForms/Forms/DialogHandler.cs
+++ b/src/Eto.WinForms/Forms/DialogHandler.cs
@@ -79,6 +79,9 @@ namespace Eto.WinForms.Forms
 		public void ShowModal()
         {
             ReloadButtons();
+			var owner = Widget.Owner;
+			if (owner != null && !owner.HasFocus)
+				owner.Focus();
 
             Control.ShowDialog();
 			Control.Owner = null; // without this, the dialog is still active as part of the owner form

--- a/src/Eto.WinForms/Forms/FormHandler.cs
+++ b/src/Eto.WinForms/Forms/FormHandler.cs
@@ -138,6 +138,12 @@ namespace Eto.WinForms.Forms
 			Resizable = true;
 		}
 
+		internal override void InternalClosing()
+		{
+			base.InternalClosing();
+			SetOwner(null);
+		}
+
 		public void Show()
 		{
 			Control.Show();

--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -442,35 +442,20 @@ namespace Eto.WinForms.Forms
 
 		public void SuspendLayout()
 		{
-			throw new NotImplementedException();
 		}
 
 		public void ResumeLayout()
 		{
-			throw new NotImplementedException();
 		}
 
-		public void Focus()
-		{
-			throw new NotImplementedException();
-		}
+		public void Focus() => Win32.SetActiveWindow(Control);
 
-		public bool HasFocus
-		{
-			get { throw new NotImplementedException(); }
-		}
+		public bool HasFocus => Win32.GetActiveWindow() == Control;
 
 		public bool Visible
 		{
-			get
-			{
-				return Win32.IsWindowVisible(Control);
-			}
-			set
-			{
-				Win32.ShowWindow(Control, value ? Win32.SW.SHOWNA : Win32.SW.HIDE);
-			}
-
+			get => Win32.IsWindowVisible(Control);
+			set => Win32.ShowWindow(Control, value ? Win32.SW.SHOWNA : Win32.SW.HIDE);
 		}
 
 		public void OnPreLoad(EventArgs e)

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -285,6 +285,12 @@ namespace Eto
 		[DllImport("user32.dll")]
 		[return: MarshalAs(UnmanagedType.Bool)]
 		public static extern bool ShowWindow(IntPtr hWnd, SW nCmdShow);
+		
+		[DllImport("user32.dll")]
+		public static extern IntPtr GetActiveWindow();
+
+		[DllImport("user32.dll")]
+		public static extern IntPtr SetActiveWindow(IntPtr hWnd);
 
 		[DllImport("user32.dll")]
 		[return: MarshalAs(UnmanagedType.Bool)]

--- a/src/Eto.Wpf/Forms/DialogHandler.cs
+++ b/src/Eto.Wpf/Forms/DialogHandler.cs
@@ -12,8 +12,8 @@ namespace Eto.Wpf.Forms
 	{
 		Button defaultButton;
 		Rectangle? parentWindowBounds;
-        swc.DockPanel dockMain;
-        swc.Grid gridButtons;
+		swc.DockPanel dockMain;
+		swc.Grid gridButtons;
 
 		public DialogHandler() : this(new sw.Window()) { }
 
@@ -34,19 +34,19 @@ namespace Eto.Wpf.Forms
 			gridButtons.Margin = new sw.Thickness();
 		}
 
-        public override void SetContainerContent(sw.FrameworkElement content)
-        {
-            this.content.Children.Add(dockMain);
-            swc.DockPanel.SetDock(gridButtons, swc.Dock.Bottom);
-            dockMain.Children.Add(gridButtons);
-            dockMain.Children.Add(content);
-        }
+		public override void SetContainerContent(sw.FrameworkElement content)
+		{
+			this.content.Children.Add(dockMain);
+			swc.DockPanel.SetDock(gridButtons, swc.Dock.Bottom);
+			dockMain.Children.Add(gridButtons);
+			dockMain.Children.Add(content);
+		}
 
-        public DialogDisplayMode DisplayMode { get; set; }
+		public DialogDisplayMode DisplayMode { get; set; }
 
 		public void ShowModal()
 		{
-            ReloadButtons();
+			ReloadButtons();
 
 			if (LocationSet)
 			{
@@ -59,10 +59,13 @@ namespace Eto.Wpf.Forms
 				parentWindowBounds = Widget.Owner.Bounds;
 				Control.Loaded += HandleLoaded;
 			}
+			// if the owner doesn't have focus, WPF changes the owner's z-order after the dialog closes.
+			if (!Widget.Owner.HasFocus)
+				Widget.Owner?.Focus();
 			Control.ShowDialog();
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 
-            ClearButtons();
+			ClearButtons();
 		}
 
 		void Control_PreviewKeyDown(object sender, sw.Input.KeyEventArgs e)
@@ -99,59 +102,59 @@ namespace Eto.Wpf.Forms
 		}
 
 		private void ClearButtons()
-        {
-            gridButtons.ColumnDefinitions.Clear();
-            gridButtons.Children.Clear();
-        }
+		{
+			gridButtons.ColumnDefinitions.Clear();
+			gridButtons.Children.Clear();
+		}
 
-        private void ReloadButtons()
-        {
-            gridButtons.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = new sw.GridLength(100, sw.GridUnitType.Star) });
-            
-            var negativeButtons = Widget.NegativeButtons;
-            var positiveButtons = Widget.PositiveButtons;
-            var hasButtons = negativeButtons.Count + positiveButtons.Count > 0;
+		private void ReloadButtons()
+		{
+			gridButtons.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = new sw.GridLength(100, sw.GridUnitType.Star) });
 
-            for (int i = positiveButtons.Count - 1; i >= 0; i--)
-                AddButton(positiveButtons.Count - i, positiveButtons[i]);
+			var negativeButtons = Widget.NegativeButtons;
+			var positiveButtons = Widget.PositiveButtons;
+			var hasButtons = negativeButtons.Count + positiveButtons.Count > 0;
 
-            for (int i = 0;i < negativeButtons.Count;i++)
-                AddButton(positiveButtons.Count + 1 + i, negativeButtons[i]);
-            
-            gridButtons.Visibility = hasButtons ? System.Windows.Visibility.Visible : System.Windows.Visibility.Hidden;
-            gridButtons.Margin = new sw.Thickness(hasButtons ? 8 : 0);
-        }
+			for (int i = positiveButtons.Count - 1; i >= 0; i--)
+				AddButton(positiveButtons.Count - i, positiveButtons[i]);
 
-        private void AddButton(int pos, Button button)
-        {
-            var native = button.ToNative();
-            native.Margin = new sw.Thickness(6, 0, 0, 0);
+			for (int i = 0; i < negativeButtons.Count; i++)
+				AddButton(positiveButtons.Count + 1 + i, negativeButtons[i]);
 
-            swc.Grid.SetColumn(native, pos);
+			gridButtons.Visibility = hasButtons ? System.Windows.Visibility.Visible : System.Windows.Visibility.Hidden;
+			gridButtons.Margin = new sw.Thickness(hasButtons ? 8 : 0);
+		}
 
-            gridButtons.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = new sw.GridLength(1, sw.GridUnitType.Auto) });
-            gridButtons.Children.Add(native);
-        }
+		private void AddButton(int pos, Button button)
+		{
+			var native = button.ToNative();
+			native.Margin = new sw.Thickness(6, 0, 0, 0);
 
-        public void InsertDialogButton(bool positive, int index, Button item)
-        {
-            if(Widget.Visible)
-            {
-                ClearButtons();
-                ReloadButtons();
-            }
-        }
+			swc.Grid.SetColumn(native, pos);
 
-        public void RemoveDialogButton(bool positive, int index, Button item)
-        {
-            if (Widget.Visible)
-            {
-                ClearButtons();
-                ReloadButtons();
-            }
-        }
+			gridButtons.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = new sw.GridLength(1, sw.GridUnitType.Auto) });
+			gridButtons.Children.Add(native);
+		}
 
-        public Button DefaultButton
+		public void InsertDialogButton(bool positive, int index, Button item)
+		{
+			if (Widget.Visible)
+			{
+				ClearButtons();
+				ReloadButtons();
+			}
+		}
+
+		public void RemoveDialogButton(bool positive, int index, Button item)
+		{
+			if (Widget.Visible)
+			{
+				ClearButtons();
+				ReloadButtons();
+			}
+		}
+
+		public Button DefaultButton
 		{
 			get { return defaultButton; }
 			set

--- a/src/Eto.Wpf/Forms/DialogHandler.cs
+++ b/src/Eto.Wpf/Forms/DialogHandler.cs
@@ -48,20 +48,24 @@ namespace Eto.Wpf.Forms
 		{
 			ReloadButtons();
 
+			var owner = Widget.Owner;
+			
 			if (LocationSet)
 			{
 				Control.WindowStartupLocation = sw.WindowStartupLocation.Manual;
 			}
-			else if (Widget.Owner != null)
+			else if (owner != null)
 			{
 				// CenterOwner does not work in certain cases (e.g. with autosizing)
 				Control.WindowStartupLocation = sw.WindowStartupLocation.Manual;
-				parentWindowBounds = Widget.Owner.Bounds;
+				parentWindowBounds = owner.Bounds;
 				Control.Loaded += HandleLoaded;
 			}
-			// if the owner doesn't have focus, WPF changes the owner's z-order after the dialog closes.
-			if (!Widget.Owner.HasFocus)
-				Widget.Owner?.Focus();
+			
+			// if the owner doesn't have focus, windows changes the owner's z-order after the dialog closes.
+			if (owner != null && !owner.HasFocus)
+				owner.Focus();
+
 			Control.ShowDialog();
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 

--- a/src/Eto.Wpf/Forms/FormHandler.cs
+++ b/src/Eto.Wpf/Forms/FormHandler.cs
@@ -56,11 +56,10 @@ namespace Eto.Wpf.Forms
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 		}
 
-		protected override void InternalClose()
+		protected override void InternalClosing()
 		{
 			// Clear owner so WPF doesn't change the z-order of the parent when closing
 			SetOwner(null);
-			Control.Close();
 		}
 
 		public bool ShowActivated

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -281,6 +281,10 @@ namespace Eto.Wpf.Forms
 			e.Cancel = args.Cancel;
 			IsApplicationClosing = !e.Cancel && willShutDown;
 			IsClosing = !e.Cancel;
+			if (!e.Cancel)
+			{
+				InternalClosing();
+			}
 		}
 
 		float LastPixelSize
@@ -403,7 +407,9 @@ namespace Eto.Wpf.Forms
 			}
 		}
 		
-		protected virtual void InternalClose() => Control.Close();
+		protected virtual void InternalClosing()
+		{
+		}
 
 		public void Close()
 		{
@@ -412,7 +418,7 @@ namespace Eto.Wpf.Forms
 				// prevent crash if we call this more than once..
 				if (!IsClosing)
 				{
-					InternalClose();
+					Control.Close();
 				}
 			}
 			else

--- a/test/Eto.Test/UnitTests/Forms/DialogTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/DialogTests.cs
@@ -176,5 +176,45 @@ namespace Eto.Test.UnitTests.Forms
 			Assert.IsTrue(firstWasClosedFirst, "Modal 1 did not close before Modal 2");
 		}
 
+		[Test]
+		[ManualTest]
+		public void DialogShouldCloseWithoutHidingParent()
+		{
+			ManualForm("Click on the child window to open another child.\nClosing by clicking or hitting the 'x' should\nnot make any windows go behind other applications.",
+			form =>
+			{
+				var content = new Panel { MinimumSize = new Size(100, 100) };
+				form.Shown += (sender, e) =>
+				{
+					// this form is used so the parent of the dialog won't have focus when it is shown
+					var someOtherActivatingForm = new Form
+					{
+						ClientSize = new Size(100, 100), 
+						Content = TableLayout.AutoSized("Click Me", centered: true)
+					};
+					someOtherActivatingForm.LostFocus += (s2, e2) => someOtherActivatingForm.Close();
+					someOtherActivatingForm.MouseDown += (s3, e3) => {
+						
+						var childForm = new Dialog
+						{
+							Title = "Child Dialog",
+							ClientSize = new Size(100, 100),
+							Owner = form,
+							Content = TableLayout.AutoSized("Click Me too", centered: true)
+						};
+						childForm.MouseDown += (s2, e2) => childForm.Close();
+						
+						// form doesn't have focus here (yet)
+						childForm.ShowModal();
+					};
+					someOtherActivatingForm.Show();
+				};
+				form.Title = "Test Form";
+				form.Owner = Application.Instance.MainForm;
+				return content;
+			}
+			);
+		}
+
 	}
 }


### PR DESCRIPTION
- Fix closing a form with the 'x' vs. just programmatically.
- Fix window focus issues with Dialog if the owner does not have focus it'll mess up its z-order when closed.
Implement `HwndFormHandler.Focus()` and `HasFocus`
Relates to #2131.. this will get done properly eventually.. I swear..