### PR TITLE
Mac: FloatingForm should not hide owner when deactivated

### DIFF
--- a/src/Eto.Mac/Forms/FloatingFormHandler.cs
+++ b/src/Eto.Mac/Forms/FloatingFormHandler.cs
@@ -36,10 +36,6 @@ namespace Eto.Mac.Forms
 		{
 			base.SetOwner(owner);
 
-			// When this is true, the NSPanel would hide the panel and owner if they aren't key.
-			// So, only hide on deactivate if it is an ownerless form.
-			Control.HidesOnDeactivate = owner == null;
-
 			SetLevelAdjustment();
 		}
 
@@ -130,7 +126,10 @@ namespace Eto.Mac.Forms
 		void SetAsTopmost()
 		{
 			Control.Level = TopmostWindowLevel;
-			Control.HidesOnDeactivate = true;
+
+			// When this is true, the NSPanel would hide the panel and owner if they aren't key.
+			// So, only hide on deactivate if it is an ownerless form.
+			Control.HidesOnDeactivate = Widget.Owner == null;
 		}
 
 		private void Owner_LostFocus(object sender, EventArgs e)

--- a/src/Eto.Mac/Forms/NativeFormHandler.cs
+++ b/src/Eto.Mac/Forms/NativeFormHandler.cs
@@ -30,7 +30,7 @@ namespace Eto.Mac.Forms
 					NSNotificationCenter.DefaultCenter.AddObserver(NSWindow.DidBecomeKeyNotification, n => Callback.OnGotFocus(Widget, EventArgs.Empty));
 					break;
 				case Window.LostFocusEvent:
-					NSNotificationCenter.DefaultCenter.AddObserver(NSWindow.DidResignKeyNotification, n => Callback.OnGotFocus(Widget, EventArgs.Empty));
+					NSNotificationCenter.DefaultCenter.AddObserver(NSWindow.DidResignKeyNotification, n => Callback.OnLostFocus(Widget, EventArgs.Empty));
 					break;
 			}
 			return;

--- a/src/Eto.Mac/Forms/WindowHandler.cs
+++ b/src/Eto.Mac/Forms/WindowHandler.cs
@@ -13,7 +13,7 @@ namespace Eto.Mac.Forms
 			var windowNumber = NSWindow.WindowNumberAtPoint(nspoint, 0);
 			foreach (var window in Application.Instance.Windows)
 			{
-				if (window.Handler is IMacWindow handler && handler.Control.WindowNumber == windowNumber)
+				if (!window.IsDisposed && window.Handler is IMacWindow handler && handler.Control.WindowNumber == windowNumber)
 				{
 					return window;
 				}


### PR DESCRIPTION
- NativeFormHandler didn't wire up LostFocusEvent properly
- Only look at non-disposed windows in Window.FromPoint()

Follow up to #2235 to fix a few issues.