### PR TITLE
Mac/Gtk: Ensure control gets Got/LostFocus events when window Got/LostFocus is triggered

### DIFF
--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -293,7 +293,7 @@ namespace Eto.GtkSharp.Forms
 			Eto.Forms.Application.Instance.AsyncInvoke(GrabFocus);
 		}
 
-		public bool HasFocus
+		public virtual bool HasFocus
 		{
 			get { return Control.HasFocus; }
 		}
@@ -691,7 +691,7 @@ namespace Eto.GtkSharp.Forms
 				var handler = Handler;
 				if (handler == null)
 					return;
-				handler.Callback.OnGotFocus(handler.Widget, EventArgs.Empty);
+				Application.Instance.AsyncInvoke(() => handler.Callback.OnGotFocus(handler.Widget, EventArgs.Empty));
 			}
 
 			public virtual void FocusOutEvent(object o, Gtk.FocusOutEventArgs args)

--- a/src/Eto.Gtk/Forms/GtkWindow.cs
+++ b/src/Eto.Gtk/Forms/GtkWindow.cs
@@ -128,6 +128,8 @@ namespace Eto.GtkSharp.Forms
 			}
 		}
 
+		public override bool HasFocus => Control.HasToplevelFocus;
+
 		public Gtk.Widget WindowContentControl
 		{
 			get { return vbox; }

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1062,7 +1062,7 @@ namespace Eto.Mac.Forms
 		{
 			get
 			{
-				return ShouldHaveFocus ?? (FocusControl.Window != null && FocusControl.Window.FirstResponder == Control);
+				return ShouldHaveFocus ?? (FocusControl.Window?.FirstResponder == Control && FocusControl.Window?.IsKeyWindow == true);
 			}
 		}
 

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -339,6 +339,10 @@ namespace Eto.Mac.Forms
 			if (handler == null)
 				return;
 			handler.Callback.OnGotFocus(handler.Widget, EventArgs.Empty);
+			if (GetHandler(handler.Control.FirstResponder) is IMacViewHandler ctlHandler)
+			{
+				ctlHandler.Callback.OnGotFocus(ctlHandler.Widget, EventArgs.Empty);
+			}
 		}
 
 		static void HandleLostFocus(object sender, EventArgs e)
@@ -346,6 +350,12 @@ namespace Eto.Mac.Forms
 			var handler = GetHandler(sender) as MacWindow<TControl, TWidget, TCallback>;
 			if (handler == null)
 				return;
+
+			if (GetHandler(handler.Control.FirstResponder) is IMacViewHandler ctlHandler)
+			{
+				ctlHandler.Callback.OnLostFocus(ctlHandler.Widget, EventArgs.Empty);
+			}
+			
 			handler.Callback.OnLostFocus(handler.Widget, EventArgs.Empty);
 		}
 
@@ -1043,6 +1053,14 @@ namespace Eto.Mac.Forms
 			set => Widget.Properties.Set(MacWindow.AnimateSizeChanges_Key, value);
 		}
 
+		protected override void Initialize()
+		{
+			base.Initialize();
+
+			// need to send Got/LostFocus to child when window Got/LostFocus is called
+			HandleEvent(Window.LostFocusEvent);
+			HandleEvent(Window.GotFocusEvent);
+		}
 
 		public override void OnLoad(EventArgs e)
 		{

--- a/test/Eto.Test/Sections/Behaviors/FocusEventsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/FocusEventsSection.cs
@@ -3,6 +3,32 @@ namespace Eto.Test.Sections.Behaviors
 	[Section("Behaviors", "Focus Events")]
 	public class FocusEventsSection : AllControlsBase
 	{
+		protected override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+			ParentWindow.GotFocus += Window_GotFocus;
+			ParentWindow.LostFocus += Window_LostFocus;
+		}
+
+		protected override void OnUnLoad(EventArgs e)
+		{
+			base.OnUnLoad(e);
+			ParentWindow.GotFocus -= Window_GotFocus;
+			ParentWindow.LostFocus -= Window_LostFocus;
+		}
+
+		protected void Window_GotFocus(object sender, EventArgs e)
+		{
+			if (sender is Window window)
+				Log.Write(sender, $"Window.GotFocus, HasFocus: {window.HasFocus}");
+		}
+
+		protected void Window_LostFocus(object sender, EventArgs e)
+		{
+			if (sender is Window window)
+				Log.Write(sender, $"Window.LostFocus, HasFocus: {window.HasFocus}");
+		}
+
 		protected override void LogEvents(Control control)
 		{
 			base.LogEvents(control);


### PR DESCRIPTION
Mac: Fixes Control.Got/LostFocus to fire when the window gets/loses focus.
Mac: Ensures Control.HasFocus only returns true when the window has focus (is key).
Gtk: Fixes Window.HasFocus to ensure it returns whether the window is the topmost window.