### PR TITLE
Mac: Fix using DoDragDrop when command key is down

### DIFF
--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -95,6 +95,9 @@ namespace Eto.Mac.Forms.Controls
 				return Handler?.DragInfo?.AllowedOperation ?? NSDragOperation.None;
 			}
 
+			[Export("ignoreModifierKeysForDraggingSession:")]
+			public bool IgnoreModifierKeysForDraggingSession(NSDraggingSession session) => true;
+
 			public override void Layout()
 			{
 				if (MacView.NewLayout)

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -586,6 +586,9 @@ namespace Eto.Mac.Forms.Controls
 				return Handler?.DragInfo?.AllowedOperation ?? NSDragOperation.None;
 			}
 
+			[Export("ignoreModifierKeysForDraggingSession:")]
+			public bool IgnoreModifierKeysForDraggingSession(NSDraggingSession session) => true;
+
 			public override void RightMouseDown(NSEvent theEvent)
 			{
 				if (Handler?.HandleMouseEvent(theEvent) == true)

--- a/src/Eto.Mac/Forms/EtoDragSource.cs
+++ b/src/Eto.Mac/Forms/EtoDragSource.cs
@@ -30,5 +30,8 @@ namespace Eto.Mac.Forms
 			args.Effects = operation.ToEto();
 			h.Callback.OnDragEnd(h.Widget, args);
 		}
+
+		[Export("ignoreModifierKeysForDraggingSession:")]
+		public bool IgnoreModifierKeysForDraggingSession(NSDraggingSession session) => true;
 	}
 }


### PR DESCRIPTION
When the command key is down on macOS, it would set the allowed effects to none automatically which prevents you from controlling this yourself.