### PR TITLE
Set TargetFramework only for Eto.macOS

### DIFF
--- a/src/Eto.Mac/Eto.macOS.csproj
+++ b/src/Eto.Mac/Eto.macOS.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-macos10.15</TargetFrameworks>
+    <TargetFramework>net6.0-macos10.15</TargetFramework>
     <RootNamespace>Eto.Mac</RootNamespace>
     <DefineConstants>$(DefineConstants);OSX;DESKTOP;UNIFIED;MACOS_NET;USE_CFSTRING</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>


### PR DESCRIPTION
This gives the ability to use Eto.macOS.csproj directly from a net6.0 tfm project by adding `<TargetFrameworks>net6.0-macos10.15;net6.0</TargetFrameworks>` for the project in Eto.Common.props.