### PR TITLE
Add GridColumn.HeaderToolTip/CellToolTipBinding

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridColumnHandler.cs
@@ -228,6 +228,18 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
+#if GTK3
+		public string HeaderToolTip
+		{
+			get => Control.Button.TooltipText;
+			set => Control.Button.TooltipText = value;
+		}
+#else
+		public string HeaderToolTip { get; set; }
+#endif
+
+		public IIndirectBinding<string> CellToolTipBinding { get; set; }
+
 		internal void SetDisplayIndex()
 		{
 			if (displayIndex != null && GridHandler != null)

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -146,6 +146,38 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			Widget.MouseDown += Widget_MouseDown;
 
+			Control.QueryTooltip += Control_QueryTooltip;
+			Control.HasTooltip = true;
+
+
+		}
+
+		private void Control_QueryTooltip(object o, Gtk.QueryTooltipArgs args)
+		{
+			var offset = 0;
+			if (Control.HeadersVisible)
+			{
+				Control.BinWindow.GetPosition(out var bx, out offset);
+			}
+			var isData = Control.GetPathAtPos((int)args.X, (int)args.Y - offset, out var path, out var col);
+			
+			if (isData)
+			{
+				var columnIndex = GetColumnIndex(col);
+				if (columnIndex != -1)
+				{
+					var etoColumn = Widget.Columns[columnIndex];
+					if (etoColumn.CellToolTipBinding != null)
+					{
+						var item = GetItem(path);
+						var cellRect = Control.GetCellArea(path, col);
+						cellRect.Y += offset;
+						args.Tooltip.Text = etoColumn.CellToolTipBinding.GetValue(item);
+						args.Tooltip.TipArea = cellRect;
+						args.RetVal = true;
+					}
+				}
+			}
 		}
 
 		protected new GridConnector Connector => (GridConnector)base.Connector;
@@ -592,6 +624,10 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public void OnCellFormatting(GridCellFormatEventArgs args)
 		{
+			// var tooltipBinding = args.Column?.CellToolTipBinding;
+			// if (tooltipBinding != null && args is GtkGridCellFormatEventArgs macargs && macargs.View != null)
+			// 	macargs.View.ToolTip = tooltipBinding.GetValue(args.Item) ?? string.Empty;
+			
 			Callback.OnCellFormatting(Widget, args);
 		}
 

--- a/src/Eto.Mac/Eto.Mac64.csproj
+++ b/src/Eto.Mac/Eto.Mac64.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Eto.Mac</RootNamespace>
     <DefineConstants>$(DefineConstants);OSX;DESKTOP;MONOMAC;Mac64</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefaultItemExcludes>build\*</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);build\*</DefaultItemExcludes>
     <LangVersion>10.0</LangVersion>
     <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyProjectReferencesToPackage</TargetsForTfmSpecificBuildOutput>
 

--- a/src/Eto.Mac/Eto.XamMac2.csproj
+++ b/src/Eto.Mac/Eto.XamMac2.csproj
@@ -8,7 +8,7 @@
     <DefineConstants>$(DefineConstants);OSX;DESKTOP;XAMMAC;XAMMAC2;UNIFIED</DefineConstants>
     <DefineConstants Condition="$(UseCFString) != 'False'">$(DefineConstants);USE_CFSTRING</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefaultItemExcludes>build\*</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);build\*</DefaultItemExcludes>
     <NoWarn>CA1416</NoWarn>
     <LangVersion>10</LangVersion>
   </PropertyGroup>

--- a/src/Eto.Mac/Eto.macOS.csproj
+++ b/src/Eto.Mac/Eto.macOS.csproj
@@ -5,7 +5,7 @@
     <RootNamespace>Eto.Mac</RootNamespace>
     <DefineConstants>$(DefineConstants);OSX;DESKTOP;UNIFIED;MACOS_NET;USE_CFSTRING</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <DefaultItemExcludes>build\*</DefaultItemExcludes>
+    <DefaultItemExcludes>$(DefaultItemExcludes);build\*</DefaultItemExcludes>
     <NoWarn>CA1416</NoWarn>
   </PropertyGroup>
   <ItemGroup>

--- a/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
@@ -38,7 +38,7 @@ namespace Eto.Mac.Forms.Controls
 
 		void ResetAutoSizedColumns();
 		bool AutoSizeColumns(bool force, bool forceNewSize = false);
-		
+
 		int GetColumnDisplayIndex(GridColumn column);
 		void SetColumnDisplayIndex(GridColumn column, int index);
 	}
@@ -327,7 +327,7 @@ namespace Eto.Mac.Forms.Controls
 		public int MinWidth
 		{
 			get => (int)Control.MinWidth + IntercellSpacingWidth;
-			set 
+			set
 			{
 				if (value == MinWidth)
 					return;
@@ -399,8 +399,8 @@ namespace Eto.Mac.Forms.Controls
 		}
 
 		public void SizeToFit() => Control.SizeToFit();
-		
-		
+
+
 		static readonly object DisplayIndex_Key = new object();
 		public int DisplayIndex
 		{
@@ -411,7 +411,21 @@ namespace Eto.Mac.Forms.Controls
 				DataViewHandler?.SetColumnDisplayIndex(Widget, value);
 			}
 		}
