### PR TITLE
Mac: Fix possible NRE when firing MouseEnter/Leave

### DIFF
--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -58,20 +58,20 @@ namespace Eto.Mac.Forms
 			var h = Handler;
 			if (h == null || !entered) return;
 			entered = false;
+			var theEvent = NSApplication.SharedApplication.CurrentEvent;
+			var args = MacConversions.GetMouseEvent(h, theEvent, false);
 			if (async)
 			{
 				Application.Instance.AsyncInvoke(() =>
 				{
 					if (h.Widget.IsDisposed)
 						return;
-					var theEvent = NSApplication.SharedApplication.CurrentEvent;
-					h.Callback.OnMouseLeave(h.Widget, MacConversions.GetMouseEvent(h, theEvent, false));
+					h.Callback.OnMouseLeave(h.Widget, args);
 				});
 			}
 			else
 			{
-				var theEvent = NSApplication.SharedApplication.CurrentEvent;
-				h.Callback.OnMouseLeave(h.Widget, MacConversions.GetMouseEvent(h, theEvent, false));
+				h.Callback.OnMouseLeave(h.Widget, args);
 			}
 		}
 
@@ -80,20 +80,20 @@ namespace Eto.Mac.Forms
 			var h = Handler;
 			if (h == null || entered) return;
 			entered = true;
+			var theEvent = NSApplication.SharedApplication.CurrentEvent;
+			var args = MacConversions.GetMouseEvent(h, theEvent, false);
 			if (async)
 			{
 				Application.Instance.AsyncInvoke(() =>
 				{
 					if (h.Widget.IsDisposed)
 						return;
-					var theEvent = NSApplication.SharedApplication.CurrentEvent;
-					h.Callback.OnMouseEnter(h.Widget, MacConversions.GetMouseEvent(h, theEvent, false));
+					h.Callback.OnMouseEnter(h.Widget, args);
 				});
 			}
 			else
 			{
-				var theEvent = NSApplication.SharedApplication.CurrentEvent;
-				h.Callback.OnMouseEnter(h.Widget, MacConversions.GetMouseEvent(h, theEvent, false));
+				h.Callback.OnMouseEnter(h.Widget, args);
 			}
 		}
 		

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -187,15 +187,28 @@ namespace Eto.Mac
 
 		public static MouseEventArgs GetMouseEvent(IMacViewHandler handler, NSEvent theEvent, bool includeWheel)
 		{
-			var view = handler.ContainerControl;
-			var pt = theEvent.LocationInWindow;
-			pt = handler.GetAlignmentPointForFramePoint(pt);
-			Keys modifiers = theEvent.ModifierFlags.ToEto();
-			MouseButtons buttons = theEvent.GetMouseButtons();
 			SizeF? delta = null;
-			if (includeWheel)
-				delta = new SizeF((float)theEvent.DeltaX, (float)theEvent.DeltaY);
-			return new MouseEventArgs(buttons, modifiers, pt.ToEto(view), delta);
+			PointF point;
+			Keys modifiers;
+			MouseButtons buttons;
+			if (theEvent != null)
+			{
+				var view = handler.ContainerControl;
+				var pt = theEvent.LocationInWindow;
+				pt = handler.GetAlignmentPointForFramePoint(pt);
+				point = pt.ToEto(view);
+				if (includeWheel)
+					delta = new SizeF((float)theEvent.DeltaX, (float)theEvent.DeltaY);
+				modifiers = theEvent.ModifierFlags.ToEto();
+				buttons = theEvent.GetMouseButtons();
+			}
+			else
+			{
+				point = handler.Widget.PointFromScreen(Mouse.Position);
+				modifiers = Keyboard.Modifiers;
+				buttons = Mouse.Buttons;
+			}
+			return new MouseEventArgs(buttons, modifiers, point, delta);
 		}
 
 		public static MouseButtons GetMouseButtons(this NSEvent theEvent)


### PR DESCRIPTION
This is a regression from #2532 to better capture mouse event info and also prevent an NRE when the event is null.