### PR TITLE
Allow overriding target framework for Eto.macOS

### DIFF
--- a/src/Eto.Mac/Eto.macOS.csproj
+++ b/src/Eto.Mac/Eto.macOS.csproj
@@ -1,12 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0-macos10.15</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) == ''">net6.0-macos10.15</TargetFramework>
+    <TargetFramework Condition="$(TargetFrameworkOverride) != ''">$(TargetFrameworkOverride)</TargetFramework>
     <RootNamespace>Eto.Mac</RootNamespace>
     <DefineConstants>$(DefineConstants);OSX;DESKTOP;UNIFIED;MACOS_NET;USE_CFSTRING</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefaultItemExcludes>$(DefaultItemExcludes);build\*</DefaultItemExcludes>
-    <NoWarn>CA1416</NoWarn>
+    <NoWarn>$(NoWarn);CA1416;CS8981</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="AppKit" />


### PR DESCRIPTION
This allows overriding the TFM for Eto.macOS.csproj when compiling, and hide warnings that result of using .NET 7.0