### PR TITLE
Wpf: Allow ToolItem and MenuItem to have different icon sizes

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -98,7 +98,7 @@
 			"request": "launch",
 			"preLaunchTask": "build-wpf",
             "program": "${workspaceFolder}/artifacts/test/Eto.Test.Wpf/${config:var.configuration}/net6.0-windows/Eto.Test.Wpf.exe",
-			"targetArchitecture": "x86_64",
+			// "targetArchitecture": "x86_64",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart",

--- a/src/Eto.Wpf/Forms/Menu/MenuItemHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/MenuItemHandler.cs
@@ -13,6 +13,13 @@ namespace Eto.Wpf.Forms.Menu
 	{
 		void Validate();
 	}
+	
+	public static class MenuItemHandler
+	{
+		// note this does not affect the main menu by default due to WPF hard coding a size of 16,16 in its styles.
+		public static Size? DefaultImageSize = new Size(16, 16);
+		internal static readonly object ImageSize_Key = new object();
+	}
 
 	public class MenuItemHandler<TControl, TWidget, TCallback> : MenuHandler<TControl, TWidget, TCallback>, MenuItem.IHandler, swi.ICommand, IWpfValidateBinding, IMenuItemHandler
 		where TControl : swc.MenuItem
@@ -32,14 +39,31 @@ namespace Eto.Wpf.Forms.Menu
 		{
 			Callback.OnClick(Widget, EventArgs.Empty);
 		}
