### PR TITLE
Mac: no need to measure when setting CheckBox.BackgroundColor

### DIFF
--- a/src/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/CheckBoxHandler.cs
@@ -178,10 +178,5 @@ namespace Eto.Mac.Forms.Controls
 			set { Control.AllowsMixedState = value; }
 		}
 
-		protected override void SetBackgroundColor(Color? color)
-		{
-			base.SetBackgroundColor(color);
-			InvalidateMeasure();
-		}
 	}
 }


### PR DESCRIPTION
This can have unintended effects such as when scrolling and the background color is set it would cause the smooth scrolling to stutter.