### PR TITLE
Add Control.DragEnd event

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridViewHandler.cs
@@ -249,7 +249,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public new GridViewHandler Handler { get { return (GridViewHandler)base.Handler; } }
 
-			protected override DragEventArgs GetDragEventArgs(Gdk.DragContext context, PointF? location, uint time = 0, object controlObject = null)
+			protected override DragEventArgs GetDragEventArgs(Gdk.DragContext context, PointF? location, uint time = 0, object controlObject = null, DataObject data = null)
 			{
 				var t = Handler?.Control;
 				GridViewDragInfo dragInfo = _dragInfo;
@@ -264,7 +264,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					}
 				}
 
-				return base.GetDragEventArgs(context, location, time, dragInfo);
+				return base.GetDragEventArgs(context, location, time, dragInfo, data);
 			}
 
 			public override void HandleDragMotion(object o, Gtk.DragMotionArgs args)

--- a/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
@@ -271,7 +271,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				Handler?.Callback.OnActivated(Handler.Widget, new TreeGridViewItemEventArgs(Handler.model.GetItemAtPath(args.Path)));
 			}
 
-			protected override DragEventArgs GetDragEventArgs(Gdk.DragContext context, PointF? location, uint time = 0, object controlObject = null)
+			protected override DragEventArgs GetDragEventArgs(Gdk.DragContext context, PointF? location, uint time = 0, object controlObject = null, DataObject data = null)
 			{
 				var h = Handler;
 				var t = h?.Control;
@@ -298,7 +298,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					}
 				}
 
-				return base.GetDragEventArgs(context, location, time, dragInfo);
+				return base.GetDragEventArgs(context, location, time, dragInfo, data);
 			}
 
 			public override void HandleDragMotion(object o, Gtk.DragMotionArgs args)

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -63,6 +63,7 @@ namespace Eto.GtkSharp.Forms
 		public static readonly object ScrollAmount_Key = new object();
 		public static readonly object DragInfo_Key = new object();
 		public static readonly object DropSource_Key = new object();
+		public static readonly object DropSourceData_Key = new object();
 		public static readonly object Font_Key = new object();
 		public static readonly object TabIndex_Key = new object();
 		public static readonly object Cursor_Key = new object();
@@ -455,6 +456,9 @@ namespace Eto.GtkSharp.Forms
 					HandleEvent(Eto.Forms.Control.DragOverEvent);
 					DragControl.DragLeave += Connector.HandleDragLeave;
 					break;
+				case Eto.Forms.Control.DragEndEvent:
+					DragControl.DragEnd += Connector.HandleDragEnd;
+					break;
 				case Eto.Forms.Control.EnabledChangedEvent:
 #if GTK3
 					ContainerControl.StateFlagsChanged += Connector.HandleStateFlagsChangedForEnabled;
@@ -720,7 +724,7 @@ namespace Eto.GtkSharp.Forms
 				Handler?.Callback.OnShown(Handler.Widget, EventArgs.Empty);
 			}
 
-			protected virtual DragEventArgs GetDragEventArgs(Gdk.DragContext context, PointF? location, uint time = 0, object controlObject = null)
+			protected virtual DragEventArgs GetDragEventArgs(Gdk.DragContext context, PointF? location = null, uint time = 0, object controlObject = null, DataObject data = null)
 			{
 				var widget = Gtk.Drag.GetSourceWidget(context);
 				var source = widget?.Data[GtkControl.DropSource_Key] as Eto.Forms.Control;
@@ -731,7 +735,7 @@ namespace Eto.GtkSharp.Forms
 				var action = context.SelectedAction;
 #endif
 
-				var data = new DataObject(new DataObjectHandler(Handler.DragControl, context, time));
+				data = data ?? new DataObject(new DataObjectHandler(Handler.DragControl, context, time));
 				if (location == null)
 					location = Handler.PointFromScreen(Mouse.Position);
 
@@ -807,6 +811,23 @@ namespace Eto.GtkSharp.Forms
 				handler.Callback.OnDragLeave(handler.Widget, DragArgs);
 				_dragEnterEffects = null;
 				Eto.Forms.Application.Instance.AsyncInvoke(() => DragArgs = null);
+			}
+
+			public virtual void HandleDragEnd(object o, Gtk.DragEndArgs args)
+			{
+				var handler = Handler;
+				if (handler == null)
+					return;
+				var data = handler.DragControl.Data[GtkControl.DropSourceData_Key] as DataObject;
+
+				var e = GetDragEventArgs(args.Context, data: data);
+#if GTK2
+				e.Effects = args.Context.Action.ToEto();
+#else
+				e.Effects = args.Context.SelectedAction.ToEto();
+#endif
+				handler.Callback.OnDragEnd(handler.Widget, e);
+				handler.DragControl.Data[GtkControl.DropSourceData_Key] = null;
 			}
 
 #if GTK3
