### PR TITLE
Add Control.TriggerStyleChanged to reapply styles

### DIFF
--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -1394,6 +1394,12 @@ namespace Eto.Forms
 				OnApplyCascadingStyles();
 		}
 
+
+		/// <summary>
+		/// Triggers the StyleChanged event and re-applies the styles to this control and its children.
+		/// </summary>
+		public void TriggerStyleChanged() => OnStyleChanged(EventArgs.Empty);
+
 		/// <summary>
 		/// Called when cascading styles should be applied to this control.
 		/// </summary>


### PR DESCRIPTION
This adds a way to programatically trigger a style changed event so styles can be re-applied.  This is useful for custom IStyleProvider implementations so you can trigger changes when necessary. 