### PR TITLE
Wpf: Fix releasing mouse capture in parent when clicking on a child

### DIFF
--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -845,7 +845,8 @@ namespace Eto.Wpf.Forms
 
 		protected virtual void HandleMouseDown(object sender, swi.MouseButtonEventArgs e)
 		{
-			var args = e.ToEto(ContainerControl);
+            isMouseCaptured = false;
+            var args = e.ToEto(ContainerControl);
 			if (!(Control is swc.Control) && e.ClickCount == 2)
 				Callback.OnMouseDoubleClick(Widget, args);
 			if (!args.Handled)
@@ -862,12 +863,8 @@ namespace Eto.Wpf.Forms
 					|| e.Handled
 				))
 			{
-				isMouseCaptured = true;
 				Control.CaptureMouse();
-			}
-			else
-			{
-				isMouseCaptured = false;
+				isMouseCaptured = true;
 			}
 		}
 

--- a/test/Eto.Test/UnitTests/Forms/Behaviors/MouseTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Behaviors/MouseTests.cs
@@ -86,9 +86,41 @@ namespace Eto.Test.UnitTests.Forms.Behaviors
 			Assert.IsTrue(mouseDownInChild, "#3 - MouseUp should NOT be called on child even though it was removed");
 			Assert.IsFalse(mouseMovedEvenAfterRemoved, "#4 - MouseMoved should NOT be called on child after it was removed");
 		}
-		
-		
+
+		[Test, ManualTest]
+		public void MouseDownHandledInPanelWithChildShouldReleaseMouseCapture() => ManualForm("Click once on both blue squares,\nthey should both turn green.", form =>
+		{
+			StackLayout CreateClickableBox()
+			{
+				var child = new Panel
+				{
+					BackgroundColor = Colors.Blue,
+					Size = new Size(40, 40)
+				};
+
+				var parent = new Panel();
+				parent.Content = child;
+
+				parent.MouseDown += (sender, e) =>
+				{
+					child.BackgroundColor = child.BackgroundColor == Colors.Blue ? Colors.Green : Colors.Blue;
+					e.Handled = true;
+				};
+				
+				return new StackLayout(parent);
+			}
+			
+			var section1 = CreateClickableBox();
+
+			var section2 = CreateClickableBox();
+
+			return new TableLayout
+			{
+				Rows = { section1, section2, null },
+				Size = new Size(200, 200),
+				Spacing = new Size(4, 4),
+				Padding = 8
+			};
+		});
 	}
-	
-	
 }


### PR DESCRIPTION
This regression was introduced in #2308.  Added a unit test to verify desired behaviour.