### PR TITLE
Tree/GridView column width and cell types for GetCellAt

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridColumnHandler.cs
@@ -13,6 +13,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		void ColumnClicked(GridColumnHandler column);
 		int GetColumnDisplayIndex(GridColumnHandler column);
 		void SetColumnDisplayIndex(GridColumnHandler column, int index);
+		void ColumnWidthChanged(GridColumnHandler h);
 	}
 
 	public class GridColumnHandler : WidgetHandler<Gtk.TreeViewColumn, GridColumn>, GridColumn.IHandler
@@ -31,32 +32,32 @@ namespace Eto.GtkSharp.Forms.Controls
 			AutoSize = true;
 			Resizable = true;
 			DataCell = new TextBoxCell();
+			Control.Clickable = true;
 		}
 
 		public string HeaderText
 		{
-			get { return Control.Title; }
-			set { Control.Title = value; }
+			get => Control.Title;
+			set => Control.Title = value;
 		}
 
 		public bool Resizable
 		{
-			get { return Control.Resizable; }
-			set { Control.Resizable = value; }
+			get => Control.Resizable;
+			set => Control.Resizable = value;
 		}
+
+		static readonly object Sortable_Key = new object();
 
 		public bool Sortable
 		{
-			get { return Control.Clickable; }
-			set { Control.Clickable = value; }
+			get => Widget.Properties.Get<bool>(Sortable_Key);
+			set => Widget.Properties.Set(Sortable_Key, value);
 		}
 
 		public bool AutoSize
 		{
-			get
-			{
-				return autoSize;
-			}
+			get => Control.Sizing == Gtk.TreeViewColumnSizing.Fixed ? false : true;
 			set
 			{
 				autoSize = value;
@@ -90,7 +91,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public int Width
 		{
-			get { return Control.Width; }
+			get => Control.Width;
 			set
 			{
 				autoSize = value == -1;
@@ -101,20 +102,14 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public Cell DataCell
 		{
-			get
-			{
-				return dataCell;
-			}
-			set
-			{
-				dataCell = value;
-			}
+			get => dataCell;
+			set => dataCell = value;
 		}
 
 		public bool Visible
 		{
-			get { return Control.Visible; }
-			set { Control.Visible = value; }
+			get => Control.Visible;
+			set => Control.Visible = value;
 		}
 
 		public void SetupCell(IGridHandler grid, ICellDataSource source, int columnIndex, ref int dataIndex)
@@ -146,6 +141,8 @@ namespace Eto.GtkSharp.Forms.Controls
 				HandleEvent(Grid.ColumnHeaderClickEvent);
 			if (grid.IsEventHandled(Grid.CellFormattingEvent))
 				HandleEvent(Grid.CellFormattingEvent);
+			if (grid.IsEventHandled(Grid.ColumnWidthChangedEvent))
+				HandleEvent(Grid.ColumnWidthChangedEvent);
 		}
 
 		public override void AttachEvent(string id)
@@ -157,9 +154,23 @@ namespace Eto.GtkSharp.Forms.Controls
 					Control.Clicked += (sender, e) =>
 					{
 						var h = ((GridColumnHandler)handler.Target);
-						if (h != null && h.grid != null)
+						if (h != null && h.grid != null && h.Sortable)
 							h.grid.ColumnClicked(h);
 					};
+					break;
+				case Grid.ColumnWidthChangedEvent:
+					var handler2 = new WeakReference(this);
+					var lastWidth = -1;
+					Control.AddNotification("width", (o, args) =>
+					{
+						var h = (GridColumnHandler)handler2.Target;
+						if (h == null)
+							return;
+						if (lastWidth == h.Width)
+							return;
+						lastWidth = h.Width;
+						h.grid?.ColumnWidthChanged(h);
+					});
 					break;
 				default:
 					((ICellHandler)dataCell.Handler).HandleEvent(id);
@@ -202,7 +213,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				GridHandler?.Tree?.ColumnsAutosize();
 			}
 		}
-		
+
 		int? displayIndex;
 
 		public int DisplayIndex

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -17,7 +17,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		internal static readonly object AllowEmptySelection_Key = new object();
 	}
 
