### PR TITLE
Mac: Fix modifying and blending system colors

### DIFF
--- a/src/Eto.Mac/Drawing/ColorHandler.cs
+++ b/src/Eto.Mac/Drawing/ColorHandler.cs
@@ -1,0 +1,45 @@
+using System;
+using Eto.Drawing;
+
+namespace Eto.Mac.Drawing
+{
+	public class ColorHandler : Color.IHandler
+	{
+		// this actually just converts to RGB anyway, so don't bother as this is more computationally expensive
+		// keeping this here in c
+		/*
+		public Color? Blend(in Color baseColor, in Color blendColor, float blendFactor)
+		{
+			if (baseColor.ControlObject is NSColor || blendColor.ControlObject is NSColor)
+			{
+				// blend colors using native APIs and the effective appearance
+				NSAppearance saved = NSAppearance.CurrentAppearance;
+				var appearance = NSApplication.SharedApplication.MainWindow?.EffectiveAppearance;
+				if (appearance != null)
+					NSAppearance.CurrentAppearance = appearance;
+				var blendedColor = baseColor.ToNSUI().BlendedColor(blendFactor, blendColor.ToNSUI());
+				NSAppearance.CurrentAppearance = saved;
+				if (blendedColor != null)
+					return blendedColor.ToEto();
+			}
+			return null;
+		}
+		*/
+
+		public object ModifyComponent(object controlObject, float? r, float? g, float? b, float? a)
+		{
+			if (r != null || g != null || b != null)
+				return null;
+				
+			if (controlObject is NSColor color && a != null)
+			{
+				// we can change the alpha component of system colors
+				return color.ColorWithAlphaComponent((nfloat)a.Value);
+			}
+			
+			// nothing is changing, use the same control object
+			return controlObject;
+		}
+	}
+}
+

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -150,6 +150,7 @@ namespace Eto.Mac
 			p.Add<TextureBrush.IHandler>(() => new TextureBrushHandler());
 			p.Add<LinearGradientBrush.IHandler>(() => new LinearGradientBrushHandler());
 			p.Add<RadialGradientBrush.IHandler>(() => new RadialGradientBrushHandler());
+			p.Add<Color.IHandler>(() => new ColorHandler());
 			p.Add<SystemColors.IHandler>(() => new SystemColorsHandler());
 			p.Add<FormattedText.IHandler>(() => new FormattedTextHandler());
 


### PR DESCRIPTION
- Fix blending a system color by not using a copy of baseColor when blending
- Modifying one of the components (RGBA) will now work for system colors on Mac
- Optimize Color struct a little by avoiding double initialization of members.