### PR TITLE
Update CustomCellHandler to check if the cell is not null when handling mouse click

### DIFF
--- a/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
@@ -131,6 +131,9 @@ namespace Eto.Wpf.Forms.Cells
 			{
 				var ctl = sender as sw.FrameworkElement;
 				var cell = ctl?.GetVisualParent<swc.DataGridCell>();
+				if (cell == null)
+					return;
+
 				if (!cell.IsKeyboardFocusWithin && !cell.Column.IsReadOnly)
 				{
 					cell.IsEditing = true;


### PR DESCRIPTION
Update CustomCellHandler to check if the cell content handler is connected to a cell when handling mouse click.

Otherwise, a null reference exception might get thrown when the user clicks too fast on a cell.

In the following scenario we can get a content that is not connected to a cell:
 - a tree has logic expanding/collapsing items on a cell double-click;
 - the user clicks too fast on a cell;
 - double-click causes the row expanding/collapsing;
 - the third click (e.ClickCount > 2) happens when the cells presenter is refreshed;
 - at this moment the cell content is disconnected from any cell (ctl?.GetVisualParent<swc.DataGridCell>() returns null).