### PR TITLE
Wpf: RichTextArea should not auto size to width of constraints

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
@@ -109,6 +109,12 @@ namespace Eto.Wpf.Forms.Controls
 			};
 			Wrap = true;
 		}
+		
+		protected override void Initialize()
+		{
+			base.Initialize();
+			UserPreferredSize = DefaultSize; // otherwise it grows to the constraint, which we don't want.
+		}
 
 		public override sw.Size MeasureOverride(sw.Size constraint, Func<sw.Size, sw.Size> measure)
 		{

--- a/test/Eto.Test/UnitTests/Forms/Controls/TextAreaTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TextAreaTests.cs
@@ -10,7 +10,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 	}
 
 	public class TextAreaTests<T> : TestBase
-		where T: TextArea, new()
+		where T : TextArea, new()
 	{
 		[Test]
 		public void CheckSelectionTextCaretAfterSettingText()
@@ -117,5 +117,14 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				Assert.AreEqual(string.Empty, textArea.SelectedText, "SelectedText should *still* be empty not null after setting text");
 			});
 		}
+
+		[Test]
+		[ManualTest]
+		public void ScaledShouldNotGrowDialog() => Invoke(() =>
+		{
+			var dlg = new Dialog();
+			dlg.Content = new T() { Text = "Hello!  The dialog should not grow too large or anything, and should make this text wrap." };
+			dlg.ShowModal();
+		}, -1);
 	}
 }


### PR DESCRIPTION
When the RichTextArea isn't given a size then it'd grow to the constraint which is usually the size of the display(s) the form is shown on. 