### PR TITLE
Wpf: Ensure TreeGridItem is expandable before checking if Expanded is true

### DIFF
--- a/src/Eto.WinForms/CustomControls/TreeController.cs
+++ b/src/Eto.WinForms/CustomControls/TreeController.cs
@@ -76,7 +76,7 @@ namespace Eto.CustomControls
 				for (int row = 0; row < Store.Count; row++)
 				{
 					var item = Store[row];
-					if (item.Expanded)
+					if (item.Expandable && item.Expanded)
 					{
 						var children = (ITreeGridStore<ITreeGridItem>)item;
 						var section = new TreeController { StartRow = row, Handler = Handler, parent = this };

--- a/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -240,7 +240,7 @@ namespace Eto.Wpf.Forms.Controls
 				{
 					position = GridDragPosition.After;
 					var treeGridItem = item as ITreeGridItem;
-					if (treeGridItem?.Expanded == true)
+					if (treeGridItem?.Expandable == true && treeGridItem?.Expanded == true)
 					{
 						// insert as a child of the parent
 						parent = item;


### PR DESCRIPTION
Technically, `ITreeGridItem.Expanded` should not be true if it is not expandable, but in the case that perhaps it is true but you don't want it to expand then that should be supported.  This fixes issues dropping after items if they report expanded but are not expandable.

