### PR TITLE
Mac: Fix errors with ListBox when switching from light to dark mode

### DIFF
--- a/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
@@ -69,8 +69,11 @@ namespace Eto.Mac.Forms.Controls
 
 			public override NSObject GetObjectValue(NSTableView tableView, NSTableColumn tableColumn, nint row)
 			{
-				var w = Handler.Widget;
-				var item = Handler.collection.ElementAt((int)row);
+				var h = Handler;
+				if (h == null)
+					return null;
+				var w = h.Widget;
+				var item = h.collection.ElementAt((int)row);
 				return new MacImageData
 				{
 					Text = new NSString(Convert.ToString(w.ItemTextBinding.GetValue(item))),
@@ -80,7 +83,10 @@ namespace Eto.Mac.Forms.Controls
 
 			public override nint GetRowCount(NSTableView tableView)
 			{
-				return Handler.collection.Collection == null ? 0 : Handler.collection.Collection.Count();
+				var h = Handler;
+				if (h == null)
+					return 0;
+				return h.collection.Collection == null ? 0 : h.collection.Collection.Count();
 			}
 		}
 
@@ -97,12 +103,18 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void SelectionDidChange(NSNotification notification)
 			{
-				Handler.Callback.OnSelectedIndexChanged(Handler.Widget, EventArgs.Empty);
+				var h = Handler;
+				if (h == null)
+					return;
+				h.Callback.OnSelectedIndexChanged(h.Widget, EventArgs.Empty);
 			}
 
 			public override nfloat GetRowHeight(NSTableView tableView, nint row)
 			{
-				return Handler.Control.GetCell(0, row).CellSize.Height;
+				var h = Handler;
+				if (h == null)
+					return tableView.RowHeight;
+				return h.Control.GetCell(0, row).CellSize.Height;
 			}
 		}
 
@@ -118,8 +130,9 @@ namespace Eto.Mac.Forms.Controls
 
 			public override NSMenu MenuForEvent(NSEvent theEvent)
 			{
-				if (Handler.ContextMenu != null)
-					return Handler.ContextMenu.ControlObject as NSMenu;
+				var h = Handler;
+				if (h?.ContextMenu != null)
+					return h.ContextMenu.ControlObject as NSMenu;
 				return base.MenuForEvent(theEvent);
 			}
 


### PR DESCRIPTION
If you had a ListBox created before that is now gone it still calls methods on the delegate when switching display modes if they are still "alive". 