### PR TITLE
Create an interface for controls to show that they can hide the border

### DIFF
--- a/src/Eto/Forms/Controls/DateTimePicker.cs
+++ b/src/Eto/Forms/Controls/DateTimePicker.cs
@@ -28,7 +28,7 @@ public enum DateTimePickerMode
 /// Date/time picker control to enter a date and/or time value
 /// </summary>
 [Handler(typeof(DateTimePicker.IHandler))]
-public class DateTimePicker : CommonControl
+public class DateTimePicker : CommonControl, IHideControlBorder
 {
 	new IHandler Handler { get { return (IHandler)base.Handler; } }
 
@@ -119,15 +119,7 @@ public class DateTimePicker : CommonControl
 		set { Handler.TextColor = value; }
 	}
 
-	/// <summary>
-	/// Gets or sets a value indicating whether to show the control's border.
-	/// </summary>
-	/// <remarks>
-	/// This is a hint to omit the border of the control and show it as plainly as possible.
-	/// 
-	/// Typically used when you want to show the control within a cell of the <see cref="GridView"/>.
-	/// </remarks>
-	/// <value><c>true</c> to show the control border; otherwise, <c>false</c>.</value>
+	/// <inheritdoc/>
 	[DefaultValue(true)]
 	public bool ShowBorder
 	{

--- a/src/Eto/Forms/Controls/DropDown.cs
+++ b/src/Eto/Forms/Controls/DropDown.cs
@@ -60,7 +60,7 @@ public class DropDownFormatEventArgs : EventArgs
 /// Presents a drop down to select from a list of items
 /// </summary>
 [Handler(typeof(DropDown.IHandler))]
-public class DropDown : ListControl
+public class DropDown : ListControl, IHideControlBorder
 {
 	new IHandler Handler => (IHandler)base.Handler;
 
@@ -90,15 +90,7 @@ public class DropDown : ListControl
 	/// <value>The binding to get the image for each item.</value>
 	public IIndirectBinding<Image> ItemImageBinding { get; set; }
 
-	/// <summary>
-	/// Gets or sets a value indicating whether to show the control's border.
-	/// </summary>
-	/// <remarks>
-	/// This is a hint to omit the border of the control and show it as plainly as possible.
-	/// 
-	/// Typically used when you want to show the control within a cell of the <see cref="GridView"/>.
-	/// </remarks>
-	/// <value><c>true</c> to show the control border; otherwise, <c>false</c>.</value>
+	/// <inheritdoc/>
 	[DefaultValue(true)]
 	public bool ShowBorder
 	{

--- a/src/Eto/Forms/Controls/TextBox.cs
+++ b/src/Eto/Forms/Controls/TextBox.cs
@@ -36,7 +36,7 @@ public enum AutoSelectMode
 /// </summary>
 /// <seealso cref="TextArea"/>
 [Handler(typeof(TextBox.IHandler))]
-public class TextBox : TextControl
+public class TextBox : TextControl, IHideControlBorder
 {
 	static readonly object SuppressTextChanging_Key = new object();
 
@@ -127,15 +127,7 @@ public class TextBox : TextControl
 		set { Handler.PlaceholderText = value; }
 	}
 
-	/// <summary>
-	/// Gets or sets a value indicating whether to show the control's border.
-	/// </summary>
-	/// <remarks>
-	/// This is a hint to omit the border of the control and show it as plainly as possible.
-	/// 
-	/// Typically used when you want to show the control within a cell of the <see cref="GridView"/>.
-	/// </remarks>
-	/// <value><c>true</c> to show the control border; otherwise, <c>false</c>.</value>
+	/// <inheritdoc/>
 	[DefaultValue(true)]
 	public bool ShowBorder
 	{

--- a/src/Eto/Forms/IHideControlBorder.cs
+++ b/src/Eto/Forms/IHideControlBorder.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel;
+
+namespace Eto.Forms;
+
+/// <summary>
+/// Defines an interface for controls or classes that implement toggling the visibility of their borders.
+/// </summary>
+public interface IHideControlBorder
+{
+	/// <summary>
+	/// Gets or sets a value indicating whether to show the control's border.
+	/// </summary>
+	/// <remarks>
+	/// This is a hint to omit the border of the control and show it as plainly as possible.
+	/// Typically used when you want to show the control within a cell of the <see cref="GridView"/>.
+	/// </remarks>
+	/// <value><see langword="true"/> to show the control border; otherwise, <see langword="false"/>.</value>
+	[DefaultValue(true)] 
+	public bool ShowBorder { get; set; }
+}


### PR DESCRIPTION
This PR creates a new interface (`IHideControlBorder`) which defines whether controls can show/hide the controls around their borders.
This makes it possible to later get rid of duplicated documentation text, and also make it easier to figure out whether (custom) controls support that feature.
For example, when one wants to disable the borders for all possible controls that are in a grid view, one could just do something akin to
```cs
foreach (var control in GetGridViewItems())
{
    if ((control as IHideControlBorder) is not null)
        (control as IHideControlBorder).ShowBorder = false;
}
```