### PR TITLE
Wpf: Fix odd sizes of toolitems when there is no label

### DIFF
--- a/src/Eto.Wpf/Forms/ToolBar/ButtonToolItemHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/ButtonToolItemHandler.cs
@@ -4,48 +4,26 @@ using Eto.Forms;
 using swc = System.Windows.Controls;
 using swm = System.Windows.Media;
 using sw = System.Windows;
-using System.Windows;
 
 namespace Eto.Wpf.Forms.ToolBar
 {
 	public class ButtonToolItemHandler : ToolItemHandler<swc.Button, ButtonToolItem>, ButtonToolItem.IHandler
 	{
-		Image image;
-		readonly swc.Image swcImage;
-		readonly swc.TextBlock label;
-
 		public ButtonToolItemHandler ()
 		{
 			Control = new swc.Button();
-			swcImage = new swc.Image();
-			label = new swc.TextBlock();
-			label.VerticalAlignment = sw.VerticalAlignment.Center;
-			label.Margin = new Thickness(2, 0, 2, 0);
-			var panel = new swc.StackPanel { Orientation = swc.Orientation.Horizontal };
-			panel.Children.Add(swcImage);
-			panel.Children.Add(label);
-			Control.Content = panel;
 			Control.Click += Control_Click;
-			sw.Automation.AutomationProperties.SetLabeledBy(Control, label);
 		}
 
-		protected override void OnImageSizeChanged()
+		protected override void Initialize()
 		{
-			base.OnImageSizeChanged();
-			var size = ImageSize;
-			swcImage.MaxHeight = size?.Height ?? double.PositiveInfinity;
-			swcImage.MaxWidth = size?.Width ?? double.PositiveInfinity;
+			base.Initialize();
+			Control.Content = CreateContent();
 		}
 
-		private void Control_Click(object sender, RoutedEventArgs e)
+		private void Control_Click(object sender, sw.RoutedEventArgs e)
 		{
 			Widget.OnClick(EventArgs.Empty);
-		}
-
-		public override string Text
-		{
-			get { return label.Text.ToEtoMnemonic(); }
-			set { label.Text = value.ToPlatformMnemonic(); }
 		}
 
 		public override string ToolTip
@@ -54,24 +32,5 @@ namespace Eto.Wpf.Forms.ToolBar
 			set { Control.ToolTip = value; }
 		}
 
-		public override Image Image
-		{
-			get { return image; }
-			set
-			{
-				image = value;
-				swcImage.Source = image.ToWpf(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
-			}
-		}
-
-		public override bool Enabled
-		{
-			get { return Control.IsEnabled; }
-			set
-			{
-				Control.IsEnabled = value;
-				swcImage.IsEnabled = value;
-			}
-		}
 	}
 }

--- a/src/Eto.Wpf/Forms/ToolBar/CheckToolItemHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/CheckToolItemHandler.cs
@@ -10,36 +10,21 @@ namespace Eto.Wpf.Forms.ToolBar
 {
 	public class CheckToolItemHandler : ToolItemHandler<swc.Primitives.ToggleButton, CheckToolItem>, CheckToolItem.IHandler
 	{
-        Image image;
-		readonly swc.Image swcImage;
-		readonly swc.TextBlock label;
 		public CheckToolItemHandler ()
 		{
 			Control = new swc.Primitives.ToggleButton {
 				IsThreeState = false
 			};
-			swcImage = new swc.Image();
-			label = new swc.TextBlock ();
-			label.Margin = new Thickness(2, 0, 2, 0);
-			label.VerticalAlignment = sw.VerticalAlignment.Center;
-			var panel = new swc.StackPanel { Orientation = swc.Orientation.Horizontal };
-			panel.Children.Add (swcImage);
-			panel.Children.Add (label);
-			Control.Content = panel;
 
 			Control.Checked += Control_CheckedChanged;
 			Control.Unchecked += Control_CheckedChanged;
 			Control.Click += Control_Click;
-			
-			sw.Automation.AutomationProperties.SetLabeledBy(Control, label);
 		}
 
-		protected override void OnImageSizeChanged()
+		protected override void Initialize()
 		{
-			base.OnImageSizeChanged();
-			var size = ImageSize;
-			swcImage.MaxHeight = size?.Height ?? double.PositiveInfinity;
-			swcImage.MaxWidth = size?.Width ?? double.PositiveInfinity;
+			base.Initialize();
+			Control.Content = CreateContent();
 		}
 
 		private void Control_Click(object sender, RoutedEventArgs e)
@@ -57,33 +42,10 @@ namespace Eto.Wpf.Forms.ToolBar
 			get { return Control.IsChecked ?? false; }
 			set { Control.IsChecked = value; }
 		}
-
-		public override string Text
-		{
-			get { return label.Text.ToEtoMnemonic(); }
-			set { label.Text = value.ToPlatformMnemonic(); }
-		}
-
 		public override string ToolTip
 		{
 			get { return Control.ToolTip as string; }
 			set { Control.ToolTip = value; }
-		}
-
-		public override Image Image
-		{
-			get { return image; }
-			set
-			{
-				image = value;
-				swcImage.Source = image.ToWpf(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
-			}
-		}
-
-		public override bool Enabled
-		{
-			get { return Control.IsEnabled; }
-			set { Control.IsEnabled = value; }
 		}
 	}
 }

