### PR TITLE
Add Control.UpdateLayout() API

### DIFF
--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -939,7 +939,13 @@ namespace Eto.GtkSharp.Forms
 
 		public Point Location
 		{
-			get { return Control.Allocation.Location.ToEto(); }
+			get
+			{
+				var pt = Control.Allocation.Location.ToEto();
+				if (pt.X == -1 && pt.Y == -1)
+					return Point.Empty;
+				return pt;
+			}
 		}
 
 		public virtual bool ShowBorder
@@ -1083,6 +1089,12 @@ namespace Eto.GtkSharp.Forms
 		public void Print()
 		{
 			// ContainerControl.Print
+		}
+		
+		public virtual void UpdateLayout()
+		{
+			// is this the best way to force a layout pass?  I can't find anything else..
+			ContainerControl.Toplevel?.SizeAllocate(ContainerControl.Toplevel.Allocation);
 		}
 	}
 }

--- a/src/Eto.Mac/Forms/MacContainer.cs
+++ b/src/Eto.Mac/Forms/MacContainer.cs
@@ -36,6 +36,8 @@ namespace Eto.Mac.Forms
 		public virtual void Update()
 		{
 			InvalidateMeasure();
+			// ContainerControl.Superview?.LayoutSubtreeIfNeeded();
+			ContainerControl.Window?.LayoutIfNeeded();
 		}
 
 		protected override bool ControlEnabled

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1533,6 +1533,11 @@ namespace Eto.Mac.Forms
 			get => Widget.Properties.Get<bool>(MacView.TextInputImplemented_Key);
 			private set => Widget.Properties.Set(MacView.TextInputImplemented_Key, value);
 		}
+		
+		public virtual void UpdateLayout()
+		{
+			ContainerControl?.Window?.LayoutIfNeeded();
+		}
 	}
 }
 

--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -630,5 +630,7 @@ namespace Eto.WinForms.Forms
 		}
 
 		public void Print() => throw new NotImplementedException();
+
+		public void UpdateLayout() => throw new NotImplementedException();
 	}
 }

--- a/src/Eto.WinForms/Forms/WindowsControl.cs
+++ b/src/Eto.WinForms/Forms/WindowsControl.cs
@@ -1039,5 +1039,7 @@ namespace Eto.WinForms.Forms
 		{
 
 		}
+
+		public void UpdateLayout() => ContainerControl.PerformLayout();
 	}
 }

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -1155,5 +1155,14 @@ namespace Eto.Wpf.Forms
 			actionList.Add(action);
 			return true;
 		}
+
+		public void UpdateLayout()
+		{
+			// allow WPF controls to actually get their Loaded event fired.
+			ContainerControl.Dispatcher.Invoke(new Action(() => { }), sw.Threading.DispatcherPriority.ApplicationIdle, null);
+
+			// update the layout
+			ContainerControl.UpdateLayout();
+		}
 	}
 }

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -818,6 +818,19 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
+		/// Updates the layout of this control if necessary.
+		/// </summary>
+		/// <remarks>
+		/// This will ensure the control has had all of its layout applied so you can use its position and size right after this call.
+		/// Most platforms (except WinForms) use a deferred layout system so that after adding your control to the form dynamically it won't
+		/// get laid out until the next idle loop.
+		/// This is useful when you need to know the dimensions of the control immediately.
+		/// Note that this can be an expensive operation, so it is recommended to only call this method when necessary and after all of the
+		/// controls have been added/updated.
+		/// </remarks>
+		public void UpdateLayout() => Handler.UpdateLayout();
+
+		/// <summary>
 		/// Gets or sets the size of the control. Use -1 to specify auto sizing for either the width and/or height.
 		/// </summary>
 		/// <remarks>
@@ -2007,6 +2020,17 @@ namespace Eto.Forms
 			/// <param name="availableSize">The available size to determine the preferred size</param>
 			/// <returns>The preferred size this control would like to be, which can be larger than the specified <paramref name="availableSize" />.</returns>
 			SizeF GetPreferredSize(SizeF availableSize);