-	public abstract class GridHandler<TWidget, TCallback> : GtkControl<Gtk.ScrolledWindow, TWidget, TCallback>, Grid.IHandler, ICellDataSource, IGridHandler
+	public abstract class GridHandler<TWidget, TCallback> : GtkControl<Gtk.TreeView, TWidget, TCallback>, Grid.IHandler, ICellDataSource, IGridHandler
 		where TWidget : Grid
 		where TCallback : Grid.ICallback
 	{
@@ -28,15 +28,17 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		protected bool SkipSelectedChange { get; set; }
 
-		protected Gtk.TreeView Tree { get; private set; }
+		public Gtk.ScrolledWindow ScrolledWindow { get; private set; }
+		public EtoEventBox Box { get; private set; }
 
-		Gtk.TreeView IGridHandler.Tree => Tree;
+		Gtk.TreeView IGridHandler.Tree => Control;
 
 		protected Dictionary<int, int> ColumnMap { get { return columnMap; } }
 
-		public override Gtk.Widget EventControl => Tree;
+		public override Gtk.Widget ContainerControl => ScrolledWindow;
 
-		public override Gtk.Widget DragControl => Tree;
+		public override bool ShouldTranslatePoints => true;
+
 
 		class EtoScrolledWindow : Gtk.ScrolledWindow
 		{
@@ -80,7 +82,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		protected GridHandler()
 		{
-			Control = new EtoScrolledWindow
+			ScrolledWindow = new EtoScrolledWindow
 			{
 				Handler = this,
 				ShadowType = Gtk.ShadowType.In,
@@ -89,6 +91,8 @@ namespace Eto.GtkSharp.Forms.Controls
 				PropagateNaturalWidth = true
 #endif
 			};
+			// Box = new EtoEventBox();
+			// ScrolledWindow.Add(Box);
 		}
 
 		protected abstract ITreeModelImplementor CreateModelImplementor();
@@ -97,15 +101,15 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			SkipSelectedChange = true;
 			var selected = SelectedRows;
-			Tree.Model = new Gtk.TreeModelAdapter(CreateModelImplementor());
+			Control.Model = new Gtk.TreeModelAdapter(CreateModelImplementor());
 			SetSelectedRows(selected);
 			SkipSelectedChange = false;
 		}
 		
 		protected (double? hscroll, double? vscroll) SaveScrollState()
 		{
-			var hscrollbar = Control.HScrollbar as Gtk.Scrollbar;
-			var vscrollbar = Control.VScrollbar as Gtk.Scrollbar;
+			var hscrollbar = ScrolledWindow.HScrollbar as Gtk.Scrollbar;
+			var vscrollbar = ScrolledWindow.VScrollbar as Gtk.Scrollbar;
 			var hscroll = hscrollbar?.Value;
 			var vscroll = vscrollbar?.Value;
 			return (hscroll, vscroll);
@@ -114,8 +118,8 @@ namespace Eto.GtkSharp.Forms.Controls
 		protected void RestoreScrollState((double? hscroll, double? vscroll) state)
 		
 		{
-			var hscrollbar = Control.HScrollbar as Gtk.Scrollbar;
-			var vscrollbar = Control.VScrollbar as Gtk.Scrollbar;
+			var hscrollbar = ScrolledWindow.HScrollbar as Gtk.Scrollbar;
+			var vscrollbar = ScrolledWindow.VScrollbar as Gtk.Scrollbar;
 			if (state.hscroll != null)
 				hscrollbar.Value = state.hscroll.Value;
 			if (state.vscroll != null)
@@ -124,17 +128,17 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		protected override void Initialize()
 		{
-			Tree = new Gtk.TreeView();
+			Control = new Gtk.TreeView();
 			// always need this one so the last column doesn't expand
-			Tree.AppendColumn(spacingColumn = new Gtk.TreeViewColumn());
-			Tree.ColumnDragFunction = Connector.HandleColumnDrag;
+			Control.AppendColumn(spacingColumn = new Gtk.TreeViewColumn());
+			Control.ColumnDragFunction = Connector.HandleColumnDrag;
 
 			UpdateModel();
-			Tree.HeadersVisible = true;
-			Control.Add(Tree);
+			Control.HeadersVisible = true;
+			ScrolledWindow.Child = Control;
 
-			Tree.Events |= Gdk.EventMask.ButtonPressMask;
-			Tree.ButtonPressEvent += Connector.HandleButtonPress;
+			Control.Events |= Gdk.EventMask.ButtonPressMask;
+			Control.ButtonPressEvent += Connector.HandleButtonPress;
 
 			columns = new ColumnCollection { Handler = this };
 			columns.Register(Widget.Columns);
@@ -146,10 +150,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		protected new GridConnector Connector => (GridConnector)base.Connector;
 
-		protected override WeakConnector CreateConnector()
-		{
-			return new GridConnector();
-		}
+		protected override WeakConnector CreateConnector() => new GridConnector();
 
 		protected class GridConnector : GtkControlConnector
 		{
@@ -249,20 +250,20 @@ namespace Eto.GtkSharp.Forms.Controls
 				Gtk.TreeViewColumn clickedColumn;
 
 				// Get path and column from mouse position
-				h.Tree.GetPathAtPos((int)e.Event.X, (int)e.Event.Y, out path, out clickedColumn);
+				h.Control.GetPathAtPos((int)e.Event.X, (int)e.Event.Y, out path, out clickedColumn);
 				if (path == null || clickedColumn == null)
 					return;
 
 				var rowIndex = h.GetRowIndexOfPath(path);
-				var columnIndex = h.GetColumnOfItem(clickedColumn);
+				var columnIndex = h.GetColumnIndex(clickedColumn);
 				var item = h.GetItem(path);
 				var column = columnIndex == -1 || columnIndex >= h.Widget.Columns.Count ? null : h.Widget.Columns[columnIndex];
 
 				var loc = h.PointFromScreen(new PointF((float)e.Event.XRoot, (float)e.Event.YRoot));
 
-				if (ReferenceEquals(h.Tree.ExpanderColumn, clickedColumn))
+				if (ReferenceEquals(h.Control.ExpanderColumn, clickedColumn))
 				{
-					var cellArea = h.Tree.GetCellArea(path, clickedColumn);
+					var cellArea = h.Control.GetCellArea(path, clickedColumn);
 					if (loc.X < cellArea.Left && loc.X >= cellArea.Left - 18) // how do we get the size of the expander?
 					{
 						// clicked on the expander, don't fire the CellClick event
@@ -299,26 +300,27 @@ namespace Eto.GtkSharp.Forms.Controls
 				case Grid.CellEditingEvent:
 				case Grid.CellEditedEvent:
 				case Grid.CellFormattingEvent:
+				case Grid.ColumnWidthChangedEvent:
 					SetupColumnEvents();
 					break;
 				case Grid.CellClickEvent:
-					Tree.ButtonPressEvent += Connector.OnTreeButtonPress;
+					Control.ButtonPressEvent += Connector.OnTreeButtonPress;
 					break;
 				case Grid.CellDoubleClickEvent:
-					Tree.RowActivated += (sender, e) =>
+					Control.RowActivated += (sender, e) =>
 					{
 						var rowIndex = GetRowIndexOfPath(e.Path);
-						var columnIndex = GetColumnOfItem(e.Column);
+						var columnIndex = GetColumnIndex(e.Column);
 						var item = GetItem(e.Path);
 						var column = columnIndex == -1 ? null : Widget.Columns[columnIndex];
 						Callback.OnCellDoubleClick(Widget, new GridCellMouseEventArgs(column, rowIndex, columnIndex, item, Mouse.Buttons, Keyboard.Modifiers, PointFromScreen(Mouse.Position)));
 					};
 					break;
 				case Grid.SelectionChangedEvent:
-					Tree.Selection.Changed += Connector.HandleGridSelectionChanged;
+					Control.Selection.Changed += Connector.HandleGridSelectionChanged;
 					break;
 				case Grid.ColumnOrderChangedEvent:
-					Tree.ColumnsChanged += Connector.HandleGridColumnsChanged;
+					Control.ColumnsChanged += Connector.HandleGridColumnsChanged;
 					break;
 				default:
 					base.AttachEvent(id);
@@ -361,7 +363,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				colHandler.Control.Reorderable = AllowColumnReordering;
 				colHandler.SetupCell(this, this, columnIndex++, ref dataIndex);
 				if (i == 0)
-					Tree.ExpanderColumn = colHandler.Control;
+					Control.ExpanderColumn = colHandler.Control;
 			}
 			
 			foreach (var col in Widget.Columns.OrderBy(r => r.DisplayIndex))
@@ -379,9 +381,9 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				var colhandler = (GridColumnHandler)item.Handler;
 #if GTKCORE
-				Handler.Tree.InsertColumn(colhandler.Control, (int)Handler.Tree.NColumns - 1);
+				Handler.Control.InsertColumn(colhandler.Control, (int)Handler.Control.NColumns - 1);
 #else
-				Handler.Tree.InsertColumn(colhandler.Control, Count);
+				Handler.Control.InsertColumn(colhandler.Control, Count);
 #endif
 				Handler.UpdateColumns();
 			}
@@ -389,24 +391,24 @@ namespace Eto.GtkSharp.Forms.Controls
 			public override void InsertItem(int index, GridColumn item)
 			{
 				var colhandler = (GridColumnHandler)item.Handler;
-				Handler.Tree.InsertColumn(colhandler.Control, index);
+				Handler.Control.InsertColumn(colhandler.Control, index);
 				Handler.UpdateColumns();
 			}
 
 			public override void RemoveItem(int index)
 			{
 				var colhandler = (GridColumnHandler)Handler.Widget.Columns[index].Handler;
-				Handler.Tree.RemoveColumn(colhandler.Control);
+				Handler.Control.RemoveColumn(colhandler.Control);
 				Handler.UpdateColumns();
 			}
 
 			public override void RemoveAllItems()
 			{
-				foreach (var col in Handler.Tree.Columns)
+				foreach (var col in Handler.Control.Columns)
 				{
-					Handler.Tree.RemoveColumn(col);
+					Handler.Control.RemoveColumn(col);
 				}
-				Handler.Tree.AppendColumn(Handler.spacingColumn);
+				Handler.Control.AppendColumn(Handler.spacingColumn);
 				Handler.UpdateColumns();
 			}
 
@@ -414,8 +416,8 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public bool ShowHeader
 		{
-			get { return Tree.HeadersVisible; }
-			set { Tree.HeadersVisible = value; }
+			get { return Control.HeadersVisible; }
+			set { Control.HeadersVisible = value; }
 		}
 
 
@@ -439,9 +441,17 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public abstract object GetItem(Gtk.TreePath path);
 
-		public int GetColumnOfItem(Gtk.TreeViewColumn item)
+		public int GetColumnIndex(Gtk.TreeViewColumn item)
 		{
-			return Widget.Columns.Select(r => r.Handler as GridColumnHandler).Select(r => r.Control).ToList().IndexOf(item);
+			for (int i = 0; i < Widget.Columns.Count; i++)
+			{
+				GridColumn col = Widget.Columns[i];
+				if (col.Handler is GridColumnHandler handler && ReferenceEquals(handler.Control, item))
+				{
+					return i;
+				}
+			}
+			return -1;
 		}
 
 		public virtual int GetRowIndexOfPath(Gtk.TreePath path)
@@ -496,15 +506,15 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public bool AllowMultipleSelection
 		{
-			get { return Tree.Selection.Mode == Gtk.SelectionMode.Multiple; }
-			set { Tree.Selection.Mode = value ? Gtk.SelectionMode.Multiple : Gtk.SelectionMode.Browse; }
+			get { return Control.Selection.Mode == Gtk.SelectionMode.Multiple; }
+			set { Control.Selection.Mode = value ? Gtk.SelectionMode.Multiple : Gtk.SelectionMode.Browse; }
 		}
 
 		public virtual IEnumerable<int> SelectedRows
 		{
 			get
 			{
-				return Tree.Selection.GetSelectedRows().Select(r => r.Indices[0]);
+				return Control.Selection.GetSelectedRows().Select(r => r.Indices[0]);
 			}
 			set
 			{
@@ -525,44 +535,44 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public void SelectAll()
 		{
-			Tree.Selection.SelectAll();
+			Control.Selection.SelectAll();
 		}
 
 		public void SelectRow(int row)
 		{
-			Tree.Selection.SelectIter(GetIterAtRow(row));
+			Control.Selection.SelectIter(GetIterAtRow(row));
 		}
 
 		public void UnselectRow(int row)
 		{
-			Tree.Selection.UnselectIter(GetIterAtRow(row));
+			Control.Selection.UnselectIter(GetIterAtRow(row));
 		}
 
 		public void UnselectAll()
 		{
-			Tree.Selection.UnselectAll();
+			Control.Selection.UnselectAll();
 		}
 
 		public void BeginEdit(int row, int column)
 		{
-			var nameColumn = Tree.Columns[column];
+			var nameColumn = Control.Columns[column];
 			var cellRenderer = nameColumn.Cells[0];
-			var path = Tree.Model.GetPath(GetIterAtRow(row));
-			Tree.Model.IterNChildren();
-			Tree.SetCursorOnCell(path, nameColumn, cellRenderer, true);
+			var path = Control.Model.GetPath(GetIterAtRow(row));
+			Control.Model.IterNChildren();
+			Control.SetCursorOnCell(path, nameColumn, cellRenderer, true);
 		}
 
 		public bool CommitEdit()
 		{
 			Gtk.TreePath path;
 			Gtk.TreeViewColumn column;
-			Tree.GetCursor(out path, out column);
+			Control.GetCursor(out path, out column);
 			if (path == null || column == null)
 				return true;
 
 			// This is a hack, but it works to commit editing.  Is there a better way?
-			if (Tree.FocusChild?.HasFocus == true)
-				Tree.ChildFocus(Gtk.DirectionType.TabForward);
+			if (Control.FocusChild?.HasFocus == true)
+				Control.ChildFocus(Gtk.DirectionType.TabForward);
 			return true;
 		}
 
@@ -570,13 +580,13 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			Gtk.TreePath path;
 			Gtk.TreeViewColumn column;
-			Tree.GetCursor(out path, out column);
+			Control.GetCursor(out path, out column);
 			if (path == null || column == null)
 				return true;
 
 			// This is a hack, but it works to abort editing.  Is there a better way?
-			if (Tree.FocusChild?.HasFocus == true)
-				Tree.GrabFocus();
+			if (Control.FocusChild?.HasFocus == true)
+				Control.GrabFocus();
 			return true;
 		}
 
@@ -588,15 +598,15 @@ namespace Eto.GtkSharp.Forms.Controls
 		public void ScrollToRow(int row)
 		{
 			var path = this.GetPathAtRow(row);
-			var column = Tree.Columns.First();
-			Tree.ScrollToCell(path, column, false, 0, 0);
+			var column = Control.Columns.First();
+			Control.ScrollToCell(path, column, false, 0, 0);
 		}
 
 		public GridLines GridLines
 		{
 			get
 			{
-				switch (Tree.EnableGridLines)
+				switch (Control.EnableGridLines)
 				{
 					case Gtk.TreeViewGridLines.None:
 						return GridLines.None;
@@ -615,16 +625,16 @@ namespace Eto.GtkSharp.Forms.Controls
 				switch (value)
 				{
 					case GridLines.None:
-						Tree.EnableGridLines = Gtk.TreeViewGridLines.None;
+						Control.EnableGridLines = Gtk.TreeViewGridLines.None;
 						break;
 					case GridLines.Horizontal:
-						Tree.EnableGridLines = Gtk.TreeViewGridLines.Horizontal;
+						Control.EnableGridLines = Gtk.TreeViewGridLines.Horizontal;
 						break;
 					case GridLines.Vertical:
-						Tree.EnableGridLines = Gtk.TreeViewGridLines.Vertical;
+						Control.EnableGridLines = Gtk.TreeViewGridLines.Vertical;
 						break;
 					case GridLines.Both:
-						Tree.EnableGridLines = Gtk.TreeViewGridLines.Both;
+						Control.EnableGridLines = Gtk.TreeViewGridLines.Both;
 						break;
 					default:
 						throw new NotSupportedException();
@@ -635,7 +645,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		public BorderType Border
 		{
 			get { return Widget.Properties.Get(GridHandler.Border_Key, BorderType.Bezel); }
-			set { Widget.Properties.Set(GridHandler.Border_Key, value, () => Control.ShadowType = value.ToGtk(), BorderType.Bezel); }
+			set { Widget.Properties.Set(GridHandler.Border_Key, value, () => ScrolledWindow.ShadowType = value.ToGtk(), BorderType.Bezel); }
 		}
 
 		public bool IsEditing
@@ -644,7 +654,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				Gtk.TreePath path;
 				Gtk.TreeViewColumn focus_column;
-				Tree.GetCursor(out path, out focus_column);
+				Control.GetCursor(out path, out focus_column);
 
 #if GTK2
 				var cells = focus_column?.CellRenderers;
@@ -671,7 +681,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				if (AllowEmptySelection)
 				{
 					// clicked on an empty area
-					if (!Tree.GetPathAtPos((int)location.X, (int)location.Y, out _, out _))
+					if (!Control.GetPathAtPos((int)location.X, (int)location.Y, out _, out _))
 					{
 						UnselectAll();
 						e.Handled = true;
@@ -680,12 +690,12 @@ namespace Eto.GtkSharp.Forms.Controls
 				else
 				{
 					// cancel ctrl+clicking to remove last selected item
-					if (Tree.GetPathAtPos((int)location.X, (int)location.Y, out var path, out _))
+					if (Control.GetPathAtPos((int)location.X, (int)location.Y, out var path, out _))
 					{
-						if (Tree.Model.GetIter(out var iter, path))
+						if (Control.Model.GetIter(out var iter, path))
 						{
-							var isSelected = Tree.Selection.IterIsSelected(iter);
-							if (e.Modifiers == Keys.Control && isSelected && Tree.Selection.CountSelectedRows() == 1)
+							var isSelected = Control.Selection.IterIsSelected(iter);
+							if (e.Modifiers == Keys.Control && isSelected && Control.Selection.CountSelectedRows() == 1)
 							{
 								e.Handled = true;
 							}
@@ -697,7 +707,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		protected void EnsureSelection()
 		{
-			if (!AllowEmptySelection && Tree.Selection.CountSelectedRows() == 0)
+			if (!AllowEmptySelection && Control.Selection.CountSelectedRows() == 0)
 			{
 				SelectRow(0);
 			}
@@ -705,16 +715,21 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public int GetColumnDisplayIndex(GridColumnHandler column)
 		{
-			var columns = Tree.Columns;
+			var columns = Control.Columns;
 			return Array.IndexOf(columns, column.Control);
 		}
 
 		public void SetColumnDisplayIndex(GridColumnHandler column, int index)
 		{
-			var columns = Tree.Columns;
+			var columns = Control.Columns;
 			var currentIndex = Array.IndexOf(columns, column.Control);
 			if (index != currentIndex)
-				Tree.MoveColumnAfter(column.Control, columns[index]);
+				Control.MoveColumnAfter(column.Control, columns[index]);
+		}
+
+		public void ColumnWidthChanged(GridColumnHandler h)
+		{
+			Callback.OnColumnWidthChanged(Widget, new GridColumnEventArgs(h.Widget));
 		}
 	}
 }

--- a/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
@@ -49,7 +49,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					{
 						var newpath = path.Copy();
 						newpath.AppendIndex(i);
-						Handler.Tree.ExpandToPath(newpath);
+						Handler.Control.ExpandToPath(newpath);
 						ExpandItems((ITreeGridStore<ITreeGridItem>)item, newpath);
 					}
 				}
@@ -73,7 +73,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				var path = new Gtk.TreePath();
 				path.AppendIndex(Collection.Count);
 				var iter = Handler.model.GetIterFromItem(item, path);
-				Handler.Tree.Model.EmitRowInserted(path, iter);
+				Handler.Control.Model.EmitRowInserted(path, iter);
 			}
 
 			public override void InsertItem(int index, ITreeGridItem item)
@@ -81,14 +81,14 @@ namespace Eto.GtkSharp.Forms.Controls
 				var path = new Gtk.TreePath();
 				path.AppendIndex(index);
 				var iter = Handler.model.GetIterFromItem(item, path);
-				Handler.Tree.Model.EmitRowInserted(path, iter);
+				Handler.Control.Model.EmitRowInserted(path, iter);
 			}
 
 			public override void RemoveItem(int index)
 			{
 				var path = new Gtk.TreePath();
 				path.AppendIndex(index);
-				Handler.Tree.Model.EmitRowDeleted(path);
+				Handler.Control.Model.EmitRowDeleted(path);
 			}
 
 			public override void RemoveAllItems()
@@ -120,7 +120,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				if (AllowMultipleSelection)
 					return SelectedItems.FirstOrDefault() as ITreeGridItem;
 				Gtk.TreeIter iter;
-				return Tree.Selection.GetSelected(out iter) ? model.GetItemAtIter(iter) : null;
+				return Control.Selection.GetSelected(out iter) ? model.GetItemAtIter(iter) : null;
 			}
 			set
 			{
@@ -129,13 +129,13 @@ namespace Eto.GtkSharp.Forms.Controls
 					var path = model.GetPathFromItem(value);
 					if (path != null)
 					{
-						Tree.ExpandToPath(path);
-						Tree.Selection.SelectPath(path);
-						Tree.ScrollToCell(path, null, false, 0, 0);
+						Control.ExpandToPath(path);
+						Control.Selection.SelectPath(path);
+						Control.ScrollToCell(path, null, false, 0, 0);
 					}
 				}
 				else
-					Tree.Selection.UnselectAll();
+					Control.Selection.UnselectAll();
 			}
 		}
 
@@ -157,22 +157,22 @@ namespace Eto.GtkSharp.Forms.Controls
 			switch (id)
 			{
 				case TreeGridView.ActivatedEvent:
-					Tree.RowActivated += Connector.HandleRowActivated;
+					Control.RowActivated += Connector.HandleRowActivated;
 					break;
 				case TreeGridView.ExpandingEvent:
-					Tree.TestExpandRow += Connector.HandleTestExpandRow;
+					Control.TestExpandRow += Connector.HandleTestExpandRow;
 					break;
 				case TreeGridView.ExpandedEvent:
-					Tree.RowExpanded += Connector.HandleRowExpanded;
+					Control.RowExpanded += Connector.HandleRowExpanded;
 					break;
 				case TreeGridView.CollapsingEvent:
-					Tree.TestCollapseRow += Connector.HandleTestCollapseRow;
+					Control.TestCollapseRow += Connector.HandleTestCollapseRow;
 					break;
 				case TreeGridView.CollapsedEvent:
-					Tree.RowCollapsed += Connector.HandleRowCollapsed;
+					Control.RowCollapsed += Connector.HandleRowCollapsed;
 					break;
 				case TreeGridView.SelectedItemChangedEvent:
-					Tree.Selection.Changed += Connector.HandleSelectionChanged;
+					Control.Selection.Changed += Connector.HandleSelectionChanged;
 					break;
 				default:
 					base.AttachEvent(id);
@@ -247,8 +247,8 @@ namespace Eto.GtkSharp.Forms.Controls
 				handler.SkipSelectedChange = false;
 				if (handler.selectCollapsingItem == true)
 				{
-					handler.Tree.Selection.UnselectAll();
-					handler.Tree.Selection.SelectPath(args.Path);
+					handler.Control.Selection.UnselectAll();
+					handler.Control.Selection.SelectPath(args.Path);
 					handler.selectCollapsingItem = null;
 				}
 			}
@@ -274,7 +274,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			protected override DragEventArgs GetDragEventArgs(Gdk.DragContext context, PointF? location, uint time = 0, object controlObject = null)
 			{
 				var h = Handler;
-				var t = h?.Tree;
+				var t = h?.Control;
 				TreeGridViewDragInfo dragInfo = _dragInfo;
 				if (dragInfo == null && location != null)
 				{
@@ -336,7 +336,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					}
 
 					if (path.Depth > 0)
-						h.Tree.SetDragDestRow(path, pos);
+						h.Control.SetDragDestRow(path, pos);
 				}
 				else if (insertIndex != -1 && !ReferenceEquals(info.Parent, null) && info.Position == GridDragPosition.After)
 				{
@@ -345,7 +345,7 @@ namespace Eto.GtkSharp.Forms.Controls
 						return;
 
 					path.AppendIndex(0);
-					h.Tree.SetDragDestRow(path, Gtk.TreeViewDropPosition.Before);
+					h.Control.SetDragDestRow(path, Gtk.TreeViewDropPosition.Before);
 				}
 
 			}
@@ -397,21 +397,21 @@ namespace Eto.GtkSharp.Forms.Controls
 			Gtk.TreeIter iter;
 			Gtk.TreeIter temp;
 
-			bool valid = Tree.Model.GetIterFirst(out iter);
+			bool valid = Control.Model.GetIterFirst(out iter);
 			while (valid)
 			{
 				// Check
-				path = Tree.Model.GetPath(iter);
+				path = Control.Model.GetPath(iter);
 				if (model.GetRowIndexOfIter(iter) == row)
 					return path;
 
 				// Go Down
-				if (Tree.GetRowExpanded(path) && Tree.Model.IterChildren(out iter, iter))
+				if (Control.GetRowExpanded(path) && Control.Model.IterChildren(out iter, iter))
 					continue;
 
 				// Go Next
 				temp = iter;
-				if (Tree.Model.IterNext(ref iter))
+				if (Control.Model.IterNext(ref iter))
 					continue;
 				else
 					iter = temp;
@@ -419,11 +419,11 @@ namespace Eto.GtkSharp.Forms.Controls
 				while (valid)
 				{
 					// Go Up
-					if (Tree.Model.IterParent(out iter, iter))
+					if (Control.Model.IterParent(out iter, iter))
 					{
 						// Go Next
 						temp = iter;
-						if (Tree.Model.IterNext(ref iter))
+						if (Control.Model.IterNext(ref iter))
 							break;
 						else
 							iter = temp;
@@ -434,14 +434,14 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 
 			// Get and return first if given row does not exist
-			Tree.Model.GetIterFirst(out iter);
-			return Tree.Model.GetPath(iter);
+			Control.Model.GetIterFirst(out iter);
+			return Control.Model.GetPath(iter);
 		}
 
 		protected override void SetSelectedRows(IEnumerable<int> value)
 		
 		{
-			Tree.Selection.UnselectAll();
+			Control.Selection.UnselectAll();
 			if (value != null && collection != null)
 			{
 				int start = -1;
@@ -457,18 +457,18 @@ namespace Eto.GtkSharp.Forms.Controls
 					else
 					{
 						if (start == end)
-							Tree.Selection.SelectIter(GetIterAtRow(start));
+							Control.Selection.SelectIter(GetIterAtRow(start));
 						else
-							Tree.Selection.SelectRange(GetPathAtRow(start), GetPathAtRow(end));
+							Control.Selection.SelectRange(GetPathAtRow(start), GetPathAtRow(end));
 						start = end = row;
 					}
 				}
 				if (start != -1)
 				{
 					if (start == end)
-						Tree.Selection.SelectIter(GetIterAtRow(start));
+						Control.Selection.SelectIter(GetIterAtRow(start));
 					else
-						Tree.Selection.SelectRange(GetPathAtRow(start), GetPathAtRow(end));
+						Control.Selection.SelectRange(GetPathAtRow(start), GetPathAtRow(end));
 				}
 			}
 		}
@@ -514,12 +514,12 @@ namespace Eto.GtkSharp.Forms.Controls
 			// restore selection
 			SkipSelectedChange = true;
 			bool selectionChanged = false;
-			Tree.Selection.UnselectAll();
+			Control.Selection.UnselectAll();
 			foreach (var item in items.OfType<ITreeGridItem>())
 			{
 				var iter = model.GetIterFromItem(item, true);
 				if (iter != null)
-					Tree.Selection.SelectIter(iter.Value);
+					Control.Selection.SelectIter(iter.Value);
 				else
 					selectionChanged = true;
 			}
@@ -533,7 +533,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public void ReloadItem(ITreeGridItem item, bool reloadChildren)
 		{
-			var tree = Tree;
+			var tree = Control;
 			var path = model.GetPathFromItem(item);
 			if (path != null && path.Depth > 0 && !ReferenceEquals(item, collection.Collection))
 			{
@@ -575,26 +575,43 @@ namespace Eto.GtkSharp.Forms.Controls
 				ReloadData();
 		}
 
-		public ITreeGridItem GetCellAt(PointF location, out int column)
+		public TreeGridCell GetCellAt(PointF location)
 		{
-			Gtk.TreePath path;
-			Gtk.TreeViewColumn col;
-			if (Tree.GetPathAtPos((int)location.X, (int)location.Y, out path, out col))
+			int columnIndex;
+			int rowIndex;
+			object item;
+			GridCellType cellType;
+
+			var isData = Control.GetPathAtPos((int)location.X, (int)location.Y, out var path, out var col);
+			
+			if (isData)
 			{
-				column = GetColumnOfItem(col);
-				return model.GetItemAtPath(path);
+				columnIndex = GetColumnIndex(col);
+				rowIndex = GetRowIndexOfPath(path);
+				item = model.GetItemAtPath(path);
+				if (columnIndex == -1)
+					cellType = GridCellType.None;
+				else
+					cellType = GridCellType.Data;
 			}
-			column = -1;
-			return null;
+			else
+			{
+				columnIndex = -1;
+				rowIndex = -1;
+				item = null;
+				cellType = GridCellType.None;
+			}
+			var column = columnIndex != -1 ? Widget.Columns[columnIndex] : null;
+			return new TreeGridCell(column, columnIndex, cellType, item);
 		}
 
 		public TreeGridViewDragInfo GetDragInfo(DragEventArgs args) => args.ControlObject as TreeGridViewDragInfo;
 
 		ITreeGridItem IGtkListModelHandler<ITreeGridItem>.GetItem(int row) => DataStore?[row];
 
-		public override IEnumerable<int> SelectedRows => Tree.Selection.GetSelectedRows().Select(GetRowIndexOfPath);
+		public override IEnumerable<int> SelectedRows => Control.Selection.GetSelectedRows().Select(GetRowIndexOfPath);
 
-		public IEnumerable<object> SelectedItems => Tree.Selection.GetSelectedRows().Select(GetItem);
+		public IEnumerable<object> SelectedItems => Control.Selection.GetSelectedRows().Select(GetItem);
 
 		protected override bool HasRows => model.IterHasChild(Gtk.TreeIter.Zero);
 

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -561,7 +561,9 @@ namespace Eto.GtkSharp.Forms
 					return;
 
 				var p = new PointF((float)args.Event.X, (float)args.Event.Y);
+				p = handler.TranslatePoint(args.Event.Window, p);
 				Keys modifiers = args.Event.State.ToEtoKey();
+				
 				MouseButtons buttons = args.Event.State.ToEtoMouseButtons();
 
 				handler.Callback.OnMouseMove(handler.Widget, new MouseEventArgs(buttons, modifiers, p));
@@ -574,8 +576,8 @@ namespace Eto.GtkSharp.Forms
 				if (handler == null)
 					return;
 
-				args.Event.ToEtoLocation();
 				var p = new PointF((float)args.Event.X, (float)args.Event.Y);
+				p = handler.TranslatePoint(args.Event.Window, p);
 				Keys modifiers = args.Event.State.ToEtoKey();
 				MouseButtons buttons = args.Event.ToEtoMouseButtons();
 
@@ -592,6 +594,7 @@ namespace Eto.GtkSharp.Forms
 					return;
 
 				var p = new PointF((float)args.Event.X, (float)args.Event.Y);
+				p = handler.TranslatePoint(args.Event.Window, p);
 				Keys modifiers = args.Event.State.ToEtoKey();
 				MouseButtons buttons = args.Event.ToEtoMouseButtons();
 				var mouseArgs = new MouseEventArgs(buttons, modifiers, p);
@@ -820,6 +823,25 @@ namespace Eto.GtkSharp.Forms
 				}
 			}
 #endif
+		}
+
+		public virtual bool ShouldTranslatePoints => false;
+
+		public virtual PointF TranslatePoint(Gdk.Window window, PointF p)
+		{
+			if (!ShouldTranslatePoints || window == null)
+				return p;
+			var eventWindow = EventControl.GetWindow();
+
+			if (!ReferenceEquals(window, eventWindow))
+			{
+				// adjust point!
+				eventWindow.GetOrigin(out var x, out var y);
+				window.GetOrigin(out var ex, out var ey);
+				p.X += ex - x;
+				p.Y += ey - y;
+			}
+			return p;
 		}
 
 		protected virtual Gtk.Widget FontControl

--- a/src/Eto.Gtk/GtkConversions.cs
+++ b/src/Eto.Gtk/GtkConversions.cs
@@ -565,11 +565,6 @@ namespace Eto.GtkSharp
 			}
 		}
 
-		public static PointF ToEtoLocation(this Gdk.EventButton e)
-		{
-			return new PointF((float)e.X, (float)e.Y);
-		}
-
 		public static CellStates ToEto(this Gtk.CellRendererState value)
 		{
 			if (value.HasFlag(Gtk.CellRendererState.Selected))
@@ -882,5 +877,15 @@ namespace Eto.GtkSharp
 		}
 
 		public static Gdk.Cursor ToGdk(this Cursor cursor) => CursorHandler.GetControl(cursor);
+		
+		public static Rectangle GetBounds(this Gdk.Window window)
+		{
+			window.GetPosition(out var x, out var y);
+#if GTK2
+			return new Rectangle(x, y, 0, 0); // who cares, need to drop support for GTK2 anyway
+#else
+			return new Rectangle(x, y, window.Width, window.Height);
+#endif
+		}
 	}
 }

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1451,7 +1451,7 @@ namespace Eto.Mac.Forms
 			{
 				Callback.OnMouseDown(Widget, args);
 			}
-			if (!args.Handled)
+			if (!args.Handled && sel != IntPtr.Zero)
 			{
 				SuppressMouseTriggerCallback = false;
 				SuppressMouseEvents++;

--- a/src/Eto.WinForms/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridColumnHandler.cs
@@ -28,7 +28,11 @@ namespace Eto.WinForms.Forms.Controls
 
 		public GridColumnHandler()
 		{
-			Control = new EtoDataGridViewColumn { Handler = this };
+			Control = new EtoDataGridViewColumn
+			{
+				Handler = this,
+				AutoSizeMode = swf.DataGridViewAutoSizeColumnMode.DisplayedCells
+			};
 			DataCell = new TextBoxCell();
 			Editable = false;
 			Resizable = true;
@@ -205,6 +209,11 @@ namespace Eto.WinForms.Forms.Controls
 		public bool MouseClick(swf.MouseEventArgs e, int rowIndex)
 		{
 			return GridHandler != null && GridHandler.CellMouseClick(this, e, rowIndex);
+		}
+
+		internal void UpdateAutoSize(bool value)
+		{
+			Widget.Properties.Set(AutoSize_Key, value, true);
 		}
 	}
 }

--- a/src/Eto.WinForms/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridViewHandler.cs
@@ -153,14 +153,12 @@ namespace Eto.WinForms.Forms.Controls
 			Control.Refresh(); // Need to refresh rather than invalidate owing to WinForms DataGridView bugs.
 		}
 
-		public object GetCellAt(PointF location, out int column, out int row)
+		public GridCell GetCellAt(PointF location)
 		{
 			var result = Control.HitTest((int)location.X, (int)location.Y);
-			column = result.ColumnIndex;
-			row = result.RowIndex;
-			if (row == -1)
-				return null;
-			return GetItemAtRow(row);
+			var column = result.ColumnIndex != -1 ? Widget.Columns[result.ColumnIndex] : null;
+			var item = GetItemAtRow(result.RowIndex);
+			return new GridCell(column, result.ColumnIndex, result.RowIndex, result.Type.ToEto(), item);
 		}
 
 		public GridViewDragInfo GetDragInfo(DragEventArgs args) => args.ControlObject as GridViewDragInfo;

--- a/src/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
@@ -397,13 +397,12 @@ namespace Eto.WinForms.Forms.Controls
 				controller.ReloadItem(item);
 		}
 