-		
+
+		public string HeaderToolTip
+		{
+			get => Control.HeaderToolTip;
+			set => Control.HeaderToolTip = value ?? string.Empty;
+		}
+
+		static readonly object CellToolTipBinding_Key = new object();
+
+		public IIndirectBinding<string> CellToolTipBinding
+		{
+			get => Widget.Properties.Get<IIndirectBinding<string>>(CellToolTipBinding_Key);
+			set => Widget.Properties.Set(CellToolTipBinding_Key, value);
+		}
+
 		public void SetupDisplayIndex()
 		{
 			var displayIndex = Widget.Properties.Get<int?>(DisplayIndex_Key) ?? -1;

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -607,6 +607,10 @@ namespace Eto.Mac.Forms.Controls
 
 		public void OnCellFormatting(GridCellFormatEventArgs args)
 		{
+			var tooltipBinding = args.Column?.CellToolTipBinding;
+			if (tooltipBinding != null && args is MacCellFormatArgs macargs && macargs.View != null)
+				macargs.View.ToolTip = tooltipBinding.GetValue(args.Item) ?? string.Empty;
+			
 			Callback.OnCellFormatting(Widget, args);
 		}
 

--- a/src/Eto.WinForms/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridColumnHandler.cs
@@ -171,6 +171,26 @@ namespace Eto.WinForms.Forms.Controls
 			set => Control.DisplayIndex = value;
 		}
 
+		public string HeaderToolTip
+		{
+			get => Control.ToolTipText;
+			set => Control.ToolTipText = value;
+		}
+
+		static readonly object CellToolTipBinding_Key = new object();
+
+		public IIndirectBinding<string> CellToolTipBinding
+		{
+			get => Widget.Properties.Get<IIndirectBinding<string>>(CellToolTipBinding_Key);
+			set
+			{
+				if (Widget.Properties.TrySet(CellToolTipBinding_Key, value))
+				{
+					GridHandler?.HandleEvent(GridView.CellFormattingEvent);
+				}
+			}
+		}
+
 		public void SetCellValue(object dataItem, object value)
 		{
 			if (dataCell != null)
@@ -193,6 +213,8 @@ namespace Eto.WinForms.Forms.Controls
 		public virtual void Setup(IGridHandler gridHandler)
 		{
 			GridHandler = gridHandler;
+			if (CellToolTipBinding != null)
+				GridHandler?.HandleEvent(GridView.CellFormattingEvent);
 		}
 
 		public void Paint(sd.Graphics graphics, sd.Rectangle clipBounds, sd.Rectangle cellBounds, int rowIndex, swf.DataGridViewElementStates cellState, object value, object formattedValue, string errorText, swf.DataGridViewCellStyle cellStyle, swf.DataGridViewAdvancedBorderStyle advancedBorderStyle, ref swf.DataGridViewPaintParts paintParts)

--- a/src/Eto.WinForms/Forms/Controls/GridHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridHandler.cs
@@ -19,7 +19,9 @@ namespace Eto.WinForms.Forms.Controls
 		bool CellMouseClick(GridColumnHandler column, swf.MouseEventArgs e, int rowIndex);
 		object GetItemAtRow(int row);
 
-		Grid Grid { get; }		
+		Grid Grid { get; }
+
+		void HandleEvent(string id, bool defaultEvent = false);
 	}
 
 	public abstract class GridHandler<TWidget, TCallback> : WindowsControl<swf.DataGridView, TWidget, TCallback>, Grid.IHandler, IGridHandler
@@ -341,12 +343,7 @@ namespace Eto.WinForms.Forms.Controls
 					// handled automatically
 					break;
 				case Grid.CellFormattingEvent:
-					Control.CellFormatting += (sender, e) =>
-					{
-						var column = Widget.Columns[e.ColumnIndex];
-						var item = GetItemAtRow(e.RowIndex);
-						Callback.OnCellFormatting(Widget, new FormattingArgs(e, column, item, e.RowIndex));
-					};
+					Control.CellFormatting += HandleCellFormatting;
 					break;
 				case Grid.ColumnOrderChangedEvent:
 					Control.ColumnDisplayIndexChanged += HandleColumnDisplayIndexChanged;
@@ -359,6 +356,21 @@ namespace Eto.WinForms.Forms.Controls
 					base.AttachEvent(id);
 					break;
 			}
+		}
+
+		private void HandleCellFormatting(object sender, swf.DataGridViewCellFormattingEventArgs e)
+		{
+			var column = Widget.Columns[e.ColumnIndex];
+			var item = GetItemAtRow(e.RowIndex);
+			if (column.CellToolTipBinding != null)
+			{
+				var cell = Control.Rows[e.RowIndex].Cells[e.ColumnIndex];
+				if (cell != null)
+				{
+					cell.ToolTipText = column.CellToolTipBinding.GetValue(item);
+				}
+			}
+			Callback.OnCellFormatting(Widget, new FormattingArgs(e, column, item, e.RowIndex));
 		}
 
 		private void HandleColumnWidthChanged(object sender, swf.DataGridViewColumnEventArgs e)

