### PR TITLE
Mac: Accept first mouse events on FloatingForm when active

### DIFF
--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -37,8 +37,6 @@ namespace Eto.Mac.Forms.Controls
 
 			public override bool AcceptsFirstResponder() => CanFocus;
 
-			public override bool AcceptsFirstMouse(NSEvent theEvent) => CanFocus || base.AcceptsFirstMouse(theEvent);
-
 			public override NSView HitTest(CGPoint aPoint)
 			{
 				var view = base.HitTest(aPoint);
@@ -129,6 +127,13 @@ namespace Eto.Mac.Forms.Controls
 		public void Update(Rectangle rect)
 		{
 			Control.DisplayRect(rect.ToNS());
+		}
+
+		protected override bool OnAcceptsFirstMouse(NSEvent theEvent)
+		{
+			if (CanFocus)
+				return true;
+			return base.OnAcceptsFirstMouse(theEvent);
 		}
 	}
 }

--- a/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -343,6 +343,11 @@ namespace Eto.Mac.Forms.Controls
 				if (!MacView.NewLayout)
 					base.Layout();
 			}
+
+			public override bool AcceptsFirstMouse(NSEvent theEvent)
+			{
+				return Handler != null ? Handler.OnAcceptsFirstMouse(theEvent) : base.AcceptsFirstMouse(theEvent);
+			}
 		}
 		
 		bool changeStarted;

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1419,20 +1419,21 @@ namespace Eto.Mac.Forms
 			remove => Widget.Properties.RemoveEvent(MacView.AcceptsFirstMouse_Key, value);
 		}
 
-		protected virtual void OnAcceptsFirstMouse(MouseEventArgs e)
-		{
-			Widget?.Properties.TriggerEvent(MacView.AcceptsFirstMouse_Key, this, e);
-		}
-
-		bool IMacViewHandler.OnAcceptsFirstMouse(NSEvent theEvent)
+		protected virtual bool OnAcceptsFirstMouse(NSEvent theEvent)
 		{
 			if (!Widget.Properties.ContainsKey(MacView.AcceptsFirstMouse_Key))
+			{
+				if (ContainerControl.Window is NSPanel)
+					return Application.Instance.IsActive;
 				return false;
+			}
 
 			var args = MacConversions.GetMouseEvent(this, theEvent, false);
-			OnAcceptsFirstMouse(args);
+			Widget.Properties.TriggerEvent(MacView.AcceptsFirstMouse_Key, this, args);
 			return args.Handled;
 		}
+
+		bool IMacViewHandler.OnAcceptsFirstMouse(NSEvent theEvent) => OnAcceptsFirstMouse(theEvent);
 
 		public virtual MouseEventArgs TriggerMouseDown(NSObject obj, IntPtr sel, NSEvent theEvent)
 		{


### PR DESCRIPTION
When using a FloatingForm, all mouse events that you want should go to the controls on the form as long as the application is active, regardless whether the FloatingForm has focus.  Otherwise, a Form would need to have focus to get any of these events other than any controls that can receive focus, such as a TextBox, or Drawable if it has CanFocus = true.