-		public ITreeGridItem GetCellAt(PointF location, out int column)
+		public TreeGridCell GetCellAt(PointF location)
 		{
 			var result = Control.HitTest((int)location.X, (int)location.Y);
-			column = result.ColumnIndex;
-			if (result.RowIndex == -1)
-				return null;
-			return GetItemAtRow(result.RowIndex) as ITreeGridItem;
+			var column = result.ColumnIndex != -1 ? Widget.Columns[result.ColumnIndex] : null;
+			var item = GetItemAtRow(result.RowIndex);
+			return new TreeGridCell(column, result.ColumnIndex, result.Type.ToEto(), item);
 		}
 
 		public TreeGridViewDragInfo GetDragInfo(DragEventArgs args) => args.ControlObject as TreeGridViewDragInfo;

--- a/src/Eto.WinForms/WinConversions.cs
+++ b/src/Eto.WinForms/WinConversions.cs
@@ -892,6 +892,19 @@ namespace Eto.WinForms
 				return new Bitmap(new BitmapHandler(bitmap));
 			throw new NotSupportedException();
 		}
+		
+		public static GridCellType ToEto(this swf.DataGridViewHitTestType type)
+		{
+			switch (type)
+			{
+				case swf.DataGridViewHitTestType.ColumnHeader:
+					return GridCellType.ColumnHeader;
+				case swf.DataGridViewHitTestType.Cell:
+					return GridCellType.Data;
+				default:
+					return GridCellType.None;
+			}
+		}
 
 	}
 }