+			
+			/// <summary>
+			/// Updates the layout of this control if necessary.
+			/// </summary>
+			/// <remarks>
+			/// This will ensure the control has had all of its layout applied so you can use its position and size right after this call.
+			/// Most platforms (except WinForms) use a deferred layout system so that after adding your control to the form dynamically it won't
+			/// get laid out until the next idle loop.
+			/// This is useful when you need to know the dimensions of the control immediately.
+			/// </remarks>
+			void UpdateLayout();
 		}
 		#endregion
 	}

--- a/src/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/src/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -467,6 +467,9 @@ namespace Eto.Forms
 		/// <inheritdoc />
 		public void Print() => Control.Print();
 
+		/// <inheritdoc />
+		public void UpdateLayout() => Control.UpdateLayout();
+
 		#endregion
 
 	}

--- a/test/Eto.Test/UnitTests/Forms/Layout/LayoutTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Layout/LayoutTests.cs
@@ -1,0 +1,82 @@
+using System;
+using Eto.Drawing;
+using Eto.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Layout
+{
+	[TestFixture]
+	public class LayoutTests : TestBase
+	{
+		[Test]
+		public void UpdateLayoutShouldSetAllSizes()
+		{
+			Panel holder = null;
+			TableLayout table = null;
+			Shown(form =>
+			{
+				holder = new Panel { Size = new Size(100, 100) };
+				table = new TableLayout
+				{
+					Rows =
+					{
+						new TableRow(new Panel { Size = new Size(100, 100)}),
+						new TableRow(new TableCell(), holder)
+					}
+				};
+				form.Content = table;
+			},
+			() =>
+			{
+				holder.SuspendLayout();
+
+				var control = new Panel();
+				control.Content = "Hello then!";
+				Assert.LessOrEqual(control.Width, 0, "#1.1");
+				Assert.LessOrEqual(control.Height, 0, "#1.2");
+				Assert.AreEqual(new Point(0, 0), control.Location, "#1.3");
+
+				holder.Content = control;
+
+				// layout is suspended or deferred so nothing is set up yet
+				// Gtk is annoying and returns 1,1 for size at this stage, others return 0,0.
+				Assert.LessOrEqual(control.Width, 1, "#2.1");
+				Assert.LessOrEqual(control.Height, 1, "#2.2");
+				
+				// macOS gives us a "flipped" view of the location at this point..
+				// the value of Location isn't valid here anyway.
+				if (!Platform.Instance.IsMac)
+					Assert.AreEqual(new Point(0, 0), control.Location, "#2.3");
+
+				holder.ResumeLayout();
+
+				if (!Platform.Instance.IsWinForms)
+				{
+					// Gtk, Wpf, and Mac all use deferred layouts so it still isn't set up here.
+					Assert.LessOrEqual(control.Width, 1, "#3.1");
+					Assert.LessOrEqual(control.Height, 1, "#3.2");
+					
+					if (!Platform.Instance.IsMac)
+						Assert.AreEqual(new Point(0, 0), control.Location, "#3.3");
+				}
+				else
+				{
+					// At this point WinForms is all set up.
+					Assert.AreEqual(100, control.Width, "#3.1");
+					Assert.AreEqual(100, control.Height, "#3.2");
+					Assert.AreEqual(new Point(0, 0), control.Location, "#3.3");
+					Assert.AreEqual(new Point(100, 100), Point.Round(table.PointFromScreen(control.PointToScreen(PointF.Empty))), "#3.4");
+				}
+
+				// force a layout
+				holder.UpdateLayout();
+
+				// everything should now be set up as we expect.
+				Assert.AreEqual(100, control.Width, "#4.1");
+				Assert.AreEqual(100, control.Height, "#4.2");
+				Assert.AreEqual(new Point(0, 0), control.Location, "#4.3");
+				Assert.AreEqual(new Point(100, 100), Point.Round(table.PointFromScreen(control.PointToScreen(PointF.Empty))), "#4.4");
+			});
+		}
+	}
+}


### PR DESCRIPTION
This adds the ability to update the control layout for platforms that use a deferred layout system such as Gtk, macOS, and Wpf. 

This will ensure the control has had all of its layout applied so you can use its position and size right after this call.

Most platforms (except WinForms) use a deferred layout system so that after adding your control to the form dynamically it won't get laid out until the next idle loop.
This is useful when you need to know the dimensions of the control immediately.

Note that this can be an expensive operation, so it is recommended to only call this method when necessary and after all of the controls have been added/updated.
