### PR TITLE
Add ability to compile for VS Mac 2022 (17.0)

### DIFF
--- a/src/Eto.Mac/Drawing/FormattedTextHandler.cs
+++ b/src/Eto.Mac/Drawing/FormattedTextHandler.cs
@@ -48,7 +48,11 @@ namespace Eto.iOS.Drawing
 
 				// what to do with the attributes?? needed?
 				var m = CTFontGetMatrix(font);
+#if !VSMAC && (MONOMAC || XAMMAC)
 				m.Translate(textMatrix.x0, textMatrix.y0);
+#else
+				m.Translate(textMatrix.Tx, textMatrix.Ty);
+#endif
 				m.Scale(1, -1);
 				ctx.TextMatrix = m;
 				CTFontDrawGlyphs(font, glyphs, positions, glyphCount, ctx.Handle);

--- a/src/Eto.Mac/Drawing/MatrixHandler.cs
+++ b/src/Eto.Mac/Drawing/MatrixHandler.cs
@@ -40,33 +40,38 @@ namespace Eto.iOS.Drawing
 		{
 			control = new CGAffineTransform (xx, yx, xy, yy, dx, dy);
 		}
-		
-		public float[] Elements
-		{
-			get
-			{
-				return new float[] {
+
+#if !VSMAC && (MONOMAC || XAMMAC)
+		public float[] Elements => new float[] {
 					(float)control.xx,
 					(float)control.yx,
 					(float)control.xy,
 					(float)control.yy,
 					(float)control.x0,
-					(float)control.y0
-				};
-			}
-		}
+					(float)control.y0 };
 		
 		public float X0 { get { return (float)control.x0; } set { control.x0 = value; } }
-		
 		public float Y0 { get { return (float)control.y0; } set { control.y0 = value; } }
-		
 		public float Xx { get { return (float)control.xx; } set { control.xx = value; } }
-		
 		public float Xy { get { return (float)control.xy; } set { control.xy = value; } }
-		
 		public float Yx { get { return (float)control.yx; } set { control.yx = value; } }
-		
 		public float Yy { get { return (float)control.yy; } set { control.yy = value; } }
+#else
+		public float[] Elements => new float[] {
+					(float)control.A,
+					(float)control.B,
+					(float)control.C,
+					(float)control.D,
+					(float)control.Tx,
+					(float)control.Ty };
+		
+		public float X0 { get { return (float)control.Tx; } set { control.Tx = value; } }
+		public float Y0 { get { return (float)control.Ty; } set { control.Ty = value; } }
+		public float Xx { get { return (float)control.A; } set { control.A = value; } }
+		public float Xy { get { return (float)control.C; } set { control.C = value; } }
+		public float Yx { get { return (float)control.B; } set { control.B = value; } }
+		public float Yy { get { return (float)control.D; } set { control.D = value; } }
+#endif
 		
 		public void Rotate (float angle)
 		{

--- a/src/Eto.Mac/Drawing/TextureBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/TextureBrushHandler.cs
@@ -53,7 +53,7 @@ namespace Eto.iOS.Drawing
 
 				context.SaveState();
 				context.ConcatCTM(transform);
-				context.ConcatCTM(new CGAffineTransform(1, 0, 0, -1, 0, Image.Height));
+				context.ConcatCTM(new CGAffineTransform(1, 0, 0, -1, 0, (nfloat)Image.Height));
 				//transform.ToEto().TransformRectangle(rect);
 
 				if (Opacity < 1f)

--- a/src/Eto.Mac/Eto.XamMac2.csproj
+++ b/src/Eto.Mac/Eto.XamMac2.csproj
@@ -2,8 +2,8 @@
 
   <PropertyGroup>
     <UseXamarinMac Condition="$(UseXamarinMac) == ''">True</UseXamarinMac>
-    <TargetFrameworks>net462;xamarinmac20</TargetFrameworks>
-    <TargetFrameworks Condition="$([MSBuild]::VersionGreaterThanOrEquals($(NETCoreSdkVersion), '6.0')) AND $([MSBuild]::VersionLessThan($(NETCoreSdkVersion), '6.0.200'))">net6.0-macos10.15;$(TargetFrameworks)</TargetFrameworks>
+    <TargetFrameworks Condition="$(OverrideTargetFrameworks) != 'True'">net462;xamarinmac20</TargetFrameworks>
+    <TargetFrameworks Condition="$(OverrideTargetFrameworks) != 'True' AND $([MSBuild]::VersionGreaterThanOrEquals($(NETCoreSdkVersion), '6.0')) AND $([MSBuild]::VersionLessThan($(NETCoreSdkVersion), '6.0.200'))">net6.0-macos10.15;$(TargetFrameworks)</TargetFrameworks>
     <RootNamespace>Eto.Mac</RootNamespace>
     <DefineConstants>$(DefineConstants);OSX;DESKTOP;XAMMAC;XAMMAC2;UNIFIED</DefineConstants>
     <DefineConstants Condition="$(UseCFString) != 'False'">$(DefineConstants);USE_CFSTRING</DefineConstants>

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -6,7 +6,7 @@ using System.Collections;
 using System.Linq;
 using Eto.Mac.Forms.Cells;
 
-#if MACOS_NET
+#if MACOS_NET && !VSMAC
 using NSDraggingInfo = AppKit.INSDraggingInfo;
 #endif
 
@@ -110,19 +110,7 @@ namespace Eto.Mac.Forms.Controls
 				return Handler?.ValidateProposedFirstResponder(responder, forEvent, valid) ?? valid;
 			}
 
