### PR TITLE
Mac: Fix issues autosizing columns in some cases

### DIFF
--- a/src/Eto.Mac/Drawing/EtoFontManager.cs
+++ b/src/Eto.Mac/Drawing/EtoFontManager.cs
@@ -8,7 +8,7 @@ namespace Eto.Mac.Drawing
 		{
 		}
 
-		public EtoFontManager(IntPtr handle)
+		public EtoFontManager(NativeHandle handle)
 			: base(handle)
 		{
 		}

--- a/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
@@ -11,6 +11,7 @@
     
     <RuntimeIdentifiers>osx-x64;osx-arm64</RuntimeIdentifiers>
     <DefineConstants>MONOMAC</DefineConstants>
+    <LangVersion>10.0</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="$([MSBuild]::IsOsPlatform(OSX)) AND $(Configuration) == 'Release'">
@@ -18,6 +19,25 @@
     <EnableCodeSigning Condition="$(EnableCodeSignBuild) == 'True' AND $(TargetFramework.StartsWith('net4')) == 'False'">True</EnableCodeSigning>
     <EnableNotarization Condition="$(EnableNotarizationBuild) == 'True' AND $(TargetFramework.StartsWith('net4')) == 'False'">True</EnableNotarization>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <Using Include="MonoMac.AppKit" />
+    <Using Include="MonoMac.Foundation" />
+    <Using Include="MonoMac.CoreGraphics" />
+    <Using Include="MonoMac.ObjCRuntime" />
+    <Using Include="MonoMac.CoreAnimation" />
+    <Using Include="MonoMac.CoreImage" />
+    <Using Include="MonoMac.MobileCoreServices" />
+    <Using Include="MonoMac.CoreFoundation" />
+    <Using Include="MonoMac.ImageIO" />
+    <Using Include="MonoMac.CoreText" />
+    <Using Include="MonoMac.Constants" Alias="Constants" />
+    <Using Include="MonoMac.AppKit.NSRectEdge" Alias="NSRectEdge" />
+    <Using Include="System.Double" Alias="nfloat" />
+    <Using Include="System.Int64" Alias="nint" />
+    <Using Include="System.UInt64" Alias="nuint" />
+    <Using Include="System.IntPtr" Alias="NativeHandle" />
+  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\..\src\Eto\Eto.csproj" />

--- a/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.XamMac2.csproj
@@ -14,11 +14,26 @@
     <DefineConstants>XAMMAC;XAMMAC2</DefineConstants>
     <SupportedOSPlatformVersion>10.15</SupportedOSPlatformVersion>
     <NoWarn>CA1416</NoWarn>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
   
   <PropertyGroup Condition="$(TargetFramework) == 'xamarinmac20'">
     <LinkMode Condition="$(Configuration) == 'Release'">SdkOnly</LinkMode>
   </PropertyGroup>
+  
+  <ItemGroup>
+    <Using Include="AppKit" />
+    <Using Include="Foundation" />
+    <Using Include="CoreGraphics" />
+    <Using Include="ObjCRuntime" />
+    <Using Include="CoreAnimation" />
+    <Using Include="CoreImage" />
+    <Using Include="MobileCoreServices" />
+    <Using Include="CoreFoundation" />
+    <Using Include="ImageIO" />
+    <Using Include="CoreText" />
+    <Using Include="System.IntPtr" Alias="NativeHandle" />
+  </ItemGroup>
   
   <ItemGroup>
     <ProjectReference Include="..\Eto.Test\Eto.Test.csproj" />

--- a/test/Eto.Test.Mac/Eto.Test.macOS.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.macOS.csproj
@@ -18,6 +18,19 @@
   </PropertyGroup>
   
   <ItemGroup>
+    <Using Include="AppKit" />
+    <Using Include="Foundation" />
+    <Using Include="CoreGraphics" />
+    <Using Include="ObjCRuntime" />
+    <Using Include="CoreAnimation" />
+    <Using Include="CoreImage" />
+    <Using Include="MobileCoreServices" />
+    <Using Include="CoreFoundation" />
+    <Using Include="ImageIO" />
+    <Using Include="CoreText" />
+  </ItemGroup>
+  
+  <ItemGroup>
     <ProjectReference Include="..\Eto.Test\Eto.Test.csproj" />
     <ProjectReference Include="..\..\src\Eto\Eto.csproj" />
     <ProjectReference Include="..\..\src\Eto.Serialization.Json\Eto.Serialization.Json.csproj" />

--- a/test/Eto.Test.Mac/Startup.cs
+++ b/test/Eto.Test.Mac/Startup.cs
@@ -6,12 +6,6 @@ using Eto.Drawing;
 using Eto.Mac.Forms.ToolBar;
 using Eto.Forms;
 
-#if MONOMAC
-using MonoMac.AppKit;
-#else
-using AppKit;
-#endif
-
 namespace Eto.Test.Mac
 {
 	class Startup
@@ -77,7 +71,16 @@ namespace Eto.Test.Mac
 					//handler.Control.DisplayMode = NSToolbarDisplayMode.Icon;
 				});
 
