### PR TITLE
Wpf/WinForms: Release capture if MouseUp event is handled by user code

### DIFF
--- a/src/Eto.WinForms/Forms/ApplicationHandler.cs
+++ b/src/Eto.WinForms/Forms/ApplicationHandler.cs
@@ -172,12 +172,16 @@ namespace Eto.WinForms.Forms
 				}, null, Win32.WM.LBUTTONDBLCLK, Win32.WM.RBUTTONDBLCLK, Win32.WM.MBUTTONDBLCLK);
 				void OnMouseUpHandler(Control c, Control.ICallback cb, MouseEventArgs e)
 				{
-					if (c.Handler is IWindowsControl handler && handler.MouseCaptured)
+					var handler = c.Handler as IWindowsControl;
+					if (handler != null && handler.MouseCaptured)
 					{
 						handler.MouseCaptured = false;
 						handler.ContainerControl.Capture = false;
 					}
 					cb.OnMouseUp(c, e);
+
+					if (handler != null && e.Handled && handler.ContainerControl.Capture)
+						handler.ContainerControl.Capture = false;
 				}
 				
 				bubble.AddBubbleMouseEvent(OnMouseUpHandler, false, Win32.WM.LBUTTONUP, b => MouseButtons.Primary);

--- a/src/Eto.WinForms/Forms/WindowsControl.cs
+++ b/src/Eto.WinForms/Forms/WindowsControl.cs
@@ -534,7 +534,11 @@ namespace Eto.WinForms.Forms
 				MouseCaptured = false;
 				Control.Capture = false;
 			}
-			Callback.OnMouseUp(Widget, e.ToEto(Control));
+			var args = e.ToEto(Control);
+			Callback.OnMouseUp(Widget, args);
+			
+			if (args.Handled && Control.Capture)
+				Control.Capture = false;
 		}
 
 		void HandleMouseMove(Object sender, swf.MouseEventArgs e)

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -821,6 +821,11 @@ namespace Eto.Wpf.Forms
 
 			Callback.OnMouseUp(Widget, args);
 			e.Handled = args.Handled;
+			
+			// If the mouse was captured intrinsically we need to release capture otherwise it hangs the app
+			// since the caller is overriding default behaviour.
+			if (e.Handled && Control.IsMouseCaptured)
+				Control.ReleaseMouseCapture();
 		}
 
 		void HandleMouseDoubleClick(object sender, swi.MouseButtonEventArgs e)


### PR DESCRIPTION
E.g. if you click on a selected SegmentedButton item it would appear to hang the app.