### PR TITLE
Wpf: Get rid of solid brush "optimization"

### DIFF
--- a/src/Eto.Wpf/WpfConversions.cs
+++ b/src/Eto.Wpf/WpfConversions.cs
@@ -31,11 +31,7 @@ namespace Eto.Wpf
 
 		public static swm.Brush ToWpfBrush(this Color value, swm.Brush brush = null)
 		{
-			var solidBrush = brush as swm.SolidColorBrush;
-			if (solidBrush == null || solidBrush.IsSealed)
-			{
-				solidBrush = new swm.SolidColorBrush();
-			}
+			var solidBrush = new swm.SolidColorBrush();
 			solidBrush.Color = value.ToWpf();
 			return solidBrush;
 		}


### PR DESCRIPTION
When using custom styles, this would change the style brush instead of just setting it for the individual control