### PR TITLE
Wpf: Optimize layout of parent controls when size of control is set

### DIFF
--- a/src/Eto.Wpf/Forms/PixelLayoutHandler.cs
+++ b/src/Eto.Wpf/Forms/PixelLayoutHandler.cs
@@ -56,7 +56,7 @@ namespace Eto.Wpf.Forms
 			swc.Canvas.SetLeft(element, x);
 			swc.Canvas.SetTop(element, y);
 			Control.Children.Add(element);
-			UpdatePreferredSize();
+			OnChildPreferredSizeUpdated();
 		}
 
 		public void Move(Control child, int x, int y)
@@ -64,20 +64,20 @@ namespace Eto.Wpf.Forms
 			var element = child.GetContainerControl();
 			swc.Canvas.SetLeft(element, x);
 			swc.Canvas.SetTop(element, y);
-			UpdatePreferredSize();
+			OnChildPreferredSizeUpdated();
 		}
 
 		public void Remove(Control child)
 		{
 			var element = child.GetContainerControl();
 			Control.Children.Remove(element);
-			UpdatePreferredSize();
+			OnChildPreferredSizeUpdated();
 		}
 
 		public override void Remove(sw.FrameworkElement child)
 		{
 			Control.Children.Remove(child);
-			UpdatePreferredSize();
+			OnChildPreferredSizeUpdated();
 		}
 
 		int suspended;

--- a/src/Eto.Wpf/Forms/TableLayoutHandler.cs
+++ b/src/Eto.Wpf/Forms/TableLayoutHandler.cs
@@ -395,7 +395,7 @@ namespace Eto.Wpf.Forms
 				}
 				Control.Children.Add(control);
 			}
-			UpdatePreferredSize();
+			OnChildPreferredSizeUpdated();
 		}
 
 		public void Move(Control child, int x, int y)
@@ -420,7 +420,7 @@ namespace Eto.Wpf.Forms
 				SetScale(handler, x, y);
 			}
 			controls[x, y] = child;
-			UpdatePreferredSize();
+			OnChildPreferredSizeUpdated();
 		}
 
 		public void Remove(Control child)
@@ -434,7 +434,7 @@ namespace Eto.Wpf.Forms
 			var y = swc.Grid.GetRow(child);
 			Control.Children.Remove(child);
 			controls[x, y] = null;
-			UpdatePreferredSize();
+			OnChildPreferredSizeUpdated();
 		}
 	}
 }

--- a/src/Eto.Wpf/Forms/WpfContainer.cs
+++ b/src/Eto.Wpf/Forms/WpfContainer.cs
@@ -12,7 +12,7 @@ namespace Eto.Wpf.Forms
 	{
 		void Remove(sw.FrameworkElement child);
 
-		void UpdatePreferredSize();
+		void OnChildPreferredSizeUpdated();
 	}
 
 	public abstract class WpfContainer<TControl, TWidget, TCallback> : WpfFrameworkElement<TControl, TWidget, TCallback>, Container.IHandler, IWpfContainer

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -252,8 +252,14 @@ namespace Eto.Wpf.Forms
 		{
 			if (Widget.Loaded)
 			{
-				Widget.VisualParent.GetWpfContainer()?.UpdatePreferredSize();
+				Widget.VisualParent.GetWpfContainer()?.OnChildPreferredSizeUpdated();
 			}
+		}
+
+		public virtual void OnChildPreferredSizeUpdated()
+		{
+			if (double.IsNaN(UserPreferredSize.Width) || double.IsNaN(UserPreferredSize.Height))
+				UpdatePreferredSize();
 		}
 
 		public virtual void SetScale(bool xscale, bool yscale)

--- a/src/Eto.Wpf/Forms/WpfPanel.cs
+++ b/src/Eto.Wpf/Forms/WpfPanel.cs
@@ -113,7 +113,7 @@ namespace Eto.Wpf.Forms
 				else
 					border.Child = null;
 				Control.InvalidateMeasure();
-				UpdatePreferredSize();
+				OnChildPreferredSizeUpdated();
 			}
 		}
 
@@ -125,7 +125,7 @@ namespace Eto.Wpf.Forms
 			{
 				content = null;
 				border.Child = null;
-				UpdatePreferredSize();
+				OnChildPreferredSizeUpdated();
 			}
 		}
 	}


### PR DESCRIPTION
Don't propagate the measure invalidation to the parent if a container size is set.

This can also help prevent endless layout updates when the children size/position (e.g. in a PixelLayout) are set when the size changes, especially in odd DPI scales such as 150%.