--- a/src/Eto.Wpf/Forms/ToolBar/DropDownToolItemHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/DropDownToolItemHandler.cs
@@ -10,9 +10,6 @@ namespace Eto.Wpf.Forms.ToolBar
 {
 	public class DropDownToolItemHandler : ToolItemHandler<swc.Menu, DropDownToolItem>, DropDownToolItem.IHandler
 	{
-		Image image;
-		readonly swc.Image swcImage;
-		readonly swc.TextBlock label;
 		readonly swc.MenuItem root;
 		readonly sw.Shapes.Path arrow;
 
@@ -22,25 +19,16 @@ namespace Eto.Wpf.Forms.ToolBar
 			Control = new swc.Menu();
 			Control.Background = swm.Brushes.Transparent;
 			Control.Items.Add(root);
-			swcImage = new swc.Image();
-			label = new swc.TextBlock();
-			label.Margin = new Thickness(2, 0, 2, 0);
-			label.VerticalAlignment = sw.VerticalAlignment.Center;
 			arrow = new sw.Shapes.Path { Data = swm.Geometry.Parse("M 0 0 L 3 3 L 6 0 Z"), VerticalAlignment = sw.VerticalAlignment.Center, Margin = new Thickness(2, 2, 0, 0), Fill = swm.Brushes.Black };
-			var panel = new swc.StackPanel { Orientation = swc.Orientation.Horizontal, Children = { swcImage, label, arrow } };
 
-			root.Header = panel;
 			root.Click += Control_Click;
 			root.SubmenuOpened += Control_Click;
-			sw.Automation.AutomationProperties.SetLabeledBy(Control, label);
 		}
 
-		protected override void OnImageSizeChanged()
+		protected override void Initialize()
 		{
-			base.OnImageSizeChanged();
-			var size = ImageSize;
-			swcImage.MaxHeight = size?.Height ?? double.PositiveInfinity;
-			swcImage.MaxWidth = size?.Width ?? double.PositiveInfinity;
+			base.Initialize();
+			root.Header = CreateContent(arrow);
 		}
 
 		private void Control_Click(object sender, RoutedEventArgs e)
@@ -52,36 +40,10 @@ namespace Eto.Wpf.Forms.ToolBar
 			Widget.OnClick(EventArgs.Empty);
 		}
 
-		public override string Text
-		{
-			get { return label.Text.ToEtoMnemonic(); }
-			set { label.Text = value.ToPlatformMnemonic(); }
-		}
-
 		public override string ToolTip
 		{
 			get { return Control.ToolTip as string; }
 			set { Control.ToolTip = value; }
-		}
-
-		public override Image Image
-		{
-			get { return image; }
-			set
-			{
-				image = value;
-				swcImage.Source = image.ToWpf(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
-			}
-		}
-
-		public override bool Enabled
-		{
-			get { return Control.IsEnabled; }
-			set
-			{
-				Control.IsEnabled = value;
-				swcImage.IsEnabled = value;
-			}
 		}
 
 		/// <summary>

--- a/src/Eto.Wpf/Forms/ToolBar/RadioToolItemHandler.cs
+++ b/src/Eto.Wpf/Forms/ToolBar/RadioToolItemHandler.cs
@@ -12,41 +12,23 @@ namespace Eto.Wpf.Forms.ToolBar
 {
 	public class RadioToolItemHandler : ToolItemHandler<swc.Primitives.ToggleButton, RadioToolItem>, RadioToolItem.IHandler
 	{
-		Image image;
-		readonly swc.Image swcImage;
-		readonly swc.TextBlock label;
-
 		public RadioToolItemHandler()
 		{
 			Control = new swc.Primitives.ToggleButton
 			{
 				IsThreeState = false
 			};
-			swcImage = new swc.Image();
-			label = new swc.TextBlock();
-			label.Margin = new Thickness(2, 0, 2, 0);
-			label.VerticalAlignment = sw.VerticalAlignment.Center;
-			var panel = new swc.StackPanel { Orientation = swc.Orientation.Horizontal };
-			panel.Children.Add(swcImage);
-			panel.Children.Add(label);
-			Control.Content = panel;
-
 			Control.Checked += Control_Checked;
 			Control.Unchecked += Control_Unchecked;
 			Control.PreviewMouseDown += Control_PreviewMouseDown;
 			Control.Click += Control_Click;
-
-			sw.Automation.AutomationProperties.SetLabeledBy(Control, label);
 		}
 
-		protected override void OnImageSizeChanged()
+		protected override void Initialize()
 		{
-			base.OnImageSizeChanged();
-			var size = ImageSize;
-			swcImage.MaxHeight = size?.Height ?? double.PositiveInfinity;
-			swcImage.MaxWidth = size?.Width ?? double.PositiveInfinity;
+			base.Initialize();
+			Control.Content = CreateContent();
 		}
-
 
 		private void Control_Click(object sender, RoutedEventArgs e)
 		{
@@ -90,26 +72,10 @@ namespace Eto.Wpf.Forms.ToolBar
 			set { Control.IsChecked = value; }
 		}
 
-		public override string Text
-		{
-			get { return label.Text.ToEtoMnemonic(); }
-			set { label.Text = value.ToPlatformMnemonic(); }
-		}
-
 		public override string ToolTip
 		{
 			get { return Control.ToolTip as string; }
 			set { Control.ToolTip = value; }
-		}
-
-		public override Image Image
-		{
-			get { return image; }
-			set
-			{
-				image = value;
-				swcImage.Source = image.ToWpf(Screen.PrimaryScreen.LogicalPixelSize, swcImage.GetMaxSize().ToEtoSize());
-			}
 		}
 
 		public override bool Enabled


### PR DESCRIPTION
This is a regression due to #2481.

Also refactor to share more code.