### PR TITLE
Update checkbox documentation

### DIFF
--- a/src/Eto/Forms/Controls/CheckBox.cs
+++ b/src/Eto/Forms/Controls/CheckBox.cs
@@ -3,20 +3,27 @@ using System;
 namespace Eto.Forms
 {
 	/// <summary>
-	/// Control to show a two or three state check box
+	/// A control that shows a two or three state check box.
 	/// </summary>
 	/// <remarks>
-	/// Two state is either checked (true) or unchecked (false).
+	/// A two state check box is either checked (<see langword="true"/>) or unchecked (<see langword="false"/>).
 	/// 
-	/// Three state check box can also have a null value.
+	/// A three state check box can also have an additional <see langword="null"/> value.
 	/// </remarks>
+	/// <example>
+	/// An example to create a two and a three state check box:
+	/// <code>
+	/// var twoStateCheckBox = new Checkbox() { Text = "Two state checkbox" };
+	/// var threeStateCheckBox = new Checkbox() { Text = "Three state checkbox", ThreeState = true };
+	/// </code>
+	/// </example>
 	[Handler(typeof(CheckBox.IHandler))]
 	public class CheckBox : TextControl
 	{
 		new IHandler Handler { get { return (IHandler)base.Handler; } }
 
 		/// <summary>
-		/// Occurs when <see cref="Checked"/> property is changed by the user
+		/// Occurs when the <see cref="Checked"/> property is changed by the user.
 		/// </summary>
 		public event EventHandler<EventArgs> CheckedChanged
 		{
@@ -29,19 +36,19 @@ namespace Eto.Forms
 		/// <summary>
 		/// Raises the <see cref="CheckedChanged"/> event.
 		/// </summary>
-		/// <param name="e">Event arguments</param>
+		/// <param name="e">Event arguments.</param>
 		protected virtual void OnCheckedChanged(EventArgs e)
 		{
 			Properties.TriggerEvent(CheckedChangedKey, this, e);
 		}
 
 		/// <summary>
-		/// Gets or sets the checked state
+		/// Gets or sets the checked state.
 		/// </summary>
 		/// <remarks>
-		/// When <see cref="ThreeState"/> is true, null signifies an indeterminate value.
+		/// When <see cref="ThreeState"/> is <see langword="true"/>, <see langword="null"/> signifies an indeterminate value.
 		/// </remarks>
-		/// <value>The checked value</value>
+		/// <value>The checked value.</value>
 		public virtual bool? Checked
 		{
 			get { return Handler.Checked; }
@@ -49,9 +56,9 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Gets or sets a value indicating whether this CheckBox allows three states: true, false, or null
+		/// Gets or sets a value indicating whether this <see cref="CheckBox"/> allows three states: <see langword="true"/>, <see langword="false"/>, or <see langword="null"/>.
 		/// </summary>
-		/// <value><c>true</c> if three state; otherwise, <c>false</c>.</value>
+		/// <value><see langword="true"/> if this <see cref="CheckBox"/> allows three state; otherwise, <see langword="false"/>.</value>
 		public bool ThreeState
 		{
 			get { return Handler.ThreeState; }
@@ -59,9 +66,9 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Gets a binding for the <see cref="Checked"/> property
+		/// Gets a binding for the <see cref="Checked"/> property.
 		/// </summary>
-		/// <value>The binding for the checked property.</value>
+		/// <value>The binding for the <see cref="Checked"/> property.</value>
 		public BindableBinding<CheckBox, bool?> CheckedBinding
 		{
 			get
@@ -77,20 +84,19 @@ namespace Eto.Forms
 		}
 
 		static readonly object callback = new Callback();
-		/// <summary>
-		/// Gets an instance of an object used to perform callbacks to the widget from handler implementations
-		/// </summary>
-		/// <returns>The callback instance to use for this widget</returns>
+		
+		/// <inheritdoc/>
 		protected override object GetCallback() { return callback; }
 
 		/// <summary>
-		/// Callback interface for the <see cref="CheckBox"/>
+		/// Callback interface for the <see cref="CheckBox"/>.
 		/// </summary>
 		public new interface ICallback : TextControl.ICallback
 		{
 			/// <summary>
-			/// Raises the checked changed event.
+			/// Raises the <see cref="CheckBox.CheckedChanged"/> event.
 			/// </summary>
+			// TODO: undocumented properties
 			void OnCheckedChanged(CheckBox widget, EventArgs e);
 		}
 
@@ -99,9 +105,7 @@ namespace Eto.Forms
 		/// </summary>
 		protected new class Callback : TextControl.Callback, ICallback
 		{
-			/// <summary>
-			/// Raises the checked changed event.
-			/// </summary>
+			/// <inheritdoc cref="ICallback.OnCheckedChanged"/>
 			public void OnCheckedChanged(CheckBox widget, EventArgs e)
 			{
 				using (widget.Platform.Context)
@@ -110,23 +114,14 @@ namespace Eto.Forms
 		}
 
 		/// <summary>
-		/// Handler interface for the <see cref="CheckBox"/> control
+		/// Handler interface for the <see cref="CheckBox"/> control.
 		/// </summary>
 		public new interface IHandler : TextControl.IHandler
 		{
-			/// <summary>
-			/// Gets or sets the checked state
-			/// </summary>
-			/// <remarks>
-			/// When <see cref="ThreeState"/> is true, null signifies an indeterminate value.
-			/// </remarks>
-			/// <value>The checked value</value>
+			/// <inheritdoc cref="CheckBox.Checked"/>
 			bool? Checked { get; set; }
 
-			/// <summary>
-			/// Gets or sets a value indicating whether this CheckBox allows three states: true, false, or null
-			/// </summary>
-			/// <value><c>true</c> if three state; otherwise, <c>false</c>.</value>
+			/// <inheritdoc cref="CheckBox.ThreeState"/>
 			bool ThreeState { get; set; }
 		}
 


### PR DESCRIPTION
This PR updates the documentation of Cheeckbox. Primarily it
- adds missing punctuation characters at the end of sentences
- replaces some copy pasted entries with inheritdocs
- adds some examples to better demonstrate usage
- adds some cref references.