### PR TITLE
Mark some tests as manual, fix ColorParse tests with invalid point

### DIFF
--- a/src/Eto/Drawing/Color.cs
+++ b/src/Eto/Drawing/Color.cs
@@ -535,16 +535,16 @@ public struct Color : IEquatable<Color>, IComparable<Color>, IControlObjectSourc
 
 			if (alphaIsFloat && i == alphaIndex)
 			{
-				if (!double.TryParse(array[i], out fnum))
+				if (!double.TryParse(array[i], NumberStyles.Number, CultureInfo.InvariantCulture, out fnum))
 					goto invalid;
 				if (!isPercent)
 					fnum *= 255;
 			}
-			else if (uint.TryParse(array[i], out var num))
+			else if (uint.TryParse(array[i],NumberStyles.Number, CultureInfo.InvariantCulture, out var num))
 			{
 				fnum = num;
 			}
-			else if (double.TryParse(array[i], out fnum))
+			else if (double.TryParse(array[i], NumberStyles.Number, CultureInfo.InvariantCulture, out fnum))
 			{
 				if (!isPercent)
 					fnum *= 255;

--- a/test/Eto.Test/UnitTests/Drawing/ColorTests.cs
+++ b/test/Eto.Test/UnitTests/Drawing/ColorTests.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using Eto.Drawing;
 using NUnit.Framework;
 
@@ -158,10 +160,31 @@ namespace Eto.Test.UnitTests.Drawing
 		[TestCase("4294967295", 255, 255, 255, 255, ColorStyles.AlphaLast)] // #FFFFFFFF
 		[TestCase("16777215", 255, 0, 255, 255, ColorStyles.AlphaLast)] // #FFFFFF
 		[TestCase("305419896", 120, 18, 52, 86, ColorStyles.AlphaLast)] // #12345678 A = 78
-		public void ColorShouldParse(string text, int a, int r, int g, int b, ColorStyles? style = null)
+		
+		[TestCase("#0000", 0, 0, 0, 0, ColorStyles.AlphaLast, true)]
+		[TestCase("#1234", 68, 17, 34, 51, ColorStyles.AlphaLast, true)]
+		[TestCase("#00000000", 0, 0, 0, 0, ColorStyles.AlphaLast, true)]
+		[TestCase("#12345678", 120, 18, 52, 86, ColorStyles.AlphaLast, true)]
+		[TestCase("0, 0, 0, 0", 0, 0, 0, 0, ColorStyles.AlphaLast, true)]
+		[TestCase("12, 34, 56, 78", 78, 12, 34, 56, ColorStyles.AlphaLast, true)]
+		[TestCase("255, 255, 255, 255", 255, 255, 255, 255, ColorStyles.AlphaLast, true)]
+		[TestCase("rgba(12,34,56,0.3)", 76, 12, 34, 56, ColorStyles.AlphaLast, true)]
+		[TestCase("rgba(50%,20%,100%,0.3)", 76, 127, 51, 255, ColorStyles.AlphaLast, true)]
+		[TestCase("rgba(50%,20.5%,100%,0.3)", 76, 127, 52, 255, ColorStyles.AlphaLast, true)]
+		[TestCase("0", 0, 0, 0, 0, ColorStyles.AlphaLast, true)]
+		[TestCase("4294967295", 255, 255, 255, 255, ColorStyles.AlphaLast, true)] // #FFFFFFFF
+		[TestCase("16777215", 255, 0, 255, 255, ColorStyles.AlphaLast, true)] // #FFFFFF
+		[TestCase("305419896", 120, 18, 52, 86, ColorStyles.AlphaLast, true)] // #12345678 A = 78
+		public void ColorShouldParse(string text, int a, int r, int g, int b, ColorStyles? style = null, bool? useDifferentCulture = null)
 		{
+			var systemCulture = CultureInfo.CurrentCulture;
+			bool shouldSwitchCulture = useDifferentCulture != null && useDifferentCulture.Value;
+			Thread.CurrentThread.CurrentCulture = new CultureInfo(shouldSwitchCulture ? "de-DE" : "en-US");
 			Color color;
 			var result = style == null ? Color.TryParse(text, out color) : Color.TryParse(text, out color, style.Value);
+
+			Thread.CurrentThread.CurrentCulture = systemCulture;
+			
 			Assert.IsTrue(result, "#1 - Color could not be parsed from text");
 
 			Assert.AreEqual(a, color.Ab, "#2.1 - Alpha component is incorrect");
@@ -169,7 +192,7 @@ namespace Eto.Test.UnitTests.Drawing
 			Assert.AreEqual(g, color.Gb, "#2.3 - Green component is incorrect");
 			Assert.AreEqual(b, color.Bb, "#2.4 - Blue component is incorrect");
 		}
-
+		
 		[TestCase("#0000", 0, 0, 0, 0, ColorStyles.ShortHex)]
 		[TestCase("#1234", 17, 34, 51, 68, ColorStyles.ShortHex)]
 		[TestCase("#FFFF", 255, 255, 255, 255, ColorStyles.ShortHex)]

--- a/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
@@ -25,10 +25,10 @@ namespace Eto.Test.UnitTests.Forms
 				_ = new Application(Platform.Instance);
 			});
 		}
