### PR TITLE
Mac: Clear out DataContext on CustomCells when GridView rows change

### DIFF
--- a/src/Eto.Mac/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CellHandler.cs
@@ -37,6 +37,8 @@ namespace Eto.Mac.Forms.Cells
 		void EnabledChanged(bool value);
 
 		NSView GetViewForItem(NSTableView tableView, NSTableColumn tableColumn, int row, NSObject obj, Func<NSObject, int, object> getItem);
+
+		void ViewRemoved(NSView view);
 	}
 
 	public class EtoCellTextField : EtoTextField
@@ -134,6 +136,10 @@ namespace Eto.Mac.Forms.Cells
 		}
 
 		public virtual void SetForegroundColor(NSView view, Color color)
+		{
+		}
+		
+		public virtual void ViewRemoved(NSView view)
 		{
 		}
 

--- a/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
@@ -193,6 +193,16 @@ namespace Eto.Mac.Forms.Cells
 			Callback.OnConfigureCell(Widget, view.Args, view.EtoControl);
 			return view;
 		}
+
+		public override void ViewRemoved(NSView view)
+		{
+			base.ViewRemoved(view);
+			if (view is EtoCustomCellView etoView)
+			{
+				etoView.Args.SetItem(null);
+				Callback.OnConfigureCell(Widget, etoView.Args, etoView.EtoControl);
+			}
+		}
 	}
 }
 

--- a/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
@@ -51,6 +51,7 @@ namespace Eto.Mac.Forms.Controls
 		void SetObjectValue(object dataItem, NSObject val);
 		new GridColumn Widget { get; }
 		IDataViewHandler DataViewHandler { get; }
+		ICellHandler DataCellHandler { get; }
 		bool AutoSizeColumn(NSRange? rowRange, bool force = false);
 		void EnabledChanged(bool value);
 		nfloat GetPreferredWidth(NSRange? range = null);

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -419,6 +419,18 @@ namespace Eto.Mac.Forms.Controls
 				return tableView.MakeView(tableColumn.Identifier, this);
 			}
 
+			public override void DidRemoveRowView(NSTableView tableView, NSTableRowView rowView, nint row)
+			{
+				foreach (var col in Handler.ColumnHandlers)
+				{
+					if (col.DisplayIndex != -1)
+					{
+						var view = rowView.ViewAtColumn(col.DisplayIndex);
+						col.DataCellHandler?.ViewRemoved(view);
+					}
+				}
+			}
+
 			public override void DidDragTableColumn(NSTableView tableView, NSTableColumn tableColumn)
 			{
 				var h = Handler;

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -255,6 +255,18 @@ namespace Eto.Mac.Forms.Controls
 				return outlineView.MakeView(tableColumn?.Identifier ?? string.Empty, this);
 			}
 
+			public override void DidRemoveRowView(NSOutlineView outlineView, NSTableRowView rowView, nint row)
+			{
+				foreach (var col in Handler.ColumnHandlers)
+				{
+					if (col.DisplayIndex != -1)
+					{
+						var view = rowView.ViewAtColumn(col.DisplayIndex);
+						col.DataCellHandler?.ViewRemoved(view);
+					}
+				}
+			}
+
 			public override void DidDragTableColumn(NSOutlineView outlineView, NSTableColumn tableColumn)
 			{
 				var h = Handler;


### PR DESCRIPTION
This would cause leaks if the data bindings bound to long-lived controls, and also ensures behaviour is the same with other platforms.