### PR TITLE
Wpf: Remove border around resizable borderless windows

### DIFF
--- a/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
@@ -107,6 +107,9 @@ namespace Eto.Test.Sections.Behaviors
 		MenuBar CreateMenuBar()
 		{
 			var menu = new MenuBar();
+			menu.Items.Add(new SubMenuItem { Text = "&File", Items = {
+				new ButtonMenuItem { Text = "Click Me" }
+			}});
 			if (systemMenuItems.SelectedValues.Any())
 				menu.IncludeSystemItems = GetMenuItems();
 			return menu;


### PR DESCRIPTION
Uses System.Windows.Shell.WindowChrome to remove the border.  It has the side effect that the resizable area of the form is _within_ the window area instead of just outside the window, but alas there is no workaround for that currently.

Fixes #1928