-#if XAMMAC2
-			public override NSImage DragImageForRowsWithIndexestableColumnseventoffset(NSIndexSet dragRows, NSTableColumn[] tableColumns, NSEvent dragEvent, ref CGPoint dragImageOffset)
-			{
-				var dragInfo = Handler?.DragInfo;
-				var img = dragInfo?.DragImage;
-				if (img != null)
-				{
-					dragImageOffset = dragInfo.GetDragImageOffset();
-					return img;
-				}
-				return base.DragImageForRowsWithIndexestableColumnseventoffset(dragRows, tableColumns, dragEvent, ref dragImageOffset);
-			}
-#elif MACOS_NET
+#if MACOS_NET
 			public override NSImage DragImageForRows(NSIndexSet dragRows, NSTableColumn[] tableColumns, NSEvent dragEvent, ref CGPoint dragImageOffset)
 			{
 				var dragInfo = Handler?.DragInfo;
@@ -133,6 +121,18 @@ namespace Eto.Mac.Forms.Controls
 					return img;
 				}
 				return base.DragImageForRows(dragRows, tableColumns, dragEvent, ref dragImageOffset);
+			}
+#elif XAMMAC2
+			public override NSImage DragImageForRowsWithIndexestableColumnseventoffset(NSIndexSet dragRows, NSTableColumn[] tableColumns, NSEvent dragEvent, ref CGPoint dragImageOffset)
+			{
+				var dragInfo = Handler?.DragInfo;
+				var img = dragInfo?.DragImage;
+				if (img != null)
+				{
+					dragImageOffset = dragInfo.GetDragImageOffset();
+					return img;
+				}
+				return base.DragImageForRowsWithIndexestableColumnseventoffset(dragRows, tableColumns, dragEvent, ref dragImageOffset);
 			}
 #else
 

--- a/src/Eto.Mac/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SliderHandler.cs
@@ -26,7 +26,7 @@ namespace Eto.Mac.Forms.Controls
 				set { WeakHandler = new WeakReference(value); } 
 			}
 
-#if MACOS_NET
+#if MACOS_NET && !VSMAC
 			public override bool IsVertical => Handler?.Orientation == Orientation.Vertical;
 #else
 			public override nint IsVertical => Handler?.Orientation == Orientation.Vertical ? 1 : 0;

--- a/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -66,7 +66,7 @@ namespace Eto.Mac.Forms.Controls
 			set { WeakHandler = new WeakReference(value); }
 		}
 
-#if MACOS_NET
+#if MACOS_NET && !VSMAC
 		public override void ChangeColor(NSColorPanel sender)
 		{
 			// ignore color changes

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using Eto.Mac.Forms.Cells;
 using Eto.Drawing;
 
-#if MACOS_NET
+#if MACOS_NET && !VSMAC
 using NSDraggingInfo = AppKit.INSDraggingInfo;
 #endif
 

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -421,7 +421,7 @@ namespace Eto.Mac.Forms
 						if (handler != null)
 						{
 							var args = new NSWindowBackingPropertiesEventArgs(e.Notification);
-							if (args.OldScaleFactor != handler.Control.BackingScaleFactor)
+							if ((nfloat)args.OldScaleFactor != handler.Control.BackingScaleFactor)
 								handler.Callback.OnLogicalPixelSizeChanged(handler.Widget, EventArgs.Empty);
 						}
 					});


### PR DESCRIPTION
Unfortunately, VS Mac does not currently use the latest .net 6 macOS workload so it is incompatible with the nuget packages.  This allows Eto to compile using the VS Mac references directly which (currently) uses a version of Xamarin.Mac where it has transitioned some, but not all, of the breaking changes that are now in the latest .NET 6 macOS workloads.

This is mainly used for https://github.com/picoe/Eto.DevExtensions so we can use Eto for UI and the designer for the extensions