@@ -971,6 +992,10 @@ namespace Eto.GtkSharp.Forms
 			DragInfo = new DragInfoObject { Data = data, AllowedEffects = allowedEffects };
 
 			DragControl.Data[GtkControl.DropSource_Key] = Widget;
+			
+			// set data and ensure it gets cleared out.
+			DragControl.Data[GtkControl.DropSourceData_Key] = data;
+			HandleEvent(Eto.Forms.Control.DragEndEvent);
 
 #if GTKCORE
 			var context = Gtk.Drag.BeginWithCoordinates(DragControl, targets, allowedEffects.ToGdk(), 1, Gtk.Application.CurrentEvent, -1, -1);

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -124,6 +124,8 @@ namespace Eto.Mac.Forms.Controls
 		public NSDragOperation AllowedOperation { get; set; }
 		public NSImage DragImage { get; set; }
 		public PointF ImageOffset { get; set; }
+		
+		public DataObject Data { get; set; }
 
 		public CGPoint GetDragImageOffset()
 		{
@@ -722,7 +724,8 @@ namespace Eto.Mac.Forms.Controls
 				{
 					AllowedOperation = allowedAction.ToNS(),
 					DragImage = image.ToNS(),
-					ImageOffset = origin
+					ImageOffset = origin,
+					Data = data
 				};
 			}
 			else

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -271,6 +271,12 @@ namespace Eto.Mac.Forms.Controls
 					h.CustomSelectedRows = null;
 					h.Callback.OnSelectionChanged(h.Widget, EventArgs.Empty);
 				}
+
+				var allowedOperation = h.DragInfo?.AllowedOperation ?? NSDragOperation.None;
+				var data = h.DragInfo?.Data;
+				var args = new DragEventArgs(h.Widget, data, allowedOperation.ToEto(), endedAtScreenPoint.ToEto(h.ContainerControl), Keyboard.Modifiers, Mouse.Buttons);
+				args.Effects = operation.ToEto();
+				h.Callback.OnDragEnd(h.Widget, args);
 			}
 
 			public override bool WriteRows(NSTableView tableView, NSIndexSet rowIndexes, NSPasteboard pboard)

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -465,6 +465,12 @@ namespace Eto.Mac.Forms.Controls
 					h.CustomSelectedItems = null;
 					h.Callback.OnSelectionChanged(h.Widget, EventArgs.Empty);
 				}
+				
+				var allowedOperation = h.DragInfo?.AllowedOperation ?? NSDragOperation.None;
+				var data = h.DragInfo?.Data;
+				var args = new DragEventArgs(h.Widget, data, allowedOperation.ToEto(), screenPoint.ToEto(h.ContainerControl), Keyboard.Modifiers, Mouse.Buttons);
+				args.Effects = operation.ToEto();
+				h.Callback.OnDragEnd(h.Widget, args);
 			}
 
 			public override bool OutlineViewwriteItemstoPasteboard(NSOutlineView outlineView, NSArray items, NSPasteboard pboard)

--- a/src/Eto.Mac/Forms/EtoDragSource.cs
+++ b/src/Eto.Mac/Forms/EtoDragSource.cs
@@ -1,10 +1,13 @@
 ﻿using System;
-
+using Eto.Forms;
 
 namespace Eto.Mac.Forms
 {
 	class EtoDragSource : NSDraggingSource
 	{
+		public DataObject Data { get; set; }
+		public IMacViewHandler Handler { get; set; }
+
 		[Export("sourceView")]
 		public NSView SourceView { get; set; }
 
@@ -15,6 +18,17 @@ namespace Eto.Mac.Forms
 		public NSDragOperation DraggingSessionSourceOperationMask(NSDraggingSession session, IntPtr context)
 		{
 			return AllowedOperation;
+		}
+		
+		[Export("draggingSession:endedAtPoint:operation:")]
+		public void DraggingSessionEnded(NSDraggingSession session, CGPoint point, NSDragOperation operation)
+		{
+			var h = Handler;
+			if (h == null)
+				return;
+			var args = new DragEventArgs(h.Widget, Data, AllowedOperation.ToEto(), point.ToEto(), Keyboard.Modifiers, Mouse.Buttons, this);
+			args.Effects = operation.ToEto();
+			h.Callback.OnDragEnd(h.Widget, args);
 		}
 	}
 }

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -817,6 +817,9 @@ namespace Eto.Mac.Forms
 				case Eto.Forms.Control.DragLeaveEvent:
 					AddMethod(MacView.selDraggingExited, MacView.TriggerDraggingExited_Delegate, "v@:@", DragControl);
 					break;
