### PR TITLE
Mac: Respect Window.Topmost even when Owner is set

### DIFF
--- a/src/Eto.Mac/Forms/FloatingFormHandler.cs
+++ b/src/Eto.Mac/Forms/FloatingFormHandler.cs
@@ -65,12 +65,16 @@ namespace Eto.Mac.Forms
 				{
 					lastOwner.GotFocus -= Owner_GotFocus;
 					lastOwner.LostFocus -= Owner_LostFocus;
+					Widget.GotFocus -= Owner_GotFocus;
+					Widget.LostFocus -= Owner_LostFocus;
 					Widget.Closed -= Widget_Closed;
 				}
 				if (owner != null)
 				{
 					owner.GotFocus += Owner_GotFocus;
 					owner.LostFocus += Owner_LostFocus;
+					Widget.GotFocus += Owner_GotFocus;
+					Widget.LostFocus += Owner_LostFocus;
 					Widget.Closed += Widget_Closed;
 				}
 			}
@@ -87,6 +91,8 @@ namespace Eto.Mac.Forms
 				// when closed we need to disconnect from owner to prevent leaks
 				lastOwner.GotFocus -= Owner_GotFocus;
 				lastOwner.LostFocus -= Owner_LostFocus;
+				Widget.GotFocus -= Owner_GotFocus;
+				Widget.LostFocus -= Owner_LostFocus;
 			}
 		}
 
@@ -125,9 +131,15 @@ namespace Eto.Mac.Forms
 
 		private void Owner_LostFocus(object sender, EventArgs e)
 		{
+			if (HasFocus || Widget.Owner.HasFocus)
+				return;
 			Control.Level = NSWindowLevel.Normal;
+			
+			// Window will still be topmost until we order the window explicitly.
+			// If there are multiple app windows, we use this instead of OrderFront otherwise 
+			// the original parent window steals focus again.
 			if (Control.IsVisible)
-				Control.OrderFront(Control);
+				Control.OrderWindow(NSWindowOrderingMode.Above, Control.ParentWindow?.WindowNumber ?? 0);
 		}
 
 		protected override NSPanel CreateControl()

--- a/src/Eto.Mac/Forms/FloatingFormHandler.cs
+++ b/src/Eto.Mac/Forms/FloatingFormHandler.cs
@@ -32,17 +32,10 @@ namespace Eto.Mac.Forms
 
 		protected override NSWindowLevel TopmostWindowLevel => NSWindowLevel.Floating;
 
-		public override void SetOwner(Window owner)
-		{
-			base.SetOwner(owner);
-
-			SetLevelAdjustment();
-		}
-
 		void SetLevelAdjustment()
 		{
 			// only need to adjust level when window style is not utility and we actually want it to be topmost (default for FloatingForm).
-			var wantsTopmost = Widget.Properties.Get<bool>(Topmost_Key, true);
+			var wantsTopmost = WantsTopmost;
 			var owner = Widget.Owner;
 			var needsLevelAdjust = wantsTopmost && WindowStyle != WindowStyle.Utility && owner != null;
 
@@ -97,7 +90,7 @@ namespace Eto.Mac.Forms
 			}
 		}
 
-		static readonly object Topmost_Key = new object();
+		internal override bool DefaultTopmost => true;
 
 		public override bool Topmost
 		{
@@ -105,8 +98,6 @@ namespace Eto.Mac.Forms
 			set
 			{
 				base.Topmost = value;
-				// need to remember the preferred state as it can be changed on us when setting the owner
-				Widget.Properties.Set(Topmost_Key, value, true);
 				SetLevelAdjustment();
 			}
 		}
@@ -150,6 +141,12 @@ namespace Eto.Mac.Forms
 			panel.BecomesKeyOnlyIfNeeded = true;
 
 			return panel;
+		}
+
+		internal override void OnSetAsChildWindow()
+		{
+			// Don't call base, we do our own window level logic for FloatingForm.
+			SetLevelAdjustment();
 		}
 	}
 }

--- a/src/Eto.Mac/Forms/NativeFormHandler.cs
+++ b/src/Eto.Mac/Forms/NativeFormHandler.cs
@@ -17,20 +17,20 @@ namespace Eto.Mac.Forms
 
 		public override void AttachEvent(string id)
 		{
-			// native window, so attach notifications instead of using the delegate so we don't clobber existing functionality
+			// native window, so attach observers instead of using the delegate so we don't clobber existing functionality
 			switch (id)
 			{
 				case Window.ClosedEvent:
-					NSNotificationCenter.DefaultCenter.AddObserver(NSWindow.WillCloseNotification, n => Callback.OnClosed(Widget, EventArgs.Empty));
+					AddObserver(NSWindow.WillCloseNotification, n => Callback.OnClosed(Widget, EventArgs.Empty));
 					break;
 				case Window.SizeChangedEvent:
-					NSNotificationCenter.DefaultCenter.AddObserver(NSWindow.DidResizeNotification, n => Callback.OnSizeChanged(Widget, EventArgs.Empty));
+					AddObserver(NSWindow.DidResizeNotification, n => Callback.OnSizeChanged(Widget, EventArgs.Empty));
 					break;
 				case Window.GotFocusEvent:
-					NSNotificationCenter.DefaultCenter.AddObserver(NSWindow.DidBecomeKeyNotification, n => Callback.OnGotFocus(Widget, EventArgs.Empty));
+					AddObserver(NSWindow.DidBecomeKeyNotification, n => Callback.OnGotFocus(Widget, EventArgs.Empty));
 					break;
 				case Window.LostFocusEvent:
-					NSNotificationCenter.DefaultCenter.AddObserver(NSWindow.DidResignKeyNotification, n => Callback.OnLostFocus(Widget, EventArgs.Empty));
+					AddObserver(NSWindow.DidResignKeyNotification, n => Callback.OnLostFocus(Widget, EventArgs.Empty));
 					break;
 			}
 			return;


### PR DESCRIPTION
macOS by default will reset the window level to normal when it is added as a child window.  To be more like other platforms we respect what the developer wants when this happens.

Also:
- when FloatingForm is shown active it didn't set level properly when losing focus.
- the new NativeForm observed events were not set specific to that window