### PR TITLE
Make use of the virtual method `CreateControl` on wpf `DrawableHandler`

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DrawableHandler.cs
@@ -186,10 +186,7 @@ namespace Eto.Wpf.Forms.Controls
 			Control.Loaded += Control_Loaded;
 		}
 
-		public void Create()
-		{
-			CreateControl();
-		}
+		public void Create() { }
 
 		public void Create(bool largeCanvas)
 		{

--- a/src/Eto.Wpf/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DrawableHandler.cs
@@ -11,7 +11,12 @@ using Eto.Wpf.Drawing;
 
 namespace Eto.Wpf.Forms.Controls
 {
-	public class DrawableHandler : WpfPanel<swc.Canvas, Drawable, Drawable.ICallback>, Drawable.IHandler
+	public class DrawableHandler : DrawableHandler<swc.Canvas, Drawable, Drawable.ICallback> { }
+
+	public class DrawableHandler<TControl, TWidget, TCallback> : WpfPanel<TControl, TWidget, TCallback>, Drawable.IHandler
+		where TControl : swc.Canvas
+		where TWidget : Drawable
+		where TCallback : Drawable.ICallback
 	{
 		bool tiled;
 		sw.FrameworkElement content;
@@ -51,9 +56,12 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
-		class EtoMainCanvas : swc.Canvas
+		public class EtoMainCanvas<TTControl, TTWidget, TTCallback> : swc.Canvas
+			where TTControl : swc.Canvas
+			where TTWidget : Drawable
+			where TTCallback : Drawable.ICallback
 		{
-			public DrawableHandler Handler { get; set; }
+			public DrawableHandler<TTControl, TTWidget, TTCallback> Handler { get; set; }
 
 			protected override void OnMouseDown(sw.Input.MouseButtonEventArgs e)
 			{
@@ -111,7 +119,7 @@ namespace Eto.Wpf.Forms.Controls
 		class EtoTile : sw.FrameworkElement
 		{
 			Rectangle bounds;
-			public DrawableHandler Handler { get; set; }
+			public DrawableHandler<TControl, TWidget, TCallback> Handler { get; set; }
 
 			public Rectangle Bounds
 			{
@@ -163,16 +171,27 @@ namespace Eto.Wpf.Forms.Controls
 			UnRegisterScrollable();
 		}
 
-		public void Create()
+		protected override TControl CreateControl()
 		{
-			Control = new EtoMainCanvas
+			return new EtoMainCanvas<TControl, TWidget, TCallback>
 			{
 				Handler = this,
 				SnapsToDevicePixels = true,
 				FocusVisualStyle = null,
 				Background = swm.Brushes.Transparent
-			};
+			} as TControl;
+		}
+
+		protected override void Initialize()
+		{
+			base.Initialize();
+
 			Control.Loaded += Control_Loaded;
+		}
+
+		public void Create()
+		{
+			CreateControl();
 		}
 
 		public void Create(bool largeCanvas)

--- a/src/Eto.Wpf/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DrawableHandler.cs
@@ -56,12 +56,9 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
-		public class EtoMainCanvas<TTControl, TTWidget, TTCallback> : swc.Canvas
-			where TTControl : swc.Canvas
-			where TTWidget : Drawable
-			where TTCallback : Drawable.ICallback
+		public class EtoMainCanvas : swc.Canvas
 		{
-			public DrawableHandler<TTControl, TTWidget, TTCallback> Handler { get; set; }
+			public DrawableHandler<TControl, TWidget, TCallback> Handler { get; set; }
 
 			protected override void OnMouseDown(sw.Input.MouseButtonEventArgs e)
 			{
@@ -173,7 +170,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected override TControl CreateControl()
 		{
-			return new EtoMainCanvas<TControl, TWidget, TCallback>
+			return new EtoMainCanvas
 			{
 				Handler = this,
 				SnapsToDevicePixels = true,


### PR DESCRIPTION
* Provide a generic version of `DrawableHandler` to be able to provide custom control, widget and callback.

* Make use of the virtual method `CretaeControl` when creating the wpf canvas for the drawable control.

* This is required to enable the extending the drawable control when needed by a custom canvas.

* That was required in our case because we needed to provide a custom automation peer for the wpf canvas. and we could only do that by providing a custom canvas to the drawable.

* To make use the `EtoMainCanvas` I had to make it public. 