### PR TITLE
Fixes Eto.Gtk webview crashing with webkit2gtk-4.1

### DIFF
--- a/src/Eto.Gtk/Eto.Gtk.csproj
+++ b/src/Eto.Gtk/Eto.Gtk.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <RootNamespace>Eto.GtkSharp</RootNamespace>
     <DefineConstants>$(DefineConstants);GTK3;GTKCORE</DefineConstants>

--- a/src/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
@@ -2,6 +2,7 @@ using System;
 using Eto.Forms;
 using Eto.Drawing;
 using Eto.GtkSharp.Drawing;
+using Range = Eto.Forms.Range;
 
 namespace Eto.GtkSharp.Forms.Controls
 {

--- a/src/Eto.Gtk/NativeMethods.cs
+++ b/src/Eto.Gtk/NativeMethods.cs
@@ -1,4 +1,4 @@
-﻿
+﻿﻿
 using System;
 using System.Runtime.InteropServices;
 using System.Text;
@@ -32,6 +32,31 @@ namespace Eto.GtkSharp
 
 		static class NMWindows
 		{
+
+#if NETCOREAPP
+
+			static NMWindows()
+			{
+				NativeLibrary.SetDllImportResolver(typeof(NMWindows).Assembly, (name, assembly, path) =>
+				{
+					// Use custom import resolver for libwebkit2gtk
+					// Try loading 4.1 first, if that fails, return to default handling
+					if (name == libwebkit) 
+					{
+						IntPtr result = IntPtr.Zero;
+						if (!NativeLibrary.TryLoad("libwebkit2gtk-4.1.so.0", assembly, path, out result))
+						{
+							return IntPtr.Zero;
+						}
+
+						return result;
+					}
+
+					return IntPtr.Zero;
+				});
+			}
+#endif
+
 #if GTK2
 			const string plat = "win32-";
 #elif GTK3
@@ -226,6 +251,31 @@ namespace Eto.GtkSharp
 
 		static class NMLinux
 		{
+
+#if NETCOREAPP
+
+			static NMLinux()
+			{
+				NativeLibrary.SetDllImportResolver(typeof(NMLinux).Assembly, (name, assembly, path) =>
+				{
+					// Use custom import resolver for libwebkit2gtk
+					// Try loading 4.1 first, if that fails, return to default handling
+					if (name == libwebkit) 
+					{
+						IntPtr result = IntPtr.Zero;
+						if (!NativeLibrary.TryLoad("libwebkit2gtk-4.1.so.0", assembly, path, out result))
+						{
+							return IntPtr.Zero;
+						}
+
+						return result;
+					}
+
+					return IntPtr.Zero;
+				});
+			}
+#endif
+
 #if GTK2
 			const string plat = "x11-";
 #elif GTK3
@@ -420,6 +470,31 @@ namespace Eto.GtkSharp
 
 		static class NMMac
 		{
+
+#if NETCOREAPP
+
+			static NMMac()
+			{
+				NativeLibrary.SetDllImportResolver(typeof(NMMac).Assembly, (name, assembly, path) =>
+				{
+					// Use custom import resolver for libwebkit2gtk
+					// Try loading 4.1 first, if that fails, return to default handling
+					if (name == libwebkit) 
+					{
+						IntPtr result = IntPtr.Zero;
+						if (!NativeLibrary.TryLoad("libwebkit2gtk-4.1.so.0", assembly, path, out result))
+						{
+							return IntPtr.Zero;
+						}
+
+						return result;
+					}
+
+					return IntPtr.Zero;
+				});
+			}
+#endif
+
 #if GTK2
 			const string plat = "quartz-";
 #elif GTK3

--- a/src/Eto.Gtk/NativeMethods.tt
+++ b/src/Eto.Gtk/NativeMethods.tt
@@ -152,6 +152,31 @@ namespace Eto.GtkSharp
 
 		static class <#= pclass[i] #>
 		{
+
+#if NETCOREAPP
+
+			static <#= pclass[i] #>()
+			{
+				NativeLibrary.SetDllImportResolver(typeof(<#= pclass[i] #>).Assembly, (name, assembly, path) =>
+				{
+					// Use custom import resolver for libwebkit2gtk
+					// Try loading 4.1 first, if that fails, return to default handling
+					if (name == libwebkit) 
+					{
+						IntPtr result = IntPtr.Zero;
+						if (!NativeLibrary.TryLoad("libwebkit2gtk-4.1.so.0", assembly, path, out result))
+						{
+							return IntPtr.Zero;
+						}
+
+						return result;
+					}
+
+					return IntPtr.Zero;
+				});
+			}
+#endif
+
 #if GTK2
 			const string plat = "<#= plat[i] #>";
 #elif GTK3

--- a/test/Eto.Test/Eto.Test.csproj
+++ b/test/Eto.Test/Eto.Test.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6.0</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);PCL</DefineConstants>
   </PropertyGroup>

--- a/test/Eto.Test/UnitTests/Forms/Controls/RichTextAreaTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/RichTextAreaTests.cs
@@ -7,6 +7,7 @@ using System.Text.RegularExpressions;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
+using Range = Eto.Forms.Range;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {

--- a/test/Eto.Test/UnitTests/Forms/Controls/TextAreaTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TextAreaTests.cs
@@ -1,6 +1,7 @@
 using System;
 using Eto.Forms;
 using NUnit.Framework;
+using Range = Eto.Forms.Range;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {

--- a/test/Eto.Test/UnitTests/Forms/Controls/TextBoxTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TextBoxTests.cs
@@ -3,6 +3,7 @@ using NUnit.Framework;
 using Eto.Forms;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using Range = Eto.Forms.Range;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {

--- a/test/Eto.Test/UnitTests/Forms/Controls/TextChangingEventArgsTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TextChangingEventArgsTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using Eto.Forms;
 using NUnit.Framework;
+using Range = Eto.Forms.Range;
 
 namespace Eto.Test.UnitTests.Forms.Controls
 {


### PR DESCRIPTION
This PR
- Fixes webviews crashing on Eto.Gtk if the system only has webkit2gtk-4.1 installed instead of webkit2gtk-4.0. (4.1 is API compatible with 4.0, unlike 5.0 which currently hinders #2361)
- Allows net6.0 as an alternative TFM for Eto.Gtk and Eto.Test and fixes the System.Range vs Eto.Forms.Range conflicts that arose from it.