--- a/src/Eto.Wpf/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CellHandler.cs
@@ -32,6 +32,8 @@ namespace Eto.Wpf.Forms.Cells
 	{
 		public ICellContainerHandler ContainerHandler { get; set; }
 
+		public Controls.IGridHandler GridHandler => ContainerHandler?.Grid?.Handler as Controls.IGridHandler;
+
 		public static bool IsControlInitialized(sw.DependencyObject obj) => (bool)obj.GetValue(CellProperties.ControlInitializedProperty);
 		public static void SetControlInitialized(sw.DependencyObject obj, bool value) => obj.SetValue(CellProperties.ControlInitializedProperty, value);
 		public static bool IsControlEditInitialized(sw.DependencyObject obj) => (bool)obj.GetValue(CellProperties.ControlEditInitializedProperty);
@@ -71,6 +73,17 @@ namespace Eto.Wpf.Forms.Cells
 
 		public virtual void OnMouseUp(GridCellMouseEventArgs args, sw.DependencyObject hitTestResult, swc.DataGridCell cell)
 		{
+		}
+		
+		protected override void Initialize()
+		{
+			base.Initialize();
+			Widget.Properties.Set(swc.DataGridColumn.ActualWidthProperty, PropertyChangeNotifier.Register(swc.DataGridColumn.ActualWidthProperty, HandleWidthChanged, Control));
+		}
+
+		private void HandleWidthChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
+		{
+			GridHandler?.OnColumnWidthChanged(ContainerHandler as Controls.GridColumnHandler);
 		}
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
@@ -17,6 +17,7 @@ namespace Eto.Wpf.Forms.Controls
 		sw.FrameworkElement SetupCell(IGridColumnHandler column, sw.FrameworkElement defaultContent, swc.DataGridCell cell);
 		void FormatCell(IGridColumnHandler column, ICellHandler cell, sw.FrameworkElement element, swc.DataGridCell gridcell, object dataItem);
 		void CellEdited(int row, swc.DataGridColumn dataGridColumn, object dataItem);
+		void OnColumnWidthChanged(GridColumnHandler gridColumnHandler);
 	}
 
 	public interface IGridColumnHandler : GridColumn.IHandler
