### PR TITLE
Mac: GridView.DataSource fixes

### DIFF
--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -164,32 +164,44 @@ namespace Eto.Mac.Forms.Controls
 		{
 			WeakReference handler;
 			
-			public GridViewHandler Handler { get { return (GridViewHandler)(handler != null ? handler.Target : null); } set { handler = new WeakReference(value); } }
+			public GridViewHandler Handler { get => (GridViewHandler)handler?.Target; set => handler = new WeakReference(value); }
 
-			public override nint GetRowCount(NSTableView tableView)
-			{
-				return (Handler.collection != null && Handler.collection.Collection != null) ? Handler.collection.Count : 0;
-			}
+			public override nint GetRowCount(NSTableView tableView) => Handler?.collection?.Count ?? 0;
 
 			public override NSObject GetObjectValue(NSTableView tableView, NSTableColumn tableColumn, nint row)
 			{
-				var item = Handler.collection.ElementAt((int)row);
-				var colHandler = Handler.GetColumn(tableColumn);
-				return colHandler == null ? null : colHandler.GetObjectValue(item);
+				var h = Handler;
+				if (h == null)
+					return null;
+					
+				if (row >= h.collection.Count)
+				{
+					// re-jig as we're off somehow.. usually because of some programming error, but let's be nice and not actually crash.
+					tableView.ReloadData();
+					return null;
+				}
+				var colHandler = h.GetColumn(tableColumn);
+				var item = h.collection.ElementAt((int)row);
+				return colHandler?.GetObjectValue(item);
 			}
 
 			public override void SetObjectValue(NSTableView tableView, NSObject theObject, NSTableColumn tableColumn, nint row)
 			{
-				if (row >= Handler.collection.Count)
+				var h = Handler;
+				if (h == null)
 					return;
-				var item = Handler.collection.ElementAt((int)row);
-				var colHandler = Handler.GetColumn(tableColumn);
-				if (colHandler != null && Handler.SuppressUpdate == 0)
+
+				if (row >= h.collection.Count)
+					return;
+					
+				var item = h.collection.ElementAt((int)row);
+				var colHandler = h.GetColumn(tableColumn);
+				if (colHandler != null && h.SuppressUpdate == 0)
 				{
 					colHandler.SetObjectValue(item, theObject);
 
-					Handler.SetIsEditing(false);
-					Handler.Callback.OnCellEdited(Handler.Widget, new GridViewCellEventArgs(colHandler.Widget, (int)row, colHandler.Column, item));
+					h.SetIsEditing(false);
+					h.Callback.OnCellEdited(h.Widget, new GridViewCellEventArgs(colHandler.Widget, (int)row, colHandler.Column, item));
 				}
 			}
 
@@ -590,13 +602,19 @@ namespace Eto.Mac.Forms.Controls
 
 		public IEnumerable<object> DataStore
 		{
-			get { return collection != null ? collection.Collection : null; }
+			get => collection?.Collection;
 			set
 			{
 				if (collection != null)
+				{
+					if (ReferenceEquals(collection.Collection, value))
+						return;
 					collection.Unregister();
+				}
 				collection = new CollectionHandler { Handler = this };
 				collection.Register(value);
+				Control.ReloadData();
+				AutoSizeColumns(true);
 				ResetAutoSizedColumns();
 				InvalidateMeasure();
 			}

--- a/src/Eto/CollectionChangedHandler.cs
+++ b/src/Eto/CollectionChangedHandler.cs
@@ -76,9 +76,9 @@ namespace Eto
 			{
 				notify.CollectionChanged -= CollectionChanged;
 			}
-			OnUnregisterCollection(EventArgs.Empty);
-			
 			Collection = null;
+			
+			OnUnregisterCollection(EventArgs.Empty);
 		}
 
 		/// <summary>


### PR DESCRIPTION
- When setting DataSource to null it would not reload the row count
- Avoid crashes when GridView row count gets out of sync