### PR TITLE
Make setting DataContext non destructive to view models

### DIFF
--- a/src/Eto/Forms/Binding/BindableBinding.cs
+++ b/src/Eto/Forms/Binding/BindableBinding.cs
@@ -78,13 +78,13 @@ namespace Eto.Forms
 			{
 				GettingNullValue = defaultControlValue,
 				SettingNullValue = defaultContextValue,
-				DataItem = contextBinding.DataValue
+				GetDataItem = () => contextBinding.DataValue // don't actually store the data context object in the binding
 			};
+			// don't trigger the value changes when we are currently changing the context
+			valueBinding.Changing += (sender, e) => e.Cancel = control.IsDataContextChanging;
+			contextBinding.DataValueChanged += (sender, e) => valueBinding.TriggerDataValueChanged();
+
 			DualBinding<TValue> binding = Bind(sourceBinding: valueBinding, mode: mode);
-			contextBinding.DataValueChanged += delegate
-			{
-				((ObjectBinding<object, TValue>)binding.Source).DataItem = contextBinding.DataValue;
-			};
 			control.Bindings.Add(contextBinding);
 			return binding;
 		}

--- a/src/Eto/Forms/Binding/BindableWidget.cs
+++ b/src/Eto/Forms/Binding/BindableWidget.cs
@@ -99,7 +99,11 @@ namespace Eto.Forms
 				if (Properties.TrySet(Parent_Key, value))
 				{
 					if (!HasDataContext && !(DataContext is null))
+					{
+						IsDataContextChanging = true;
 						OnDataContextChanged(EventArgs.Empty);
+						IsDataContextChanging = false;
+					}
 				}
 			}
 		}
@@ -193,12 +197,17 @@ namespace Eto.Forms
 			set
 			{
 				if (Properties.TrySet(DataContext_Key, value))
+				{
+					IsDataContextChanging = true;
 					OnDataContextChanged(EventArgs.Empty);
+					IsDataContextChanging = false;
+				}
 			}
 		}
 
 		internal bool HasDataContext => Properties.ContainsKey(DataContext_Key);
 
+		static readonly  object IsDataContextChanging_Key = new object();
 		static readonly  object Bindings_Key = new object();
 
 		/// <summary>
@@ -212,6 +221,22 @@ namespace Eto.Forms
 		{
 			if (!HasDataContext)
 				OnDataContextChanged(EventArgs.Empty);
+		}
+		
+		/// <summary>
+		/// Gets a value indicating that the <see cref="DataContext"/> property is changing.
+		/// </summary>
+		/// <remarks>
+		/// This can be used to determine when to allow certain logic during the update of the data context.
+		/// 
+		/// It is used to disable binding setters on the model when the data context changes so that a binding
+		/// does not cause the view model to be updated when the state hasn't been fully set yet.
+		/// </remarks>
+		/// <value><c>true</c> if the DataContext is currently changing, <c>false</c> otherwise.</value>
+		public bool IsDataContextChanging
+		{
+			get => Properties.Get<bool?>(IsDataContextChanging_Key) ?? (Parent as IBindable)?.IsDataContextChanging ?? false;
+			set => Properties.Set(IsDataContextChanging_Key, value);
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/Binding/IBindable.cs
+++ b/src/Eto/Forms/Binding/IBindable.cs
@@ -16,6 +16,18 @@ namespace Eto.Forms
 		/// For example, a Control may return the data context of a parent, if it is not set explicitly.
 		/// </remarks>
 		object DataContext { get; set; }
+		
+		/// <summary>
+		/// Gets a value indicating that the <see cref="DataContext"/> property is changing.
+		/// </summary>
+		/// <remarks>
+		/// This can be used to determine when to allow certain logic during the update of the data context.
+		/// 
+		/// It is used to disable binding setters on the model when the data context changes so that a binding
+		/// does not cause the view model to be updated when the state hasn't been fully set yet.
+		/// </remarks>
+		/// <value><c>true</c> if the DataContext is currently changing, <c>false</c> otherwise.</value>
+		bool IsDataContextChanging { get; }
 
 		/// <summary>
 		/// Event to handle when the <see cref="DataContext"/> has changed

--- a/test/Eto.Test/UnitTests/Forms/DataContextTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/DataContextTests.cs
@@ -285,7 +285,7 @@ namespace Eto.Test.UnitTests.Forms
 			Shown(form =>
 			{
 				c = new Panel();
-				c.DataContextChanged += (sender, e) => 
+				c.DataContextChanged += (sender, e) =>
 					dataContextChanged++;
 
 				form.Content = new StackLayout
@@ -400,6 +400,44 @@ namespace Eto.Test.UnitTests.Forms
 				Assert.AreEqual(3, changed);
 			});
 		}
+
+		class DropDownViewModel
+		{
+			public string[] DataSource { get; set; }
+
+			public int SelectedIndex { get; set; }
+		}
+
+		[Test]
+		public void ChangingDataContextShouldNotSetValues() => Shown(
+			form =>
+			{
+				var dropDown = new DropDown();
+				dropDown.BindDataContext(c => c.DataStore, (DropDownViewModel m) => m.DataSource);
+				dropDown.BindDataContext(c => c.SelectedIndex, (DropDownViewModel m) => m.SelectedIndex);
+				return dropDown;
+			},
+			dropDown =>
+			{
+				var model1 = new DropDownViewModel
+				{
+					DataSource = new string[] { "Item 1", "Item 2", "Item 3" },
+					SelectedIndex = 0
+				};
+				dropDown.DataContext = model1;
+				Assert.AreEqual(0, dropDown.SelectedIndex, "#1");
+
+				var model2 = new DropDownViewModel
+				{
+					DataSource = new string[] { "Item 4", "Item 5", "Item 6" },
+					SelectedIndex = 1
+				};
+				dropDown.DataContext = model2;
+				Assert.AreEqual(1, dropDown.SelectedIndex, "#2");
+
+				Assert.AreEqual(0, model1.SelectedIndex, "#3 - Model 1 was changed");
+				Assert.AreEqual(1, model2.SelectedIndex, "#4 - Model 2 was changed");
+			});
 	}
 }
 


### PR DESCRIPTION
When setting a new DataContext to a control with an existing context, bindings could trigger events that would update other bindings before to either the new or old data context inadvertently.  With these changes, any updated bindings will no longer modify the view model when they trigger other events.
- Added IBindable.IsDataContextChanging which all controls inherit which can be used to perform specific logic during data context updates.
- Added ObjectBinding.GetDataItem/TriggerDataValueChanged so it no longer has to store the data context object directly, causing all bindings to get the new data context immediately instead of one at a time
- BindableBinding.BindDataContext() will no longer update the source values (view model) during a data context update.
- Added a unit test to ensure desired behaviour of switching data contexts in this scenario.