### PR TITLE
Setting e.Cancel = true in Splitter.PositionChanging event should cancel any changes

### DIFF
--- a/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -296,9 +296,13 @@ namespace Eto.Mac.Forms.Controls
 					var mainFrame = h.Control.Frame;
 					if (mainFrame.Width <= 1 || mainFrame.Height <= 1)
 						return;
-					h.position = h.Control.IsVertical ? (int)subview.Frame.Width : (int)subview.Frame.Height;
+					var newPosition = h.Control.IsVertical ? (int)subview.Frame.Width : (int)subview.Frame.Height;
 					h.TriggerChangeStarted();
-					h.Callback.OnPositionChanged(h.Widget, EventArgs.Empty);
+					if (newPosition != h.position)
+					{
+						h.position = newPosition;
+						h.Callback.OnPositionChanged(h.Widget, EventArgs.Empty);
+					}
 				}
 			}
 

--- a/src/Eto.WinForms/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/SplitterHandler.cs
@@ -161,6 +161,9 @@ namespace Eto.WinForms.Forms.Controls
 				newPosition = lastPosition;
 			}
 
+			// always set splitter distance 
+			Control.SplitterDistance = newPosition;
+
 			if (lastPosition != newPosition)
 			{
 				if (Control.IsHandleCreated)
@@ -170,9 +173,9 @@ namespace Eto.WinForms.Forms.Controls
 					position = newPosition;
 					Callback.OnPositionChanged(Widget, EventArgs.Empty);
 				}
-
-				Control.SplitterDistance = newPosition;
 			}
+			
+			
 			lastPosition = newPosition;
 			
 			if (userMoved)

--- a/src/Eto/Forms/Controls/Splitter.cs
+++ b/src/Eto/Forms/Controls/Splitter.cs
@@ -170,8 +170,8 @@ public class Splitter : Container
 	{
 		EventLookup.Register<Splitter>(c => c.OnPositionChanged(null), Splitter.PositionChangedEvent);
 		EventLookup.Register<Splitter>(c => c.OnPositionChanging(null), Splitter.PositionChangingEvent);
-		EventLookup.Register<Splitter>(c => c.OnPositionChangeStarted(null), Splitter.PositionChangingEvent);
-		EventLookup.Register<Splitter>(c => c.OnPositionChangeCompleted(null), Splitter.PositionChangingEvent);
+		EventLookup.Register<Splitter>(c => c.OnPositionChangeStarted(null), Splitter.PositionChangeStartedEvent);
+		EventLookup.Register<Splitter>(c => c.OnPositionChangeCompleted(null), Splitter.PositionChangeCompletedEvent);
 	}
 
 	/// <summary>

--- a/test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/SplitterTests.cs
@@ -440,6 +440,34 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			Assert.IsNull(outOfBounds, $"#1 - Position went out of bounds 100-200, was {outOfBounds}");
 		}
 
+		[Test, ManualTest]
+		public void SplitterShouldNotMoveWhenChangingCancelled()
+		{
+			int positionChanged = 0;
+			ManualForm("Splitter should not be able to move", form =>
+			{
+				form.ClientSize = new Size(600, 300);
+				var splitter = new Splitter
+				{
+
+					Panel1 = new Panel { BackgroundColor = Colors.Blue, Size = new Size(300, 200) },
+					Panel2 = new Panel { BackgroundColor = Colors.Red, Size = new Size(300, 200) }
+				};
+
+				splitter.PositionChanging += (sender, e) =>
+				{
+					System.Diagnostics.Debug.WriteLine($"PositionChanging, Position {splitter.Position}, NewPosition: {e.NewPosition}");
+					e.Cancel = true;
+				};
+				splitter.PositionChanged += (sender, e) =>
+				{
+					positionChanged++;
+				};
+				return splitter;
+			});
+			Assert.AreEqual(0, positionChanged, $"#1 - PositionChanged should not fire");
+		}
+
 		[TestCase(Orientation.Horizontal)]
 		[TestCase(Orientation.Vertical)]
 		public void ZeroRelativePositionShouldNotCrash(Orientation orientation)


### PR DESCRIPTION
With WPF and WinForms it would still allow changes when setting `e.Cancel = true` during the `Splitter.PositionChanging` event, unless you also set the position explicitly.  Now you can simply cancel during the changing event and it shouldn't budge.