### PR TITLE
Fix GTK Non-disposed (Leaking) Cairo.Surface when assigning Application.BadgeLabel

### DIFF
--- a/src/Eto.Gtk/Forms/ApplicationHandler.cs
+++ b/src/Eto.Gtk/Forms/ApplicationHandler.cs
@@ -87,13 +87,21 @@ namespace Eto.GtkSharp.Forms
 								form.BringToFront();
 						};
 					}
-					var bmp = new Gdk.Pixbuf(Gdk.Colorspace.Rgb, true, 8, 32, 32);
-					using (var graphics = new Graphics(new Bitmap(new BitmapHandler(bmp))))
+
+					var pixbuf = new Gdk.Pixbuf(Gdk.Colorspace.Rgb, true, 8, 32, 32);
+					using(var bmpHandler = new BitmapHandler(pixbuf))
 					{
-						graphics.Clear();
-						DrawBadgeLabel(graphics, new Size(bmp.Width, bmp.Height), badgeLabel);
+						using(var bitmap     = new Bitmap(bmpHandler))
+						{
+							using (var graphics = new Graphics(bitmap))
+							{
+								graphics.Clear();
+								DrawBadgeLabel(graphics, new Size(pixbuf.Width, pixbuf.Height), badgeLabel);
+							}
+						}
 					}
-					statusIcon.Pixbuf = bmp;
+
+					statusIcon.Pixbuf = pixbuf;
 					statusIcon.Visible = true;
 				}
 				else if (statusIcon != null)
@@ -106,11 +114,17 @@ namespace Eto.GtkSharp.Forms
 			var rect = new Rectangle(size);
 			rect.Inflate(-2, -2);
 			graphics.FillEllipse(Brushes.Red, rect);
-			graphics.DrawEllipse(new Pen(Colors.White, 2), rect);
-			var font = new Font(SystemFont.Bold, 10);
-			var labelSize = graphics.MeasureString(font, badgeLabel);
-			var labelPosition = ((PointF)(rect.Size - labelSize) / 2) + rect.Location;
-			graphics.DrawText(font, Colors.White, labelPosition, badgeLabel);
+			using (var pen = new Pen(Colors.White, 2))
+			{
+				graphics.DrawEllipse(pen, rect);
+			}
+			using (var font = new Font(SystemFont.Bold, 10))
+			{
+				var labelSize     = graphics.MeasureString(font, badgeLabel);
+				var labelPosition = ((PointF)(rect.Size - labelSize) / 2) + rect.Location;
+				graphics.DrawText(font, Colors.White, labelPosition, badgeLabel);
+			}
+
 			graphics.Flush();
 		}
 


### PR DESCRIPTION
Fixes #2252
Obseletes #2301 
Add using statements to correctly dispose all `IDisposable` objects when setting BadgeLabel for GTK `Application.IHandler`.

#2301 was a bit messy, and the author is currently unable to fix it, so I fixed it on their behalf.
All credit goes to @Ararem, I just cherry-picked the commit.