-
-		[TestCase(-1)]
-		[TestCase(10)]
-		[TestCase(1000)]
+		
+		[TestCase(-1), ManualTest]
+		[TestCase(10), ManualTest]
+		[TestCase(1000), ManualTest]
 		public void RunIterationShouldAllowBlocking(int delay)
 		{
 			int count = 0;
@@ -40,7 +40,7 @@ namespace Eto.Test.UnitTests.Forms
 			{
 				form = new Form();
 				form.Closed += (sender, e) => running = false;
-
+				form.Title = "RunIterationShouldAllowBlocking (" + nameof(delay) + ": " + delay + ")"; 
 				var stopButton = new Button { Text = "Stop" };
 				stopButton.Click += (sender, e) =>
 				{
@@ -61,7 +61,7 @@ namespace Eto.Test.UnitTests.Forms
 
 				layout.Padding = 10;
 				layout.DefaultSpacing = new Size(4, 4);
-				layout.Add(new Label { Text = "The controls in this form should\nbe functional while test is running,\nand count should increase without moving the mouse.", TextAlignment = TextAlignment.Center });
+				layout.Add(new Label { Text = "The controls in this form should\nbe functional while test is running,\nand count should increase without moving the mouse.\nControls should be non-interactable during the delay.", TextAlignment = TextAlignment.Center });
 				layout.Add(new DropDown { DataStore = new[] { "Item 1", "Item 2", "Item 3" } });
 				layout.Add(new TextBox());
 				layout.Add(new DateTimePicker());

--- a/test/Eto.Test/UnitTests/Forms/PrintingTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/PrintingTests.cs
@@ -7,8 +7,8 @@ namespace Eto.Test.UnitTests.Forms
 	[TestFixture]
 	public class PrintingTests : TestBase
 	{
-		[TestCase(10)]
-		[TestCase(1000)]
+		[TestCase(10), ManualTest]
+		[TestCase(1000), ManualTest]
 		[InvokeOnUI]
 		public void PrintControl(int count)
 		{
@@ -31,8 +31,8 @@ namespace Eto.Test.UnitTests.Forms
 			ctl.Print();
 		}
 
-		[TestCase(10)]
-		[TestCase(1000)]
+		[TestCase(10), ManualTest]
+		[TestCase(1000), ManualTest]
 		[InvokeOnUI]
 		public void PrintControlPreview(int count)
 		{
@@ -67,7 +67,7 @@ namespace Eto.Test.UnitTests.Forms
 			doc.Dispose();
 		}
 		
-		[Test]
+		[Test, ManualTest]
 		[InvokeOnUI]
 		public void PrintPreviewWithGraphics()
 		{
@@ -78,7 +78,7 @@ namespace Eto.Test.UnitTests.Forms
 			doc.Dispose();
 		}
 		
-		[Test]
+		[Test, ManualTest]
 		[InvokeOnUI]
 		public void PrintWithGraphics()
 		{
@@ -89,7 +89,7 @@ namespace Eto.Test.UnitTests.Forms
 			doc.Dispose();
 		}
 		
-		[Test]
+		[Test, ManualTest]
 		[InvokeOnUI]
 		public void PrintDialogWithoutDocument()
 		{


### PR DESCRIPTION
- Mark some tests that need manual intervention as manual (printer test and `RunIterationShouldAllowBlocking`)
- Fix a bug in `Color.TryParse` returning invalid Colors when the user is on a culture that uses something other than a `.` for decimal point (i.e. German culture with `,` trying to parse `rgba(12,34,56,0.5)`) and adds it to the test suite in order for it to not happen again.