### PR TITLE
Wpf: Fix PointTo/FromScreen in system dpi awareness mode

### DIFF
--- a/src/Eto.WinForms/Win32.dpi.cs
+++ b/src/Eto.WinForms/Win32.dpi.cs
@@ -64,11 +64,11 @@ namespace Eto
 			return dpiX;
 		}
 
-		public static Eto.Drawing.Point LogicalToScreen(this Eto.Drawing.PointF point)
+		public static Eto.Drawing.Point LogicalToScreen(this Eto.Drawing.PointF point, Eto.Forms.Screen screen = null, bool usePerMonitor = true)
 		{
-			var screen = Eto.Forms.Screen.FromPoint(point);
+			screen = screen ?? Eto.Forms.Screen.FromPoint(point);
 			var sdscreen = ScreenHandler.GetControl(screen);
-			var pixelSize = sdscreen.GetLogicalPixelSize();
+			var pixelSize = sdscreen.GetLogicalPixelSize(usePerMonitor);
 			var location = sdscreen.GetBounds().Location;
 			var screenBounds = screen.Bounds;
 
@@ -78,16 +78,16 @@ namespace Eto
 			return Drawing.Point.Round(new Drawing.PointF(x, y));
 		}
 
-		public static Eto.Drawing.PointF ScreenToLogical(this Eto.Drawing.Point point, swf.Screen sdscreen = null)
+		public static Eto.Drawing.PointF ScreenToLogical(this Eto.Drawing.Point point, swf.Screen sdscreen = null, bool usePerMonitor = true)
 		{
-			return ScreenToLogical(point.ToSD(), sdscreen);
+			return ScreenToLogical(point.ToSD(), sdscreen, usePerMonitor);
 		}
 
-		public static Eto.Drawing.PointF ScreenToLogical(this sd.Point point, swf.Screen sdscreen = null)
+		public static Eto.Drawing.PointF ScreenToLogical(this sd.Point point, swf.Screen sdscreen = null, bool usePerMonitor = true)
 		{
 			sdscreen = sdscreen ?? swf.Screen.FromPoint(point);
 			var location = sdscreen.GetLogicalLocation();
-			var pixelSize = sdscreen.GetLogicalPixelSize();
+			var pixelSize = sdscreen.GetLogicalPixelSize(usePerMonitor);
 			var sdscreenBounds = sdscreen.GetBounds();
 
 			var x = location.X + (point.X - sdscreenBounds.X) / pixelSize;
@@ -97,12 +97,12 @@ namespace Eto
 			return new Drawing.PointF(x, y);
 		}
 
