### PR TITLE
Mac: Add more NativeHandle constructors and prevent NRE's with TextBox.

### DIFF
--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -14,6 +14,14 @@ namespace Eto.Mac.Forms.Controls
 		public class EtoDrawableView : MacPanelView
 		{
 			DrawableHandler Drawable => Handler as DrawableHandler;
+			
+			public EtoDrawableView()
+			{
+			}
+
+			public EtoDrawableView(NativeHandle handle) : base(handle)
+			{
+			}
 
 			public override void DrawRect(CGRect dirtyRect)
 			{

--- a/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GroupBoxHandler.cs
@@ -13,7 +13,13 @@ namespace Eto.Mac.Forms.Controls
 		/// </summary>
 		public class EtoContentView : MacPanelView
 		{
-			
+			public EtoContentView()
+			{
+			}
+
+			public EtoContentView(NativeHandle handle) : base(handle)
+			{
+			}
 		}
 
 		public class EtoBox : NSBox, IMacControl

--- a/src/Eto.Mac/Forms/Controls/PanelHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/PanelHandler.cs
@@ -4,6 +4,12 @@ namespace Eto.Mac.Forms.Controls
 	{
 		public class EtoPanelView : MacPanelView
 		{
+			public EtoPanelView()
+			{
+			}
+			public EtoPanelView(NativeHandle handle) : base(handle)
+			{
+			}
 		}
 		
 		protected override NSView CreateControl() => new EtoPanelView();

--- a/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
@@ -61,7 +61,7 @@ namespace Eto.Mac.Forms.Controls
 			{
 			}
 
-			public EtoDocumentView(IntPtr handle)
+			public EtoDocumentView(NativeHandle handle)
 				: base(handle)
 			{
 				

--- a/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
@@ -91,9 +91,9 @@ namespace Eto.Mac.Forms.Controls
 	{
 		public WeakReference WeakHandler { get; set; }
 
-		IMacViewHandler Handler => WeakHandler.Target as IMacViewHandler;
-		IMacText TextHandler => WeakHandler.Target as IMacText;
-		ITextBoxWithMaxLength MaxLengthHandler => WeakHandler.Target as ITextBoxWithMaxLength;
+		IMacViewHandler Handler => WeakHandler?.Target as IMacViewHandler;
+		IMacText TextHandler => WeakHandler?.Target as IMacText;
+		ITextBoxWithMaxLength MaxLengthHandler => WeakHandler?.Target as ITextBoxWithMaxLength;
 
 		public int MaxLength { get { return MaxLengthHandler?.MaxLength ?? 0; } }
 		

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -155,7 +155,7 @@ namespace Eto.Mac.Forms
 		{
 		}
 
-		public EtoContentView(IntPtr handle) : base(handle)
+		public EtoContentView(NativeHandle handle) : base(handle)
 		{
 		}
 	}

--- a/src/Eto.Mac/Forms/TableLayoutHandler.cs
+++ b/src/Eto.Mac/Forms/TableLayoutHandler.cs
@@ -37,6 +37,10 @@ namespace Eto.Mac.Forms
 		{
 			new TableLayoutHandler Handler => (TableLayoutHandler)base.Handler;
 
+			public EtoTableLayoutView(NativeHandle handle) : base(handle)
+			{
+			}
+
 			public EtoTableLayoutView()
 			{
 				AutoresizesSubviews = false;


### PR DESCRIPTION
These cause crashes especially when opening/closing forms on macOS.