--- a/src/Eto/Forms/Controls/GridColumn.cs
+++ b/src/Eto/Forms/Controls/GridColumn.cs
@@ -29,6 +29,26 @@ namespace Eto.Forms
 			get { return Handler.HeaderText; }
 			set { Handler.HeaderText = value; }
 		}
+		
+		/// <summary>
+		/// Gets or sets the tooltip to display when the user moves the cursor over the header of this column.
+		/// </summary>
+		/// <value>The tooltip for the header of this column</value>
+		public string HeaderToolTip
+		{
+			get => Handler.HeaderToolTip;
+			set => Handler.HeaderToolTip = value;
+		}
+		
+		/// <summary>
+		/// Gets or sets the binding to use to get the tooltip for each cell in this column.
+		/// </summary>
+		/// <value>The binding to get the tooltip for cells in this column</value>
+		public IIndirectBinding<string> CellToolTipBinding
+		{
+			get => Handler.CellToolTipBinding;
+			set => Handler.CellToolTipBinding = value;
+		}
 
 		/// <summary>
 		/// Gets or sets a value indicating whether the column is resizable by the user.
@@ -251,7 +271,18 @@ namespace Eto.Forms
 			/// This value must be within the range of the total number of columns that are added.
 			/// </remarks>
 			int DisplayIndex { get; set; }
+
+			/// <summary>
+			/// Gets or sets the tooltip to display when the user moves the cursor over the header of this column.
+			/// </summary>
+			/// <value>The tooltip for the header of this column</value>
+			string HeaderToolTip { get; set; }
+
+			/// <summary>
+			/// Gets or sets the binding to use to get the tooltip for each cell in this column.
+			/// </summary>
+			/// <value>The binding to get the tooltip for cells in this column</value>
+			IIndirectBinding<string> CellToolTipBinding { get; set; }
 		}
 	}
 }
-

--- a/test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -400,6 +400,7 @@ namespace Eto.Test.Sections.Controls
 				control.TextBinding.BindDataContext((MyGridItem m) => m.Text);
 				control.Bind(c => c.TextColor, args, a => a.CellTextColor);
 				control.BindDataContext(c => c.Command, (MyGridItem m) => m.Command);
+				control.BindDataContext(c => c.ToolTip, (MyGridItem m) => m.ToolTip);
 				//control.Click += (sender, e) => Log.Write(sender, "Clicked row button {0}", ((Button)sender).Text);
 				return new Panel { Content = control, Padding = 2 };
 			}
@@ -468,8 +469,8 @@ namespace Eto.Test.Sections.Controls
 			var dropDown = MyDropDown("DropDownKey");
 			grid.Columns.Add(SetColumnState(0, new GridColumn { HeaderText = "ImageText", DataCell = new ImageTextCell("Image", "Text") }));
 			grid.Columns.Add(SetColumnState(1, new GridColumn { DataCell = new CheckBoxCell("Check"), AutoSize = true, Resizable = false }));
-			grid.Columns.Add(SetColumnState(2, new GridColumn { HeaderText = "Image", DataCell = new ImageViewCell("Image"), Resizable = false }));
-			grid.Columns.Add(SetColumnState(3, new GridColumn { HeaderText = "Text", DataCell = new TextBoxCell("Text"), Sortable = true }));
+			grid.Columns.Add(SetColumnState(2, new GridColumn { HeaderText = "Image", DataCell = new ImageViewCell("Image"), Resizable = false, HeaderToolTip = null }));
+			grid.Columns.Add(SetColumnState(3, new GridColumn { HeaderText = "Text", DataCell = new TextBoxCell("Text"), Sortable = true, HeaderToolTip = "Some Tooltip", CellToolTipBinding = Binding.Property((MyGridItem i) => i.ToolTip) }));
 			grid.Columns.Add(SetColumnState(4, new GridColumn { HeaderText = "Progress", DataCell = new ProgressCell("Progress") }));
 			grid.Columns.Add(SetColumnState(5, new GridColumn { HeaderText = "Drop Down", DataCell = dropDown, Sortable = true }));
 			if (Platform.Supports<CustomCell>())
@@ -705,9 +706,12 @@ namespace Eto.Test.Sections.Controls
 				{
 					text = value;
 					OnPropertyChanged();
+					OnPropertyChanged(nameof(ToolTip));
 					Log("Text", value);
 				}
 			}
+
+			public string ToolTip => $"ToolTip For {Text}";
 
 			public Image Image
 			{
@@ -771,7 +775,7 @@ namespace Eto.Test.Sections.Controls
 				val = row % 2;
 				image = val == 0 ? image1 : val == 1 ? (Image)image2 : null;
 
-				text = $"Col 1 {name}";
+				text = name;
 
 				color = Color.FromElementId(row);
 


### PR DESCRIPTION
This allows you to fully add tooltips for `GridView` and `TreeGridView` for the headers and the data cells.

Fixes #1253
Fixes #1000