### PR TITLE
Mac: Non-activating forms with an owner should not show overtop existing windows

### DIFF
--- a/src/Eto.Mac/Forms/FormHandler.cs
+++ b/src/Eto.Mac/Forms/FormHandler.cs
@@ -70,14 +70,15 @@ namespace Eto.Mac.Forms
 					Control.MakeKeyWindow();
 				else
 					Control.MakeKeyAndOrderFront(ApplicationHandler.Instance.AppDelegate);
+
+				// setting the owner shows the window, so we have to do this after making the window key
+				EnsureOwner();
 			}
-			else
+			else if (!EnsureOwner())
 			{
+				// only order front when there is no owner as it'll bring the owner above any existing non-child windows
 				Control.OrderFront(ApplicationHandler.Instance.AppDelegate);
 			}
-			
-			// setting the owner shows the window, so we have to do this here.
-			EnsureOwner();
 
 			if (!visible)
 			{

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -1247,10 +1247,13 @@ namespace Eto.Mac.Forms
 			set => Widget.Properties.Set(MacWindow.SetAsChildWindow_Key, value, DefaultSetAsChildWindow);
 		}
 
-		protected void EnsureOwner() => SetOwner(Widget.Owner);
+		protected bool EnsureOwner() => InternalSetOwner(Widget.Owner);
 
-		public virtual void SetOwner(Window owner)
+		public virtual void SetOwner(Window owner) => InternalSetOwner(owner);
+
+		bool InternalSetOwner(Window owner)
 		{
+			bool result = false;
 			if (SetAsChildWindow && Widget.Loaded)
 			{
 				if (owner != null)
@@ -1260,6 +1263,7 @@ namespace Eto.Mac.Forms
 					{
 						macWindow.Control.AddChildWindow(Control, NSWindowOrderingMode.Above);
 						OnSetAsChildWindow();
+						result = true;
 					}
 					Widget.GotFocus += HandleGotFocusAsChild;
 				}
@@ -1271,6 +1275,7 @@ namespace Eto.Mac.Forms
 						parentWindow.RemoveChildWindow(Control);
 				}
 			}
+			return result;
 		}
 
 		void HandleGotFocusAsChild(object sender, EventArgs e)


### PR DESCRIPTION
Showing a `Form` with its `Owner` set will make the owner show overtop any other existing forms even with `Form.ShowActivated` set to `false`.

On Mac, when you order a child window to front then set it as a child of a parent form, the parent form will order overtop any other existing windows.

Now we only call `OrderFront` when there is no owner.