### PR TITLE
Handle newlines in FormattedText

### DIFF
--- a/src/Eto.Gtk/Drawing/FormattedTextHandler.cs
+++ b/src/Eto.Gtk/Drawing/FormattedTextHandler.cs
@@ -1,47 +1,182 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
 using Eto.Drawing;
 
 namespace Eto.GtkSharp.Drawing
 {
 	public class FormattedTextHandler : WidgetHandler<object, FormattedText, FormattedText.ICallback>, FormattedText.IHandler
 	{
-		public FormattedTextWrapMode Wrap { get; set; }
-		public FormattedTextTrimming Trimming { get; set; }
-		public string Text { get; set; }
-		public SizeF MaximumSize { get; set; } = SizeF.MaxValue;
-		public Font Font { get; set; }
-		public Brush ForegroundBrush { get; set; } = new SolidBrush(SystemColors.ControlText);
-		public FormattedTextAlignment Alignment { get; set; }
-		public int MaximumLineCount { get; set; }
+		FormattedTextWrapMode _wrap;
+		FormattedTextTrimming _trimming;
+		string _text;
+		SizeF _maximumSize = SizeF.MaxValue;
+		Font _font;
+		Brush _foregroundBrush = new SolidBrush(SystemColors.ControlText);
+		FormattedTextAlignment _alignment;
+		int _maximumLineCount;
+		bool _shouldClip;
+
+		public FormattedTextWrapMode Wrap
+		{
+			get => _wrap;
+			set
+			{
+				if (_wrap != value)
+				{
+					_wrap = value;
+					Invalidate();
+				}
+			}
+		}
+		public FormattedTextTrimming Trimming
+		{
+			get => _trimming;
+			set
+			{
+				if (_trimming != value)
+				{
+					_trimming = value;
+					Invalidate();
+				}
+			}
+		}
+		public string Text
+		{
+			get => _text;
+			set
+			{
+				if (_text != value)
+				{
+					_text = value;
+					Invalidate();
+				}
+			}
+		}
+
+		public SizeF MaximumSize
+		{
+			get => _maximumSize;
+			set
+			{
+				if (_maximumSize != value)
+				{
+					_maximumSize = value;
+					Invalidate();
+				}
+			}
+		}
+		
+		public Font Font
+		{
+			get => _font;
+			set
+			{
+				if (_font != value)
+				{
+					_font = value;
+					Invalidate();
+				}
+			}
+		}
+		
+		public Brush ForegroundBrush
+		{
+			get => _foregroundBrush;
+			set
+			{
+				if (_foregroundBrush != value)
+				{
+					_foregroundBrush = value;
+					Invalidate();
+				}
+			}
+		}
+		
+		public FormattedTextAlignment Alignment
+		{
+			get => _alignment;
+			set
+			{
+				if (_alignment != value)
+				{
+					_alignment = value;
+					Invalidate();
+				}
+			}
+		}
+		public int MaximumLineCount
+		{
+			get => _maximumLineCount;
+			set
+			{
+				if (_maximumLineCount != value)
+				{
+					_maximumLineCount = value;
+					Invalidate();
+				}
+			}
+		}
+		
+		void Invalidate()
+		{
+			_layout?.Dispose();
+			_layout = null;
+		}
 
 		public SizeF Measure()
 		{
 			// can we do this more lightweight than creating a control?
-			using (var ctl = new Gtk.Label())
-			using (var layout = new Pango.Layout(ctl.PangoContext))
+			if (_layout == null)
 			{
-				Setup(layout);
-				layout.GetPixelSize(out var width, out var height);
-				return new SizeF(width, height);
+				EnsureLayout(new Gtk.Label().PangoContext);
 			}
+			_layout.GetPixelSize(out var width, out var height);
+			var size = new SizeF(width, height);
+			if (Wrap == FormattedTextWrapMode.None && IsUnlimited(MaximumSize.Width))
+				size.Width = Math.Min(MaximumSize.Width, width);
+			return size;
 		}
+
+		const int MaxLayoutSize = 1000000;
 
 		void Setup(Pango.Layout layout)
 		{
 			Font.Apply(layout);
-			layout.Width = (int)(MaximumSize.Width * Pango.Scale.PangoScale);
+			var hasNewlines = Text.IndexOf('\n') != -1;
+			_shouldClip = false;
+			var isRightOrCenter = Alignment == FormattedTextAlignment.Right || Alignment == FormattedTextAlignment.Center;
+			var size = SizeF.Min(MaximumSize, new SizeF(MaxLayoutSize, MaxLayoutSize));
+			if (size.Width <= 0)
+				size.Width = MaxLayoutSize;
+			if (size.Height <= 0)
+				size.Height = MaxLayoutSize;
+
+			layout.Width = (int)(size.Width * Pango.Scale.PangoScale);
+				
 #if GTK3
-			layout.Height = (int)(MaximumSize.Height * Pango.Scale.PangoScale);
+			layout.Height = (int)(size.Height * Pango.Scale.PangoScale);
 #endif
 			layout.Ellipsize = Trimming == FormattedTextTrimming.None ? Pango.EllipsizeMode.None : Pango.EllipsizeMode.End;
 			switch (Wrap)
 			{
 				case FormattedTextWrapMode.None:
-					// only draw one line!!
 					layout.Wrap = Pango.WrapMode.Char;
+
+					if (Trimming == FormattedTextTrimming.None || hasNewlines || (isRightOrCenter && !hasNewlines))
+					{
+						_shouldClip = true;
+						layout.Width = (int)(MaxLayoutSize * Pango.Scale.PangoScale);
+					}
+					// if (_shouldClip)
+					// 	layout.Width = (int)(MaxLayoutSize * Pango.Scale.PangoScale);
 #if GTK3
-					layout.Height = (int)((double)layout.FontDescription.Size / (double)Pango.Scale.PangoScale);
+					// only draw a single line so we can do ellipsizing
+					if (!hasNewlines)
+						layout.Height = layout.FontDescription.Size;
 #endif
+
 					break;
 				case FormattedTextWrapMode.Word:
 					layout.Wrap = Pango.WrapMode.Word;
@@ -67,16 +202,18 @@ namespace Eto.GtkSharp.Drawing
 					break;
 			}
 			layout.SetText(Text);
-			if (Wrap == FormattedTextWrapMode.None && layout.LineCount > 1)
+			if ((layout.Width >= MaxLayoutSize || !hasNewlines) && isRightOrCenter)
 			{
-				// line includes the full last word so keep shrinking until it isn't wrapped
-				var len = layout.GetLine(0).Length;
-				while (len > 0 && layout.IsWrapped)
-				{
-					layout.SetText(Text.Substring(0, len--));
-				}
+				layout.GetPixelSize(out var width, out var height);
+				if (hasNewlines)
+					layout.Width = (int)(width * Pango.Scale.PangoScale);
+				else if (IsUnlimited(MaximumSize.Width))
+					layout.Width = (int)(Math.Max(width, MaximumSize.Width) * Pango.Scale.PangoScale);
+				else
+					layout.Width = (int)(Math.Min(width, MaximumSize.Width) * Pango.Scale.PangoScale);
+				
 			}
-			if (Trimming == FormattedTextTrimming.None && layout.LineCount > 1)
+			if (Trimming == FormattedTextTrimming.None && layout.LineCount > 1 && IsUnlimited(MaximumSize.Height))
 			{
 				layout.GetPixelSize(out _, out var height);
 				while (layout.LineCount > 1 && height > MaximumSize.Height)
@@ -106,15 +243,34 @@ namespace Eto.GtkSharp.Drawing
 			}
 		}
 
-		public void Draw(GraphicsHandler graphics, Pango.Layout layout, Cairo.Context context, PointF location)
+		Pango.Layout _layout;
+
+		bool IsUnlimited(float value) => value < float.MaxValue || value <= 0;
+
+		public void Draw(GraphicsHandler graphics, Cairo.Context context, PointF location)
 		{
-			Setup(layout);
+			EnsureLayout(graphics.PangoContext);
 			context.Save();
+			if (_shouldClip && IsUnlimited(MaximumSize.Width))
+			{
+				context.Rectangle(new Cairo.Rectangle(location.X, location.Y, Math.Min(MaxLayoutSize, MaximumSize.Width), Math.Min(MaxLayoutSize, MaximumSize.Height)));
+				context.Clip();
+			}
 			ForegroundBrush.Apply(graphics);
 			context.MoveTo(location.X, location.Y);
-			Pango.CairoHelper.LayoutPath(context, layout);
+			Pango.CairoHelper.LayoutPath(context, _layout);
 			context.Fill();
 			context.Restore();
+		}
+
+		private void EnsureLayout(Pango.Context context)
+		{
+			if (_layout == null || _layout.Context.Handle != context.Handle)
+			{
+				_layout?.Dispose();
+				_layout = new Pango.Layout(context);
+				Setup(_layout);
+			}
 		}
 	}
 }

