### PR TITLE
Mac: Add a warning when the specified icon file is missing

### DIFF
--- a/src/Eto.Mac/build/Mac.targets
+++ b/src/Eto.Mac/build/Mac.targets
@@ -251,6 +251,9 @@
     </UpdatePList>
 
     <!-- Copy default icon if it doesn't exist -->
+    <Warning
+      Text="The icon file ($(IconFile)) does not exist in the output directory. Make sure the file exists and specify &lt;Content Include=&quot;$(IconFile)&quot; /&gt; in your project file."
+      Condition="!Exists('$(OutputResourcesPath)$(IconFile)')" />
     <Copy SourceFiles="$(ReferenceFiles)Icon.icns" DestinationFiles="$(OutputResourcesPath)$(IconFile)" Condition="!Exists('$(OutputResourcesPath)$(IconFile)')" />
 
     <!-- Set executable bit on launcher if on *nix -->


### PR DESCRIPTION
I found it confusing how the bundle always had the default icon no matter what file name I specified (I was missing the Content definition). Hopefully this prevents someone else from having the same problem.