### PR TITLE
Mac: Fix using a FontFamily loaded from file/stream to create a Font

### DIFF
--- a/src/Eto.Mac/Drawing/FontHandler.cs
+++ b/src/Eto.Mac/Drawing/FontHandler.cs
@@ -109,36 +109,7 @@ namespace Eto.Mac.Drawing
 
 		#if OSX
 		NSFontTraitMask? traits;
-		[Obsolete]
-		public static NSFont CreateFont(FontFamilyHandler familyHandler, float size, NSFontTraitMask traits, int weight = 5)
-		{
-			return CreateFont(familyHandler.MacName, size, traits, weight);
-		}
 
-		public static NSFont CreateFont(string familyName, nfloat size, NSFontTraitMask traits, int weight = 5)
-		{
-			var font = NSFontManager.SharedFontManager.FontWithFamily(familyName, traits, weight, size);
-			if (font == null)
-			{
-				if (traits.HasFlag(NSFontTraitMask.Italic))
-				{
-					// fake italics by transforming the font
-					const float kRotationForItalicText = 14.0f;
-					var fontTransform = new NSAffineTransform();
-					fontTransform.Scale(size);
-					var italicTransform = new NSAffineTransform();
-					italicTransform.TransformStruct = Matrix.FromSkew(0, kRotationForItalicText).ToCG();
-					fontTransform.AppendTransform(italicTransform);
-					traits &= ~NSFontTraitMask.Italic;
-					font = NSFontManager.SharedFontManager.FontWithFamily(familyName, traits, 5, size);
-					if (font != null)
-					{
-						font = NSFont.FromDescription(font.FontDescriptor, fontTransform);
-					}
-				}
-			}
-			return font;
-		}
 		#endif
 
 		public void Create(FontFamily family, float size, FontStyle style, FontDecoration decoration)
@@ -149,7 +120,7 @@ namespace Eto.Mac.Drawing
 #if OSX
 			var familyHandler = (FontFamilyHandler)family.Handler;
 			traits = style.ToNS() & familyHandler.TraitMask;
-			var font = CreateFont(familyHandler.MacName, size, traits.Value);
+			var font = familyHandler.CreateFont(size, traits.Value);
 
 			if (font == null || font.Handle == IntPtr.Zero)
 				throw new ArgumentOutOfRangeException(string.Empty, string.Format(CultureInfo.CurrentCulture, "Could not allocate font with family {0}, traits {1}, size {2}", family.Name, traits, size));

--- a/src/Eto.Mac/Drawing/FontTypefaceHandler.cs
+++ b/src/Eto.Mac/Drawing/FontTypefaceHandler.cs
@@ -13,15 +13,25 @@ namespace Eto.Mac.Drawing
 		NSFont _font;
 		CGFont _cgfont;
 		string _name;
+		NSFontTraitMask? _traits;
+		int? _weight;
 		static readonly object LocalizedName_Key = new object();
 
 		public NSFont Font => _font ?? (_font = CreateFont(10));
 
 		public string PostScriptName { get; private set; }
 
-		public int Weight { get; private set; }
+		public int Weight
+		{
+			get => _weight ?? (_weight = (int)NSFontManager.SharedFontManager.WeightOfFont(Font)).Value;
+			private set => _weight = value;
+		}
 
-		public NSFontTraitMask Traits { get; private set; }
+		public NSFontTraitMask Traits
+		{
+			get => _traits ?? (_traits = NSFontManager.SharedFontManager.TraitsOfFont(Font)).Value;
+			private set => _traits = value;
+		}
 
 		public FontTypefaceHandler(NSArray descriptor)
 		{
@@ -36,9 +46,6 @@ namespace Eto.Mac.Drawing
 			_font = font;
 			var descriptor = font.FontDescriptor;
 			PostScriptName = descriptor.PostscriptName;
-			var manager = NSFontManager.SharedFontManager;
-			Weight = (int)manager.WeightOfFont(font);
-			Traits = traits ?? manager.TraitsOfFont(font);
 		}
 
 		public FontTypefaceHandler(string postScriptName, string name, NSFontTraitMask traits, int weight)
@@ -139,7 +146,7 @@ namespace Eto.Mac.Drawing
 			}
 
 			var family = (FontFamilyHandler)Widget.Family.Handler;
-			return FontHandler.CreateFont(family.MacName, size, Traits, Weight);
+			return family.CreateFont(size, Traits, Weight);
 		}
 
 		public bool HasCharacterRanges(IEnumerable<Range<int>> ranges)
@@ -159,6 +166,7 @@ namespace Eto.Mac.Drawing
 
 		public void Create(Stream stream)
 		{
+			
 			using (var ms = new MemoryStream())
 			{
 				stream.CopyTo(ms);

--- a/test/Eto.Test/Sections/Dialogs/FontDialogSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/FontDialogSection.cs
@@ -83,8 +83,7 @@ namespace Eto.Test.Sections.Dialogs
 							else
 							{
 								var family = FontFamily.FromFiles(files);
-								var typeface = family.Typefaces.First();
-								font = new Font(typeface, selectedFont.Size, selectedFont.FontDecoration);
+								font = new Font(family, selectedFont.Size, selectedFont.FontStyle, selectedFont.FontDecoration);
 							}
 							UpdatePreview(font, true);
 						}
@@ -135,8 +134,8 @@ namespace Eto.Test.Sections.Dialogs
 								{
 									stream.Dispose();
 								}
-								var typeface = family.Typefaces.First();
-								font = new Font(typeface, selectedFont.Size, selectedFont.FontDecoration);
+								// create font from the current font style
+								font = new Font(family, selectedFont.Size, style: selectedFont.FontStyle, decoration: selectedFont.FontDecoration);
 							}
 							UpdatePreview(font, true);
 						}


### PR DESCRIPTION
Updated FontDialogSection to create a font using the FontFamily directly instead of using the first typeface, and the other case (creating a font from a FontTypeface) is handled when you select another one from the list of loaded typefaces.