--- a/src/Eto.Gtk/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Gtk/Drawing/GraphicsHandler.cs
@@ -403,11 +403,8 @@ namespace Eto.GtkSharp.Drawing
 			var oldAA = AntiAlias;
 			AntiAlias = true;
 			SetOffset(false);
-			using (var layout = CreateLayout())
-			{
-				var handler = (FormattedTextHandler)formattedText.Handler;
-				handler.Draw(this, layout, Control, location);
-			}
+			var handler = (FormattedTextHandler)formattedText.Handler;
+			handler.Draw(this, Control, location);
 			AntiAlias = oldAA;
 		}
 

--- a/test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
+++ b/test/Eto.Test/Sections/Behaviors/AllControlsBase.cs
@@ -41,7 +41,16 @@ namespace Eto.Test.Sections.Behaviors
 				layout.Add(GroupBoxControl());
 			layout.Add(TableLayoutControl());
 			layout.EndHorizontal();
+
+			layout.BeginHorizontal();
+			layout.AddSpace();
+			layout.Add(ExpanderControl());
+			layout.EndHorizontal();
+
 			layout.EndVertical();
+
+
+
 			layout.Add(null);
 
 			Content = layout;
@@ -52,6 +61,27 @@ namespace Eto.Test.Sections.Behaviors
 		protected virtual Control CreateOptions()
 		{
 			return null;
+		}
+
+		Control ExpanderControl()
+		{
+			var control = new Expander
+			{
+				Header = "Expander",
+				Expanded = true,
+				Content = new Panel
+				{
+					Size = new Size(100, 100),
+					Content = new Label
+					{
+						VerticalAlignment = VerticalAlignment.Center,
+						TextAlignment = TextAlignment.Center,
+						Text = "Content"
+					}
+				}
+			};
+			LogEvents(control);
+			return control;
 		}
 
 		Control LabelControl()
