### PR TITLE
Wpf/WinForms: Focus parent for all dialogs

### DIFF
--- a/src/Eto.WinForms/Forms/ColorDialogHandler.cs
+++ b/src/Eto.WinForms/Forms/ColorDialogHandler.cs
@@ -33,6 +33,9 @@ namespace Eto.WinForms.Forms
 			swf.DialogResult result;
 			if (customColors != null) Control.CustomColors = customColors;
 
+			if (parent?.HasFocus == false)
+				parent.Focus();
+
 			if (parent != null)
 				result = Control.ShowDialog(parent.GetContainerControl());
 			else

--- a/src/Eto.WinForms/Forms/FontDialogHandler.cs
+++ b/src/Eto.WinForms/Forms/FontDialogHandler.cs
@@ -58,6 +58,9 @@ namespace Eto.WinForms.Forms
 
 		public DialogResult ShowDialog(Window parent)
 		{
+			if (parent?.HasFocus == false)
+				parent.Focus();
+
 			var result = Control.ShowDialog();
 			if (result == swf.DialogResult.OK)
 			{

--- a/src/Eto.WinForms/Forms/MessageBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/MessageBoxHandler.cs
@@ -19,7 +19,11 @@ namespace Eto.WinForms.Forms
 
 		public DialogResult ShowDialog(Control parent)
 		{
-			var caption = Caption ?? ((parent != null && parent.ParentWindow != null) ? parent.ParentWindow.Title : null);
+			var parentWindow = parent?.ParentWindow;
+			if (parentWindow?.HasFocus == false)
+				parentWindow.Focus();
+
+			var caption = Caption ?? parentWindow?.Title;
 			swf.Control c = (parent == null) ? null : (swf.Control)parent.ControlObject;
 			swf.DialogResult result = swf.MessageBox.Show(c, Text, caption, Convert(Buttons), Convert(Type), Convert(DefaultButton, Buttons));
 			return result.ToEto();

--- a/src/Eto.WinForms/Forms/Printing/PrintDialogHandler.cs
+++ b/src/Eto.WinForms/Forms/Printing/PrintDialogHandler.cs
@@ -22,6 +22,9 @@ namespace Eto.WinForms.Forms.Printing
 
 		public DialogResult ShowDialog(Window parent)
 		{
+			if (parent?.HasFocus == false)
+				parent.Focus();
+
 			swf.DialogResult result;
 
 			Control.PrinterSettings = _printSettings.ToSD();

--- a/src/Eto.WinForms/Forms/Printing/PrintPreviewDialogHandler.cs
+++ b/src/Eto.WinForms/Forms/Printing/PrintPreviewDialogHandler.cs
@@ -58,6 +58,9 @@ namespace Eto.WinForms.Forms.Printing
 
 		public DialogResult ShowDialog(Window parent)
 		{
+			if (parent?.HasFocus == false)
+				parent.Focus();
+
 			swf.DialogResult result;
 			Control.Document = PrintDocumentHandler.GetControl(Document);
 

--- a/src/Eto.WinForms/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.WinForms/Forms/SelectFolderDialogHandler.cs
@@ -14,6 +14,9 @@ namespace Eto.WinForms.Forms
 
 		public DialogResult ShowDialog (Window parent)
 		{
+			if (parent?.HasFocus == false)
+				parent.Focus();
+
 			SWF.DialogResult dr;
 			if (parent != null) dr = Control.ShowDialog((SWF.IWin32Window)parent.ControlObject);
 			else dr = Control.ShowDialog();

--- a/src/Eto.WinForms/Forms/WindowsFileDialog.cs
+++ b/src/Eto.WinForms/Forms/WindowsFileDialog.cs
@@ -88,6 +88,9 @@ namespace Eto.WinForms.Forms
 
 		public DialogResult ShowDialog(Window parent)
 		{
+			if (parent?.HasFocus == false)
+				parent.Focus();
+
 			SetFilters();
 
 			swf.DialogResult dr;

--- a/src/Eto.Wpf/Forms/ColorDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/ColorDialogHandler.cs
@@ -91,6 +91,8 @@ namespace Eto.Wpf.Forms
 		{
 			if (parent != null)
 			{
+				if (!parent.HasFocus)
+					parent.Focus();
 				var owner = parent.ControlObject as sw.Window;
 				Control.Owner = owner;
 				Control.WindowStartupLocation = sw.WindowStartupLocation.CenterOwner;

--- a/src/Eto.Wpf/Forms/FontDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/FontDialogHandler.cs
@@ -98,6 +98,8 @@ namespace Eto.Wpf.Forms
 		{
 			if (parent != null)
 			{
+				if (!parent.HasFocus)
+					parent.Focus();
 				var owner = parent.ControlObject as sw.Window;
 				Control.Owner = owner;
 				Control.WindowStartupLocation = sw.WindowStartupLocation.CenterOwner;

--- a/src/Eto.Wpf/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/MessageBoxHandler.cs
@@ -22,13 +22,17 @@ namespace Eto.Wpf.Forms
 		{
 			using (var visualStyles = new EnableThemingInScope(ApplicationHandler.EnableVisualStyles))
 			{
+				var parentWindow = parent?.ParentWindow;
+				if (parentWindow?.HasFocus == false)
+					parentWindow.Focus();
+
 				var element = parent == null ? null : parent.GetContainerControl();
 				var window = element == null ? null : element.GetVisualParent<sw.Window>();
 				sw.MessageBoxResult result;
 				var buttons = Convert(Buttons);
 				var defaultButton = Convert(DefaultButton, Buttons);
 				var icon = Convert(Type);
-				var caption = Caption ?? ((parent != null && parent.ParentWindow != null) ? parent.ParentWindow.Title : null);
+				var caption = Caption ?? parentWindow?.Title;
 				if (window != null) result = WpfMessageBox.Show(window, Text, caption, buttons, icon, defaultButton);
 				else result = WpfMessageBox.Show(Text, caption, buttons, icon, defaultButton);
 				WpfFrameworkElementHelper.ShouldCaptureMouse = false;

--- a/src/Eto.Wpf/Forms/Printing/PrintDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/Printing/PrintDialogHandler.cs
@@ -19,6 +19,9 @@ namespace Eto.Wpf.Forms.Printing
 
 		public DialogResult ShowDialog(Window parent)
 		{
+			if (parent?.HasFocus == false)
+				parent.Focus();
+
 			Control.SetEtoSettings(settings);
 			var result = Control.ShowDialog();
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;

--- a/src/Eto.Wpf/Forms/Printing/PrintPreviewDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/Printing/PrintPreviewDialogHandler.cs
@@ -41,6 +41,9 @@ namespace Eto.Wpf.Forms.Printing
 
 		public DialogResult ShowDialog(Window parent)
 		{
+			if (parent?.HasFocus == false)
+				parent.Focus();
+
 			var print = new swc.PrintDialog();
 			print.SetEtoSettings(PrintSettings);
 			Control.Owner = parent?.ToNative();

--- a/src/Eto.Wpf/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/SelectFolderDialogHandler.cs
@@ -13,7 +13,10 @@ namespace Eto.Wpf.Forms
 
 		public DialogResult ShowDialog (Window parent)
 		{
-			var dr = Control.ShowDialog ();
+			if (parent?.HasFocus == false)
+				parent.Focus();
+
+			var dr = Control.ShowDialog();
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 			return dr == swf.DialogResult.OK ? DialogResult.Ok : DialogResult.Cancel;
 		}

--- a/src/Eto.Wpf/Forms/VistaSelectFolderDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/VistaSelectFolderDialogHandler.cs
@@ -20,6 +20,9 @@ namespace Eto.Wpf.Forms
 
 		public DialogResult ShowDialog(Window parent)
 		{
+			if (parent?.HasFocus == false)
+				parent.Focus();
+				
 #if WINFORMS
 			// use reflection since adding a parameter requires us to reference PresentationFramework which we don't want in winforms
 			cp.CommonFileDialogResult result;

--- a/src/Eto.Wpf/Forms/WpfFileDialog.cs
+++ b/src/Eto.Wpf/Forms/WpfFileDialog.cs
@@ -67,6 +67,8 @@ namespace Eto.Wpf.Forms
 
 		public override DialogResult ShowDialog(Window parent)
 		{
+			if (parent?.HasFocus == false)
+				parent.Focus();
 			SetFilters();
 			return base.ShowDialog(parent);
 		}


### PR DESCRIPTION
If the parent does not have focus, Windows likes to either not show the message box, then also orders the form behind other windows.  This is obviously not the intention when showing a dialog.