### PR TITLE
Mac: Add handle constructors to EtoWindow/EtoDialogWindow

### DIFF
--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -37,6 +37,11 @@ namespace Eto.Mac.Forms
 				get { return base.Handler as DialogHandler; }
 				set { base.Handler = value; }
 			}
+			
+			public EtoDialogWindow(NativeHandle handle)
+				: base(handle)
+			{
+			}
 
 			public EtoDialogWindow()
 				: base(new CGRect(0, 0, 200, 200), NSWindowStyle.Closable | NSWindowStyle.Titled, NSBackingStore.Buffered, false)
@@ -46,15 +51,12 @@ namespace Eto.Mac.Forms
 			[Export("cancelOperation:")]
 			public void CancelOperation(IntPtr sender)
 			{
-				if (Handler.AbortButton != null)
+				var handler = Handler?.AbortButton?.Handler as IMacViewHandler;
+				if (handler != null)
 				{
-					var handler = Handler.AbortButton.Handler as IMacViewHandler;
-					if (handler != null)
-					{
-						var callback = handler.Callback as Button.ICallback;
-						if (callback != null)
-							callback.OnClick(Handler.AbortButton, EventArgs.Empty);
-					}
+					var callback = handler.Callback as Button.ICallback;
+					if (callback != null)
+						callback.OnClick(Handler.AbortButton, EventArgs.Empty);
 				}
 			}
 

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -15,6 +15,11 @@ namespace Eto.Mac.Forms
 		public WeakReference WeakHandler { get; set; }
 
 		public IMacWindow Handler { get { return (IMacWindow)WeakHandler.Target; } set { WeakHandler = new WeakReference(value); } }
+		
+		public EtoWindow(NativeHandle handle)
+			: base(handle)
+		{
+		}
 
 		public EtoWindow(CGRect rect, NSWindowStyle style, NSBackingStore store, bool flag)
 			: base(rect, style, store, flag)
@@ -59,7 +64,7 @@ namespace Eto.Mac.Forms
 				base.Zoom(sender ?? this); // null when double clicking the title bar, but xammac/monomac doesn't allow it
 				zoom = true;
 			}
-			Handler.Callback.OnWindowStateChanged(Handler.Widget, EventArgs.Empty);
+			Handler?.Callback.OnWindowStateChanged(Handler.Widget, EventArgs.Empty);
 		}
 
 		public bool DisableSetOrigin { get; set; }


### PR DESCRIPTION
This is needed if macOS tries to use the window for some reason after it is GC'd, which sometimes happens and it's better not to crash in this case.