@@ -210,7 +240,7 @@ namespace Eto.Test.Sections.Behaviors
 		Control DrawableControl()
 		{
 			var control = new Drawable { Size = new Size(100, 30), CanFocus = true };
-			control.Paint += delegate(object sender, PaintEventArgs pe)
+			control.Paint += delegate (object sender, PaintEventArgs pe)
 			{
 				pe.Graphics.FillRectangle(Brushes.Blue, pe.ClipRectangle);
 				var size = pe.Graphics.MeasureString(SystemFonts.Label(), "Drawable");

--- a/test/Eto.Test/Sections/Controls/LabelSection.cs
+++ b/test/Eto.Test/Sections/Controls/LabelSection.cs
@@ -129,7 +129,7 @@ namespace Eto.Test.Sections.Controls
 		{
 			var label = new Label
 			{
-				Text = Utility.LoremText
+				Text = Utility.LoremTextWithTwoParagraphs
 			};
 
 			var wrapDropDown = new EnumDropDown<WrapMode>();

--- a/test/Eto.Test/Sections/Controls/RichTextAreaSection.cs
+++ b/test/Eto.Test/Sections/Controls/RichTextAreaSection.cs
@@ -12,7 +12,7 @@ namespace Eto.Test.Sections.Controls
 	{
 		public static string RtfString = "{\\rtf1\\ansi\\ansicpg1252\\cocoartf1343\\cocoasubrtf160\r\n{\\fonttbl\\f0\\fswiss\\fcharset0 Helvetica;}\r\n{\\colortbl;\\red255\\green255\\blue255;}\r\n\\margl1440\\margr1440\\vieww10800\\viewh8400\\viewkind0\r\n\\pard\\tx566\\tx1133\\tx1700\\tx2267\\tx2834\\tx3401\\tx3968\\tx4535\\tx5102\\tx5669\\tx6236\\tx6803\\pardirnatural\r\n\r\n\\f0\\fs24 \\cf0 This is some \r\n\\b bold\r\n\\b0 , \r\n\\i italic\r\n\\i0 , and \\ul underline\\ulnone  text! \\\r\n\\\r\n\\pard\\tx566\\tx1133\\tx1700\\tx2267\\tx2834\\tx3401\\tx3968\\tx4535\\tx5102\\tx5669\\tx6236\\tx6803\\pardirnatural\\qr\r\n\\cf0 Some other text}";
 
-		static string LastText = Utility.LoremText;
+		static string LastText = Utility.LoremTextWithTwoParagraphs;
 
 		public RichTextAreaSection()
 		{

--- a/test/Eto.Test/Sections/Controls/TextAreaSection.cs
+++ b/test/Eto.Test/Sections/Controls/TextAreaSection.cs
@@ -15,7 +15,7 @@ namespace Eto.Test.Sections.Controls
 
 		Control Default()
 		{
-			var text = new TextArea { Text = Utility.LoremText };
+			var text = new TextArea { Text = Utility.LoremTextWithTwoParagraphs };
 			LogEvents(text);
 
 			return new TableLayout

--- a/test/Eto.Test/Sections/Drawing/FormattedTextSection.cs
+++ b/test/Eto.Test/Sections/Drawing/FormattedTextSection.cs
@@ -10,13 +10,36 @@ namespace Eto.Test.Sections.Drawing
 	{
 		public FormattedTextSection()
 		{
+			Styles.Add<Label>(null, l => l.VerticalAlignment = VerticalAlignment.Center);
+			
 			var font = SystemFonts.Default();
 			var color = Colors.White;
 
+			var formattedTextSingleLine = new FormattedText
+			{
+				Text = "Some text with no new lines that should have an ellipsis when not wrapped",
+				MaximumSize = new SizeF(500, float.MaxValue),
+				Wrap = FormattedTextWrapMode.Word,
+				Trimming = FormattedTextTrimming.CharacterEllipsis,
+				ForegroundBrush = Brushes.White,
+				//ForegroundBrush = new LinearGradientBrush(Colors.White, Colors.Blue, new PointF(0, 0), new PointF(200, 200)),
+				Font = font
+			};
+
 			var formattedText = new FormattedText
 			{
-				Text = Utility.LoremText,
-				MaximumSize = new SizeF(200, 100),
+				Text = Utility.LoremTextWithTwoParagraphs,
+				MaximumSize = new SizeF(500, 80),
+				Wrap = FormattedTextWrapMode.Word,
+				Trimming = FormattedTextTrimming.CharacterEllipsis,
+				ForegroundBrush = Brushes.White,
+				//ForegroundBrush = new LinearGradientBrush(Colors.White, Colors.Blue, new PointF(0, 0), new PointF(200, 200)),
+				Font = font
+			};
+
+			var formattedTextWithNewLines = new FormattedText
+			{
+				Text = Utility.LoremTextWithNewLines,
 				Wrap = FormattedTextWrapMode.Word,
 				Trimming = FormattedTextTrimming.CharacterEllipsis,
 				ForegroundBrush = Brushes.White,
@@ -29,52 +52,78 @@ namespace Eto.Test.Sections.Drawing
 			{
 				var g = e.Graphics;
 
-				var location = new Point(10, 10);
+				var location = new PointF(10, 10);
 
 				g.DrawText(font, color, location, "Single Line Text That Will Not Wrap 漢字");
 
 				location.Y += 40;
+				
 				var rect = new RectangleF(location, new SizeF(300, 20));
 				g.DrawRectangle(Colors.Blue, rect);
 				g.DrawText(font, new SolidBrush(color), rect, "Should Be Right Aligned", FormattedTextWrapMode.None, FormattedTextAlignment.Right, FormattedTextTrimming.None);
 
 				location.Y += 40;
 
-				g.DrawRectangle(Colors.Blue, new RectangleF(location, formattedText.MaximumSize));
+				var sizeSingleLine = formattedTextSingleLine.Measure();
+				g.DrawText(formattedTextSingleLine, location);
+				g.DrawRectangle(Colors.Silver, new RectangleF(location, sizeSingleLine));
 
+				location.Y += sizeSingleLine.Height + 20;
+
+				g.DrawRectangle(Colors.Blue, new RectangleF(location, formattedText.MaximumSize));
 				var size = formattedText.Measure();
 				g.DrawText(formattedText, location);
 				g.DrawRectangle(Colors.Silver, new RectangleF(location, size));
+
+				location.Y += (int)formattedText.MaximumHeight + 20;
+
+				var sizeWithNewLines = formattedTextWithNewLines.Measure();
+				g.DrawText(formattedTextWithNewLines, location);
+				g.DrawRectangle(Colors.Silver, new RectangleF(location, sizeWithNewLines));
+				
 			};
 
 			var wrapMode = new EnumDropDown<FormattedTextWrapMode>();
 			wrapMode.SelectedValueBinding.Bind(formattedText, f => f.Wrap);
+			wrapMode.SelectedValueBinding.Bind(formattedTextWithNewLines, f => f.Wrap);
+			wrapMode.SelectedValueBinding.Bind(formattedTextSingleLine, f => f.Wrap);
 			wrapMode.SelectedValueChanged += (sender, e) => control.Invalidate();
 
 			var trimming = new EnumDropDown<FormattedTextTrimming>();
 			trimming.SelectedValueBinding.Bind(formattedText, f => f.Trimming);
+			trimming.SelectedValueBinding.Bind(formattedTextWithNewLines, f => f.Trimming);
+			trimming.SelectedValueBinding.Bind(formattedTextSingleLine, f => f.Trimming);
 			trimming.SelectedValueChanged += (sender, e) => control.Invalidate();
 
 			var alignment = new EnumDropDown<FormattedTextAlignment>();
 			alignment.SelectedValueBinding.Bind(formattedText, f => f.Alignment);
+			alignment.SelectedValueBinding.Bind(formattedTextWithNewLines, f => f.Alignment);
+			alignment.SelectedValueBinding.Bind(formattedTextSingleLine, f => f.Alignment);
 			alignment.SelectedValueChanged += (sender, e) => control.Invalidate();
 
 			var fontSelection = new FontPicker();
 			fontSelection.ValueBinding.Bind(formattedText, f => f.Font);
+			fontSelection.ValueBinding.Bind(formattedTextWithNewLines, f => f.Font);
+			fontSelection.ValueBinding.Bind(formattedTextSingleLine, f => f.Font);
 			fontSelection.ValueChanged += (sender, e) => control.Invalidate();
 
 			var maxSizeEntry = new SizeFEntry();
 			maxSizeEntry.ValueBinding.Bind(formattedText, f => f.MaximumSize);
+			maxSizeEntry.ValueBinding.Child(r => r.Width).Bind(formattedTextSingleLine, f => (int)f.MaximumSize.Width);
 			maxSizeEntry.ValueChanged += (sender, e) => control.Invalidate();
 
 			var layout = new DynamicLayout();
+			layout.DefaultSpacing = new Size(4, 4);
 
 			layout.BeginCentered();
 
-			layout.AddSeparateRow("Wrap:", wrapMode, null);
-			layout.AddSeparateRow("Trimming:", trimming, null);
-			layout.AddSeparateRow("Alignment:", alignment, null);
-			layout.AddSeparateRow("Font:", fontSelection, null);
+			layout.AddSeparateRow(
+				"Wrap:", wrapMode,
+				"Trimming:", trimming,
+				"Alignment:", alignment,
+				"Font:", fontSelection,
+				null
+				);
 			layout.AddSeparateRow("MaximumSize:", maxSizeEntry, null);
 
 

--- a/test/Eto.Test/UnitTests/Drawing/FontTests.cs
+++ b/test/Eto.Test/UnitTests/Drawing/FontTests.cs
@@ -9,7 +9,7 @@ using System.Threading.Tasks;
 namespace Eto.Test.UnitTests.Drawing
 {
 	[TestFixture]
-	public class FontTests
+	public class FontTests : TestBase
 	{
 		[Test]
 		public async Task FontShouldWorkInMultipleThreads()
@@ -30,5 +30,16 @@ namespace Eto.Test.UnitTests.Drawing
 				}
 			});
 		}
+
+		[Test]
+		public void FontMeasureStringShouldWorkForMultiLineStrings() => Invoke(() =>
+		{
+			var font = Fonts.Sans(10);
+			var singleLineSize = font.MeasureString("A single-line string!");
+			var multiLineSize = font.MeasureString("A\nmulti\nline\nstring!");
+			Console.WriteLine($"Single-line: {singleLineSize}, Multi-line: {multiLineSize}");
+			Assert.Greater(multiLineSize.Height, singleLineSize.Height, "#1 The multi-line string does not have a greater height than the single line");
+			Assert.Less(multiLineSize.Width, singleLineSize.Width, "#2 The multi-line string should not be as wide as the single line string");
+		});
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/WindowTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/WindowTests.cs
@@ -96,7 +96,7 @@ namespace Eto.Test.UnitTests.Forms
 				const string infoText = "Click to change text.\n";
 				var label = new Label();
 				label.TextColor = Colors.White;
-				label.Text = infoText + Utility.LoremText;
+				label.Text = infoText + Utility.LoremTextWithTwoParagraphs;
 
 				Window window = useForm ? (Window)new Form { ShowActivated = false } : new Dialog();
 				window.AutoSize = true;

--- a/test/Eto.Test/Utility.cs
+++ b/test/Eto.Test/Utility.cs
@@ -4,11 +4,12 @@ namespace Eto.Test
 {
 	public static class Utility
 	{
-		public static string LoremText = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+		public static string LoremTextWithTwoParagraphs = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+		public static string LoremTextWithNewLines = "Lorem ipsum dolor sit amet,\nconsectetur adipiscing elit,\nsed do eiusmod tempor incididunt ut labore et dolore magna aliqua.\nUt enim ad minim veniam,\nquis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.\nDuis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.\nExcepteur sint occaecat cupidatat non proident,\nsunt in culpa qui officia deserunt mollit anim id est laborum.";
 
 		public static string GenerateLoremText(int length)
 		{
-			var words = LoremText.Split(' ');
+			var words = LoremTextWithTwoParagraphs.Split(' ');
 			var sb = new StringBuilder();
 			var loremIndex = 0;
 			for (int i = 0; i < length; i++)


### PR DESCRIPTION
This allows you to measure and draw text that has newlines. There's still some issues on WPF and Gtk where multiple paragraph strings won't align right/center each paragraph separately when wrapping is turned off, but this makes this immensely more useful.

Some additional changes:

- WinForms: Fixed issue where single lines or last lines in the paragraph were justified, but they should not be.
- Gtk: Improved performance of FormattedText in most cases, and caches the pango layout instead of creating it each time it is drawn/measured.