-		public static Eto.Drawing.RectangleF ScreenToLogical(this Eto.Drawing.Rectangle rect, swf.Screen screen)
+		public static Eto.Drawing.RectangleF ScreenToLogical(this Eto.Drawing.Rectangle rect, swf.Screen sdscreen, bool usePerMonitor = true)
 		{
-			screen = screen ?? swf.Screen.FromPoint(rect.Location.ToSD());
-			var location = screen.GetLogicalLocation();
-			var pixelSize = screen.GetLogicalPixelSize();
-			var screenBounds = screen.GetBounds();
+			sdscreen = sdscreen ?? swf.Screen.FromPoint(rect.Location.ToSD());
+			var location = sdscreen.GetLogicalLocation();
+			var pixelSize = sdscreen.GetLogicalPixelSize(usePerMonitor);
+			var screenBounds = sdscreen.GetBounds();
 			return new Eto.Drawing.RectangleF(
 				location.X + (rect.X - screenBounds.X) / pixelSize,
 				location.Y + (rect.Y - screenBounds.Y) / pixelSize,
@@ -117,6 +117,10 @@ namespace Eto
 		{
 			return new Eto.Drawing.RectangleF(GetLogicalLocation(screen), GetLogicalSize(screen));
 		}
+		
+		public static bool IsSystemDpiAware => Win32.GetProcessDpiAwareness(IntPtr.Zero, out var awareness) == 0 && awareness == Win32.PROCESS_DPI_AWARENESS.SYSTEM_DPI_AWARE;
+
+		public static float SystemDpi => Win32.GetDpiForSystem() / 96f;
 
 		class ScreenHelper : LogicalScreenHelper<swf.Screen>
 		{
@@ -147,7 +151,7 @@ namespace Eto
 			}
 
 
-			public override float GetLogicalPixelSize(swf.Screen screen)
+			public override float GetLogicalPixelSize(swf.Screen screen, bool usePerMonitor = true)
 			{
 				if (!MonitorDpiSupported)
 				{
@@ -161,7 +165,7 @@ namespace Eto
 				var mon = MonitorFromPoint(screen.Bounds.Location, MONITOR.DEFAULTTONEAREST);
 
 				// use per-monitor aware dpi awareness to get ACTUAL dpi here
-				var oldDpiAwareness = SetThreadDpiAwarenessContextSafe(DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2);
+				var oldDpiAwareness = usePerMonitor ? SetThreadDpiAwarenessContextSafe(DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2) : DPI_AWARENESS_CONTEXT.NONE;
 
 				uint dpiX, dpiY;
 				GetDpiForMonitor(mon, MDT.EFFECTIVE_DPI, out dpiX, out dpiY);
@@ -183,7 +187,7 @@ namespace Eto
 
 		public static Eto.Drawing.SizeF GetLogicalSize(this swf.Screen screen) => locationHelper.GetLogicalSize(screen);
 
-		public static float GetLogicalPixelSize(this swf.Screen screen) => locationHelper.GetLogicalPixelSize(screen);
+		public static float GetLogicalPixelSize(this swf.Screen screen, bool usePerMonitor = true) => locationHelper.GetLogicalPixelSize(screen, usePerMonitor);
 
 		public static void GetMonitorInfo(this swf.Screen screen, ref MONITORINFOEX info)
 		{
@@ -227,6 +231,40 @@ namespace Eto
 			if (!PerMontiorThreadDpiSupported)
 				return DPI_AWARENESS_CONTEXT.NONE;
 			return SetThreadDpiAwarenessContext(dpiContext);
+		}
+		
+		public static swf.Screen GetScreenFromWindow(IntPtr nativeHandle)
+		{
+			if (nativeHandle == IntPtr.Zero)
+				return swf.Screen.PrimaryScreen;
+
+			return swf.Screen.FromHandle(nativeHandle);
+
+			// var monitorPtr = Win32.MonitorFromWindow(nativeHandle, MONITOR.DEFAULTTONEAREST);
+			// var info = new MONITORINFOEX();
+			// Win32.GetMonitorInfo(new HandleRef(null, monitorPtr), info);
+			// var monitorBounds = info.rcMonitor.ToSD();
+			// foreach (var screen in swf.Screen.AllScreens)
+			// {
+			// 	if (screen.Bounds == monitorBounds)
+			// 		return screen;
+			// }
+			// return swf.Screen.PrimaryScreen;
+		}
+
+		
+		public static T ExecuteInDpiAwarenessContext<T>(Func<T> func)
+		{
+			var oldDpiAwareness = Win32.SetThreadDpiAwarenessContextSafe(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2);
+			try
+			{
+				return func();
+			}
+			finally
+			{
+				if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
+					Win32.SetThreadDpiAwarenessContextSafe(oldDpiAwareness);
+			}
 		}
 
 		[DllImport("User32.dll")]

--- a/src/Eto.Wpf/Forms/MouseHandler.cs
+++ b/src/Eto.Wpf/Forms/MouseHandler.cs
@@ -18,19 +18,13 @@ namespace Eto.Wpf.Forms
 			get
 			{
 				var screen = swf.Screen.FromPoint(swf.Control.MousePosition);
-				var oldDpiAwareness = Win32.SetThreadDpiAwarenessContextSafe(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2);
-				var result = swf.Control.MousePosition;
-				if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
-					Win32.SetThreadDpiAwarenessContextSafe(oldDpiAwareness);
+				var result = Win32.ExecuteInDpiAwarenessContext(() => swf.Control.MousePosition);
 				return result.ScreenToLogical(screen);
 			}
 			set
 			{
 				var pos = value.LogicalToScreen();
-				var oldDpiAwareness = Win32.SetThreadDpiAwarenessContextSafe(Win32.DPI_AWARENESS_CONTEXT.PER_MONITOR_AWARE_v2);
-				swf.Cursor.Position = Point.Round(pos).ToSD();
-				if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
-					Win32.SetThreadDpiAwarenessContextSafe(oldDpiAwareness);
+				Win32.ExecuteInDpiAwarenessContext(() => swf.Cursor.Position = Point.Round(pos).ToSD());
 			}
 		}
 

--- a/src/Eto.Wpf/LogicalScreenHelper.cs
+++ b/src/Eto.Wpf/LogicalScreenHelper.cs
@@ -19,9 +19,17 @@ namespace Eto
 
 		public abstract Eto.Drawing.SizeF GetLogicalSize(T screen);
 
-		public abstract float GetLogicalPixelSize(T screen);
+		public abstract float GetLogicalPixelSize(T screen, bool usePerMonitor = true);
 
-		public virtual float GetMaxLogicalPixelSize() => AllScreens.Max((Func<T, float>)GetLogicalPixelSize);
+		public virtual float GetMaxLogicalPixelSize()
+		{
+			float logicalPixelSize = 0;
+			foreach (var screen in AllScreens)
+			{
+				logicalPixelSize = Math.Max(logicalPixelSize, GetLogicalPixelSize(screen));
+			}
+			return logicalPixelSize;
+		}
 
 		public Eto.Drawing.PointF GetLogicalLocation(T screen)
 		{

--- a/test/Eto.Test.Wpf/UnitTests/ScreenTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/ScreenTests.cs
@@ -33,7 +33,7 @@ namespace Eto.Test.Wpf.UnitTests
 
 			public override sd.Rectangle GetBounds(TestScreen screen) => screen.Bounds;
 
-			public override float GetLogicalPixelSize(TestScreen screen) => screen.LogicalPixelSize;
+			public override float GetLogicalPixelSize(TestScreen screen, bool usePerMonitor = true) => screen.LogicalPixelSize;
 
 			public override SizeF GetLogicalSize(TestScreen screen) => screen.LogicalSize.ToEto();
 		}

--- a/test/Eto.Test/UnitTests/Forms/Controls/ControlTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ControlTests.cs
@@ -303,6 +303,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		public void PointToScreenShouldWorkOnSecondaryScreen()
 		{
 			bool wasClicked = false;
+			PointF? controlPoint = null;
+			PointF? rountripPoint = null;
 			Form childForm = null;
 			try
 			{
@@ -317,6 +319,16 @@ namespace Eto.Test.UnitTests.Forms.Controls
 
 					form.Shown += (sender, e) =>
 					{
+						controlPoint = PointF.Empty;
+						var screenPoint = textBox.PointToScreen(PointF.Empty);
+						rountripPoint = Point.Truncate(textBox.PointFromScreen(screenPoint));
+						
+						if (controlPoint != rountripPoint)
+						{
+							form.Close();
+							return;
+						}
+						
 						childForm = new Form
 						{
 							WindowStyle = WindowStyle.None,
@@ -325,8 +337,13 @@ namespace Eto.Test.UnitTests.Forms.Controls
 							Resizable = false,
 							BackgroundColor = Colors.Red,
 							Topmost = true,
-							Location = Point.Round(textBox.PointToScreen(PointF.Empty)),
+							Location = Point.Round(screenPoint),
 							Size = textBox.Size
+						};
+						form.LocationChanged += (sender2, e2) =>
+						{
+							childForm.Location = Point.Round(textBox.PointToScreen(PointF.Empty));
+							childForm.Size = textBox.Size;
 						};
 						var b = new Button { Text = "Click Me!" };
 						b.Click += (sender2, e2) =>
@@ -352,6 +369,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				if (childForm != null)
 					Application.Instance.Invoke(() => childForm.Close());
 			}
+			Assert.AreEqual(controlPoint, rountripPoint, "Point could not round trip to screen then back");
 			Assert.IsTrue(wasClicked, "The test completed without clicking the button");
 		}
 


### PR DESCRIPTION
When you have multiple monitors with different DPI/scale settings in a system-dpi aware Windows application, the PointToScreen/PointFromScreen will now work as expected and give you the correct location on a secondary monitor with a different DPI.