### PR TITLE
Mac: Ensure controls only get mouse events when enabled

### DIFF
--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -38,7 +38,7 @@ namespace Eto.Mac.Forms.Controls
 
 			public bool CanFocus { get; set; }
 
-			public override bool AcceptsFirstResponder() => CanFocus;
+			public override bool AcceptsFirstResponder() => CanFocus && Drawable?.Enabled == true;
 
 			public override NSView HitTest(CGPoint aPoint)
 			{

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -24,7 +24,7 @@ namespace Eto.Mac.Forms
 		public void MouseMoved(NSEvent theEvent)
 		{
 			var h = Handler;
-			if (h == null) return;
+			if (h == null || !h.Enabled) return;
 			h.Callback.OnMouseMove(h.Widget, MacConversions.GetMouseEvent(h, theEvent, false));
 		}
 
@@ -32,7 +32,7 @@ namespace Eto.Mac.Forms
 		public void MouseEntered(NSEvent theEvent)
 		{
 			var h = Handler;
-			if (h == null) return;
+			if (h == null || !h.Enabled) return;
 			h.Callback.OnMouseEnter(h.Widget, MacConversions.GetMouseEvent(h, theEvent, false));
 		}
 
@@ -45,7 +45,7 @@ namespace Eto.Mac.Forms
 		public void MouseExited(NSEvent theEvent)
 		{
 			var h = Handler;
-			if (h == null) return;
+			if (h == null || !h.Enabled) return;
 			h.Callback.OnMouseLeave(h.Widget, MacConversions.GetMouseEvent(h, theEvent, false));
 		}
 
@@ -84,6 +84,7 @@ namespace Eto.Mac.Forms
 		bool TextInputCancelled { get; set; }
 		bool TextInputImplemented { get; }
 		bool UseNSBoxBackgroundColor { get; set; }
+		bool Enabled { get; set; }
 
 		DragEventArgs GetDragEventArgs(NSDraggingInfo info, object customControl);
 
@@ -234,7 +235,7 @@ namespace Eto.Mac.Forms
 		{
 			var obj = Runtime.GetNSObject(sender);
 
-			if (MacBase.GetHandler(obj) is IMacViewHandler handler)
+			if (MacBase.GetHandler(obj) is IMacViewHandler handler && handler.Enabled)
 			{
 				var theEvent = Messaging.GetNSObject<NSEvent>(e);
 				handler.TriggerMouseUp(obj, sel, theEvent);
@@ -245,7 +246,7 @@ namespace Eto.Mac.Forms
 		static void TriggerMouseWheel(IntPtr sender, IntPtr sel, IntPtr e)
 		{
 			var obj = Runtime.GetNSObject(sender);
-			if (MacBase.GetHandler(obj) is IMacViewHandler handler)
+			if (MacBase.GetHandler(obj) is IMacViewHandler handler && handler.Enabled)
 			{
 				var theEvent = Messaging.GetNSObject<NSEvent>(e);
 				var args = MacConversions.GetMouseEvent(handler, theEvent, true);
@@ -1459,6 +1460,9 @@ namespace Eto.Mac.Forms
 			// do a mouse tracking loop.  This is needed since the mouse up event gets buried when 
 			// showing context menus, dialogs, etc.
 			MacView.InMouseTrackingLoop = true;
+			
+			if (!Enabled)
+				return null;
 			
 			var args = MacConversions.GetMouseEvent(this, theEvent, false);
 			if (theEvent.ClickCount >= 2)

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -329,8 +329,8 @@ namespace Eto.Wpf.Forms
 
 		public virtual bool Enabled
 		{
-			get { return Control.IsEnabled; }
-			set { Control.IsEnabled = value; }
+			get { return ContainerControl.IsEnabled; }
+			set { ContainerControl.IsEnabled = value; }
 		}
 
 		public virtual Cursor Cursor

--- a/test/Eto.Test/Sections/UnitTestSection.cs
+++ b/test/Eto.Test/Sections/UnitTestSection.cs
@@ -7,14 +7,17 @@ namespace Eto.Test.Sections
 	[Section("Automated Tests", "Unit Tests")]
 	public class UnitTestSection : Panel
 	{
-		UnitTestPanel unitTestPanel;
+		static UnitTestPanel unitTestPanel;
 		UnitTestRunner runner;
 
 		public UnitTestSection()
 		{
-			runner = new UnitTestRunner(((TestApplication)TestApplication.Instance).TestAssemblies);
-			unitTestPanel = new UnitTestPanel(runner, false);
-			unitTestPanel.Log += (sender, e) => Log.Write(null, e.Message);
+			if (unitTestPanel == null)
+			{
+				runner = new UnitTestRunner(((TestApplication)TestApplication.Instance).TestAssemblies);
+				unitTestPanel = new UnitTestPanel(runner, false);
+				unitTestPanel.Log += (sender, e) => Log.Write(null, e.Message);
+			}
 
 			Content = unitTestPanel;
 		}

--- a/test/Eto.Test/UnitTests/Forms/Controls/ControlTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ControlTests.cs
@@ -388,5 +388,73 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			Assert.That(containerSize.Height, Is.EqualTo(size.Height + padding.Vertical).Within(0.1), "#2.2 - panel with padding should have correct height");
 		}
 
+		[ManualTest]
+		[TestCaseSource(nameof(GetControlTypes))]
+		public void ControlsShouldNotGetMouseOrFocusEventsWhenDisabled(IControlTypeInfo<Control> info)
+		{
+			ControlsShouldNotGetMouseOrFocusEventsWhenParentDisabled(info, false);
+		}
+		
+		[ManualTest]
+		[TestCaseSource(nameof(GetControlTypes))]
+		public void ControlsShouldNotGetMouseOrFocusEventsWhenParentDisabled(IControlTypeInfo<Control> info)
+		{
+			ControlsShouldNotGetMouseOrFocusEventsWhenParentDisabled(info, true);
+		}
+
+		public void ControlsShouldNotGetMouseOrFocusEventsWhenParentDisabled(IControlTypeInfo<Control> info, bool disableWithParent)
+		{
+			bool gotFocus = false;
+			bool gotMouseDown = false;
+			bool gotMouseUp = false;
+			bool gotMouseEnter = false;
+			bool gotMouseLeave = false;
+			ManualForm("Click on the Drawable, it should not get focus", form =>
+			{
+				var control = info.CreatePopulatedControl();
+				if (!disableWithParent)
+					control.Enabled = false;
+
+				control.GotFocus += (sender, e) =>
+				{
+					Console.WriteLine("GotFocus");
+					gotFocus = true;
+				};
+				control.LostFocus += (sender, e) =>
+				{
+					Console.WriteLine("LostFocus");
+				};
+				control.MouseDown += (sender, e) =>
+				{
+					Console.WriteLine("MouseDown");
+					gotMouseDown = true;
+				};
+				control.MouseUp += (sender, e) =>
+				{
+					Console.WriteLine("MouseUp");
+					gotMouseUp = true;
+				};
+				control.MouseEnter += (sender, e) =>
+				{
+					Console.WriteLine("MouseEnter");
+					gotMouseEnter = true;
+				};
+				control.MouseLeave += (sender, e) =>
+				{
+					Console.WriteLine("MouseLeave");
+					gotMouseLeave = true;
+				};
+
+				var panel = new Panel { Content = control };
+				if (disableWithParent)
+					panel.Enabled = false;
+				return panel;
+			});
+			Assert.IsFalse(gotFocus, "#1.1 - Control should not be able to get focus");
+			Assert.IsFalse(gotMouseEnter, "#1.2 - Got MouseEnter");
+			Assert.IsFalse(gotMouseLeave, "#1.3 - Got MouseLeave");
+			Assert.IsFalse(gotMouseDown, "#1.4 - Got MouseDown");
+			Assert.IsFalse(gotMouseUp, "#1.5 - Got MouseUp");
+		}
 	}
 }


### PR DESCRIPTION
Wpf: Fix issues disabling some controls when they have a different container

This makes sure Mac platforms behave the same as others, when the control is disabled either directly or though the parent it should not get any MouseDown/Move/Up/Enter/Leave events, nor should it get focus when clicked (e.g. Drawable).