### PR TITLE
Mac: Use event tracking loop for click and drag by default

### DIFF
--- a/src/Eto.WinForms/Forms/ApplicationHandler.cs
+++ b/src/Eto.WinForms/Forms/ApplicationHandler.cs
@@ -156,16 +156,34 @@ namespace Eto.WinForms.Forms
 				var bubble = new BubbleEventFilter();
 				bubble.AddBubbleMouseEvent((c, cb, e) => cb.OnMouseWheel(c, e), null, Win32.WM.MOUSEWHEEL);
 				bubble.AddBubbleMouseEvent((c, cb, e) => cb.OnMouseMove(c, e), null, Win32.WM.MOUSEMOVE);
-				bubble.AddBubbleMouseEvents((c, cb, e) => cb.OnMouseDown(c, e), true, Win32.WM.LBUTTONDOWN, Win32.WM.RBUTTONDOWN, Win32.WM.MBUTTONDOWN);
+				bubble.AddBubbleMouseEvents((c, cb, e) => 
+				{
+					cb.OnMouseDown(c, e);
+					if (e.Handled && c.Handler is IWindowsControl handler && handler.ShouldCaptureMouse)
+					{
+						handler.ContainerControl.Capture = true;
+						handler.MouseCaptured = true;
+					}
+				}, true, Win32.WM.LBUTTONDOWN, Win32.WM.RBUTTONDOWN, Win32.WM.MBUTTONDOWN);
 				bubble.AddBubbleMouseEvents((c, cb, e) =>
 				{
 					cb.OnMouseDoubleClick(c, e);
 					if (!e.Handled)
 						cb.OnMouseDown(c, e);
 				}, null, Win32.WM.LBUTTONDBLCLK, Win32.WM.RBUTTONDBLCLK, Win32.WM.MBUTTONDBLCLK);
-				bubble.AddBubbleMouseEvent((c, cb, e) => cb.OnMouseUp(c, e), false, Win32.WM.LBUTTONUP, b => MouseButtons.Primary);
-				bubble.AddBubbleMouseEvent((c, cb, e) => cb.OnMouseUp(c, e), false, Win32.WM.RBUTTONUP, b => MouseButtons.Alternate);
-				bubble.AddBubbleMouseEvent((c, cb, e) => cb.OnMouseUp(c, e), false, Win32.WM.MBUTTONUP, b => MouseButtons.Middle);
+				void OnMouseUpHandler(Control c, Control.ICallback cb, MouseEventArgs e)
+				{
+					if (c.Handler is IWindowsControl handler && handler.MouseCaptured)
+					{
+						handler.MouseCaptured = false;
+						handler.ContainerControl.Capture = false;
+					}
+					cb.OnMouseUp(c, e);
+				}
+				
+				bubble.AddBubbleMouseEvent(OnMouseUpHandler, false, Win32.WM.LBUTTONUP, b => MouseButtons.Primary);
+				bubble.AddBubbleMouseEvent(OnMouseUpHandler, false, Win32.WM.RBUTTONUP, b => MouseButtons.Alternate);
+				bubble.AddBubbleMouseEvent(OnMouseUpHandler, false, Win32.WM.MBUTTONUP, b => MouseButtons.Middle);
 				swf.Application.AddMessageFilter(bubble);
 			}
 			if (BubbleKeyEvents)

--- a/test/Eto.Test/UnitTests/Forms/Behaviors/MouseTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Behaviors/MouseTests.cs
@@ -1,0 +1,94 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Behaviors
+{
+	[TestFixture]
+	public class MouseTests : TestBase
+	{
+		[Test, ManualTest]
+		public void EventsFromParentShouldWorkWhenChildRemoved()
+		{
+			var mouseUpCalled = false;
+			var contentRemoved = false;
+			var mouseDown = false;
+			var mouseDownInChild = false;
+			var mouseMovedEvenAfterRemoved = false;
+			ManualForm("Click and drag the blue square,\nit should dissapear and the MouseUp event should be fired",
+			form =>
+			{
+				var top = new Panel { Size = new Size(200, 200) };
+				top.MouseDown += (sender, e) =>
+				{
+					if (e.Buttons == MouseButtons.Primary)
+					{
+						e.Handled = true;
+						mouseDown = true;
+					}
+				};
+
+				top.MouseMove += (sender, e) =>
+				{
+					if (mouseDown && mouseDownInChild && e.Buttons == MouseButtons.Primary)
+					{
+						top.Content = new Panel();
+						contentRemoved = true;
+					}
+				};
+
+				top.MouseUp += (sender, e) =>
+				{
+					if (contentRemoved)
+					{
+						e.Handled = true;
+						mouseDown = false;
+						mouseUpCalled = true;
+						Application.Instance.AsyncInvoke(form.Close);
+					}
+				};
+
+				var child = new Panel { Size = new Size(100, 100), BackgroundColor = Colors.Blue };
+
+				child.MouseDown += (sender, e) =>
+				{
+					if (e.Buttons == MouseButtons.Primary)
+					{
+						mouseDownInChild = true;
+						// explicitly not setting e.Handled here so it bubbles to the top control
+					}
+				};
+				child.MouseMove += (sender, e) =>
+				{
+					if (contentRemoved && e.Buttons == MouseButtons.Primary)
+					{
+						mouseMovedEvenAfterRemoved = true;
+					}
+				};
+
+				child.MouseUp += (sender, e) =>
+				{
+					if (mouseDownInChild && e.Buttons == MouseButtons.Primary)
+					{
+						mouseDownInChild = false;
+					}
+				};
+
+				top.Content = TableLayout.AutoSized(child, centered: true);
+
+				return top;
+
+			}, allowPass: false);
+
+			Assert.IsTrue(mouseUpCalled, "#1 - MouseUp was not called on top control");
+			Assert.IsTrue(contentRemoved, "#2 - Content (blue square) was not removed");
+			Assert.IsTrue(mouseDownInChild, "#3 - MouseUp should NOT be called on child even though it was removed");
+			Assert.IsFalse(mouseMovedEvenAfterRemoved, "#4 - MouseMoved should NOT be called on child after it was removed");
+		}
+		
+		
+	}
+	
+	
+}


### PR DESCRIPTION
- WinForms: properly capture mouse when MouseDown is handled on a control

This fixes the issue when you click on a child control but handle the event in the parent, then moving or removing the child during the click+drag logic, and makes it behave like it does on windows.