### PR TITLE
Mac: Fix crash with IconFrame on ARM64 / XamMac2 / .NET 6.0.1xx

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
 
   build-mac:
 
-    runs-on: macos-12
+    runs-on: macos-11
 
     steps:
     - uses: actions/checkout@v2

--- a/src/Eto.Mac/Drawing/IconFrameHandler.cs
+++ b/src/Eto.Mac/Drawing/IconFrameHandler.cs
@@ -52,7 +52,7 @@ namespace Eto.Mac.Drawing
 				}
 			}
 
-#if MACOS_NET
+#if MACOS_NET || ( XAMMAC && NET6_0_OR_GREATER )
 			// .NET 6 on ARM64 crashes when using the override in macos workload preview 11, remove this when fixed.
 			[Export("CGImageForProposedRect:context:hints:")]
 			public CGImage AsCGImage(IntPtr proposedDestRectPtr, NSGraphicsContext context, NSDictionary hints)


### PR DESCRIPTION
This was a regression when adding support for .NET 6.0.2xx+ SDK, when using Eto.XamMac2.csproj with .NET 6.0.1xx SDK. 