### PR TITLE
Mac: Fix flipping when drawing template images on Graphics

### DIFF
--- a/src/Eto.Mac/Drawing/ImageHandler.cs
+++ b/src/Eto.Mac/Drawing/ImageHandler.cs
@@ -75,6 +75,13 @@ namespace Eto.Mac.Drawing
 			var ctx = graphics.Control;
 			ctx.SaveState();
 
+			if (graphics.GraphicsContext.IsFlipped)
+			{
+				// draw flipped
+				ctx.ConcatCTM(new CGAffineTransform(1, 0, 0, -1, 0, graphics.ViewHeight));
+				destination.Y = graphics.ViewHeight - destination.Y - destination.Height;
+			}
+
 			RectangleF destMask;
 			if (destination.Size != source.Size)
 			{
@@ -87,25 +94,21 @@ namespace Eto.Mac.Drawing
 				// just position
 				destMask = new RectangleF(destination.Location - source.Location, imageSize);
 			}
-			
+
 			var destRect = destination.ToNS();
 			var cgImage = GetImage().AsCGImage(ref destRect, graphics.GraphicsContext, null);
 
 			// clip to the image as a mask, using only alpha channel
 			ctx.ClipToMask(destMask.ToNS(), cgImage);
 
-			// set fill color based on current dark/light theme
+			// set fill color based on current dark/light theme	
 			// this is the best approximation I can find to get it to draw the same as NSImageView
 			// thus far..
 			NSColor color;
-			if (MacVersion.IsAtLeast(10, 14) && graphics.DisplayView.HasDarkTheme())
-			{
+			if (graphics.DisplayView.HasDarkTheme())
 				color = NSColor.FromWhite(1f, .55f);
-			}
 			else
-			{
 				color = NSColor.FromWhite(0, .5f);
-			}
 			color.SetFill();
 
 			ctx.FillRect(destRect);

--- a/test/Eto.Test.Mac/UnitTests/BitmapTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/BitmapTests.cs
@@ -41,7 +41,10 @@ namespace Eto.Test.Mac.UnitTests
 
 					g.DrawRectangle(Colors.Black, 0.5f, 0.5f, 199, 199);
 					g.FillRectangle(Colors.Black, 59, 59, 80, 80);
-					
+
+					var path = new GraphicsPath();
+					g.DrawPolygon(Colors.Black, new PointF(100, 20), new PointF(180, 180), new PointF(20, 180));
+
 				}
 				
 				var drawable = new Drawable { Size = bmp.Size };


### PR DESCRIPTION
The orientation of the template images where upside down when drawn on a Graphics object, and updated the test to have a triangle so you can tell if it's right side up or not.