@@ -41,6 +42,11 @@ namespace Eto.Wpf.Forms.Controls
 			DataCell = new TextBoxCell();
 			Editable = false;
 			Sortable = false;
+		}
+
+		private void HandleWidthChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
+		{
+			GridHandler.OnColumnWidthChanged(this);
 		}
 
 		public string HeaderText

--- a/src/Eto.Wpf/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridViewHandler.cs
@@ -35,27 +35,11 @@ namespace Eto.Wpf.Forms.Controls
 					break;
 			}
 		}
-
-		public object GetCellAt(PointF location, out int column, out int row)
+		
+		public GridCell GetCellAt(PointF location)
 		{
-			var hitTestResult = swm.VisualTreeHelper.HitTest(Control, location.ToWpf())?.VisualHit;
-			if (hitTestResult == null)
-			{
-				column = -1;
-				row = -1;
-				return null;
-			}
-			var dataGridCell = hitTestResult.GetVisualParent<swc.DataGridCell>();
-			column = dataGridCell?.Column != null ? Control.Columns.IndexOf(dataGridCell.Column) : -1;
-
-			var dataGridRow = hitTestResult.GetVisualParent<swc.DataGridRow>();
-			if (dataGridRow != null)
-			{
-				row = dataGridRow.GetIndex();
-				return GetItemAtRow(row);
-			}
-			row = -1;
-			return null;
+			var info = GetCellInfo(location);
+			return new GridCell(info.Column, info.ColumnIndex, info.RowIndex, info.CellType, info.Item);
 		}
 
 

