### PR TITLE
Update Windows API CodePack

### DIFF
--- a/src/Eto.WinForms/Eto.WinForms.csproj
+++ b/src/Eto.WinForms/Eto.WinForms.csproj
@@ -14,8 +14,7 @@
     <OutputType>Library</OutputType>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);WINFORMS</DefineConstants>
-    <!-- Suppress warning NU1701: Package 'Windows7APICodePack-Core 1.1.0' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v3.0'. This package may not be fully compatible with your project. -->
-    <NoWarn>NU1701;MSB4011;$(NoWarn)</NoWarn>
+    <NoWarn>MSB4011;$(NoWarn)</NoWarn>
     <UseWindowsForms Condition="$(HaveWindowsDesktopSdk) == 'True'">true</UseWindowsForms>
   </PropertyGroup>
   
@@ -117,7 +116,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Windows7APICodePack-Shell" Version="1.1.0" />
+    <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
   	<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1020.30" PrivateAssets="all" />
   </ItemGroup>
 

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -19,8 +19,6 @@
     <UseWPF Condition="$(HaveWindowsDesktopSdk) == 'True'">true</UseWPF>
     <UseWindowsForms Condition="$(HaveWindowsDesktopSdk) == 'True'">true</UseWindowsForms>
     <!-- Suppress warning NU1701: Package 'Extended.Wpf.Toolkit 3.2.0' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v3.0'. This package may not be fully compatible with your project. -->
-    <!-- Suppress warning NU1701: Package 'Windows7APICodePack-Core 1.1.0' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v3.0'. This package may not be fully compatible with your project. -->
-    <!-- Suppress warning NU1701: Package 'Windows7APICodePack-Shell 1.1.0' was restored using '.NETFramework,Version=v4.6.1' instead of the project target framework '.NETCoreApp,Version=v3.0'. This package may not be fully compatible with your project. -->
     <NoWarn>NU1701;MSB4011;$(NoWarn)</NoWarn>
   </PropertyGroup>
   
@@ -154,7 +152,7 @@ You do not need to use any of the classes of this assembly (unless customizing t
   
   <ItemGroup>
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.6.0" />
-    <PackageReference Include="Windows7APICodePack-Shell" Version="1.1.0" />
+    <PackageReference Include="Microsoft-WindowsAPICodePack-Shell" Version="1.1.4" />
   	<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1020.30" PrivateAssets="all" />
   </ItemGroup>
 


### PR DESCRIPTION
This package appears to have better support and is more well used.  It also has .NET Core/6 support eliminating some of the warnings when compiling.

Cite #1807