### PR TITLE
Build from CI using specific macos workload

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
     types: [ published ]
 
 env:
-  DotNetVersion: "6.0.202"
+  DotNetVersion: "7.0.108"
   BuildConfiguration: "Release"
   BuildParameters: "build/Build.proj /v:Minimal /consoleLoggerParameters:NoSummary /p:Configuration=Release /p:BuildVersion=${{ github.run_id }} /p:BuildBranch=${{ github.ref }}"
 
@@ -24,7 +24,7 @@ jobs:
         submodules: true
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ env.DotNetVersion }}
 
@@ -71,12 +71,15 @@ jobs:
         submodules: true
 
     - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
+      uses: actions/setup-dotnet@v3
       with:
         dotnet-version: ${{ env.DotNetVersion }}
 
+    - name: Create global.json for the version we are using
+      run: del global.json || echo '{"sdk":{"version":"${{ env.DotNetVersion }}"}}' > global.json
+
     - name: Install macos workload
-      run: sudo dotnet workload install macos
+      run: sudo dotnet workload install macos --from-rollback-file dotnet-workloads.json
         
     - name: Setup Xamarin and XCode
       uses: maxim-lobanov/setup-xamarin@v1

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -175,7 +175,17 @@
 			"presentation": {
 				"clear": true
 			}
-		}
+		},
+		{
+			"label": "install-macos-workload",
+			"type": "shell",
+			"command": "sudo dotnet workload install macos --from-rollback-file dotnet-workloads.json",
+			"problemMatcher": "$msCompile",
+			"presentation": {
+			  "clear": true,
+			  "focus": true
+			}
+		  }
 	],
 	"inputs": [
 		{

--- a/dotnet-workloads.json
+++ b/dotnet-workloads.json
@@ -1,0 +1,3 @@
+{
+    "microsoft.net.sdk.macos": "12.3.2372"
+}


### PR DESCRIPTION
Using the latest workload causes errors when you are using older versions.

Now targeting version 12.3.2372 (earliest for .NET 7.0.1xx SDK) so you should now be able to use Eto.macOS with any version after that.