### PR TITLE
Mac: Fix flipped graphics with DrawableCell

### DIFF
--- a/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
@@ -67,13 +67,13 @@ namespace Eto.Mac.Forms.Cells
 
 				if (DrawsBackground)
 				{
-					var context = nscontext.GraphicsPort;
+					var context = nscontext.CGContext;
 					context.SetFillColor(BackgroundColor.ToCG());
 					context.FillRect(cellFrame);
 				}
 
 				var handler = Handler;
-				var graphicsHandler = new GraphicsHandler(null, nscontext, (float)cellFrame.Height, flipped: true);
+				var graphicsHandler = new GraphicsHandler(inView, nscontext, (float)cellFrame.Height);
 				using (var graphics = new Graphics(graphicsHandler))
 				{
 					var state = Highlighted ? CellStates.Selected : CellStates.None;
@@ -162,7 +162,7 @@ namespace Eto.Mac.Forms.Cells
 
 				if (DrawsBackground)
 				{
-					var context = nscontext.GraphicsPort;
+					var context = nscontext.CGContext;
 					context.SetFillColor(BackgroundColor.ToCG());
 					context.FillRect(dirtyRect);
 				}
@@ -171,7 +171,7 @@ namespace Eto.Mac.Forms.Cells
 				var handler = Handler;
 				if (handler == null)
 					return;
-				var graphicsHandler = new GraphicsHandler(null, nscontext, (float)cellFrame.Height, flipped: true);
+				var graphicsHandler = new GraphicsHandler(this, nscontext, (float)cellFrame.Height);
 				using (var graphics = new Graphics(graphicsHandler))
 				{
 					var rowView = this.Superview as NSTableRowView;

--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -1,3 +1,4 @@
+using System;
 using Eto.Drawing;
 using Eto.Forms;
 using Eto.Mac.Drawing;
@@ -9,9 +10,9 @@ namespace Eto.Mac.Forms.Controls
 		Brush backgroundBrush;
 		Color backgroundColor;
 
-		public bool SupportsCreateGraphics { get { return true; } }
+		public bool SupportsCreateGraphics => false;
 
-		public override NSView ContainerControl { get { return Control; } }
+		public override NSView ContainerControl => Control;
 
 		public class EtoDrawableView : MacPanelView
 		{
@@ -33,6 +34,8 @@ namespace Eto.Mac.Forms.Controls
 				ApplicationHandler.QueueResizing = false;
 			}
 
+			// public override bool IsFlipped => true;  // uncomment to test flipped views with GraphicsHandler.
+
 			public bool CanFocus { get; set; }
 
 			public override bool AcceptsFirstResponder() => CanFocus;
@@ -52,7 +55,7 @@ namespace Eto.Mac.Forms.Controls
 
 		public Graphics CreateGraphics()
 		{
-			return new Graphics(new GraphicsHandler(Control));
+			throw new NotSupportedException();
 		}
 
 		public override Color BackgroundColor
@@ -111,7 +114,7 @@ namespace Eto.Mac.Forms.Controls
 			var context = NSGraphicsContext.CurrentContext;
 			if (context != null)
 			{
-				var handler = new GraphicsHandler(Control, context, (float)Control.Frame.Height, Control.IsFlipped);
+				var handler = new GraphicsHandler(Control, context, (float)Control.Frame.Height);
 				using (var graphics = new Graphics(handler))
 				{
 					if (backgroundBrush != null)

--- a/src/Eto.Mac/Forms/Printing/PrintDocumentHandler.cs
+++ b/src/Eto.Mac/Forms/Printing/PrintDocumentHandler.cs
@@ -70,7 +70,7 @@ namespace Eto.Mac.Forms.Printing
 				var height = Frame.Height;
 				var pageRect = RectForPage(operation.CurrentPage);
 
-				using (var graphics = new Graphics(new GraphicsHandler(this, context, (float)height, IsFlipped)))
+				using (var graphics = new Graphics(new GraphicsHandler(this, context, (float)height)))
 				{
 					graphics.TranslateTransform((float)pageRect.X, (float)(height-pageRect.Y-pageRect.Height));
 					Handler.Callback.OnPrintPage(Handler.Widget, new PrintPageEventArgs(graphics, operation.PrintInfo.ImageablePageBounds.Size.ToEto(), (int)operation.CurrentPage - 1));


### PR DESCRIPTION
- Removed Drawable.CreateGraphics() support on Mac (it has not worked in a long time)
- Use newer NSGraphicsContext.FromCGContext vs. deprecated GraphicsPort APIs (macOS 10.10+)