+				case Eto.Forms.Control.DragEndEvent:
+					// handled in EtoDragSource, TreeGridViewHandler.EtoDragSource, and GridViewHandler.EtoDragSource
+					break;
 				default:
 					base.AttachEvent(id);
 					break;
@@ -1268,7 +1271,7 @@ namespace Eto.Mac.Forms
 		{
 			var handler = data.Handler as IDataObjectHandler;
 
-			var source = new EtoDragSource { AllowedOperation = allowedAction.ToNS(), SourceView = ContainerControl };
+			var source = new EtoDragSource { AllowedOperation = allowedAction.ToNS(), SourceView = ContainerControl, Handler = this, Data = data };
 
 			NSDraggingItem[] draggingItems = null;
 			if (image != null)

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -531,7 +531,12 @@ namespace Eto.Mac
 			}
 		}
 
-		public static DataObject ToEto(this NSPasteboard pasteboard) => new DataObject(new DataObjectHandler(pasteboard));
+		public static DataObject ToEto(this NSPasteboard pasteboard)
+		{
+			if (pasteboard == null)
+				return null;
+			return new DataObject(new DataObjectHandler(pasteboard));
+		}
 
 		public static NSPasteboard ToNS(this DataObject data) => DataObjectHandler.GetControl(data);
 

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -516,6 +516,9 @@ namespace Eto.Wpf.Forms
 						Control.DragLeave += Control_DragLeave;
 					HandleEvent(Eto.Forms.Control.DragEnterEvent); // need DragEnter so it doesn't get called when going over children
 					break;
+				case Eto.Forms.Control.DragEndEvent:
+					// handled in DoDragDrop, as it is blocking on Windows
+					break;
 				case Eto.Forms.Control.EnabledChangedEvent:
 					Control.IsEnabledChanged += Control_IsEnabledChanged;
 					break;
@@ -1028,10 +1031,14 @@ namespace Eto.Wpf.Forms
 				sw.WpfDataObjectExtensions.SetDragImage(dataObject, image.ToWpf(), PointF.Empty.ToWpf());
 			}
 
-			sw.DragDrop.DoDragDrop(Control, dataObject, allowedAction.ToWpf());
+			var effects = sw.DragDrop.DoDragDrop(Control, dataObject, allowedAction.ToWpf());
 
 			WpfFrameworkElement.DragSourceControl = null;
 			sw.DragSourceHelper.UnregisterDefaultDragSource(Control);
+			
+			var args = new DragEventArgs(Widget, data, allowedAction, PointFromScreen(Mouse.Position), Keyboard.Modifiers, Mouse.Buttons);
+			args.Effects = effects.ToEto();
+			Callback.OnDragEnd(Widget, args);
 		}
 
 

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -682,6 +682,31 @@ namespace Eto.Forms
 		/// <param name="e">Event arguments</param>
 		protected virtual void OnDragLeave(DragEventArgs e) => Properties.TriggerEvent(DragLeaveEvent, this, e);
 
+
+		/// <summary>
+		/// Event identifier for handlers when attaching the <see cref="DragEnd"/> event
+		/// </summary>
+		public const string DragEndEvent = "Control.DragEnd";
+
+		/// <summary>
+		/// Occurs for a source control after a call to <see cref="DoDragDrop(DataObject, DragEffects, Image, PointF)"/> when the drag operation has ended.
+		/// The <see cref="DragEventArgs.Effects"/> is the final <see cref="DragEffects"/> used at the drop destination.
+		/// </summary>
+		/// <remarks>
+		/// For controls that you are dragging from this event is useful to know what to do with the dragged content after it is dropped in a different control or application.
+		/// </remarks>
+		public event EventHandler<DragEventArgs> DragEnd
+		{
+			add { Properties.AddHandlerEvent(DragEndEvent, value); }
+			remove { Properties.RemoveEvent(DragEndEvent, value); }
+		}
+
+		/// <summary>
+		/// Raises the <see cref="DragEnd"/> event.
+		/// </summary>
+		/// <param name="e">Event arguments</param>
+		protected virtual void OnDragEnd(DragEventArgs e) => Properties.TriggerEvent(DragEndEvent, this, e);
+
 		/// <summary>
 		/// Event identifier for handlers when attaching the <see cref="EnabledChanged"/> event
 		/// </summary>
@@ -724,6 +749,7 @@ namespace Eto.Forms
 			EventLookup.Register<Control>(c => c.OnDragOver(null), Control.DragOverEvent);
 			EventLookup.Register<Control>(c => c.OnDragEnter(null), Control.DragEnterEvent);
 			EventLookup.Register<Control>(c => c.OnDragLeave(null), Control.DragLeaveEvent);
+			EventLookup.Register<Control>(c => c.OnDragEnd(null), Control.DragEndEvent);
 			EventLookup.Register<Control>(c => c.OnEnabledChanged(null), Control.EnabledChangedEvent);
 		}
 