+      		Style.Add<TreeGridViewHandler>(null, c => StyleGrid(c.Control));
+      		Style.Add<GridViewHandler>(null, c => StyleGrid(c.Control));
 		}
+		
+		private static void StyleGrid(NSTableView control)
+		{
+		// macOS Big Sur changed default from 3,2 to 17,0.  This appears to be more sane for our purposes.
+		// control.IntercellSpacing = new CGSize(3, 2);
+		}
+		
 	}
 }
 

--- a/test/Eto.Test.Mac/UnitTests/BitmapTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/BitmapTests.cs
@@ -3,14 +3,6 @@ using Eto.Forms;
 using Eto.Test.UnitTests;
 using NUnit.Framework;
 
-#if MONOMAC
-using MonoMac.AppKit;
-using MonoMac.CoreGraphics;
-#else
-using AppKit;
-using CoreGraphics;
-#endif
-
 namespace Eto.Test.Mac.UnitTests
 {
 	[TestFixture]

--- a/test/Eto.Test.Mac/UnitTests/ButtonTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/ButtonTests.cs
@@ -8,13 +8,6 @@ using System.Runtime.ExceptionServices;
 using System.Threading.Tasks;
 using Eto.Mac;
 
-#if MONOMAC
-using MonoMac.AppKit;
-using MonoMac.CoreGraphics;
-#else
-using AppKit;
-using CoreGraphics;
-#endif
 namespace Eto.Test.Mac.UnitTests
 {
 	[TestFixture]

--- a/test/Eto.Test.Mac/UnitTests/CheckBoxTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/CheckBoxTests.cs
@@ -5,14 +5,6 @@ using Eto.Mac.Forms.Controls;
 using Eto.Test.UnitTests;
 using NUnit.Framework;
 
-#if MONOMAC
-using MonoMac.AppKit;
-using MonoMac.CoreGraphics;
-#else
-using AppKit;
-using CoreGraphics;
-#endif
-
 namespace Eto.Test.Mac.UnitTests
 {
 	[TestFixture]

--- a/test/Eto.Test.Mac/UnitTests/GridViewTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/GridViewTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Eto.Drawing;
+using Eto.Forms;
+using Eto.Mac;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+
+namespace Eto.Test.Mac.UnitTests
+{
+	public abstract class GridTests<T> : TestBase
+		where T: Grid, new()
+	{
+		class GridTestItem : TreeGridItem
+		{
+			public string Text { get; set; }
+			
+			public Image Image { get; set; }
+
+			public override string ToString() => Text ?? base.ToString();
+		}
+		
+		protected abstract void SetDataStore(T grid, IEnumerable<object> dataStore);
+
+		public IEnumerable<object> CreateDataStore(int rows = 40)
+		{
+			var list = new TreeGridItemCollection();
+			for (int i = 0; i < rows; i++)
+			{
+				Image image = i % 2 == 0 ? (Image)TestIcons.Logo : (Image)TestIcons.TestImage;
+				list.Add(new GridTestItem { Text = $"Item {i}", Image = image, Values = new[] { $"col {i}.2", $"col {i}.3", $"col {i}.4", $"col {i}.5" } });
+			}
+			return list;
+		}
+		
+		[ManualTest]
+		[TestCase(NSTableViewStyle.FullWidth, -1, 1)]
+		[TestCase(NSTableViewStyle.FullWidth, -1, 3)]
+		[TestCase(NSTableViewStyle.FullWidth, 3, 3)]
+		[TestCase(NSTableViewStyle.Inset, -1, 1)]
+		[TestCase(NSTableViewStyle.Inset, -1, 3)]
+		[TestCase(NSTableViewStyle.Inset, 3, 3)]
+		[TestCase(NSTableViewStyle.SourceList, -1, 1)]
+		[TestCase(NSTableViewStyle.SourceList, -1, 3)]
+		[TestCase(NSTableViewStyle.SourceList, 3, 3)]
+		[TestCase(NSTableViewStyle.Plain, -1, 1)]
+		[TestCase(NSTableViewStyle.Plain, -1, 3)]
+		[TestCase(NSTableViewStyle.Plain, 3, 3)]
+		public void ScrollingExpandedColumnShouldKeepItsSize(NSTableViewStyle style, int intercellSpacing, int numColumns)
+		{
+			ManualForm("Scrolling should not cause the widths of the columns to go beyond the width of the grid,\nso the horizontal scrollbar should never show up.", form =>
+			{
+				form.Title = $"TesNSTableViewStyle: {style}";
+				var grid = new T();
+				grid.Height = 200;
+				if (grid.ControlObject is NSTableView tableView)
+				{
+					if (ObjCExtensions.InstancesRespondToSelector<NSTableView>(Selector.GetHandle("style")))
+						tableView.Style = style;
+					else
+					{
+						// macos 10.15 and older
+						if (style == NSTableViewStyle.SourceList)
+							tableView.SelectionHighlightStyle = NSTableViewSelectionHighlightStyle.SourceList;
+					}
+					if (intercellSpacing >= 0)
+						tableView.IntercellSpacing = new CGSize(intercellSpacing, 2);
+				}
+
+				SetDataStore(grid, CreateDataStore());
+
+				grid.Columns.Add(new GridColumn { DataCell = new ImageTextCell { TextBinding = Binding.Property((GridTestItem m) => m.Text), ImageBinding = Binding.Property((GridTestItem m) => m.Image) } });
+				for (int i = 0; i < numColumns; i++)
+					grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(i) });
+
+				var expandColumn = grid.Columns[0];
+				expandColumn.HeaderText = "Expanded";
+				expandColumn.Expand = true;
+
+				return grid;
+			});
+		}
+	}
+	
+	[TestFixture]
+	public class GridViewTests : GridTests<GridView>
+	{
+		protected override void SetDataStore(GridView grid, IEnumerable<object> dataStore) => grid.DataStore = dataStore;
+	}
+
+	[TestFixture]
+	public class TreeGridViewTests : GridTests<TreeGridView>
+	{
+		protected override void SetDataStore(TreeGridView grid, IEnumerable<object> dataStore) => grid.DataStore = (ITreeGridStore<ITreeGridItem>)dataStore;
+	}
+}

--- a/test/Eto.Test.Mac/UnitTests/IconTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/IconTests.cs
@@ -5,14 +5,6 @@ using Eto.Test.UnitTests;
 using NUnit.Framework;
 using Eto.Mac;
 
-#if MONOMAC
-using MonoMac.AppKit;
-using MonoMac.CoreGraphics;
-#else
-using AppKit;
-using CoreGraphics;
-#endif
-
 namespace Eto.Test.Mac64.UnitTests
 {
 	[TestFixture]

--- a/test/Eto.Test.Mac/UnitTests/NativeParentWindowTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/NativeParentWindowTests.cs
@@ -4,14 +4,6 @@ using NUnit.Framework;
 using Eto.Forms;
 using System.Threading;
 
-#if MONOMAC
-using MonoMac.AppKit;
-using MonoMac.CoreGraphics;
-#else
-using AppKit;
-using CoreGraphics;
-#endif
-
 namespace Eto.Test.Mac.UnitTests
 {
 	[TestFixture]

--- a/test/Eto.Test.Mac/UnitTests/RadioButtonTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/RadioButtonTests.cs
@@ -5,14 +5,6 @@ using Eto.Mac.Forms.Controls;
 using Eto.Test.UnitTests;
 using NUnit.Framework;
 
-#if MONOMAC
-using MonoMac.AppKit;
-using MonoMac.CoreGraphics;
-#else
-using AppKit;
-using CoreGraphics;
-#endif
-
 namespace Eto.Test.Mac.UnitTests
 {
 	[TestFixture]

--- a/test/Eto.Test/Sections/Behaviors/ScreenSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ScreenSection.cs
@@ -233,8 +233,6 @@ namespace Eto.Test.Sections.Behaviors
 
 			cornerWindows.Add(adjacentForm);
 
-			return;
-
 			int i = 0;
 			foreach (var screen in Screen.Screens)
 			{

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
@@ -11,6 +11,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		class GridTestItem : TreeGridItem
 		{
 			public string Text { get; set; }
+			
+			public Image Image { get; set; }
 
 			public override string ToString() => Text ?? base.ToString();
 		}
@@ -137,7 +139,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			var list = new TreeGridItemCollection();
 			for (int i = 0; i < rows; i++)
 			{
-				list.Add(new GridTestItem { Text = $"Item {i}", Values = new[] { $"col {i}.2", $"col {i}.3", $"col {i}.4" } });
+				Image image = i % 2 == 0 ? (Image)TestIcons.Logo : (Image)TestIcons.TestImage;
+				list.Add(new GridTestItem { Text = $"Item {i}", Image = image, Values = new[] { $"col {i}.2", $"col {i}.3", $"col {i}.4", $"col {i}.5" } });
 			}
 			return list;
 		}
@@ -154,11 +157,16 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			ManualForm("First Column should be expanded, and change size with the Grid", form =>
 			{
 				var grid = new T();
+				// grid.RowHeight = 48;
+				// grid.ShowHeader = false;
 				SetDataStore(grid, CreateDataStore());
 
+				// grid.Columns.Add(new GridColumn { DataCell = new ImageTextCell { TextBinding = Binding.Property((GridTestItem m) => m.Text), ImageBinding = Binding.Property((GridTestItem m) => m.Image) } });
 				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell { Binding = Binding.Property((GridTestItem m) => m.Text) } });
 				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(0) });
 				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(1) });
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(2) });
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(3) });
 
 				var expandColumn = grid.Columns[columnToExpand];
 				expandColumn.HeaderText = "Expanded";


### PR DESCRIPTION
Simplified the logic for autosizing by removing the intercell spacing before calculating the column sizes.  Unfortunately, the insets used for the different NSTableViewStyle values cannot be retrieved by any particular APIs so it needs to be hard coded.

- Now properly handles all the different styles of NSTableView/NSOutlineView from Big Sur and later
- Fixed warning in test app with unreachable code
- Fixed warning when running wrt. the EtoFontManager constructor.
- Added unit tests for all cases and tested on macOS 10.15, 11, 12, and 13.