### PR TITLE
Mac: Ensure TableLayout updates when resized

### DIFF
--- a/src/Eto.Mac/Forms/TableLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/TableLayoutHandler.cs
@@ -401,5 +401,17 @@ namespace Eto.Mac.Forms
 		{
 			return yscaling[row];
 		}
+
+		protected override void Initialize()
+		{
+			base.Initialize();
+			HandleEvent(Eto.Forms.Control.SizeChangedEvent);
+		}
+
+		public override void OnSizeChanged(EventArgs e)
+		{
+			base.OnSizeChanged(e);
+			Control.NeedsLayout = true;
+		}
 	}
 }


### PR DESCRIPTION
This fixes an issue where sometimes the children of a `TableLayout` aren't laid out properly when `UseNSBoxBackgroundColor` is set to false.