### PR TITLE
Remove extensions and tweak publishing workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,20 +34,11 @@ jobs:
     - name: Build
       run: dotnet build ${{ env.BuildParameters }} /p:Platform=Windows /t:Build /bl:artifacts/log/Build.Windows.binlog
 
-    - name: Build VS/Win Extension
-      run: msbuild ${{ env.BuildParameters }} /t:BuildAddins /bl:artifacts/log/Addin.Windows.binlog
-
     - name: Upload nuget artifacts
       uses: actions/upload-artifact@v2
       with:
         name: nuget
         path: artifacts/nuget/${{ env.BuildConfiguration }}/*.nupkg
-
-    - name: Upload extension artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: addins
-        path: artifacts/addin/${{ env.BuildConfiguration }}/Eto.Addin.VisualStudio.Windows*.vsix
 
     - name: Upload test artifacts
       uses: actions/upload-artifact@v2
@@ -72,7 +63,7 @@ jobs:
 
   build-mac:
 
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v2
@@ -91,7 +82,7 @@ jobs:
       uses: maxim-lobanov/setup-xamarin@v1
       with:
         mono-version: latest
-        xamarin-mac-version: 8.6
+        xamarin-mac-version: latest
         xcode-version: latest
     
     - name: Import code signing certificate
@@ -114,9 +105,6 @@ jobs:
     - name: Build
       run: dotnet build ${{ env.BuildParameters }} /p:Platform=Mac /t:Build /bl:artifacts/log/Build.Mac.binlog
 
-    - name: Build VS/Mac extension
-      run: msbuild ${{ env.BuildParameters }} /t:BuildAddins /bl:artifacts/log/Addin.Mac.binlog
-
     - name: Upload nuget artifacts
       uses: actions/upload-artifact@v2
       with:
@@ -124,12 +112,6 @@ jobs:
         path: |
           artifacts/nuget/${{ env.BuildConfiguration }}/Eto.Platform.XamMac2*.nupkg
           artifacts/nuget/${{ env.BuildConfiguration }}/Eto.Platform.Gtk2*.nupkg
-
-    - name: Upload extension artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: addins
-        path: artifacts/addin/${{ env.BuildConfiguration }}/Eto.Addin.VisualStudio.Mac*.mpack
 
     - name: Upload test artifacts
       uses: actions/upload-artifact@v2
@@ -149,46 +131,6 @@ jobs:
           artifacts/log/**/*
           lib/monomac/artifacts/generated/**/*.binlog
 
-  update-release:
-    needs: [ build-windows, build-mac ]
-    runs-on: ubuntu-latest
-    if: (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.ref, 'refs/tags/'))
-    steps:
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/tags/}
-
-      - name: Get release
-        id: get_release
-        uses: bruceadams/get-release@v1.2.0
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        
-      - name: Download extension artifacts
-        uses: actions/download-artifact@v2
-        with:
-          name: addins
-
-      - name: Upload VS/Win addin
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: Eto.Addin.VisualStudio.Windows-${{ steps.get_version.outputs.VERSION }}.vsix
-          asset_name: Eto.Addin.VisualStudio.Windows-${{ steps.get_version.outputs.VERSION }}.vsix
-          asset_content_type: application/octet-stream
-
-      - name: Upload VS/Mac addin
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.get_release.outputs.upload_url }}
-          asset_path: Eto.Addin.VisualStudio.Mac-${{ steps.get_version.outputs.VERSION }}.mpack
-          asset_name: Eto.Addin.VisualStudio.Mac-${{ steps.get_version.outputs.VERSION }}.mpack
-          asset_content_type: application/octet-stream
-
   publish:
     needs: [ build-windows, build-mac ]
     runs-on: ubuntu-latest
@@ -202,6 +144,9 @@ jobs:
       - name: Push packages to myget.org
         run: dotnet nuget push '*.nupkg' --skip-duplicate -s https://www.myget.org/F/eto/api/v2/package -k ${{secrets.MYGET_API_KEY}}
 
-      - name: Push packages to nuget.org
+      - name: Add nuget packages to release
+        uses: softprops/action-gh-release@v1
         if: (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.ref, 'refs/tags/'))
-        run: dotnet nuget push '*.nupkg' --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: '*.nupkg'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,23 @@
+name: Release
+
+on:
+  release:
+    types: [ released ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    if: (github.event_name == 'release' && github.event.action == 'released' && startsWith(github.ref, 'refs/tags/'))
+    steps:
+      - name: Get the version
+        id: get_version
+        run: echo ::set-output name=VERSION::${GITHUB_REF#refs/}
+
+      - uses: dsaltares/fetch-gh-release-asset@master
+        with:
+          version: ${{ steps.get_version.outputs.VERSION }}
+          file: "*.nupkg"
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push packages to nuget.org
+        run: dotnet nuget push '*.nupkg' --skip-duplicate -s https://api.nuget.org/v3/index.json -k ${{secrets.NUGET_API_KEY}}


### PR DESCRIPTION
Extensions are moving to a separate repo (coming soon).  Also trying to tweak the publish workflow a bit so I don't have to delete/recreate tags manually each time.