### PR TITLE
Mac: Fix GroupBox preferred size when set explicitly

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,7 +91,7 @@ jobs:
       uses: maxim-lobanov/setup-xamarin@v1
       with:
         mono-version: latest
-        xamarin-mac-version: latest
+        xamarin-mac-version: 8.6
         xcode-version: latest
     
     - name: Import code signing certificate

--- a/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
@@ -125,10 +125,10 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		public override SizeF GetPreferredSize(SizeF availableSize)
+		protected override SizeF GetNaturalSize(SizeF availableSize)
 		{
 			var borderSize = _borderSize ?? (_borderSize = CalculateBorderSize()) ?? SizeF.Empty;
-			return base.GetPreferredSize(availableSize - borderSize) + borderSize;
+			return base.GetNaturalSize(availableSize - borderSize) + borderSize;
 		}
 
 		SizeF CalculateBorderSize()


### PR DESCRIPTION
If you set the GroupBox size explicitly, the preferred size would add the border size of the group box causing it to get the wrong size.