--- a/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -227,24 +227,10 @@ namespace Eto.Wpf.Forms.Controls
 				controller.ReloadData();
 		}
 
-		public ITreeGridItem GetCellAt(PointF location, out int column)
+		public TreeGridCell GetCellAt(PointF location)
 		{
-			var hitTestResult = swm.VisualTreeHelper.HitTest(Control, location.ToWpf())?.VisualHit;
-			if (hitTestResult == null)
-			{
-				column = -1;
-				return null;
-			}
-			var dataGridCell = hitTestResult.GetVisualParent<swc.DataGridCell>();
-			column = dataGridCell?.Column != null ? Control.Columns.IndexOf(dataGridCell.Column) : -1;
-
-			var dataGridRow = hitTestResult.GetVisualParent<swc.DataGridRow>();
-			if (dataGridRow != null)
-			{
-				int row = dataGridRow.GetIndex();
-				return GetItemAtRow(row) as ITreeGridItem;
-			}
-			return null;
+			var info = GetCellInfo(location);
+			return new TreeGridCell(info.Column, info.ColumnIndex, info.CellType, info.Item);
 		}
 
 		public TreeGridViewDragInfo GetDragInfo(DragEventArgs args) => args.ControlObject as TreeGridViewDragInfo;

--- a/src/Eto/Forms/Controls/Grid.cs
+++ b/src/Eto/Forms/Controls/Grid.cs
@@ -384,6 +384,29 @@ namespace Eto.Forms
 			Properties.TriggerEvent(ColumnOrderChangedEvent, this, e);
 		}
 
+		/// <summary>
+		/// Event identifier for handlers when attaching the <see cref="Grid.ColumnWidthChanged"/> event
+		/// </summary>
+		public const string ColumnWidthChangedEvent = "Grid.ColumnWidthChanged";
+		
+		/// <summary>
+		/// Event to handle when a column width has been changed.
+		/// </summary>
+		public event EventHandler<GridColumnEventArgs> ColumnWidthChanged
+		{
+			add { Properties.AddHandlerEvent(ColumnWidthChangedEvent, value); }
+			remove { Properties.RemoveEvent(ColumnWidthChangedEvent, value); }
+		}
+		
+		/// <summary>
+		/// Raises the <see cref="Grid.ColumnWidthChanged"/> event
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnColumnWidthChanged(GridColumnEventArgs e)
+		{
+			Properties.TriggerEvent(ColumnWidthChangedEvent, this, e);
+		}
+
 		#endregion
 
 		static Grid()
@@ -396,6 +419,7 @@ namespace Eto.Forms
 			EventLookup.Register<Grid>(c => c.OnSelectionChanged(null), Grid.SelectionChangedEvent);
 			EventLookup.Register<Grid>(c => c.OnColumnHeaderClick(null), Grid.ColumnHeaderClickEvent);
 			EventLookup.Register<Grid>(c => c.OnColumnOrderChanged(null), Grid.ColumnOrderChangedEvent);
+			EventLookup.Register<Grid>(c => c.OnColumnWidthChanged(null), Grid.ColumnWidthChangedEvent);
 		}
 
 		/// <summary>
@@ -695,6 +719,11 @@ namespace Eto.Forms
 			/// Raises the column display index changed event.
 			/// </summary>
 			void OnColumnOrderChanged(Grid widget, GridColumnEventArgs e);
+
+			/// <summary>
+			/// Raises the column width changed event.
+			/// </summary>
+			void OnColumnWidthChanged(Grid widget, GridColumnEventArgs e);
 		}
 
 		/// <summary>
@@ -775,6 +804,15 @@ namespace Eto.Forms
 			{
 				using (widget.Platform.Context)
 					widget.OnColumnOrderChanged(e);
+			}
+
+			/// <summary>
+			/// Raises the column width changed event.
+			/// </summary>
+			public void OnColumnWidthChanged(Grid widget, GridColumnEventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnColumnWidthChanged(e);
 			}
 		}
 

--- a/src/Eto/Forms/Controls/GridView.cs
+++ b/src/Eto/Forms/Controls/GridView.cs
@@ -57,35 +57,50 @@ namespace Eto.Forms
 	public class GridCell
 	{
 		/// <summary>
-		/// Gets the item associated with the row of the cell.
+		/// Gets the item associated with the row of the cell, or null if there is no row.
 		/// </summary>
 		/// <value>The row item.</value>
 		public object Item { get; }
 
 		/// <summary>
-		/// Gets the index of the row.
+		/// Gets the index of the row, or -1 if there is no row at this location.
 		/// </summary>
 		/// <value>The index of the row.</value>
 		public int RowIndex { get; }
 
 		/// <summary>
-		/// Gets the column of the cell, or null
+		/// Gets the column of the cell, or null if there is no column at the specified location.
 		/// </summary>
 		/// <value>The column.</value>
 		public GridColumn Column { get; }
 
 		/// <summary>
-		/// Gets the index of the column.
+		/// Gets the index of the column, or -1 if there is no column at the specified location.
 		/// </summary>
 		/// <value>The index of the column.</value>
 		public int ColumnIndex { get; }
+		
+		/// <summary>
+		/// Gets the type of the cell
+		/// </summary>
+		/// <value>Type of the cell</value>
+		public GridCellType Type { get; }
 
-		internal GridCell(object item, GridColumn column, int columnIndex, int rowIndex)
+		/// <summary>
+		/// Initializes a new instance of the GridCell class
+		/// </summary>
+		/// <param name="column">Column instance, or null if no column (e.g. empty area to right of columns)</param>
+		/// <param name="columnIndex">Index of the column for this cell, or -1 if no column (e.g. empty area to right of columns)</param>
+		/// <param name="rowIndex">Index of the row at the cell, or -1 if no row (e.g. header or empty area)</param>
+		/// <param name="type">Type of the cell, e.g. header, data, none</param>
+		/// <param name="item">Item instance for this row</param>
+		public GridCell(GridColumn column, int columnIndex, int rowIndex, GridCellType type, object item)
 		{
 			Item = item;
 			Column = column;
 			ColumnIndex = columnIndex;
 			RowIndex = rowIndex;
+			Type = type;
 		}
 	}
 
