### PR TITLE
Mac: Fix showing MessageBox or FileDialog on secondary dialogs

### DIFF
--- a/src/Eto.Mac/Forms/MacModal.cs
+++ b/src/Eto.Mac/Forms/MacModal.cs
@@ -168,48 +168,38 @@ namespace Eto.Mac.Forms
 
 		public static int Run(NSAlert view, Control parent)
 		{
-			int ret;
 			if (parent != null)
 			{
 				var window = parent.ControlObject as NSWindow;
 				if (window == null && parent.ControlObject is NSView)
 					window = ((NSView)parent.ControlObject).Window;
-				if (window == null || !view.RespondsToSelector(new Selector("beginSheetModalForWindow:modalDelegate:didEndSelector:contextInfo:")))
-					ret = (int)view.RunModal();
-				else
+				
+				if (window != null && view.RespondsToSelector(new Selector("beginSheetModalForWindow:modalDelegate:didEndSelector:contextInfo:")))
 				{
-					ret = 0;
-					NSApplication.SharedApplication.InvokeOnMainThread(delegate
-					{
-						view.BeginSheet(window, new MacModal(), new Selector("alertDidEnd:returnCode:contextInfo:"), IntPtr.Zero);
-						ret = (int)NSApplication.SharedApplication.RunModalForWindow(window);
-					});
+					// show attached as a sheet
+					view.BeginSheet(window, new MacModal(), new Selector("alertDidEnd:returnCode:contextInfo:"), IntPtr.Zero);
 				}
 			}
-			else
-				ret = (int)view.RunModal();
-			return ret;
+			
+			return (int)view.RunModal();
 		}
 
 		public static int Run(NSSavePanel panel, Control parent)
 		{
-			int ret;
 			if (parent != null)
 			{
 				var window = parent.ControlObject as NSWindow;
 				if (window == null && parent.ControlObject is NSView)
 					window = ((NSView)parent.ControlObject).Window;
-				if (window == null || !panel.RespondsToSelector(new Selector("beginSheetModalForWindow:completionHandler:")))
-					ret = (int)panel.RunModal();
-				else
+				
+				if (window != null && panel.RespondsToSelector(new Selector("beginSheetModalForWindow:completionHandler:")))
 				{
+					// show attached as a sheet
 					panel.BeginSheet(window, result => NSApplication.SharedApplication.StopModalWithCode(result));
-					ret = (int)NSApplication.SharedApplication.RunModalForWindow(window);
 				}
 			}
-			else
-				ret = (int)panel.RunModal();
-			return ret;
+
+			return (int)panel.RunModal();
 		}
 
 		public static void Run(Window window, NSWindow nativeWindow, out ModalEventArgs helper, bool isSheet = false)

--- a/test/Eto.Test/UnitTests/Forms/FileDialogTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/FileDialogTests.cs
@@ -16,9 +16,9 @@ namespace Eto.Test.UnitTests.Forms
 	public class SaveFileDialogTests : FileDialogTests<SaveFileDialog>
 	{
 	}
-	
+
 	public class FileDialogTests<T> : TestBase
-		where T: FileDialog, new()
+		where T : FileDialog, new()
 	{
 		[Test, InvokeOnUI, ManualTest]
 		public void FileNameShouldHaveConsistentValues()
@@ -27,12 +27,12 @@ namespace Eto.Test.UnitTests.Forms
 			fd.Filters.Add(new FileFilter("Text Files (*.txt)", ".txt"));
 
 			Assert.That(fd.FileName, Is.Null.Or.Empty.Or.EqualTo("Untitled"), "#1");
-			
+
 			fd.FileName = null;
 			Assert.That(fd.FileName, Is.Null.Or.Empty.Or.EqualTo("Untitled"), "#2");
 
 			fd.FileName = "SomeFile.txt";
-			
+
 			Assert.AreEqual("SomeFile.txt", Path.GetFileName(fd.FileName), "#3");
 
 			var result = fd.ShowDialog(null);
@@ -47,9 +47,50 @@ namespace Eto.Test.UnitTests.Forms
 				Assert.IsNotEmpty(directoryName, "#5.2");
 				Console.WriteLine($"Directory: {directoryName}");
 			}
-			
+
 			Console.WriteLine($"FileName: {fd.FileName}");
 
+		}
+
+		[Test, ManualTest, InvokeOnUI]
+		public void OpenFromSecondaryDialogShouldNotChangeItsOrder()
+		{
+			var btn1 = new Button { Text = "Click Me" };
+			btn1.Click += (s, e) =>
+			{
+				var btn2 = new Button { Text = "File Dialog" };
+				btn2.Click += (s1, e1) =>
+				{
+					var fileDialog = new T();
+					fileDialog.Filters.Add(new FileFilter("Text Files (*.txt)", ".txt"));
+					fileDialog.CurrentFilterIndex = 0;
+					
+					// Close the file dialog and the dialog with the "File Dialog" button should stay on top.
+					fileDialog.ShowDialog(btn2.ParentWindow);
+				};
+				var dlg2 = new Dialog
+				{
+					Title = "Test FileDialog",
+					ClientSize = new Size(200, 200),
+					Content = new TableLayout
+					{
+						Rows = {
+							null,
+							"This dialog should remain on top\nafter the file dialog closes",
+							TableLayout.AutoSized(btn2, centered: true),
+							null
+						}
+					}
+				};
+				dlg2.ShowModal(btn1.ParentWindow);
+			};
+			var dlg1 = new Dialog
+			{
+				Title = "TestEtoFileDialog",
+				ClientSize = new Size(200, 200),
+				Content = TableLayout.AutoSized(btn1, centered: true)
+			};
+			dlg1.ShowModal(Application.Instance.MainForm);
 		}
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/MessageBoxTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/MessageBoxTests.cs
@@ -1,0 +1,48 @@
+using System;
+using System.IO;
+using System.Threading.Tasks;
+using Eto.Drawing;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms
+{
+	[TestFixture]
+	public class MessageBoxTests : TestBase
+	{
+		[Test, ManualTest, InvokeOnUI]
+		public void OpenFromSecondaryDialogShouldNotChangeItsOrder()
+		{
+			var btn1 = new Button { Text = "Click Me" };
+			btn1.Click += (s, e) =>
+			{
+				var btn2 = new Button { Text = "Show MessageBox" };
+				btn2.Click += (s1, e1) =>
+				{
+					MessageBox.Show(btn2.ParentWindow, "This is a message.");
+				};
+				var dlg2 = new Dialog
+				{
+					Title = "Test MessageBox",
+					ClientSize = new Size(200, 200),
+					Content = new TableLayout
+					{
+						Rows = {
+							null,
+							"This dialog should remain on top\nafter the message box closes",
+							TableLayout.AutoSized(btn2, centered: true),
+							null
+						}
+					}
+				};
+				dlg2.ShowModal(btn1.ParentWindow);
+			};
+			var dlg1 = new Dialog
+			{
+				ClientSize = new Size(200, 200),
+				Content = TableLayout.AutoSized(btn1, centered: true)
+			};
+			dlg1.ShowModal(Application.Instance.MainForm);
+		}
+	}
+}


### PR DESCRIPTION
When showing a `MessageBox` or `OpenFileDialog`/`SaveFileDialog` on macOS, Eto incorrectly started a modal session on the parent window which when stopped caused that window to be ordered below its parent.

Now things should work correctly as we start the modal session on the `NSAlert`/`NSSavePanel` directly.