### PR TITLE
Mac: Fix building unified binary

### DIFF
--- a/src/Eto.Mac/build/BundleDotNetCore.targets
+++ b/src/Eto.Mac/build/BundleDotNetCore.targets
@@ -29,7 +29,7 @@
     
     <ItemGroup>
       <UnifiedFiles Include="$(BaseOutputAppPath)%(MacBundleRuntimeIdentifiers.Identity)\$(MacBundleName).app\**" RuntimeIdentifier="%(MacBundleRuntimeIdentifiers.Identity)" BasePath="$(BaseOutputAppPath)%(MacBundleRuntimeIdentifiers.Identity)\$(MacBundleName).app\" />
-      <UnifiedFiles TargetPath="$([System.String]::Copy('%(FullPath)').TrimStart('%(BasePath)'))" />
+      <UnifiedFiles TargetPath="$([System.String]::Copy('%(Identity)').TrimStart('%(BasePath)'))" />
     </ItemGroup>
     
     <!-- <Message Importance="high" Text="%(UnifiedFiles.RelativeDir)%(UnifiedFiles.FileName)%(UnifiedFiles.Extension) > %(UnifiedFiles.TargetPath)" /> -->


### PR DESCRIPTION
The following snippet does not make much sense
```xml
<UnifiedFiles TargetPath="$([System.String]::Copy('%(FullPath)').TrimStart('%(BasePath)'))" />
```
Because `'%(BasePath)'` is a relative path and so `%(FullPath)` does not start with it. Therefore `%(TargetPath)` becomes equal to  `'%(FullPath)'` which is obviously unique (because these are the actual files).

Here is an example produced with a template project (2.6.1) created at`~/Projects/Private/eto-test2` (`~` is `/Users/alex.z/`):

```
  UnifiedFiles.BasePath = bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/
  UnifiedFiles.BasePath = bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/

  UnifiedFiles.Identity = bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/Info.plist
  UnifiedFiles.Identity = bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/MacOS/eto-test2
  UnifiedFiles.Identity = bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/Resources/MacIcon.icns
  UnifiedFiles.Identity = bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/Info.plist
  UnifiedFiles.Identity = bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/MacOS/eto-test2
  UnifiedFiles.Identity = bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/Resources/MacIcon.icns

  UnifiedFiles.FullPath = /Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/Info.plist
  UnifiedFiles.FullPath = /Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/MacOS/eto-test2
  UnifiedFiles.FullPath = /Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/Resources/MacIcon.icns
  UnifiedFiles.FullPath = /Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/Info.plist
  UnifiedFiles.FullPath = /Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/MacOS/eto-test2
  UnifiedFiles.FullPath = /Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/Resources/MacIcon.icns
```

Here is part of output of `dotnet build` if I uncomment this line: https://github.com/picoe/Eto/blob/f5d7804858d3df2e0213912c89e4d3dc20d09ae9/src/Eto.Mac/build/BundleDotNetCore.targets#L35

```
  bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/Info.plist > Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/Info.plist
  bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/MacOS/eto-test2 > Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/MacOS/eto-test2
  bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/Resources/MacIcon.icns > Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/Resources/MacIcon.icns
  bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/Info.plist > Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/Info.plist
  bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/MacOS/eto-test2 > Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/MacOS/eto-test2
  bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/Resources/MacIcon.icns > Users/alex.z/Projects/Private/eto-test2/bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/Resources/MacIcon.icns
```

And here's the output with a fixed version:

```
  bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/Info.plist > Contents/Info.plist
  bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/MacOS/eto-test2 > Contents/MacOS/eto-test2
  bin/Mac64/Debug/net6.0/osx-x64/eto-test2.app/Contents/Resources/MacIcon.icns > Contents/Resources/MacIcon.icns
  bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/Info.plist > Contents/Info.plist
  bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/MacOS/eto-test2 > Contents/MacOS/eto-test2
  bin/Mac64/Debug/net6.0/osx-arm64/eto-test2.app/Contents/Resources/MacIcon.icns > Contents/Resources/MacIcon.icns
```