@@ -399,20 +414,14 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Gets the node at a specified location from the origin of the control
+		/// Gets the cell information at a specified location from the origin of the control
 		/// </summary>
 		/// <remarks>
-		/// Useful for determining which node is under the mouse cursor.
+		/// Useful for determining which cell is under the mouse cursor.
 		/// </remarks>
-		/// <returns>The item from the data store that is displayed at the specified location</returns>
+		/// <returns>The cell information at the specified location</returns>
 		/// <param name="location">Point to find the node</param>
-		public GridCell GetCellAt(PointF location)
-		{
-			int column;
-			int row;
-			var item = Handler.GetCellAt(location, out column, out row);
-			return new GridCell(item, column >= 0 ? Columns[column] : null, column, row);
-		}
+		public GridCell GetCellAt(PointF location) => Handler.GetCellAt(location);
 
 		/// <summary>
 		/// Gets a new selection preserver instance for the grid.
@@ -521,16 +530,14 @@ namespace Eto.Forms
 			void ReloadData(IEnumerable<int> rows);
 
 			/// <summary>
-			/// Gets the node at a specified point from the origin of the control
+			/// Gets the cell information at a specified location from the origin of the control
 			/// </summary>
 			/// <remarks>
-			/// Useful for determining which node is under the mouse cursor.
+			/// Useful for determining which cell is under the mouse cursor.
 			/// </remarks>
-			/// <returns>The item from the data store that is displayed at the specified location</returns>
+			/// <returns>The cell information at the specified location</returns>
 			/// <param name="location">Point to find the node</param>
-			/// <param name="row">Row under the specified location</param>
-			/// <param name="column">Column under the specified location</param>
-			object GetCellAt(PointF location, out int column, out int row);
+			GridCell GetCellAt(PointF location);
 
 			/// <summary>
 			/// Gets the grid drag info for the specified DragEventArgs.

--- a/src/Eto/Forms/Controls/TreeGridView.cs
+++ b/src/Eto/Forms/Controls/TreeGridView.cs
@@ -55,6 +55,25 @@ namespace Eto.Forms
 			this.Item = item;
 		}
 	}
+	
+	/// <summary>
+	/// Enumeration of the types of grid cells
+	/// </summary>
+	public enum GridCellType
+	{
+		/// <summary>
+		/// Empty part of the grid
+		/// </summary>
+		None,
+		/// <summary>
+		/// Cell containing the data, that is when the row and column are a valid value.
+		/// </summary>
+		Data,
+		/// <summary>
+		/// Column header
+		/// </summary>
+		ColumnHeader
+	}
 
 	/// <summary>
 	/// Information of a cell in the <see cref="TreeGridView"/>
@@ -62,28 +81,42 @@ namespace Eto.Forms
 	public class TreeGridCell
 	{
 		/// <summary>
-		/// Gets the item associated with the row of the cell.
+		/// Gets the item associated with the row of the cell, or null if there is no item.
 		/// </summary>
 		/// <value>The row item.</value>
 		public object Item { get; }
 
 		/// <summary>
-		/// Gets the column of the cell, or null
+		/// Gets the column of the cell, or null if there is no column at the specified location.
 		/// </summary>
 		/// <value>The column.</value>
 		public GridColumn Column { get; }
 
 		/// <summary>
-		/// Gets the index of the column.
+		/// Gets the index of the column, or -1 if there is no column at the specified location.
 		/// </summary>
 		/// <value>The index of the column.</value>
 		public int ColumnIndex { get; }
+		
+		/// <summary>
+		/// Gets the type of the cell
+		/// </summary>
+		/// <value>Type of the cell</value>
+		public GridCellType Type { get; }
 
-		internal TreeGridCell(object item, GridColumn column, int columnIndex)
+		/// <summary>
+		/// Initializes a new instance of the TreeGridCell class
+		/// </summary>
+		/// <param name="column">Column instance, or null if no column (e.g. empty area to right of columns)</param>
+		/// <param name="columnIndex">Index of the column for this cell, or -1 if no column (e.g. empty area to right of columns)</param>
+		/// <param name="type">Type of the cell, e.g. header, data, none</param>
+		/// <param name="item">Item instance for this row</param>
+		public TreeGridCell(GridColumn column, int columnIndex, GridCellType type, object item)
 		{
 			Item = item;
 			Column = column;
 			ColumnIndex = columnIndex;
+			Type = type;
 		}
 	}
 
@@ -567,19 +600,14 @@ namespace Eto.Forms
 		public void ReloadItem(ITreeGridItem item, bool reloadChildren) => Handler.ReloadItem(item, reloadChildren);
 
 		/// <summary>
-		/// Gets the node at a specified location from the origin of the control
+		/// Gets the cell information at a specified location from the origin of the control
 		/// </summary>
 		/// <remarks>
 		/// Useful for determining which node is under the mouse cursor.
 		/// </remarks>
-		/// <returns>The item from the data store that is displayed at the specified location</returns>
+		/// <returns>The cell information at the specified location</returns>
 		/// <param name="location">Point to find the node</param>
-		public TreeGridCell GetCellAt(PointF location)
-		{
-			int column;
-			var item = Handler.GetCellAt(location, out column);
-			return new TreeGridCell(item, column >= 0 ? Columns[column] : null, column);
-		}
+		public TreeGridCell GetCellAt(PointF location) => Handler.GetCellAt(location);
 
 		/// <summary>
 		/// Gets the tree grid drag info for the specified DragEventArgs.
@@ -737,12 +765,11 @@ namespace Eto.Forms
 			void ReloadItem(ITreeGridItem item, bool reloadChildren);
 
 			/// <summary>
-			/// Gets the item and column of a location in the control.
+			/// Gets the cell information at a specified location from the origin of the control
 			/// </summary>
-			/// <returns>The item from the data store that is displayed at the specified location</returns>
+			/// <returns>The cell information at the specified location</returns>
 			/// <param name="location">Point to find the node</param>
-			/// <param name="column">Column at the location, or -1 if no column (e.g. at the end of the row)</param>
-			ITreeGridItem GetCellAt(PointF location, out int column);
+			TreeGridCell GetCellAt(PointF location);
 
 			/// <summary>
 			/// Gets the tree grid drag info for the specified DragEventArgs.

--- a/test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -18,7 +18,7 @@ namespace Eto.Test.Sections.Controls
 		protected override string GetCellInfo(GridView grid, PointF location)
 		{
 			var cell = grid.GetCellAt(location);
-			return $"Row: {cell?.RowIndex}, Column: {cell?.ColumnIndex} ({cell?.Column?.HeaderText}), Item: {cell?.Item}";
+			return $"Row: {cell?.RowIndex}, Column: {cell?.ColumnIndex} ({cell?.Column?.HeaderText}), Type: {cell?.Type}, Item: {cell?.Item}";
 		}
 
 		protected override int GetRowCount(GridView grid) => ((ICollection)grid.DataStore).Count;
@@ -135,7 +135,7 @@ namespace Eto.Test.Sections.Controls
 		{
 			Styles.Add<Label>(null, l => l.VerticalAlignment = VerticalAlignment.Center);
 
-			grid = CreateGrid();
+			CreateGrid();
 
 			SetDataStore(grid);
 
@@ -274,24 +274,10 @@ namespace Eto.Test.Sections.Controls
 		}
 
 
