### PR TITLE
Use native file pickers for GTK

### DIFF
--- a/src/Eto.Gtk/Eto.Gtk.csproj
+++ b/src/Eto.Gtk/Eto.Gtk.csproj
@@ -23,7 +23,7 @@ When building for the full framework, .NET Framework 4.6.1 or mono framework 5.1
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="GtkSharp" Version="3.24.24.34" />
+    <PackageReference Include="GtkSharp" Version="3.24.24.38" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Eto\Eto.csproj" />

--- a/src/Eto.Gtk/Forms/Controls/FilePickerHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/FilePickerHandler.cs
@@ -59,7 +59,13 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		private void Savebutton_Clicked(object sender, EventArgs e)
 		{
+#if GTKCORE
 			var savedialog = new Gtk.FileChooserNative(string.Empty, null, Gtk.FileChooserAction.Save, null, null);
+#else
+			var savedialog = new Gtk.FileChooserDialog(string.Empty, null, Gtk.FileChooserAction.Save);
+			savedialog.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
+			savedialog.AddButton(Gtk.Stock.Save, Gtk.ResponseType.Ok);
+#endif
 			savedialog.DoOverwriteConfirmation = true;
 
 			savedialog.Title = filebutton.Title;
@@ -69,6 +75,10 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			var result = savedialog.Run();
 			savedialog.Hide();
+#if !GTKCORE
+			savedialog.Unrealize();
+#endif
+			
 
 			if (result == (int)Gtk.ResponseType.Ok)
 				saveentry.Text = savedialog.Filename;

--- a/src/Eto.Gtk/Forms/Controls/FilePickerHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/FilePickerHandler.cs
@@ -59,11 +59,8 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		private void Savebutton_Clicked(object sender, EventArgs e)
 		{
-			var savedialog = new Gtk.FileChooserDialog(string.Empty, null, Gtk.FileChooserAction.Save);
+			var savedialog = new Gtk.FileChooserNative(string.Empty, null, Gtk.FileChooserAction.Save, null, null);
 			savedialog.DoOverwriteConfirmation = true;
-			savedialog.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
-			savedialog.AddButton(Gtk.Stock.Save, Gtk.ResponseType.Ok);
-			savedialog.DefaultResponse = Gtk.ResponseType.Ok;
 
 			savedialog.Title = filebutton.Title;
 			foreach (var filter in filebutton.Filters)
@@ -72,7 +69,6 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			var result = savedialog.Run();
 			savedialog.Hide();
-			savedialog.Unrealize();
 
 			if (result == (int)Gtk.ResponseType.Ok)
 				saveentry.Text = savedialog.Filename;

--- a/src/Eto.Gtk/Forms/GtkFileDialog.cs
+++ b/src/Eto.Gtk/Forms/GtkFileDialog.cs
@@ -7,7 +7,7 @@ using System.Linq;
 namespace Eto.GtkSharp.Forms
 {
 	public abstract class GtkFileDialog<TControl, TWidget> : WidgetHandler<TControl, TWidget>, FileDialog.IHandler
-		where TControl: Gtk.FileChooserDialog
+		where TControl: Gtk.FileChooserNative
 		where TWidget: FileDialog
 	{
 		public virtual string FileName
@@ -98,12 +98,10 @@ namespace Eto.GtkSharp.Forms
 		public virtual DialogResult ShowDialog(Window parent)
 		{
 			SetFilters();
-			if (parent != null) Control.TransientFor = (Gtk.Window)parent.ControlObject;
 
 			int result = Control.Run();
 
 			Control.Hide ();
-			Control.Unrealize();
 
 			DialogResult response = ((Gtk.ResponseType)result).ToEto ();
 			if (response == DialogResult.Ok && !string.IsNullOrEmpty(Control.CurrentFolder))

--- a/src/Eto.Gtk/Forms/GtkFileDialog.cs
+++ b/src/Eto.Gtk/Forms/GtkFileDialog.cs
@@ -7,7 +7,11 @@ using System.Linq;
 namespace Eto.GtkSharp.Forms
 {
 	public abstract class GtkFileDialog<TControl, TWidget> : WidgetHandler<TControl, TWidget>, FileDialog.IHandler
+#if GTKCORE
 		where TControl: Gtk.FileChooserNative
+#else
+		where TControl: Gtk.FileChooserDialog
+#endif
 		where TWidget: FileDialog
 	{
 		public virtual string FileName
@@ -98,10 +102,16 @@ namespace Eto.GtkSharp.Forms
 		public virtual DialogResult ShowDialog(Window parent)
 		{
 			SetFilters();
+#if !GTKCORE
+			if (parent != null) Control.TransientFor = (Gtk.Window)parent.ControlObject;
+#endif
 
 			int result = Control.Run();
 
-			Control.Hide ();
+			Control.Hide();
+#if !GTKCORE
+			Control.Unrealize();
+#endif
 
 			DialogResult response = ((Gtk.ResponseType)result).ToEto ();
 			if (response == DialogResult.Ok && !string.IsNullOrEmpty(Control.CurrentFolder))

--- a/src/Eto.Gtk/Forms/OpenFileDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/OpenFileDialogHandler.cs
@@ -4,13 +4,24 @@ using System.IO;
 
 namespace Eto.GtkSharp.Forms
 {
+	#if GTKCORE
 	public class OpenFileDialogHandler : GtkFileDialog<Gtk.FileChooserNative, OpenFileDialog>, OpenFileDialog.IHandler
+#else
+	public class OpenFileDialogHandler : GtkFileDialog<Gtk.FileChooserDialog, OpenFileDialog>, OpenFileDialog.IHandler
+#endif
 	{
 		string fileName;
 
 		public OpenFileDialogHandler()
 		{
+#if GTKCORE
 			Control = new Gtk.FileChooserNative(string.Empty, null, Gtk.FileChooserAction.Open, null, null);
+#else
+			Control = new Gtk.FileChooserDialog(string.Empty, null, Gtk.FileChooserAction.Open);
+			Control.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
+			Control.AddButton(Gtk.Stock.Open, Gtk.ResponseType.Ok);
+			Control.DefaultResponse = Gtk.ResponseType.Ok;
+#endif
 			Control.SetCurrentFolder(System.IO.Directory.GetCurrentDirectory());
 		}
 

--- a/src/Eto.Gtk/Forms/OpenFileDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/OpenFileDialogHandler.cs
@@ -4,18 +4,14 @@ using System.IO;
 
 namespace Eto.GtkSharp.Forms
 {
-	public class OpenFileDialogHandler : GtkFileDialog<Gtk.FileChooserDialog, OpenFileDialog>, OpenFileDialog.IHandler
+	public class OpenFileDialogHandler : GtkFileDialog<Gtk.FileChooserNative, OpenFileDialog>, OpenFileDialog.IHandler
 	{
 		string fileName;
-		
+
 		public OpenFileDialogHandler()
 		{
-			Control = new Gtk.FileChooserDialog(string.Empty, null, Gtk.FileChooserAction.Open);
+			Control = new Gtk.FileChooserNative(string.Empty, null, Gtk.FileChooserAction.Open, null, null);
 			Control.SetCurrentFolder(System.IO.Directory.GetCurrentDirectory());
-
-			Control.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
-			Control.AddButton(Gtk.Stock.Open, Gtk.ResponseType.Ok);
-			Control.DefaultResponse = Gtk.ResponseType.Ok;
 		}
 
 		public bool MultiSelect

--- a/src/Eto.Gtk/Forms/SaveFileDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/SaveFileDialogHandler.cs
@@ -2,17 +2,13 @@ using Eto.Forms;
 
 namespace Eto.GtkSharp.Forms
 {
-	public class SaveFileDialogHandler : GtkFileDialog<Gtk.FileChooserDialog, SaveFileDialog>, SaveFileDialog.IHandler
+	public class SaveFileDialogHandler : GtkFileDialog<Gtk.FileChooserNative, SaveFileDialog>, SaveFileDialog.IHandler
 	{
 		public SaveFileDialogHandler()
 		{
-			Control = new Gtk.FileChooserDialog(string.Empty, null, Gtk.FileChooserAction.Save);
+			Control = new Gtk.FileChooserNative(string.Empty, null, Gtk.FileChooserAction.Save, null, null);
 			Control.DoOverwriteConfirmation = true;
 			Control.SetCurrentFolder(System.IO.Directory.GetCurrentDirectory());
-			
-			Control.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
-			Control.AddButton(Gtk.Stock.Save, Gtk.ResponseType.Ok);
-			Control.DefaultResponse = Gtk.ResponseType.Ok;
 		}
 	}
 }

--- a/src/Eto.Gtk/Forms/SaveFileDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/SaveFileDialogHandler.cs
@@ -2,11 +2,22 @@ using Eto.Forms;
 
 namespace Eto.GtkSharp.Forms
 {
+#if GTKCORE
 	public class SaveFileDialogHandler : GtkFileDialog<Gtk.FileChooserNative, SaveFileDialog>, SaveFileDialog.IHandler
+#else
+	public class SaveFileDialogHandler : GtkFileDialog<Gtk.FileChooserDialog, SaveFileDialog>, SaveFileDialog.IHandler
+#endif
 	{
 		public SaveFileDialogHandler()
 		{
+#if GTKCORE
 			Control = new Gtk.FileChooserNative(string.Empty, null, Gtk.FileChooserAction.Save, null, null);
+#else
+			Control = new Gtk.FileChooserDialog(string.Empty, null, Gtk.FileChooserAction.Save);
+			Control.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
+			Control.AddButton(Gtk.Stock.Save, Gtk.ResponseType.Ok);
+			Control.DefaultResponse = Gtk.ResponseType.Ok;
+#endif
 			Control.DoOverwriteConfirmation = true;
 			Control.SetCurrentFolder(System.IO.Directory.GetCurrentDirectory());
 		}

--- a/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
@@ -2,20 +2,37 @@ using Eto.Forms;
 
 namespace Eto.GtkSharp.Forms
 {
+#if GTKCORE
 	public class SelectFolderDialogHandler : WidgetHandler<Gtk.FileChooserNative, SelectFolderDialog>, SelectFolderDialog.IHandler
+#else
+	public class SelectFolderDialogHandler : WidgetHandler<Gtk.FileChooserDialog, SelectFolderDialog>, SelectFolderDialog.IHandler
+#endif
 	{
 		public SelectFolderDialogHandler()
 		{
+#if GTKCORE
 			Control = new Gtk.FileChooserNative(string.Empty, null, Gtk.FileChooserAction.SelectFolder, null, null);
+#else
+			Control = new Gtk.FileChooserDialog(string.Empty, null, Gtk.FileChooserAction.SelectFolder);
+			Control.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
+			Control.AddButton(Gtk.Stock.Open, Gtk.ResponseType.Ok);
+			Control.DefaultResponse = Gtk.ResponseType.Ok;
+#endif
 			Control.SetCurrentFolder(System.IO.Directory.GetCurrentDirectory());
 		}
 
 
 		public DialogResult ShowDialog(Window parent)
 		{
+#if !GTKCORE
+			if (parent != null) Control.TransientFor = (Gtk.Window)parent.ControlObject;
+#endif
 			int result = Control.Run();
 
 			Control.Hide();
+#if !GTKCORE
+			Control.Unrealize();
+#endif
 
 			DialogResult response = ((Gtk.ResponseType)result).ToEto();
 			if (response == DialogResult.Ok) System.IO.Directory.SetCurrentDirectory(Control.CurrentFolder);

--- a/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
@@ -2,27 +2,20 @@ using Eto.Forms;
 
 namespace Eto.GtkSharp.Forms
 {
-	public class SelectFolderDialogHandler : WidgetHandler<Gtk.FileChooserDialog, SelectFolderDialog>, SelectFolderDialog.IHandler
+	public class SelectFolderDialogHandler : WidgetHandler<Gtk.FileChooserNative, SelectFolderDialog>, SelectFolderDialog.IHandler
 	{
 		public SelectFolderDialogHandler()
 		{
-			Control = new Gtk.FileChooserDialog(string.Empty, null, Gtk.FileChooserAction.SelectFolder);
+			Control = new Gtk.FileChooserNative(string.Empty, null, Gtk.FileChooserAction.SelectFolder, null, null);
 			Control.SetCurrentFolder(System.IO.Directory.GetCurrentDirectory());
-
-			Control.AddButton(Gtk.Stock.Cancel, Gtk.ResponseType.Cancel);
-			Control.AddButton(Gtk.Stock.Open, Gtk.ResponseType.Ok);
-			Control.DefaultResponse = Gtk.ResponseType.Ok;
 		}
 
 
 		public DialogResult ShowDialog(Window parent)
 		{
-			if (parent != null) Control.TransientFor = (Gtk.Window)parent.ControlObject;
-
 			int result = Control.Run();
 
 			Control.Hide();
-			Control.Unrealize();
 
 			DialogResult response = ((Gtk.ResponseType)result).ToEto();
 			if (response == DialogResult.Ok) System.IO.Directory.SetCurrentDirectory(Control.CurrentFolder);
@@ -43,4 +36,3 @@ namespace Eto.GtkSharp.Forms
 		}
 	}
 }
-


### PR DESCRIPTION
This uses the native GTK file pickers instead of the normal ones, which will result in the application choosing the system's file picker when the environment variable `GTK_USE_PORTAL` (or `GDK_DEBUG=portals` in the future) is passed on.
I have not tested this on either Windows or MacOS. This *should* lead to the picker using the native controls there as well, but cannot say for certain as I haven't tested it.
Fixes #2138 
Before:
![grafik](https://user-images.githubusercontent.com/38186597/199588380-d9af6874-adde-4022-b847-6da6fd79337f.png)
After:
![grafik](https://user-images.githubusercontent.com/38186597/199588402-2d6523c0-3330-4d1d-a002-a7bda9266ae2.png)

# Caveat
For some odd reason that I still haven't figured out, passing that environment variable also causes the application to choose some non-native GTK theme on Linux. Seems to only happen on Wayland.
Without the env var:
![grafik](https://user-images.githubusercontent.com/38186597/199588846-50886a35-d70d-436c-95b5-bbb708008735.png)
With the env var:
![grafik](https://user-images.githubusercontent.com/38186597/199588924-338b3e8f-278e-4f43-b1a0-b7a1512c5b77.png)

I am unsure what causes it exactly, as it only appears when the environment variable is passed on. Potentially a GTK# issue, but am completely clueless there.