@@ -1313,6 +1339,10 @@ namespace Eto.Forms
 		/// <summary>
 		/// Starts drag operation using this control as drag source.
 		/// </summary>
+		/// <remarks>
+		/// This method can be blocking on some platforms (Wpf, WinForms), and non-blocking on others (Mac, Gtk).
+		/// Use the <see cref="DragEnd"/> event to determine when the drag operation is completed and get its resulting DragEffects.
+		/// </remarks>
 		/// <param name="data">Drag data.</param>
 		/// <param name="allowedEffects">Allowed action.</param>
 		public virtual void DoDragDrop(DataObject data, DragEffects allowedEffects)
@@ -1323,6 +1353,10 @@ namespace Eto.Forms
 		/// <summary>
 		/// Starts drag operation using this control as drag source.
 		/// </summary>
+		/// <remarks>
+		/// This method can be blocking on some platforms (Wpf, WinForms), and non-blocking on others (Mac, Gtk).
+		/// Use the <see cref="DragEnd"/> event to determine when the drag operation is completed and get its resulting DragEffects.
+		/// </remarks>
 		/// <param name="data">Drag data.</param>
 		/// <param name="allowedEffects">Allowed effects.</param>
 		/// <param name="image">Custom drag image</param>
@@ -1510,6 +1544,10 @@ namespace Eto.Forms
 			/// </summary>
 			void OnDragLeave(Control widget, DragEventArgs e);
 			/// <summary>
+			/// Raises the DragEnd event.
+			/// </summary>
+			void OnDragEnd(Control widget, DragEventArgs e);
+			/// <summary>
 			/// Raises the EnabledChanged event.
 			/// </summary>
 			void OnEnabledChanged(Control widget, EventArgs e);
@@ -1667,6 +1705,15 @@ namespace Eto.Forms
 			{
 				using (widget.Platform.Context)
 					widget.OnDragLeave(e);
+			}
+
+			/// <summary>
+			/// Raises the DragEnd event.
+			/// </summary>
+			public void OnDragEnd(Control widget, DragEventArgs e)
+			{
+				using (widget.Platform.Context)
+					widget.OnDragEnd(e);
 			}
 
 			/// <summary>

--- a/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
@@ -76,6 +76,7 @@ namespace Eto.Test.Sections.Behaviors
 			// sources
 
 			var buttonSource = new Button { Text = "Source" };
+			LogSourceEvents(buttonSource);
 			buttonSource.MouseDown += (sender, e) =>
 			{
 				if (e.Buttons != MouseButtons.None)
@@ -86,6 +87,7 @@ namespace Eto.Test.Sections.Behaviors
 			};
 
 			var panelSource = new Panel { BackgroundColor = Colors.Red, Size = new Size(50, 50) };
+			LogSourceEvents(panelSource);
 			panelSource.MouseMove += (sender, e) =>
 			{
 				if (e.Buttons != MouseButtons.None)
@@ -96,6 +98,7 @@ namespace Eto.Test.Sections.Behaviors
 			};
 
 			var treeSource = new TreeGridView { Size = new Size(200, 200) };
+			LogSourceEvents(treeSource);
 			treeSource.SelectedItemsChanged += (sender, e) => Log.Write(treeSource, $"TreeGridView.SelectedItemsChanged (source) Rows: {string.Join(", ", treeSource.SelectedRows.Select(r => r.ToString()))}");
 			treeSource.DataStore = CreateTreeData();
 			SetupTreeColumns(treeSource);
@@ -116,6 +119,7 @@ namespace Eto.Test.Sections.Behaviors
 			};
 
 			var gridSource = new GridView {  };
+			LogSourceEvents(gridSource);
 			gridSource.SelectedRowsChanged += (sender, e) => Log.Write(gridSource, $"GridView.SelectedItemsChanged (source): {string.Join(", ", gridSource.SelectedRows.Select(r => r.ToString()))}");
 			SetupGridColumns(gridSource);
 			gridSource.DataStore = CreateGridData();
@@ -380,6 +384,14 @@ namespace Eto.Test.Sections.Behaviors
 			if (uris != null)
 				sb.Append($"\n\tUris: {string.Join(", ", uris.Select(r => r.IsFile ? r.LocalPath : r.AbsoluteUri))})");
 			return sb.ToString();
+		}
+		
+		void LogSourceEvents(Control control)
+		{
+			control.DragEnd += (sender, e) =>
+			{
+				Log.Write(sender, $"DragEnd: Effects: {e.Effects}, {WriteDragInfo(sender, e)}");
+			};
 		}
 
 		void LogEvents(Control control)


### PR DESCRIPTION
This is useful when you want to know when the drag operation finishes after DoDragDrop() is called, since it is only blocking on Windows.