### PR TITLE
Mac: Fix setting Tree/GridView.BackgroundColor

### DIFF
--- a/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
@@ -162,7 +162,14 @@ namespace Eto.Mac.Forms.Controls
 		public string HeaderText
 		{
 			get { return Control.HeaderCell.StringValue; }
-			set { Control.HeaderCell.StringValue = value; }
+			set
+			{
+				if (value != HeaderText)
+				{
+					Control.HeaderCell.StringValue = value;
+					Control.TableView?.HeaderView?.SetNeedsDisplay();
+				}
+			}
 		}
 
 		public bool Resizable

--- a/src/Eto.Mac/Forms/MacBase.cs
+++ b/src/Eto.Mac/Forms/MacBase.cs
@@ -176,13 +176,22 @@ namespace Eto.Mac.Forms
 
 		public bool AddMethod(IntPtr selector, Delegate action, string arguments, object control)
 		{
-			var type = control.GetType();
-#if OSX
-			if (!typeof(IMacControl).IsAssignableFrom(type))
-				throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Control '{0}' does not inherit from IMacControl", type));
-			if (((IMacControl)control).WeakHandler?.Target == null)
-				throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Control '{0}' has a null handler", type));
-#endif
+			if (control is Type type)
+			{
+				if (!typeof(IMacControl).IsAssignableFrom(type))
+					throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Control '{0}' does not inherit from IMacControl", type));
+			}
+			else
+			{
+				type = control.GetType();
+				
+				if (!typeof(IMacControl).IsAssignableFrom(type))
+					throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Control '{0}' does not inherit from IMacControl", type));
+				if (((IMacControl)control).WeakHandler?.Target == null)
+					throw new ArgumentException(string.Format(CultureInfo.CurrentCulture, "Control '{0}' has a null handler", type));
+			}
+
+				
 			var classHandle = Class.GetHandle(type);
 
 			return ObjCExtensions.AddMethod(classHandle, selector, action, arguments);


### PR DESCRIPTION
Setting `BackgroundColor` of a `GridView`/`TreeGridView` on Mac now will work properly and not use any tinting effects if `UseNSBoxBackgroundColor` is false.