### PR TITLE
Make using CFString optional

### DIFF
--- a/src/Eto.Mac/Eto.XamMac2.csproj
+++ b/src/Eto.Mac/Eto.XamMac2.csproj
@@ -5,7 +5,8 @@
     <TargetFrameworks>net462;xamarinmac20</TargetFrameworks>
     <TargetFrameworks Condition="$([MSBuild]::VersionGreaterThanOrEquals($(NETCoreSdkVersion), '6.0')) AND $([MSBuild]::VersionLessThan($(NETCoreSdkVersion), '6.0.200'))">net6.0-macos10.15;$(TargetFrameworks)</TargetFrameworks>
     <RootNamespace>Eto.Mac</RootNamespace>
-    <DefineConstants>$(DefineConstants);OSX;DESKTOP;XAMMAC;XAMMAC2;UNIFIED;USE_CFSTRING</DefineConstants>
+    <DefineConstants>$(DefineConstants);OSX;DESKTOP;XAMMAC;XAMMAC2;UNIFIED</DefineConstants>
+    <DefineConstants Condition="$(UseCFString) != 'False'">$(DefineConstants);USE_CFSTRING</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefaultItemExcludes>build\*</DefaultItemExcludes>
     <NoWarn>CA1416</NoWarn>


### PR DESCRIPTION
If you want to support older Xamarin.Mac versions without the CFString changes you can now set UseCFString=False.