-		bool orderEventAdded;
 		Control AllowColumnReorderingCheckBox(T grid)
 		{
 			var control = new CheckBox { Text = "AllowColumnReordering" };
 			control.CheckedBinding.Bind(grid, g => g.AllowColumnReordering);
-			control.CheckedChanged += (sender1, e1) =>
-			{
-				if (!orderEventAdded && grid.AllowColumnReordering)
-				{
-					orderEventAdded = true;
-					grid.ColumnOrderChanged += (sender, e) =>
-					{
-						SaveColumnOrder();
-						Log.Write(grid, $"ColumnDisplayIndexChanged, Column: {e.Column}, DisplayIndex: {e.Column.DisplayIndex}, Indexes: {GetDisplayIndexString(grid)}");
-					};
-				}
-			};
-
 			return control;
 		}
 
@@ -303,6 +289,7 @@ namespace Eto.Test.Sections.Controls
 			{
 				SaveColumnOrder();
 				SaveColumnVisibility();
+				SaveColumnWidths();
 			};
 
 			return control;
@@ -458,27 +445,37 @@ namespace Eto.Test.Sections.Controls
 			{
 				column.Visible = visibleIndexes[index];
 			}
+			var widths = TestApplication.Settings.GridViewSection_ColumnWidths;
+			if (widths != null && index < widths.Count)
+			{
+				column.Width = widths[index];
+			}
+			var autoSize = TestApplication.Settings.GridViewSection_ColumnAutoSize;
+			if (autoSize != null && index < autoSize.Count)
+			{
+				column.AutoSize = autoSize[index];
+			}
 
 			return column;
 		}
 
 
-		T CreateGrid()
+		void CreateGrid()
 		{
-			var control = new T();
-			LogEvents(control);
+			grid = new T();
+			LogEvents(grid);
 
 			var dropDown = MyDropDown("DropDownKey");
-			control.Columns.Add(SetColumnState(0, new GridColumn { HeaderText = "ImageText", DataCell = new ImageTextCell("Image", "Text") }));
-			control.Columns.Add(SetColumnState(1, new GridColumn { DataCell = new CheckBoxCell("Check"), AutoSize = true, Resizable = false }));
-			control.Columns.Add(SetColumnState(2, new GridColumn { HeaderText = "Image", DataCell = new ImageViewCell("Image"), Resizable = false }));
-			control.Columns.Add(SetColumnState(3, new GridColumn { HeaderText = "Text", DataCell = new TextBoxCell("Text"), Sortable = true }));
-			control.Columns.Add(SetColumnState(4, new GridColumn { HeaderText = "Progress", DataCell = new ProgressCell("Progress") }));
-			control.Columns.Add(SetColumnState(5, new GridColumn { HeaderText = "Drop Down", DataCell = dropDown, Sortable = true }));
+			grid.Columns.Add(SetColumnState(0, new GridColumn { HeaderText = "ImageText", DataCell = new ImageTextCell("Image", "Text") }));
+			grid.Columns.Add(SetColumnState(1, new GridColumn { DataCell = new CheckBoxCell("Check"), AutoSize = true, Resizable = false }));
+			grid.Columns.Add(SetColumnState(2, new GridColumn { HeaderText = "Image", DataCell = new ImageViewCell("Image"), Resizable = false }));
+			grid.Columns.Add(SetColumnState(3, new GridColumn { HeaderText = "Text", DataCell = new TextBoxCell("Text"), Sortable = true }));
+			grid.Columns.Add(SetColumnState(4, new GridColumn { HeaderText = "Progress", DataCell = new ProgressCell("Progress") }));
+			grid.Columns.Add(SetColumnState(5, new GridColumn { HeaderText = "Drop Down", DataCell = dropDown, Sortable = true }));
 			if (Platform.Supports<CustomCell>())
 			{
 				var col = SetColumnState(6, new GridColumn { HeaderText = "Custom", Sortable = true, DataCell = new MyCustomCell() });
-				control.Columns.Add(col);
+				grid.Columns.Add(col);
 			}
 
 			if (Platform.Supports<DrawableCell>())
@@ -502,14 +499,13 @@ namespace Eto.Test.Sections.Controls
 						e.Graphics.DrawLine(color, rect.Right, rect.Bottom, rect.MiddleX, rect.Top);
 					}
 				};
-				control.Columns.Add(SetColumnState(7, new GridColumn
+				grid.Columns.Add(SetColumnState(7, new GridColumn
 				{
 					HeaderText = "Drawable",
 					DataCell = drawableCell
 				}));
 			}
 
-			return control;
 		}
 
 		ContextMenu CreateContextMenu(T grid)
@@ -578,6 +574,14 @@ namespace Eto.Test.Sections.Controls
 
 			return menu;
 		}
+
+		private void SaveColumnWidths()
+		{
+			if (!TestApplication.Settings.GridViewSection_SaveColumnDisplayIndexes)
+				return;
+			TestApplication.Settings.GridViewSection_ColumnWidths = grid.Columns.Select(r => r.Width).ToList();			
+			TestApplication.Settings.GridViewSection_ColumnAutoSize = grid.Columns.Select(r => r.AutoSize).ToList();			
+		}
 		
 		private void SaveColumnOrder()
 		{
@@ -611,8 +615,19 @@ namespace Eto.Test.Sections.Controls
 			control.ColumnHeaderClick += (sender, e) => Log.Write(control, $"ColumnHeaderClick: {e.Column.HeaderText}");
 			control.CellClick += (sender, e) => Log.Write(control, $"CellClick, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
 			control.CellDoubleClick += (sender, e) => Log.Write(control, $"CellDoubleClick, Row: {e.Row}, Column: {e.Column}, Item: {e.Item}, GridColumn: {e.GridColumn}, IsEditing: {control.IsEditing}");
+			control.ColumnOrderChanged += (sender, e) =>
+			{
+				SaveColumnOrder();
+				Log.Write(grid, $"ColumnDisplayIndexChanged, Column: {e.Column}, DisplayIndex: {e.Column.DisplayIndex}, Indexes: {GetDisplayIndexString(grid)}");
+			};
+			control.ColumnWidthChanged += (sender, e) =>
+			{
+				SaveColumnWidths();
+				Log.Write(control, $"ColumnWidthChanged, Column: {e.Column.HeaderText}, Width: {e.Column.Width}, AutoSize: {e.Column.AutoSize}");				
+			};
 
 			control.MouseDown += (sender, e) => Log.Write(control, $"MouseDown, Buttons: {e.Buttons}, Location: {e.Location}");
+			control.MouseUp += (sender, e) => Log.Write(control, $"MouseUp, Buttons: {e.Buttons}, Location: {e.Location}");
 			control.MouseDoubleClick += (sender, e) => Log.Write(control, $"MouseDoubleClick, Buttons: {e.Buttons}, Location: {e.Location}");
 		}
 

--- a/test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
@@ -18,7 +18,7 @@ namespace Eto.Test.Sections.Controls
 		protected override string GetCellInfo(TreeGridView grid, PointF location)
 		{
 			var cell = grid.GetCellAt(location);
-			return $"Column: {cell?.ColumnIndex} ({cell?.Column?.HeaderText}), Item: {cell?.Item}";
+			return $"Column: {cell?.ColumnIndex} ({cell?.Column?.HeaderText}), Type: {cell?.Type}, Item: {cell?.Item}";
 		}
 
 		protected override int GetRowCount(TreeGridView grid) => grid.DataStore.Count;

--- a/test/Eto.Test/Settings.cs
+++ b/test/Eto.Test/Settings.cs
@@ -28,13 +28,16 @@ namespace Eto.Test
 				_GridViewSection_SaveColumnDisplayIndexes = value;
 				if (!value)
 				{
+					GridViewSection_ColumnWidths = null;
+					GridViewSection_ColumnAutoSize = null;
 					GridViewSection_DisplayIndexes = null;
 					GridViewSection_VisibleIndexes = null;
 				}
 			}
 		}
+		public List<int> GridViewSection_ColumnWidths { get; set; }
+		public List<bool> GridViewSection_ColumnAutoSize { get; set; }
 		public List<int> GridViewSection_DisplayIndexes { get; set; }
-
 		public List<bool> GridViewSection_VisibleIndexes { get; set; }
 
 		public static Settings Load()


### PR DESCRIPTION
- Added new Grid.ColumnWidthChanged event
- Added GridCellType to GridCell and TreeGridCell for GetCellAt() APIs, which can be used to determine if the mouse is over the header or not
- Mac/Gtk: Enable mouse events on the header
- Gtk: Fix location in mouse events for Tree/GridView
- Mac: Fix context menu selected rows when not right clicking on a row
- Mac: Show Grid.ContextMenu for the header

These changes allow you to reliably show context menus or handle various mouse events for Tree/GridView headers, and to know which column header the mouse is over.