### PR TITLE
Mac: Fix setting SaveFileDialog.FileName with a path

### DIFF
--- a/src/Eto.Mac/Forms/SaveFileDialogHandler.cs
+++ b/src/Eto.Mac/Forms/SaveFileDialogHandler.cs
@@ -1,4 +1,5 @@
 using System;
+using System.IO;
 using Eto.Forms;
 
 namespace Eto.Mac.Forms
@@ -6,13 +7,24 @@ namespace Eto.Mac.Forms
 	public class SaveFileDialogHandler : MacFileDialog<NSSavePanel, SaveFileDialog>, SaveFileDialog.IHandler
 	{
 		bool hasShown;
+		string selectedFileName;
+
 
 		public override string FileName
 		{
-			get => hasShown ? base.FileName : Control.NameFieldStringValue;
+			get => hasShown ? base.FileName : selectedFileName;
 			set
 			{
-				Control.NameFieldStringValue = value ?? string.Empty;
+				selectedFileName = value;
+				var name = value;
+				if (!string.IsNullOrEmpty(name))
+				{
+					var dir = Path.GetDirectoryName(name);
+					if (!string.IsNullOrEmpty(dir) && System.IO.Directory.Exists(dir))
+						Directory = new Uri(dir);
+					name = Path.GetFileName(name);
+				}
+				Control.NameFieldStringValue = name ?? string.Empty;
 				hasShown = false;
 			}
 		}
@@ -33,10 +45,13 @@ namespace Eto.Mac.Forms
 
 		public override DialogResult ShowDialog(Window parent)
 		{
-			hasShown = true;
 			var result = base.ShowDialog(parent);
-			if (result != DialogResult.Ok)
-				hasShown = false;
+			if (result == DialogResult.Ok)
+			{
+				selectedFileName = null;
+				hasShown = true;
+			}
+
 			return result;
 		}
 	}


### PR DESCRIPTION
This was a regression introduced with #2310, if you set the FileName to a file with a path it would return `/Path/To/Path:To:MyFile.png`, instead of `/Path/To/MyFile.png`