### PR TITLE
Wpf: Fix setting TextColor/BackgroundColor of DropDown/ComboBox

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/ComboBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ComboBoxHandler.cs
@@ -120,6 +120,19 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
+		public override Color TextColor
+		{
+			get => Control.TextBox?.Foreground.ToEtoColor() ?? base.TextColor;
+			set
+			{
+				var textBox = Control.TextBox;
+				if (textBox != null)
+					textBox.Foreground = value.ToWpfBrush();
+				else
+					PerformOnLoad(() => TextColor = value);
+			}
+		}
+
 		public bool ReadOnly
 		{
 			get { return Control.IsReadOnly; }

--- a/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DropDownHandler.cs
@@ -205,18 +205,18 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				var border = BorderControl;
 				if (border != null)
-				{
 					border.Background = value.ToWpfBrush(border.Background);
-				}
+				else
+					PerformOnLoad(() => BackgroundColor = value);
 			}
 		}
-
+		
 		public override Color TextColor
 		{
 			get
 			{
 				var block = Control.FindChild<swc.TextBlock>();
-				return block != null ? block.Foreground.ToEtoColor() : base.TextColor;
+				return block?.Foreground.ToEtoColor() ?? base.TextColor;
 			}
 			set
 			{
@@ -224,7 +224,7 @@ namespace Eto.Wpf.Forms.Controls
 				if (block != null)
 					block.Foreground = value.ToWpfBrush();
 				else
-					base.TextColor = value;
+					PerformOnLoad(() => TextColor = value);
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -94,6 +94,8 @@ namespace Eto.Wpf.Forms
 		internal const string CustomCursor_DataKey = "Eto.CustomCursor";
 
 		internal static IWpfFrameworkElement LastDragTarget;
+		
+		internal static readonly object LoadActionList_Key = new object();
 	}
 
 	public abstract partial class WpfFrameworkElement<TControl, TWidget, TCallback> : WidgetHandler<TControl, TWidget, TCallback>, Control.IHandler, IWpfFrameworkElement
@@ -1052,6 +1054,28 @@ namespace Eto.Wpf.Forms
 				dlg.PrintVisual(ContainerControl, string.Empty);
 			}
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
+		}
+
+		internal bool PerformOnLoad(Action action)
+		{
+			if (Control.IsLoaded)
+				return false;
+			var actionList = Widget.Properties.Get<List<Action>>(WpfFrameworkElement.LoadActionList_Key);
+			if (actionList == null)
+			{
+				actionList = new List<Action>();
+				Control.Loaded += (sender, e) =>
+				{
+					for (int i = 0; i < actionList.Count; i++)
+					{
+						actionList[i]();
+					}
+					actionList.Clear();
+				};
+				Widget.Properties.Set(WpfFrameworkElement.LoadActionList_Key, actionList);
+			}
+			actionList.Add(action);
+			return true;
 		}
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/Controls/ListControlTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ListControlTests.cs
@@ -92,5 +92,26 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			Assert.AreEqual(2, changed, "3.1 - Setting selected index again should trigger event again");
 			Assert.AreEqual(1, list.SelectedIndex, "3.2");
 		}
+		
+		[Test, ManualTest]
+		public void ColorsShouldBeSet()
+		{
+			ManualForm("Control should have blue background with yellow text", form =>
+			{
+				return new TableLayout
+				{
+					Rows = {
+						new TableRow(new T { 
+							BackgroundColor = Colors.Blue, 
+							TextColor = Colors.Yellow,
+							DataStore = new[] { "Item 1", "Item 2", "Item 3" },
+							SelectedIndex = 0 
+						}, null),
+						null
+					}
+				};
+			});
+		}
+		
 	}
 }


### PR DESCRIPTION
It appears to work after the control is loaded, but not before because we're trying to set properties of controls in the visual tree that aren't built yet.

Fixes #2142