### PR TITLE
Wpf: Allow theme resources to override colors used for CustomCellEventArgs.CellTextColor

### DIFF
--- a/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
@@ -45,7 +45,9 @@ namespace Eto.Wpf.Forms.Cells
 				var selected = cell.IsSelected;
 				IsSelected = selected;
 				var focused = grid?.IsKeyboardFocusWithin != false;
-				CellTextColor = selected && focused ? Eto.Drawing.SystemColors.HighlightText : Eto.Drawing.SystemColors.ControlText;
+				CellTextColor = selected && focused 
+					? (cell.GetResourceColor(sw.SystemColors.HighlightTextColorKey, sw.SystemColors.HighlightTextBrushKey) ?? Eto.Drawing.SystemColors.HighlightText) 
+					: (cell.GetResourceColor(sw.SystemColors.ControlTextColorKey, sw.SystemColors.ControlTextBrushKey) ?? Eto.Drawing.SystemColors.ControlText);
 			}
 			public void SetRow(sw.FrameworkElement element)
 			{

--- a/src/Eto.Wpf/WpfConversions.cs
+++ b/src/Eto.Wpf/WpfConversions.cs
@@ -942,5 +942,27 @@ namespace Eto.Wpf
 				return swm.PixelFormats.Rgba64;
 			return format;
 		}
+
+		public static Color? GetResourceColor(this sw.FrameworkElement cell, sw.ResourceKey key)
+		{
+			var res = cell.TryFindResource(key);
+			if (res is swm.SolidColorBrush brush)
+				return brush.ToEtoColor();
+			if (res is swm.Color color)
+				return color.ToEto();
+			return null;
+		}
+
+		public static Color? GetResourceColor(this sw.FrameworkElement cell, params sw.ResourceKey[] keys)
+		{
+			for (int i = 0; i < keys.Length; i++)
+			{
+				sw.ResourceKey key = keys[i];
+				var value = GetResourceColor(cell, key);
+				if (value != null)
+					return value;
+			}
+			return null;
+		}
 	}
 }


### PR DESCRIPTION
.. useful when defining custom themes and colors for WPF