+		
+		public Size? ImageSize
+		{
+			get => Widget.Properties.Get<Size?>(MenuItemHandler.ImageSize_Key, MenuItemHandler.DefaultImageSize);
+			set
+			{
+				if (Widget.Properties.TrySet(MenuItemHandler.ImageSize_Key, value, MenuItemHandler.DefaultImageSize))
+				{
+					OnImageSizeChanged();
+				}
+			}
+		}
+
+		protected virtual void OnImageSizeChanged()
+		{
+			Control.Icon = image.ToWpfImage(Screen.PrimaryScreen.LogicalPixelSize, ImageSize);
+		}
 
 		public Image Image
 		{
-			get { return image; }
+			get => image;
 			set
 			{
 				image = value;
-				Control.Icon = image.ToWpfImage(Screen.PrimaryScreen.LogicalPixelSize, new Size(16, 16));
+				OnImageSizeChanged();
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/ToolBar/ButtonToolItemHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/ButtonToolItemHandler.cs
@@ -17,14 +17,24 @@ namespace Eto.Wpf.Forms.ToolBar
 		public ButtonToolItemHandler ()
 		{
 			Control = new swc.Button();
-			swcImage = new swc.Image { MaxHeight = 16, MaxWidth = 16 };
+			swcImage = new swc.Image();
 			label = new swc.TextBlock();
+			label.VerticalAlignment = sw.VerticalAlignment.Center;
+			label.Margin = new Thickness(2, 0, 2, 0);
 			var panel = new swc.StackPanel { Orientation = swc.Orientation.Horizontal };
 			panel.Children.Add(swcImage);
 			panel.Children.Add(label);
 			Control.Content = panel;
 			Control.Click += Control_Click;
 			sw.Automation.AutomationProperties.SetLabeledBy(Control, label);
+		}
+
+		protected override void OnImageSizeChanged()
+		{
+			base.OnImageSizeChanged();
+			var size = ImageSize;
+			swcImage.MaxHeight = size?.Height ?? double.PositiveInfinity;
+			swcImage.MaxWidth = size?.Width ?? double.PositiveInfinity;
 		}
 
 		private void Control_Click(object sender, RoutedEventArgs e)

--- a/src/Eto.Wpf/Forms/ToolBar/CheckToolItemHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/CheckToolItemHandler.cs
@@ -18,8 +18,10 @@ namespace Eto.Wpf.Forms.ToolBar
 			Control = new swc.Primitives.ToggleButton {
 				IsThreeState = false
 			};
-			swcImage = new swc.Image { MaxHeight = 16, MaxWidth = 16 };
+			swcImage = new swc.Image();
 			label = new swc.TextBlock ();
+			label.Margin = new Thickness(2, 0, 2, 0);
+			label.VerticalAlignment = sw.VerticalAlignment.Center;
 			var panel = new swc.StackPanel { Orientation = swc.Orientation.Horizontal };
 			panel.Children.Add (swcImage);
 			panel.Children.Add (label);
@@ -30,6 +32,14 @@ namespace Eto.Wpf.Forms.ToolBar
 			Control.Click += Control_Click;
 			
 			sw.Automation.AutomationProperties.SetLabeledBy(Control, label);
+		}
+
+		protected override void OnImageSizeChanged()
+		{
+			base.OnImageSizeChanged();
+			var size = ImageSize;
+			swcImage.MaxHeight = size?.Height ?? double.PositiveInfinity;
+			swcImage.MaxWidth = size?.Width ?? double.PositiveInfinity;
 		}
 
 		private void Control_Click(object sender, RoutedEventArgs e)

--- a/src/Eto.Wpf/Forms/ToolBar/DropDownToolItemHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/DropDownToolItemHandler.cs
@@ -20,10 +20,13 @@ namespace Eto.Wpf.Forms.ToolBar
 		{
 			root = new swc.MenuItem();
 			Control = new swc.Menu();
+			Control.Background = swm.Brushes.Transparent;
 			Control.Items.Add(root);
-			swcImage = new swc.Image { MaxHeight = 16, MaxWidth = 16 };
+			swcImage = new swc.Image();
 			label = new swc.TextBlock();
-			arrow = new sw.Shapes.Path { Data = swm.Geometry.Parse("M 0 0 L 3 3 L 6 0 Z"), VerticalAlignment = sw.VerticalAlignment.Center, Margin = new Thickness(8, 2, 0, 0), Fill = swm.Brushes.Black };
+			label.Margin = new Thickness(2, 0, 2, 0);
+			label.VerticalAlignment = sw.VerticalAlignment.Center;
+			arrow = new sw.Shapes.Path { Data = swm.Geometry.Parse("M 0 0 L 3 3 L 6 0 Z"), VerticalAlignment = sw.VerticalAlignment.Center, Margin = new Thickness(2, 2, 0, 0), Fill = swm.Brushes.Black };
 			var panel = new swc.StackPanel { Orientation = swc.Orientation.Horizontal, Children = { swcImage, label, arrow } };
 
 			root.Header = panel;
@@ -31,7 +34,15 @@ namespace Eto.Wpf.Forms.ToolBar
 			root.SubmenuOpened += Control_Click;
 			sw.Automation.AutomationProperties.SetLabeledBy(Control, label);
 		}
-		
+
+		protected override void OnImageSizeChanged()
+		{
+			base.OnImageSizeChanged();
+			var size = ImageSize;
+			swcImage.MaxHeight = size?.Height ?? double.PositiveInfinity;
+			swcImage.MaxWidth = size?.Width ?? double.PositiveInfinity;
+		}
+
 		private void Control_Click(object sender, RoutedEventArgs e)
 		{
 			// WPF raises this event for all child items as well as the root menu, so check sender

--- a/src/Eto.Wpf/Forms/ToolBar/RadioToolItemHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/RadioToolItemHandler.cs
@@ -22,8 +22,10 @@ namespace Eto.Wpf.Forms.ToolBar
 			{
 				IsThreeState = false
 			};
-			swcImage = new swc.Image { MaxHeight = 16, MaxWidth = 16 };
+			swcImage = new swc.Image();
 			label = new swc.TextBlock();
+			label.Margin = new Thickness(2, 0, 2, 0);
+			label.VerticalAlignment = sw.VerticalAlignment.Center;
 			var panel = new swc.StackPanel { Orientation = swc.Orientation.Horizontal };
 			panel.Children.Add(swcImage);
 			panel.Children.Add(label);
@@ -36,6 +38,15 @@ namespace Eto.Wpf.Forms.ToolBar
 
 			sw.Automation.AutomationProperties.SetLabeledBy(Control, label);
 		}
+
+		protected override void OnImageSizeChanged()
+		{
+			base.OnImageSizeChanged();
+			var size = ImageSize;
+			swcImage.MaxHeight = size?.Height ?? double.PositiveInfinity;
+			swcImage.MaxWidth = size?.Width ?? double.PositiveInfinity;
+		}
+
 
 		private void Control_Click(object sender, RoutedEventArgs e)
 		{

--- a/src/Eto.Wpf/Forms/ToolBar/SeparatorToolItemHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/SeparatorToolItemHandler.cs
@@ -1,5 +1,6 @@
 using System;
 using Eto.Forms;
+using sw = System.Windows;
 using swc = System.Windows.Controls;
 using swm = System.Windows.Media;
 using Eto.Drawing;
@@ -40,7 +41,7 @@ namespace Eto.Wpf.Forms.ToolBar
 				switch (value)
 				{
 					case SeparatorToolItemType.Divider:
-						control = new swc.Separator { LayoutTransform = new swm.RotateTransform(90) };
+						control = new swc.Separator { LayoutTransform = new swm.RotateTransform(90), Margin = new sw.Thickness(2, 0, 2, 0) };
 						break;
 					case SeparatorToolItemType.FlexibleSpace:
 					case SeparatorToolItemType.Space:

--- a/src/Eto.Wpf/Forms/ToolBar/ToolBarHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/ToolBarHandler.cs
@@ -9,6 +9,7 @@ namespace Eto.Wpf.Forms.ToolBar
 		public ToolBarHandler()
 		{
 			Control = new swc.ToolBar { IsTabStop = false, Tag = this };
+			swc.ToolBarTray.SetIsLocked(Control, true);
 			swi.KeyboardNavigation.SetTabNavigation(Control, swi.KeyboardNavigationMode.Continue);
 		}
 

--- a/src/Eto.Wpf/Forms/ToolBar/ToolItemHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/ToolItemHandler.cs
@@ -5,6 +5,12 @@ using sw = System.Windows;
 
 namespace Eto.Wpf.Forms.ToolBar
 {
+	public static class ToolItemHandler
+	{
+		public static Size? DefaultImageSize = new Size(16, 16);
+		internal static readonly object ImageSize_Key = new object();
+	}
+	
 	public abstract class ToolItemHandler<TControl, TWidget> : WidgetHandler<TControl, TWidget>, ToolItem.IHandler
 		where TControl : System.Windows.UIElement
 		where TWidget : ToolItem
@@ -14,6 +20,28 @@ namespace Eto.Wpf.Forms.ToolBar
 		public abstract string ToolTip { get; set; }
 
 		public abstract Image Image { get; set; }
+
+		public Size? ImageSize
+		{
+			get => Widget.Properties.Get<Size?>(ToolItemHandler.ImageSize_Key, ToolItemHandler.DefaultImageSize);
+			set
+			{
+				if (Widget.Properties.TrySet(ToolItemHandler.ImageSize_Key, value, ToolItemHandler.DefaultImageSize))
+				{
+					OnImageSizeChanged();
+				}
+			}
+		}
+
+		protected virtual void OnImageSizeChanged()
+		{
+		}
+
+		protected override void Initialize()
+		{
+			base.Initialize();
+			OnImageSizeChanged();
+		}
 
 		public abstract bool Enabled { get; set; }
 		public bool Visible


### PR DESCRIPTION
This allows ToolItem and MenuItem to have different icon sizes other than 16,16.  Note that the MenuItem icon size is hard coded in WPF, so changing the size may not have an affect unless you define your own MenuItem styling.

This also removes the gripper as it is useless and adjusts the margins a little between the label and image and with splitters.

You can use Eto styles to define the sizes for individual items, or change the default like so:

```
// change for all
Eto.Wpf.Forms.ToolBar.ToolItemHandler.DefaultImageSize = new Size(24, 24);

// change only for specific items
Styles.Add<ButtonToolItemHandler>("my-style", c => c.ImageSize = new Size(24, 24));
```