### PR TITLE
Mac: Fix grid column auto sizing when reusing the same control

### DIFF
--- a/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
@@ -51,7 +51,7 @@ namespace Eto.Mac.Forms.Controls
 		void SetObjectValue(object dataItem, NSObject val);
 		new GridColumn Widget { get; }
 		IDataViewHandler DataViewHandler { get; }
-		void AutoSizeColumn(NSRange? rowRange, bool force = false);
+		bool AutoSizeColumn(NSRange? rowRange, bool force = false);
 		void EnabledChanged(bool value);
 		nfloat GetPreferredWidth(NSRange? range = null);
 		void SizeToFit();
@@ -93,18 +93,22 @@ namespace Eto.Mac.Forms.Controls
 			base.Initialize();
 		}
 
-		public void AutoSizeColumn(NSRange? rowRange, bool force = false)
+		public bool AutoSizeColumn(NSRange? rowRange, bool force = false)
 		{
 			var handler = DataViewHandler;
 			if (handler == null)
-				return;
+				return false;
 
 			if (AutoSize)
 			{
 				var width = GetPreferredWidth(rowRange);
 				if (force || width > Control.Width)
+				{
 					Control.Width = (nfloat)Math.Ceiling(width);
+					return true;
+				}
 			}
+			return false;
 		}
 
 		public nfloat GetPreferredWidth(NSRange? range = null)

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -100,11 +100,8 @@ namespace Eto.Mac.Forms.Controls
 
 			public override void Layout()
 			{
-				if (MacView.NewLayout)
-					base.Layout();
 				Handler?.PerformLayout();
-				if (!MacView.NewLayout)
-					base.Layout();
+				base.Layout();
 			}
 			
 			public override bool ValidateProposedFirstResponder(NSResponder responder, NSEvent forEvent)

--- a/test/Eto.Test.Mac/UnitTests/GridViewTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/GridViewTests.cs
@@ -27,9 +27,11 @@ namespace Eto.Test.Mac.UnitTests
 		public IEnumerable<object> CreateDataStore(int rows = 40)
 		{
 			var list = new TreeGridItemCollection();
+			Image logo = TestIcons.Logo;
+			Image testImage = TestIcons.TestImage;
 			for (int i = 0; i < rows; i++)
 			{
-				Image image = i % 2 == 0 ? (Image)TestIcons.Logo : (Image)TestIcons.TestImage;
+				Image image = i % 2 == 0 ? logo : testImage;
 				list.Add(new GridTestItem { Text = $"Item {i}", Image = image, Values = new[] { $"col {i}.2", $"col {i}.3", $"col {i}.4", $"col {i}.5" } });
 			}
 			return list;

--- a/test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -467,7 +467,7 @@ namespace Eto.Test.Sections.Controls
 			LogEvents(grid);
 
 			var dropDown = MyDropDown("DropDownKey");
-			grid.Columns.Add(SetColumnState(0, new GridColumn { HeaderText = "ImageText", DataCell = new ImageTextCell("Image", "Text") }));
+			grid.Columns.Add(SetColumnState(0, new GridColumn { HeaderText = "ImageText", DataCell = new ImageTextCell("Image", "Text"), Expand = true }));
 			grid.Columns.Add(SetColumnState(1, new GridColumn { DataCell = new CheckBoxCell("Check"), AutoSize = true, Resizable = false }));
 			grid.Columns.Add(SetColumnState(2, new GridColumn { HeaderText = "Image", DataCell = new ImageViewCell("Image"), Resizable = false, HeaderToolTip = null }));
 			grid.Columns.Add(SetColumnState(3, new GridColumn { HeaderText = "Text", DataCell = new TextBoxCell("Text"), Sortable = true, HeaderToolTip = "Some Tooltip", CellToolTipBinding = Binding.Property((MyGridItem i) => i.ToolTip) }));


### PR DESCRIPTION
When using the same control instance again it would size the columns incorrectly.  This fixes that and sets the column positions during layout before calling the base method.