### PR TITLE
Gtk: Ensure handler is not null in connector before using it

### DIFF
--- a/src/Eto.Gtk/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/CellHandler.cs
@@ -146,7 +146,7 @@ namespace Eto.GtkSharp.Forms.Cells
 
 			public void HandleEditingStarted(object o, Gtk.EditingStartedArgs args)
 			{
-				Handler.Source.BeginCellEditing(new Gtk.TreePath(args.Path), Handler.ColumnIndex);
+				Handler?.Source.BeginCellEditing(new Gtk.TreePath(args.Path), Handler.ColumnIndex);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Cells/CheckBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/CheckBoxCellHandler.cs
@@ -75,12 +75,12 @@ namespace Eto.GtkSharp.Forms.Cells
 
 			public void HandleToggled(object o, Gtk.ToggledArgs args)
 			{
-				Handler.SetValue(args.Path, !Handler.Control.Active);
+				Handler?.SetValue(args.Path, !Handler.Control.Active);
 			}
 
 			public void HandleEndCellEditing(object o, Gtk.ToggledArgs args)
 			{
-				Handler.Source.EndCellEditing(new Gtk.TreePath(args.Path), Handler.ColumnIndex);
+				Handler?.Source.EndCellEditing(new Gtk.TreePath(args.Path), Handler.ColumnIndex);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Cells/ComboBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ComboBoxCellHandler.cs
@@ -89,12 +89,12 @@ namespace Eto.GtkSharp.Forms.Cells
 
 			public void HandleEdited(object o, Gtk.EditedArgs args)
 			{
-				Handler.SetValue(args.Path, args.NewText);
+				Handler?.SetValue(args.Path, args.NewText);
 			}
 
 			public void HandleEndEditing(object o, Gtk.EditedArgs args)
 			{
-				Handler.Source.EndCellEditing(new Gtk.TreePath(args.Path), Handler.ColumnIndex);
+				Handler?.Source.EndCellEditing(new Gtk.TreePath(args.Path), Handler.ColumnIndex);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ImageTextCellHandler.cs
@@ -89,12 +89,12 @@ namespace Eto.GtkSharp.Forms.Cells
 
 			public void HandleEdited(object o, Gtk.EditedArgs args)
 			{
-				Handler.SetValue(args.Path, args.NewText);
+				Handler?.SetValue(args.Path, args.NewText);
 			}
 
 			public void HandleEndCellEditing(object o, Gtk.EditedArgs args)
 			{
-				Handler.Source.EndCellEditing(new Gtk.TreePath(args.Path), Handler.ColumnIndex);
+				Handler?.Source.EndCellEditing(new Gtk.TreePath(args.Path), Handler.ColumnIndex);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/TextBoxCellHandler.cs
@@ -163,12 +163,12 @@ namespace Eto.GtkSharp.Forms.Cells
 
 			public void HandleEdited(object o, Gtk.EditedArgs args)
 			{
-				Handler.SetValue(args.Path, args.NewText);
+				Handler?.SetValue(args.Path, args.NewText);
 			}
 
 			public void HandleEndEditing(object o, Gtk.EditedArgs args)
 			{
-				Handler.Source.EndCellEditing(new Gtk.TreePath(args.Path), Handler.ColumnIndex);
+				Handler?.Source.EndCellEditing(new Gtk.TreePath(args.Path), Handler.ColumnIndex);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/CheckBoxHandler.cs
@@ -41,6 +41,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleToggled(object sender, EventArgs e)
 			{
 				var h = Handler;
+				if (h == null)
+					return;
 				var c = h.Control;
 				if (toggling)
 					return;

--- a/src/Eto.Gtk/Forms/Controls/ColorPickerHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ColorPickerHandler.cs
@@ -37,7 +37,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleSelectedColorChanged(object sender, EventArgs e)
 			{
-				Handler.Callback.OnColorChanged(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnColorChanged(Handler.Widget, EventArgs.Empty);
 			}
 		}
 #if GTK3

--- a/src/Eto.Gtk/Forms/Controls/DateTimePickerHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DateTimePickerHandler.cs
@@ -31,7 +31,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleDateChanged(object sender, EventArgs e)
 			{
-				Handler.Callback.OnValueChanged(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnValueChanged(Handler.Widget, EventArgs.Empty);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
@@ -61,8 +61,11 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleDrawableButtonPressEvent(object o, Gtk.ButtonPressEventArgs args)
 			{
-				if (Handler.CanFocus)
-					Handler.Control.GrabFocus();
+				var handler = Handler;
+				if (handler == null)
+					return;
+				if (handler.CanFocus)
+					handler.Control.GrabFocus();
 			}
 
 #if GTK2
@@ -82,21 +85,23 @@ namespace Eto.GtkSharp.Forms.Controls
 			[GLib.ConnectBefore]
 			public void HandleDrawn(object o, Gtk.DrawnArgs args)
 			{
-				var h = Handler;
+				var handler = Handler;
+				if (handler == null)
+					return;
 
-				var allocation = h.Control.Allocation.Size;
+				var allocation = handler.Control.Allocation.Size;
 				args.Cr.Rectangle(new Cairo.Rectangle(0, 0, allocation.Width, allocation.Height));
 				args.Cr.Clip();
 				Gdk.Rectangle rect = new Gdk.Rectangle();
 				if (!GraphicsHandler.GetClipRectangle(args.Cr, ref rect))
 					rect = new Gdk.Rectangle(Gdk.Point.Zero, allocation);
 
-				using (var graphics = new Graphics(new GraphicsHandler(args.Cr, h.Control.PangoContext, false)))
+				using (var graphics = new Graphics(new GraphicsHandler(args.Cr, handler.Control.PangoContext, false)))
 				{
-					if (h.SelectedBackgroundColor != null)
-						graphics.Clear(h.SelectedBackgroundColor.Value);
+					if (handler.SelectedBackgroundColor != null)
+						graphics.Clear(handler.SelectedBackgroundColor.Value);
 					
-					h.Callback.OnPaint(h.Widget, new PaintEventArgs(graphics, rect.ToEto()));
+					handler.Callback.OnPaint(handler.Widget, new PaintEventArgs(graphics, rect.ToEto()));
 				}
 			}
 #endif

--- a/src/Eto.Gtk/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DropDownHandler.cs
@@ -67,12 +67,16 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public virtual void HandleChanged(object sender, EventArgs e)
 			{
-				if (Handler.SuppressIndexChanged > 0)
+				var handler = Handler;
+				if (handler == null)
 					return;
-				var newIndex = Handler.SelectedIndex;
+					
+				if (handler.SuppressIndexChanged > 0)
+					return;
+				var newIndex = handler.SelectedIndex;
 				if (newIndex != lastIndex)
 				{
-					Handler.Callback.OnSelectedIndexChanged(Handler.Widget, EventArgs.Empty);
+					handler.Callback.OnSelectedIndexChanged(handler.Widget, EventArgs.Empty);
 					lastIndex = newIndex;
 				}
 			}
@@ -80,21 +84,25 @@ namespace Eto.GtkSharp.Forms.Controls
 #if GTK2
 			internal void HandlePopupShownChanged(object o, GLib.NotifyArgs args)
 			{
-				if (Handler.Control.PopupShown)
-					Handler.Callback.OnDropDownOpening(Handler.Widget, EventArgs.Empty);
+				var handler = Handler;
+				if (handler == null)
+					return;
+
+				if (handler.Control.PopupShown)
+					handler.Callback.OnDropDownOpening(handler.Widget, EventArgs.Empty);
 				else
-					Handler.Callback.OnDropDownClosed(Handler.Widget, EventArgs.Empty);
+					handler.Callback.OnDropDownClosed(handler.Widget, EventArgs.Empty);
 			}
 #elif GTK3
 			[GLib.ConnectBefore]
 			public virtual void HandlePoppedUp(object sender, EventArgs e)
 			{
-				Handler.Callback.OnDropDownOpening(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnDropDownOpening(Handler.Widget, EventArgs.Empty);
 			}
 
 			public virtual void HandlePoppedDown(object o, Gtk.PoppedDownArgs args)
 			{
-				Handler.Callback.OnDropDownClosed(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnDropDownClosed(Handler.Widget, EventArgs.Empty);
 			}
 #endif
 		}

--- a/src/Eto.Gtk/Forms/Controls/ExpanderHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ExpanderHandler.cs
@@ -25,7 +25,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleActivated(object sender, EventArgs e)
 			{
-				Handler.Callback.OnExpandedChanged(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnExpandedChanged(Handler.Widget, EventArgs.Empty);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/FontPickerHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/FontPickerHandler.cs
@@ -53,7 +53,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleValueChanged(object sender, EventArgs e)
 			{
-				Handler.Callback.OnValueChanged(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnValueChanged(Handler.Widget, EventArgs.Empty);
 			}
 		}
 	}

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -167,6 +167,9 @@ namespace Eto.GtkSharp.Forms.Controls
 				}
 
 				var handler = Handler;
+				if (handler == null)
+					return;
+					
 				if (handler.contextMenu != null && args.Event.Button == 3 && args.Event.Type == Gdk.EventType.ButtonPress)
 				{
 					var menu = ((ContextMenuHandler)handler.contextMenu.Handler).Control;
@@ -199,12 +202,15 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleGridSelectionChanged(object sender, EventArgs e)
 			{
-				if (!Handler.SkipSelectedChange)
+				var handler = Handler;
+				if (handler == null)
+					return;
+				if (!handler.SkipSelectedChange)
 				{
-					var selected = Handler.SelectedRows.ToArray();
+					var selected = handler.SelectedRows.ToArray();
 					if (!ArraysEqual(selectedRows, selected))
 					{
-						Handler.Callback.OnSelectionChanged(Handler.Widget, EventArgs.Empty);
+						handler.Callback.OnSelectionChanged(handler.Widget, EventArgs.Empty);
 						selectedRows = selected;
 					}
 				}

--- a/src/Eto.Gtk/Forms/Controls/ImageViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ImageViewHandler.cs
@@ -51,11 +51,15 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				Gdk.EventExpose ev = args.Event;
 				var h = Handler;
+				if (h == null)
+					return;
 				var handler = new GraphicsHandler(h.Control, ev.Window);
 #else
 			public void HandleDrawn(object o, Gtk.DrawnArgs args)
 			{
 				var h = Handler;
+				if (h == null)
+					return;
 				var handler = new GraphicsHandler(args.Cr, h.Control.CreatePangoContext(), false);
 #endif
 				if (h.image == null)

--- a/src/Eto.Gtk/Forms/Controls/LinkButtonHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/LinkButtonHandler.cs
@@ -79,7 +79,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleClicked(object sender, EventArgs e)
 			{
-				Handler.Callback.OnClick(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnClick(Handler.Widget, EventArgs.Empty);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
@@ -63,9 +63,12 @@ namespace Eto.GtkSharp.Forms.Controls
 			[GLib.ConnectBefore]
 			public void HandleTreeButtonPressEvent(object o, Gtk.ButtonPressEventArgs args)
 			{
-				if (Handler.contextMenu != null && args.Event.Button == 3 && args.Event.Type == Gdk.EventType.ButtonPress)
+				var handler = Handler;
+				if (handler == null)
+					return;
+				if (handler.contextMenu != null && args.Event.Button == 3 && args.Event.Type == Gdk.EventType.ButtonPress)
 				{
-					var menu = (Gtk.Menu)Handler.contextMenu.ControlObject;
+					var menu = (Gtk.Menu)handler.contextMenu.ControlObject;
 					menu.Popup();
 					menu.ShowAll();
 				}
@@ -73,12 +76,12 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleSelectionChanged(object sender, EventArgs e)
 			{
-				Handler.Callback.OnSelectedIndexChanged(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnSelectedIndexChanged(Handler.Widget, EventArgs.Empty);
 			}
 
 			public void HandleTreeRowActivated(object o, Gtk.RowActivatedArgs args)
 			{
-				Handler.Callback.OnActivated(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnActivated(Handler.Widget, EventArgs.Empty);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
@@ -53,10 +53,13 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleValueChanged(object sender, EventArgs e)
 			{
-				if (Handler.SuppressValueChanged <= 0)
+				var handler = Handler;
+				if (handler == null)
+					return;
+				if (handler.SuppressValueChanged <= 0)
 				{
-					Handler.UpdateRequiredDigits();
-					Handler.Callback.OnValueChanged(Handler.Widget, EventArgs.Empty);
+					handler.UpdateRequiredDigits();
+					handler.Callback.OnValueChanged(handler.Widget, EventArgs.Empty);
 				}
 			}
 
@@ -67,17 +70,19 @@ namespace Eto.GtkSharp.Forms.Controls
 			[GLib.ConnectBefore]
 			public void HandleInput(object o, InputArgs args)
 			{
-				var h = Handler;
-				if (h.NeedsFormat)
+				var handler = Handler;
+				if (handler == null)
+					return;
+				if (handler.NeedsFormat)
 				{
-					var text = h.Text;
-					if (h.HasFormatString)
-						text = Regex.Replace(text, $@"(?!\d|{Regex.Escape(h.CultureInfo.NumberFormat.NumberDecimalSeparator)}|{Regex.Escape(h.CultureInfo.NumberFormat.NegativeSign)}).", ""); // strip any non-numeric value
+					var text = handler.Text;
+					if (handler.HasFormatString)
+						text = Regex.Replace(text, $@"(?!\d|{Regex.Escape(handler.CultureInfo.NumberFormat.NumberDecimalSeparator)}|{Regex.Escape(handler.CultureInfo.NumberFormat.NegativeSign)}).", ""); // strip any non-numeric value
 
 					double result;
-					if (double.TryParse(text, NumberStyles.Any, h.CultureInfo, out result))
+					if (double.TryParse(text, NumberStyles.Any, handler.CultureInfo, out result))
 					{
-						if (h.HasFormatString && result > 0 && NumberStringsMatch((-result).ToString(h.FormatString, h.CultureInfo), h.Text))
+						if (handler.HasFormatString && result > 0 && NumberStringsMatch((-result).ToString(handler.FormatString, handler.CultureInfo), handler.Text))
 							result = -result;
 
 						args.NewValue = result;
@@ -85,20 +90,22 @@ namespace Eto.GtkSharp.Forms.Controls
 						return;
 					}
 				}
-				args.NewValue = h.Control.Adjustment.Value;
+				args.NewValue = handler.Control.Adjustment.Value;
 				args.RetVal = 0;
 			}
 
 			[GLib.ConnectBefore]
 			public void HandleOutput(object o, OutputArgs args)
 			{
-				var h = Handler;
-				if (h.NeedsFormat)
+				var handler = Handler;
+				if (handler == null)
+					return;
+				if (handler.NeedsFormat)
 				{
-					var val = h.Control.Adjustment.Value;
-					var format = h.CurrentFormatString;
-					var text = format == null ? val.ToString(h.CultureInfo) : val.ToString(format, h.CultureInfo);
-					h.Control.Text = text;
+					var val = handler.Control.Adjustment.Value;
+					var format = handler.CurrentFormatString;
+					var text = format == null ? val.ToString(handler.CultureInfo) : val.ToString(format, handler.CultureInfo);
+					handler.Control.Text = text;
 					args.RetVal = 1;
 					return;
 				}

--- a/src/Eto.Gtk/Forms/Controls/PasswordBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/PasswordBoxHandler.cs
@@ -40,7 +40,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleTextChanged(object sender, EventArgs e)
 			{
-				Handler.Callback.OnTextChanged(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnTextChanged(Handler.Widget, EventArgs.Empty);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/RadioButtonHandler.cs
@@ -65,10 +65,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			public new RadioButtonHandler Handler { get { return (RadioButtonHandler)base.Handler; } }
 
-			public void HandleCheckedChanged(object sender, EventArgs e)
-			{
-				Handler.Callback.OnCheckedChanged(Handler.Widget, EventArgs.Empty);
-			}
+			public void HandleCheckedChanged(object sender, EventArgs e) => Handler?.Callback.OnCheckedChanged(Handler.Widget, EventArgs.Empty);
 
 			internal void Control_Realized(object sender, EventArgs e) => Handler?.Control_Realized(sender, e);
 		}

--- a/src/Eto.Gtk/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ScrollableHandler.cs
@@ -127,9 +127,12 @@ namespace Eto.GtkSharp.Forms.Controls
 #if GTK2
 			public void HandleControlSizeRequested(object o, Gtk.SizeRequestedArgs args)
 			{
-				if (Handler.autoSize)
+				var handler = Handler;
+				if (handler == null)
+					return;
+				if (handler.autoSize)
 				{
-					args.Requisition = Handler.vp.SizeRequest();
+					args.Requisition = handler.vp.SizeRequest();
 				}
 			}
 
@@ -150,12 +153,12 @@ namespace Eto.GtkSharp.Forms.Controls
 #endif
 			public void HandleScrollbarVisibilityChanged(object sender, EventArgs e)
 			{
-				Handler.Callback.OnSizeChanged(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnSizeChanged(Handler.Widget, EventArgs.Empty);
 			}
 
 			public void HandleScrollableScrollEvent(object sender, EventArgs e)
 			{
-				Handler.Callback.OnScroll(Handler.Widget, new ScrollEventArgs(Handler.ScrollPosition));
+				Handler?.Callback.OnScroll(Handler.Widget, new ScrollEventArgs(Handler.ScrollPosition));
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/SliderHandler.cs
@@ -39,13 +39,16 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleScaleValueChanged(object sender, EventArgs e)
 			{
-				var scale = Handler.scale;
-				var tick = Handler.tick;
+				var handler = Handler;
+				if (handler == null)
+					return;
+				var scale = handler.scale;
+				var tick = handler.tick;
 				var value = (int)scale.Value;
 				if (tick > 0)
 				{
 					var offset = value % tick;
-					if (Handler.SnapToTick && offset != 0)
+					if (handler.SnapToTick && offset != 0)
 					{
 						// snap to the tick
 						if (offset > tick / 2)
@@ -58,7 +61,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 				if (lastValue == null || lastValue.Value != value)
 				{
-					Handler.Callback.OnValueChanged(Handler.Widget, EventArgs.Empty);
+					handler.Callback.OnValueChanged(handler.Widget, EventArgs.Empty);
 					lastValue = value;
 				}
 			}

--- a/src/Eto.Gtk/Forms/Controls/StepperHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/StepperHandler.cs
@@ -157,7 +157,10 @@ namespace Eto.GtkSharp.Forms.Controls
 			[GLib.ConnectBefore]
 			public void HandleInput(object o, Gtk.InputArgs args)
 			{
-				args.NewValue = Handler.Control.Value;
+				var handler = Handler;
+				if (handler == null)
+					return;
+				args.NewValue = handler.Control.Value;
 				args.RetVal = 1;
 			}
 		}

--- a/src/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
@@ -76,6 +76,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleBufferChanged(object sender, EventArgs e)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				if (handler.suppressSelectionAndTextChanged == 0)
 					handler.Callback.OnTextChanged(Handler.Widget, EventArgs.Empty);
 			}
@@ -83,6 +85,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleSelectionChanged(object o, Gtk.MarkSetArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				var selection = handler.Selection;
 				if (handler.suppressSelectionAndTextChanged == 0 && selection != lastSelection)
 				{
@@ -94,6 +98,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleCaretIndexChanged(object o, Gtk.MarkSetArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				var caretIndex = handler.CaretIndex;
 				if (handler.suppressSelectionAndTextChanged == 0 && caretIndex != lastCaretIndex)
 				{
@@ -104,8 +110,11 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleApplyTag(object sender, EventArgs e)
 			{
-				var buffer = Handler.Control.Buffer;
-				var tag = Handler.tag;
+				var handler = Handler;
+				if (handler == null)
+					return;
+				var buffer = handler.Control.Buffer;
+				var tag = handler.tag;
 				buffer.ApplyTag(tag, buffer.StartIter, buffer.EndIter);
 			}
 		}

--- a/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
@@ -96,7 +96,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleTextChanged(object sender, EventArgs e)
 			{
-				Handler.Callback.OnTextChanged(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnTextChanged(Handler.Widget, EventArgs.Empty);
 			}
 
 			static Clipboard clipboard;
@@ -136,13 +136,16 @@ namespace Eto.GtkSharp.Forms.Controls
 			[GLib.ConnectBefore]
 			public void HandleTextDeleted(object o, Gtk.TextDeletedArgs args)
 			{
+				var handler = Handler;
+				if (handler == null)
+					return;
 				if (!deleting)
 				{
 					deleting = true;
 					if (args.StartPos < args.EndPos)
 					{
-						var tia = new TextChangingEventArgs(string.Empty, new Range<int>(args.StartPos, Math.Min(args.EndPos - 1, Handler.Control.Text.Length - 1)), true);
-						Handler.Callback.OnTextChanging(Handler.Widget, tia);
+						var tia = new TextChangingEventArgs(string.Empty, new Range<int>(args.StartPos, Math.Min(args.EndPos - 1, handler.Control.Text.Length - 1)), true);
+						handler.Callback.OnTextChanging(handler.Widget, tia);
 						if (tia.Cancel)
 							args.RetVal = true;
 					}
@@ -168,22 +171,25 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public virtual void HandleExposeEvent(object o, Gtk.ExposeEventArgs args)
 			{
-				var control = Handler.Control;
+				var handler = Handler;
+				if (handler == null)
+					return;
+				var control = handler.Control;
 				if (!string.IsNullOrEmpty(control.Text) || args.Event.Window == control.GdkWindow)
 					return;
 
-				if (Handler.placeholderLayout == null)
+				if (handler.placeholderLayout == null)
 				{
-					Handler.placeholderLayout = new Pango.Layout(control.PangoContext);
-					Handler.placeholderLayout.FontDescription = control.PangoContext.FontDescription.Copy();
+					handler.placeholderLayout = new Pango.Layout(control.PangoContext);
+					handler.placeholderLayout.FontDescription = control.PangoContext.FontDescription.Copy();
 				}
-				Handler.placeholderLayout.SetText(Handler.placeholderText);
+				handler.placeholderLayout.SetText(handler.placeholderText);
 
 				int currentHeight, currentWidth;
 				args.Event.Window.GetSize(out currentWidth, out currentHeight);
 
 				int width, height;
-				Handler.placeholderLayout.GetPixelSize(out width, out height);
+				handler.placeholderLayout.GetPixelSize(out width, out height);
 
 				var style = control.Style;
 				var bc = style.Base(Gtk.StateType.Normal);
@@ -195,13 +201,13 @@ namespace Eto.GtkSharp.Forms.Controls
 
 					gc.RgbFgColor = new Gdk.Color((byte)(((int)bc.Red + tc.Red) / 2 / 256), (byte)(((int)bc.Green + (int)tc.Green) / 2 / 256), (byte)((bc.Blue + tc.Blue) / 2 / 256));
 
-					args.Event.Window.DrawLayout(gc, 2, (currentHeight - height) / 2 + 1, Handler.placeholderLayout);
+					args.Event.Window.DrawLayout(gc, 2, (currentHeight - height) / 2 + 1, handler.placeholderLayout);
 				}
 			}
 
 #endif
 		}
-		#if GTK2
+#if GTK2
 		Pango.Layout placeholderLayout;
 
 		public override Eto.Drawing.Font Font
@@ -213,7 +219,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				placeholderLayout = null;
 			}
 		}
-		#else
+#else
 		protected override void SetBackgroundColor(Eto.Drawing.Color? color)
 		{
 		}

--- a/src/Eto.Gtk/Forms/Controls/TextStepperHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextStepperHandler.cs
@@ -163,7 +163,10 @@ namespace Eto.GtkSharp.Forms.Controls
 #if GTK2
 			public override void HandleExposeEvent(object o, Gtk.ExposeEventArgs args)
 			{
-				if (args.Event.Window == Handler.Control.GdkWindow.Children[0]) // skip painting over up/down
+				var handler = Handler;
+				if (handler == null)
+					return;
+				if (args.Event.Window == handler.Control.GdkWindow.Children[0]) // skip painting over up/down
 					return;
 				base.HandleExposeEvent(o, args);
 			}

--- a/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
@@ -192,73 +192,83 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleTestExpandRow(object o, Gtk.TestExpandRowArgs args)
 			{
-				var h = Handler;
-				if (h.suppressExpandCollapseEvents > 0)
+				var handler = Handler;
+				if (handler == null)
 					return;
-				var e = new TreeGridViewItemCancelEventArgs(h.GetItem(args.Path) as ITreeGridItem);
-				h.Callback.OnExpanding(h.Widget, e);
+				if (handler.suppressExpandCollapseEvents > 0)
+					return;
+				var e = new TreeGridViewItemCancelEventArgs(handler.GetItem(args.Path) as ITreeGridItem);
+				handler.Callback.OnExpanding(handler.Widget, e);
 				args.RetVal = e.Cancel;
 			}
 
 			public void HandleRowExpanded(object o, Gtk.RowExpandedArgs args)
 			{
-				var h = Handler;
-				if (h.suppressExpandCollapseEvents > 0)
+				var handler = Handler;
+				if (handler == null)
 					return;
-				var e = new TreeGridViewItemEventArgs(h.GetItem(args.Path) as ITreeGridItem);
+				if (handler.suppressExpandCollapseEvents > 0)
+					return;
+				var e = new TreeGridViewItemEventArgs(handler.GetItem(args.Path) as ITreeGridItem);
 				e.Item.Expanded = true;
-				h.suppressExpandCollapseEvents++;
-				h.collection.ExpandItems(e.Item as ITreeGridStore<ITreeGridItem>, args.Path);
-				h.suppressExpandCollapseEvents--;
-				h.Callback.OnExpanded(h.Widget, e);
+				handler.suppressExpandCollapseEvents++;
+				handler.collection.ExpandItems(e.Item as ITreeGridStore<ITreeGridItem>, args.Path);
+				handler.suppressExpandCollapseEvents--;
+				handler.Callback.OnExpanded(handler.Widget, e);
 			}
 
 			public void HandleTestCollapseRow(object o, Gtk.TestCollapseRowArgs args)
 			{
-				var h = Handler;
-				if (h.suppressExpandCollapseEvents > 0)
+				var handler = Handler;
+				if (handler == null)
 					return;
-				var e = new TreeGridViewItemCancelEventArgs(h.GetItem(args.Path) as ITreeGridItem);
-				h.Callback.OnCollapsing(h.Widget, e);
+				if (handler.suppressExpandCollapseEvents > 0)
+					return;
+				var e = new TreeGridViewItemCancelEventArgs(handler.GetItem(args.Path) as ITreeGridItem);
+				handler.Callback.OnCollapsing(handler.Widget, e);
 				args.RetVal = e.Cancel;
 				if (!e.Cancel)
 				{
-					h.selectCollapsingItem = !h.AllowMultipleSelection && h.ChildIsSelected(e.Item);
-					h.SkipSelectedChange = true;
+					handler.selectCollapsingItem = !handler.AllowMultipleSelection && handler.ChildIsSelected(e.Item);
+					handler.SkipSelectedChange = true;
 				}
 			}
 
 			public void HandleRowCollapsed(object o, Gtk.RowCollapsedArgs args)
 			{
-				var h = Handler;
-				if (h.suppressExpandCollapseEvents > 0)
+				var handler = Handler;
+				if (handler == null)
 					return;
-				var e = new TreeGridViewItemEventArgs(h.GetItem(args.Path) as ITreeGridItem);
+				if (handler.suppressExpandCollapseEvents > 0)
+					return;
+				var e = new TreeGridViewItemEventArgs(handler.GetItem(args.Path) as ITreeGridItem);
 				e.Item.Expanded = false;
-				h.Callback.OnCollapsed(h.Widget, e);
-				h.SkipSelectedChange = false;
-				if (h.selectCollapsingItem == true)
+				handler.Callback.OnCollapsed(handler.Widget, e);
+				handler.SkipSelectedChange = false;
+				if (handler.selectCollapsingItem == true)
 				{
-					h.Tree.Selection.UnselectAll();
-					h.Tree.Selection.SelectPath(args.Path);
-					h.selectCollapsingItem = null;
+					handler.Tree.Selection.UnselectAll();
+					handler.Tree.Selection.SelectPath(args.Path);
+					handler.selectCollapsingItem = null;
 				}
 			}
 
 			public void HandleSelectionChanged(object sender, EventArgs e)
 			{
-				var h = Handler;
-				var item = h.SelectedItem;
-				if (!h.SkipSelectedChange && !object.ReferenceEquals(item, h.lastSelected))
+				var handler = Handler;
+				if (handler == null)
+					return;
+				var item = handler.SelectedItem;
+				if (!handler.SkipSelectedChange && !object.ReferenceEquals(item, handler.lastSelected))
 				{
-					h.Callback.OnSelectedItemChanged(h.Widget, EventArgs.Empty);
-					h.lastSelected = item;
+					handler.Callback.OnSelectedItemChanged(handler.Widget, EventArgs.Empty);
+					handler.lastSelected = item;
 				}
 			}
 
 			public void HandleRowActivated(object o, Gtk.RowActivatedArgs args)
 			{
-				Handler.Callback.OnActivated(Handler.Widget, new TreeGridViewItemEventArgs(Handler.model.GetItemAtPath(args.Path)));
+				Handler?.Callback.OnActivated(Handler.Widget, new TreeGridViewItemEventArgs(Handler.model.GetItemAtPath(args.Path)));
 			}
 
 			protected override DragEventArgs GetDragEventArgs(Gdk.DragContext context, PointF? location, uint time = 0, object controlObject = null)

--- a/src/Eto.Gtk/Forms/Controls/TreeViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TreeViewHandler.cs
@@ -190,6 +190,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleTestExpandRow(object o, Gtk.TestExpandRowArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				if (handler.cancelExpandCollapseEvents)
 					return;
 				var e = new TreeViewItemCancelEventArgs(handler.GetItem(args.Path) as ITreeItem);
@@ -200,6 +202,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleTestCollapseRow(object o, Gtk.TestCollapseRowArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				if (handler.cancelExpandCollapseEvents)
 					return;
 				var e = new TreeViewItemCancelEventArgs(handler.GetItem(args.Path) as ITreeItem);
@@ -210,6 +214,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleRowExpanded(object o, Gtk.RowExpandedArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				if (handler.cancelExpandCollapseEvents)
 					return;
 				var item = handler.GetItem(args.Path) as ITreeItem;
@@ -224,6 +230,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleRowCollapsed(object o, Gtk.RowCollapsedArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				if (handler.cancelExpandCollapseEvents)
 					return;
 				var item = handler.GetItem(args.Path) as ITreeItem;
@@ -236,17 +244,19 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleRowActivated(object o, Gtk.RowActivatedArgs args)
 			{
-				Handler.Callback.OnActivated(Handler.Widget, new TreeViewItemEventArgs(Handler.model.GetItemAtPath(args.Path)));
+				Handler?.Callback.OnActivated(Handler.Widget, new TreeViewItemEventArgs(Handler.model.GetItemAtPath(args.Path)));
 			}
 
 			public void HandleSelectionChanged(object sender, EventArgs e)
 			{
-				Handler.Callback.OnSelectionChanged(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnSelectionChanged(Handler.Widget, EventArgs.Empty);
 			}
 
 			public void HandleEditingStarted(object o, Gtk.EditingStartedArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				var item = handler.model.GetItemAtPath(args.Path);
 				if (item != null)
 				{
@@ -259,6 +269,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleEdited(object o, Gtk.EditedArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				var item = handler.model.GetItemAtPath(args.Path);
 				if (item != null)
 				{
@@ -271,6 +283,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleTreeButtonPressEvent(object o, Gtk.ButtonPressEventArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				if (handler.contextMenu != null && args.Event.Button == 3 && args.Event.Type == Gdk.EventType.ButtonPress)
 				{
 					var menu = ((ContextMenuHandler)handler.contextMenu.Handler).Control;

--- a/src/Eto.Gtk/Forms/Controls/WebViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/WebViewHandler.cs
@@ -94,6 +94,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandlePopulatePopup(object o, WebKit.PopulatePopupArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				if (handler.BrowserContextMenuEnabled)
 					return;
 				// don't allow context menu by default
@@ -106,6 +108,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleLoadFinished(object o, WebKit.LoadFinishedArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				var uri = args.Frame.Uri != null ? new Uri(args.Frame.Uri) : null;
 				var e = new WebViewLoadedEventArgs(uri);
 				if (args.Frame == handler.Control.MainFrame)
@@ -116,6 +120,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleNavigationRequested(object o, WebKit.NavigationRequestedArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				if (args.Request.Uri.StartsWith(EtoReturnPrefix, StringComparison.Ordinal))
 				{
 					// pass back the response to ExecuteScript()
@@ -135,6 +141,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleNavigationPolicyDecisitionRequested(object o, WebKit.NavigationPolicyDecisionRequestedArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				if (args.Request.Uri.StartsWith(EtoReturnPrefix, StringComparison.Ordinal))
 				{
 					// pass back the response to ExecuteScript()
@@ -157,6 +165,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public void HandleNewWindowPolicyDecisionRequested(object sender, NewWindowPolicyDecisionRequestedArgs args)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				var e = new WebViewNewWindowEventArgs(new Uri(args.Request.Uri), args.Frame.Name);
 				handler.Callback.OnOpenNewWindow(handler.Widget, e);
 				#if GTK2
@@ -179,7 +189,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleTitleChanged(object o, WebKit.TitleChangedArgs args)
 			{
-				Handler.Callback.OnDocumentTitleChanged(Handler.Widget, new WebViewTitleEventArgs(args.Title));
+				Handler?.Callback.OnDocumentTitleChanged(Handler.Widget, new WebViewTitleEventArgs(args.Title));
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/DialogHandler.cs
+++ b/src/Eto.Gtk/Forms/DialogHandler.cs
@@ -234,7 +234,7 @@ namespace Eto.GtkSharp.Forms
 		{
 			public new DialogHandler Handler => (DialogHandler)base.Handler;
 
-			internal void Control_KeyPressEvent(object o, Gtk.KeyPressEventArgs args) => Handler.Control_KeyPressEvent(o, args);
+			internal void Control_KeyPressEvent(object o, Gtk.KeyPressEventArgs args) => Handler?.Control_KeyPressEvent(o, args);
 		}
 	}
 }

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -485,8 +485,8 @@ namespace Eto.GtkSharp.Forms
 
 			public void HandleScrollEvent(object o, Gtk.ScrollEventArgs args)
 			{
-				var h = Handler;
-				if (h == null)
+				var handler = Handler;
+				if (handler == null)
 					return;
 				var p = new PointF((float)args.Event.X, (float)args.Event.Y);
 				Keys modifiers = args.Event.State.ToEtoKey();
@@ -496,16 +496,16 @@ namespace Eto.GtkSharp.Forms
 				switch (args.Event.Direction)
 				{
 					case Gdk.ScrollDirection.Down:
-						delta = new SizeF(0f, -h.ScrollAmount);
+						delta = new SizeF(0f, -handler.ScrollAmount);
 						break;
 					case Gdk.ScrollDirection.Left:
-						delta = new SizeF(h.ScrollAmount, 0f);
+						delta = new SizeF(handler.ScrollAmount, 0f);
 						break;
 					case Gdk.ScrollDirection.Right:
-						delta = new SizeF(-h.ScrollAmount, 0f);
+						delta = new SizeF(-handler.ScrollAmount, 0f);
 						break;
 					case Gdk.ScrollDirection.Up:
-						delta = new SizeF(0f, h.ScrollAmount);
+						delta = new SizeF(0f, handler.ScrollAmount);
 						break;
 #if GTKCORE
 					case Gdk.ScrollDirection.Smooth:
@@ -516,12 +516,16 @@ namespace Eto.GtkSharp.Forms
 						throw new NotSupportedException();
 				}
 
-				h.Callback.OnMouseWheel(h.Widget, new MouseEventArgs(buttons, modifiers, p, delta));
+				handler.Callback.OnMouseWheel(handler.Widget, new MouseEventArgs(buttons, modifiers, p, delta));
 			}
 
 			[GLib.ConnectBefore]
 			public void HandleControlLeaveNotifyEvent(object o, Gtk.LeaveNotifyEventArgs args)
 			{
+				var handler = Handler;
+				if (handler == null)
+					return;
+
 				// ignore child events
 				if (args.Event.Detail == Gdk.NotifyType.Inferior)
 					return;
@@ -529,12 +533,16 @@ namespace Eto.GtkSharp.Forms
 				Keys modifiers = args.Event.State.ToEtoKey();
 				MouseButtons buttons = MouseButtons.None;
 
-				Handler.Callback.OnMouseLeave(Handler.Widget, new MouseEventArgs(buttons, modifiers, p));
+				handler.Callback.OnMouseLeave(handler.Widget, new MouseEventArgs(buttons, modifiers, p));
 			}
 
 			[GLib.ConnectBefore]
 			public void HandleControlEnterNotifyEvent(object o, Gtk.EnterNotifyEventArgs args)
 			{
+				var handler = Handler;
+				if (handler == null)
+					return;
+
 				// ignore child events
 				if (args.Event.Detail == Gdk.NotifyType.Inferior)
 					return;
@@ -542,49 +550,61 @@ namespace Eto.GtkSharp.Forms
 				Keys modifiers = args.Event.State.ToEtoKey();
 				MouseButtons buttons = MouseButtons.None;
 
-				Handler.Callback.OnMouseEnter(Handler.Widget, new MouseEventArgs(buttons, modifiers, p));
+				handler.Callback.OnMouseEnter(handler.Widget, new MouseEventArgs(buttons, modifiers, p));
 			}
 
 			[GLib.ConnectBefore]
 			public void HandleMotionNotifyEvent(System.Object o, Gtk.MotionNotifyEventArgs args)
 			{
+				var handler = Handler;
+				if (handler == null)
+					return;
+
 				var p = new PointF((float)args.Event.X, (float)args.Event.Y);
 				Keys modifiers = args.Event.State.ToEtoKey();
 				MouseButtons buttons = args.Event.State.ToEtoMouseButtons();
 
-				Handler.Callback.OnMouseMove(Handler.Widget, new MouseEventArgs(buttons, modifiers, p));
+				handler.Callback.OnMouseMove(handler.Widget, new MouseEventArgs(buttons, modifiers, p));
 			}
 
 			[GLib.ConnectBefore]
 			public void HandleButtonReleaseEvent(object o, Gtk.ButtonReleaseEventArgs args)
 			{
+				var handler = Handler;
+				if (handler == null)
+					return;
+
 				args.Event.ToEtoLocation();
 				var p = new PointF((float)args.Event.X, (float)args.Event.Y);
 				Keys modifiers = args.Event.State.ToEtoKey();
 				MouseButtons buttons = args.Event.ToEtoMouseButtons();
 
 				var mouseArgs = new MouseEventArgs(buttons, modifiers, p);
-				Handler.Callback.OnMouseUp(Handler.Widget, mouseArgs);
+				handler.Callback.OnMouseUp(handler.Widget, mouseArgs);
 				args.RetVal = mouseArgs.Handled;
 			}
 
 			[GLib.ConnectBefore]
 			public void HandleButtonPressEvent(object sender, Gtk.ButtonPressEventArgs args)
 			{
+				var handler = Handler;
+				if (handler == null)
+					return;
+
 				var p = new PointF((float)args.Event.X, (float)args.Event.Y);
 				Keys modifiers = args.Event.State.ToEtoKey();
 				MouseButtons buttons = args.Event.ToEtoMouseButtons();
 				var mouseArgs = new MouseEventArgs(buttons, modifiers, p);
 				if (args.Event.Type == Gdk.EventType.ButtonPress)
 				{
-					Handler.Callback.OnMouseDown(Handler.Widget, mouseArgs);
+					handler.Callback.OnMouseDown(handler.Widget, mouseArgs);
 				}
 				else if (args.Event.Type == Gdk.EventType.TwoButtonPress)
 				{
-					Handler.Callback.OnMouseDoubleClick(Handler.Widget, mouseArgs);
+					handler.Callback.OnMouseDoubleClick(handler.Widget, mouseArgs);
 				}
-				if (!mouseArgs.Handled && Handler.EventControl.CanFocus && !Handler.EventControl.HasFocus)
-					Handler.EventControl.GrabFocus();
+				if (!mouseArgs.Handled && handler.EventControl.CanFocus && !handler.EventControl.HasFocus)
+					handler.EventControl.GrabFocus();
 				if (args.RetVal != null && (bool)args.RetVal == true)
 					return;
 				args.RetVal = mouseArgs.Handled;
@@ -592,11 +612,15 @@ namespace Eto.GtkSharp.Forms
 
 			public void HandleSizeAllocated(object o, Gtk.SizeAllocatedArgs args)
 			{
-				if (Handler.asize != args.Allocation.Size.ToEto())
+				var handler = Handler;
+				if (handler == null)
+					return;
+
+				if (handler.asize != args.Allocation.Size.ToEto())
 				{
 					// only call when the size has actually changed, gtk likes to call anyway!!  grr.
-					Handler.asize = args.Allocation.Size.ToEto();
-					Handler.Callback.OnSizeChanged(Handler.Widget, EventArgs.Empty);
+					handler.asize = args.Allocation.Size.ToEto();
+					handler.Callback.OnSizeChanged(handler.Widget, EventArgs.Empty);
 				}
 			}
 
@@ -681,13 +705,16 @@ namespace Eto.GtkSharp.Forms
 
 			public void HandleControlRealized(object sender, EventArgs e)
 			{
-				Handler.RealizedSetup();
-				Handler.Control.Realized -= HandleControlRealized;
+				var handler = Handler;
+				if (handler == null)
+					return;
+				handler.RealizedSetup();
+				handler.Control.Realized -= HandleControlRealized;
 			}
 
 			public virtual void MappedEvent(object sender, EventArgs e)
 			{
-				Handler.Callback.OnShown(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnShown(Handler.Widget, EventArgs.Empty);
 			}
 
 			protected virtual DragEventArgs GetDragEventArgs(Gdk.DragContext context, PointF? location, uint time = 0, object controlObject = null)
@@ -731,8 +758,11 @@ namespace Eto.GtkSharp.Forms
 			[GLib.ConnectBefore]
 			public virtual void HandleDragDrop(object o, Gtk.DragDropArgs args)
 			{
+				var handler = Handler;
+				if (handler == null)
+					return;
 				DragArgs = GetDragEventArgs(args.Context, new PointF(args.X, args.Y), args.Time);
-				Handler.Callback.OnDragDrop(Handler.Widget, DragArgs);
+				handler.Callback.OnDragDrop(handler.Widget, DragArgs);
 				Gtk.Drag.Finish(args.Context, true, DragArgs.Effects.HasFlag(DragEffects.Move), args.Time);
 				DragArgs = null;
 				args.RetVal = true;
@@ -743,17 +773,20 @@ namespace Eto.GtkSharp.Forms
 			[GLib.ConnectBefore]
 			public virtual void HandleDragMotion(object o, Gtk.DragMotionArgs args)
 			{
+				var handler = Handler;
+				if (handler == null)
+					return;
 				DragArgs = GetDragEventArgs(args.Context, new PointF(args.X, args.Y), args.Time);
 
 				if (_dragEnterEffects == null)
 				{
-					Handler.Callback.OnDragEnter(Handler.Widget, DragArgs);
+					handler.Callback.OnDragEnter(handler.Widget, DragArgs);
 					_dragEnterEffects = DragArgs.Effects;
 				}
 				else
 				{
 					DragArgs.Effects = _dragEnterEffects.Value;
-					Handler.Callback.OnDragOver(Handler.Widget, DragArgs);
+					handler.Callback.OnDragOver(handler.Widget, DragArgs);
 				}
 
 				Gdk.Drag.Status(args.Context, DragArgs.Effects.ToGdk(), args.Time);
@@ -763,9 +796,12 @@ namespace Eto.GtkSharp.Forms
 
 			public virtual void HandleDragLeave(object o, Gtk.DragLeaveArgs args)
 			{
+				var handler = Handler;
+				if (handler == null)
+					return;
 				// use old args in case of a drop so we use the last motion args to determine position of drop for TreeGridView/GridView.
 				DragArgs = DragArgs ?? GetDragEventArgs(args.Context, Handler.PointFromScreen(Mouse.Position), args.Time);
-				Handler.Callback.OnDragLeave(Handler.Widget, DragArgs);
+				handler.Callback.OnDragLeave(handler.Widget, DragArgs);
 				_dragEnterEffects = null;
 				Eto.Forms.Application.Instance.AsyncInvoke(() => DragArgs = null);
 			}
@@ -773,14 +809,14 @@ namespace Eto.GtkSharp.Forms
 #if GTK3
 			public virtual void HandleStateFlagsChangedForEnabled(object o, Gtk.StateFlagsChangedArgs args)
 			{
-				var h = Handler;
-				if (h == null)
+				var handler = Handler;
+				if (handler == null)
 					return;
 				var wasSensitive = args.PreviousStateFlags.HasFlag(Gtk.StateFlags.Insensitive);
-				var isSensitive = h.ContainerControl.StateFlags.HasFlag(Gtk.StateFlags.Insensitive);
+				var isSensitive = handler.ContainerControl.StateFlags.HasFlag(Gtk.StateFlags.Insensitive);
 				if (wasSensitive != isSensitive)
 				{
-					h.Callback.OnEnabledChanged(h.Widget, EventArgs.Empty);
+					handler.Callback.OnEnabledChanged(handler.Widget, EventArgs.Empty);
 				}
 			}
 #endif

--- a/src/Eto.Gtk/Forms/GtkWindow.cs
+++ b/src/Eto.Gtk/Forms/GtkWindow.cs
@@ -402,12 +402,15 @@ namespace Eto.GtkSharp.Forms
 
 			public void HandleDeleteEvent(object o, Gtk.DeleteEventArgs args)
 			{
-				args.RetVal = !Handler.CloseWindow();
+				var handler = Handler;
+				if (handler == null)
+					return;
+				args.RetVal = !handler.CloseWindow();
 			}
 
 			public void HandleShownEvent(object sender, EventArgs e)
 			{
-				Handler.Callback.OnShown(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnShown(Handler.Widget, EventArgs.Empty);
 			}
 
 			public void HandleWindowStateEvent(object o, Gtk.WindowStateEventArgs args)
@@ -442,10 +445,13 @@ namespace Eto.GtkSharp.Forms
 			// do not connect before, otherwise it is sent before sending to child
 			public void HandleWindowKeyPressEvent(object o, Gtk.KeyPressEventArgs args)
 			{
+				var handler = Handler;
+				if (handler == null)
+					return;
 				var e = args.Event.ToEto();
 				if (e != null)
 				{
-					Handler.Callback.OnKeyDown(Handler.Widget, e);
+					handler.Callback.OnKeyDown(handler.Widget, e);
 					args.RetVal = e.Handled;
 				}
 			}
@@ -495,11 +501,13 @@ namespace Eto.GtkSharp.Forms
 
 			internal void ButtonPressEvent_Movable(object o, Gtk.ButtonPressEventArgs args)
 			{
-				var h = Handler;
+				var handler = Handler;
+				if (handler == null)
+					return;
 				var evt = args.Event;
-				if (h != null && evt.Type == Gdk.EventType.ButtonPress && evt.Button == 1)
+				if (handler != null && evt.Type == Gdk.EventType.ButtonPress && evt.Button == 1)
 				{
-					h.Control.BeginMoveDrag((int)evt.Button, (int)evt.XRoot, (int)evt.YRoot, evt.Time);
+					handler.Control.BeginMoveDrag((int)evt.Button, (int)evt.XRoot, (int)evt.YRoot, evt.Time);
 				}
 			}
 		}

--- a/src/Eto.Gtk/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/src/Eto.Gtk/Forms/Menu/ButtonMenuItemHandler.cs
@@ -47,10 +47,13 @@ namespace Eto.GtkSharp.Forms.Menu
 
 			public void HandleActivated(object sender, EventArgs e)
 			{
-				if (Handler.Control.Submenu != null)
-					Handler.ValidateItems();
+				var handler = Handler;
+				if (handler == null)
+					return;
+				if (handler.Control.Submenu != null)
+					handler.ValidateItems();
 				
-				Handler.Callback.OnClick (Handler.Widget, e);
+				handler.Callback.OnClick (handler.Widget, e);
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Menu/CheckMenuItemHandler.cs
+++ b/src/Eto.Gtk/Forms/Menu/CheckMenuItemHandler.cs
@@ -41,6 +41,8 @@ namespace Eto.GtkSharp.Forms.Menu
 			public void HandleActivated(object sender, EventArgs e)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				if (handler.SuppressClick == 0)
 					handler.Callback.OnClick(handler.Widget, e);
 			}
@@ -48,6 +50,8 @@ namespace Eto.GtkSharp.Forms.Menu
 			public void HandleToggled(object sender, EventArgs e)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				handler.Callback.OnCheckedChanged(handler.Widget, e);
 			}
 		}

--- a/src/Eto.Gtk/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Gtk/Forms/Menu/ContextMenuHandler.cs
@@ -63,29 +63,34 @@ namespace Eto.GtkSharp.Forms.Menu
 
 			public void HandleMenuOpening(object sender, EventArgs e)
 			{
-				Handler.Callback.OnOpening(Handler.Widget, EventArgs.Empty);
+				Handler?.Callback.OnOpening(Handler.Widget, EventArgs.Empty);
 			}
 
 			public void HandleMenuClosed(object sender, EventArgs e)
 			{
-				var h = Handler;
+				var handler = Handler;
+				if (handler == null)
+					return;
 				// before menuitem click is processed
-				h.Callback.OnClosing(h.Widget, EventArgs.Empty);
+				handler.Callback.OnClosing(handler.Widget, EventArgs.Empty);
 				// call OnClosed after menuitem click is processed
-				Application.Instance.AsyncInvoke(() => h.Callback.OnClosed(h.Widget, EventArgs.Empty));
+				Application.Instance.AsyncInvoke(() => handler.Callback.OnClosed(handler.Widget, EventArgs.Empty));
 			}
 
 			[GLib.ConnectBefore]
 			public void HandleKeyPressEvent(object o, Gtk.KeyPressEventArgs args)
 			{
+				var handler = Handler;
+				if (handler == null)
+					return;
 				// Handle pressing shortcut keys when the context menu is open
 				var shortcut = args.Event.Key.ToEto() | args.Event.State.ToEtoKey();
 				if (shortcut == Keys.None)
 					return;
-				var item = Handler.Widget.GetChildren().FirstOrDefault(r => r.Shortcut == shortcut);
+				var item = handler.Widget.GetChildren().FirstOrDefault(r => r.Shortcut == shortcut);
 				if (item != null)
 				{
-					Handler.Control.Hide();
+					handler.Control.Hide();
 					item.PerformClick();
 				}
 			}

--- a/src/Eto.Gtk/Forms/Menu/RadioMenuItemHandler.cs
+++ b/src/Eto.Gtk/Forms/Menu/RadioMenuItemHandler.cs
@@ -59,6 +59,8 @@ namespace Eto.GtkSharp.Forms.Menu
 			public void HandleActivated(object sender, EventArgs e)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				if (handler.SuppressClick > 0 || !handler.Control.Active)
 					return;
 				handler.Callback.OnClick(handler.Widget, e);
@@ -67,6 +69,8 @@ namespace Eto.GtkSharp.Forms.Menu
 			public void HandleToggled(object sender, EventArgs e)
 			{
 				var handler = Handler;
+				if (handler == null)
+					return;
 				handler.Callback.OnCheckedChanged(handler.Widget, e);
 			}
 		}

--- a/src/Eto.Gtk/Forms/Menu/SubMenuItemHandler.cs
+++ b/src/Eto.Gtk/Forms/Menu/SubMenuItemHandler.cs
@@ -49,13 +49,13 @@ namespace Eto.GtkSharp.Forms.Menu
 
 			public void HandleMenuClosed(object sender, EventArgs e)
 			{
-				var h = Handler;
-				if (h == null)
+				var handler = Handler;
+				if (handler == null)
 					return;
 				// before menuitem click is processed
-				h.Callback.OnClosing(h.Widget, EventArgs.Empty);
+				handler.Callback.OnClosing(handler.Widget, EventArgs.Empty);
 				// call OnClosed after menuitem click is processed
-				Application.Instance.AsyncInvoke(() => h.Callback.OnClosed(h.Widget, EventArgs.Empty));
+				Application.Instance.AsyncInvoke(() => handler.Callback.OnClosed(handler.Widget, EventArgs.Empty));
 			}
 		}
 	}

--- a/src/Eto.Gtk/Forms/ToolBar/ButtonToolItemHandler.cs
+++ b/src/Eto.Gtk/Forms/ToolBar/ButtonToolItemHandler.cs
@@ -41,7 +41,7 @@ namespace Eto.GtkSharp.Forms.ToolBar
 
 			public void HandleClicked(object sender, EventArgs e)
 			{
-				Handler.Widget.OnClick(e);
+				Handler?.Widget.OnClick(e);
 			}
 		}
 	}

--- a/src/Eto.Gtk/Forms/ToolBar/CheckToolItemHandler.cs
+++ b/src/Eto.Gtk/Forms/ToolBar/CheckToolItemHandler.cs
@@ -54,12 +54,12 @@ namespace Eto.GtkSharp.Forms.ToolBar
 
 			public void HandleToggled(object sender, EventArgs e)
 			{
-				Handler.Widget.OnCheckedChanged(EventArgs.Empty);
+				Handler?.Widget.OnCheckedChanged(EventArgs.Empty);
 			}
 			
 			public void HandleClicked(object sender, EventArgs e)
 			{
-				Handler.Widget.OnClick(EventArgs.Empty);
+				Handler?.Widget.OnClick(EventArgs.Empty);
 			}
 		}
 	}

--- a/src/Eto.Gtk/Forms/ToolBar/RadioToolItemHandler.cs
+++ b/src/Eto.Gtk/Forms/ToolBar/RadioToolItemHandler.cs
@@ -55,12 +55,12 @@ namespace Eto.GtkSharp.Forms.ToolBar
 
 			public void HandleToggled(object sender, EventArgs e)
 			{
-				Handler.Widget.OnCheckedChanged(EventArgs.Empty);
+				Handler?.Widget.OnCheckedChanged(EventArgs.Empty);
 			}
 			
 			public void HandleClicked(object sender, EventArgs e)
 			{
-				Handler.Widget.OnClick(EventArgs.Empty);
+				Handler?.Widget.OnClick(EventArgs.Empty);
 			}
 		}
 	}


### PR DESCRIPTION
When (re) creating windows and controls events could still be forwarded to these controls even when the actual .NET object no longer exists.  In this case, the connector's Handle will be null.  We need to check for null on every event callback that uses the connector object which uses a weak reference to the handler.

Fixes #1812
Fixes #1757