### PR TITLE
Wpf: Trigger SubMenuItem.Opening/Closing for proper controls

### DIFF
--- a/src/Eto.Wpf/Forms/Menu/MenuItemHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/MenuItemHandler.cs
@@ -134,6 +134,9 @@ namespace Eto.Wpf.Forms.Menu
 
 		protected virtual void HandleContextMenuOpening(object sender, sw.RoutedEventArgs e)
 		{
+			if (e.OriginalSource != Control)
+				return;
+
 			var submenu = Widget as ISubmenu;
 			if (submenu != null)
 			{

--- a/src/Eto.Wpf/Forms/Menu/SubMenuItemHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/SubMenuItemHandler.cs
@@ -46,12 +46,14 @@ namespace Eto.Wpf.Forms.Menu
 
 		private void Control_SubmenuClosed(object sender, RoutedEventArgs e)
 		{
-			Callback.OnClosed(Widget, EventArgs.Empty);
+			if (e.OriginalSource == Control)
+				Callback.OnClosed(Widget, EventArgs.Empty);
 		}
 
 		protected override void HandleContextMenuOpening(object sender, RoutedEventArgs e)
 		{
-			Callback.OnOpening(Widget, EventArgs.Empty);
+			if (e.OriginalSource == Control)
+				Callback.OnOpening(Widget, EventArgs.Empty);
 			base.HandleContextMenuOpening(sender, e);
 		}
 

--- a/test/Eto.Test/Sections/Behaviors/ContextMenuSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ContextMenuSection.cs
@@ -86,7 +86,7 @@ namespace Eto.Test.Sections.Behaviors
 		{
 			if (_menu != null)
 				return _menu;
-			
+
 			_menu = new ContextMenu();
 
 			_menu.Opening += (sender, e) => Log.Write(sender, "Opening");
@@ -106,18 +106,25 @@ namespace Eto.Test.Sections.Behaviors
 
 
 			var dynamicSubMenu = new SubMenuItem { Text = "Dynamic Sub Menu" };
-			dynamicSubMenu.Opening += (sender, e) => {
-				Log.Write(dynamicSubMenu, "Opening");
+			LogEvents(dynamicSubMenu);
+			dynamicSubMenu.Opening += (sender, e) =>
+			{
 				dynamicSubMenu.Items.Add(new ButtonMenuItem { Text = "Dynamic Item 1" });
 				dynamicSubMenu.Items.Add(new ButtonMenuItem { Text = "Dynamic Item 2" });
 				dynamicSubMenu.Items.Add(new ButtonMenuItem { Text = "Dynamic Item 3", Enabled = false });
+				var dynamicSubMenu2 = new SubMenuItem { Text = "Dynamic Sub Menu2" };
+				LogEvents(dynamicSubMenu2);
+				dynamicSubMenu2.Opening += (s2, e2) =>
+				{
+					dynamicSubMenu2.Items.Add(new ButtonMenuItem { Text = "Dynamic Item 1" });
+					dynamicSubMenu2.Items.Add(new ButtonMenuItem { Text = "Dynamic Item 2" });
+					dynamicSubMenu2.Items.Add(new ButtonMenuItem { Text = "Dynamic Item 3", Enabled = false });
+				};
+				dynamicSubMenu.Items.Add(dynamicSubMenu2);
 				LogEvents(dynamicSubMenu);
 			};
-			dynamicSubMenu.Closing += (sender, e) => {
-				Log.Write(dynamicSubMenu, "Closing");
-			};
-			dynamicSubMenu.Closed += (sender, e) => {
-				Log.Write(dynamicSubMenu, "Closed");
+			dynamicSubMenu.Closed += (sender, e) =>
+			{
 				dynamicSubMenu.Items.Clear();
 			};
 
@@ -179,6 +186,23 @@ namespace Eto.Test.Sections.Behaviors
 					menu.Show();
 			};
 			return label;
+		}
+
+		void LogEvents(SubMenuItem subMenuItem)
+		{
+			subMenuItem.Closing += (s2, e2) =>
+			{
+				Log.Write(subMenuItem, $"Closing {subMenuItem.Text}");
+			};
+			subMenuItem.Closed += (s2, e2) =>
+			{
+				Log.Write(subMenuItem, $"Closed {subMenuItem.Text}");
+			};
+			subMenuItem.Opening += (s2, e2) =>
+			{
+				Log.Write(subMenuItem, $"Opening {subMenuItem.Text}");
+			};
+
 		}
 
 		void LogEvents(ISubmenu menu)


### PR DESCRIPTION
This prevents the events from firing of parent menus when a child menu opens/closes.