### PR TITLE
Mac: Allow FloatingForm to get focus by default

### DIFF
--- a/src/Eto.Mac/Forms/FloatingFormHandler.cs
+++ b/src/Eto.Mac/Forms/FloatingFormHandler.cs
@@ -40,6 +40,7 @@ namespace Eto.Mac.Forms
 			var panel = new EtoPanel(new CGRect(0, 0, 200, 200), 
 				NSWindowStyle.Resizable | NSWindowStyle.Closable | NSWindowStyle.Titled, 
 				NSBackingStore.Buffered, false);
+			panel.CanFocus = true;
 
 			panel.FloatingPanel = true;
 			panel.BecomesKeyOnlyIfNeeded = true;


### PR DESCRIPTION
If you have a TextBox on a `FloatingForm`, it would not let you set focus to it to enter text.  Some controls will still not get focus on Mac, such as a DropDown, RadioButton, CheckBox, etc based on the `NSPanel.BecomesKeyOnlyIfNeeded` property, which is true by default.