### PR TITLE
Re-throw property binding exceptions

### DIFF
--- a/src/Eto/Forms/Binding/PropertyBinding.cs
+++ b/src/Eto/Forms/Binding/PropertyBinding.cs
@@ -128,7 +128,20 @@ public class PropertyBinding<T> : IndirectBinding<T>
 		if (EnsureProperty(dataItem) && CanRead)
 		{
 			var propertyType = typeof(T);
-			object val = descriptor != null ? descriptor.GetValue(dataItem) : propInfo.GetValue(dataItem);
+			object val;
+			try
+			{
+				if (descriptor != null)
+					val = descriptor.GetValue(dataItem);
+				else if (propInfo != null)
+					val = propInfo.GetValue(dataItem);
+				else
+					return default(T);
+			}
+			catch (Exception ex)
+			{
+				throw new PropertyBindingException($"Could not get property '{Property}' on '{dataItem?.GetType()}'", ex);
+			}
 			if (val != null && !propertyType.IsInstanceOfType(val))
 			{
 				try
@@ -171,10 +184,17 @@ public class PropertyBinding<T> : IndirectBinding<T>
 					val = propertyType.GetTypeInfo().IsValueType ? Activator.CreateInstance(propertyType) : null;
 				}
 			}
-			if (descriptor != null)
-				descriptor.SetValue(dataItem, val);
-			else if (propInfo != null)
-				propInfo.SetValue(dataItem, val);
+			try
+			{
+				if (descriptor != null)
+					descriptor.SetValue(dataItem, val);
+				else if (propInfo != null)
+					propInfo.SetValue(dataItem, val);
+			}
+			catch (Exception ex)
+			{
+				throw new PropertyBindingException($"Could not set property '{Property}' on '{dataItem?.GetType()}'", ex);
+			}
 		}
 	}
 

--- a/src/Eto/Forms/Binding/PropertyBindingException.cs
+++ b/src/Eto/Forms/Binding/PropertyBindingException.cs
@@ -1,0 +1,37 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Exception when getting/setting values in a <see cref="PropertyBinding{T}" />
+/// </summary>
+/// <remarks>
+/// This exception is thrown explicitly if there is a problem getting or setting the value on the data item.
+/// Since using descriptors can sometimes bury the actual stack trace, this can be useful to figure out what property
+/// setter/getter is throwing.
+/// </remarks>
+[System.Serializable]
+public class PropertyBindingException : System.Exception
+{
+	/// <summary>
+	/// Initializes a new instance of the PropertyBindingException class.
+	/// </summary>
+	public PropertyBindingException() { }
+	/// <summary>
+	/// Initializes a new instance of the PropertyBindingException class with the specified message.
+	/// </summary>
+	/// <param name="message">Message of the exception</param>
+	public PropertyBindingException(string message) : base(message) { }
+	/// <summary>
+	/// Initializes a new instance of the PropertyBindingException class with the specified message and inner exception.
+	/// </summary>
+	/// <param name="message">Message of the exception</param>
+	/// <param name="inner">Original exception</param>
+	public PropertyBindingException(string message, System.Exception inner) : base(message, inner) { }
+	/// <summary>
+	/// Initializes a new instance of the PropertyBindingException class from serialization.
+	/// </summary>
+	/// <param name="info">Serialization info</param>
+	/// <param name="context">Streaming context</param>
+	protected PropertyBindingException(
+		System.Runtime.Serialization.SerializationInfo info,
+		System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+}


### PR DESCRIPTION
In some cases with property descriptors, the actual stack trace can be hidden so it is not known which property is failing.  Re-throwing exceptions when getting/setting allows us to show the property name and type it is getting/setting to.

This happens when [this code path](https://github.com/dotnet/runtime/blob/a29d84885d3d316822a89ca7f950d33a2ac9505d/src/libraries/System.ComponentModel.TypeConverter/src/System/ComponentModel/ReflectPropertyDescriptor.cs#L1120) is executed in .NET.