### PR TITLE
Mac: create DmgOutputPath if not already created

### DIFF
--- a/src/Eto.Mac/build/Dmg.targets
+++ b/src/Eto.Mac/build/Dmg.targets
@@ -39,6 +39,10 @@
   <Target Name="MacCreateDmg" DependsOnTargets="MacBuildAppBundle">
     <Message Text="Creating $(DmgName).dmg" />
 
+    <!-- Create the output path where the dmg will go if it doesn't exist yet-->
+    <MakeDir Directories="$(DmgOutputPath)" />
+
+    <!-- Remove the old/current temp files and dmg -->
     <RemoveDir Directories="$(_MacDmgTempPath)" />
     <Delete Files="$(_DmgPath)" />
 


### PR DESCRIPTION
Fixes issue trying to put the dmg in a path other than the output directory.