### PR TITLE
DataObject/Clipboard enhancements

### DIFF
--- a/src/Eto.Gtk/Forms/ClipboardHandler.cs
+++ b/src/Eto.Gtk/Forms/ClipboardHandler.cs
@@ -177,15 +177,34 @@ namespace Eto.GtkSharp.Forms
 
 		public bool TrySetObject(object value, string type) => false;
 
-		public bool TryGetObject(string type, out object value)
+		public bool TryGetObject(string type, Type objectType, out object value)
 		{
+			if (objectType == null || objectType == typeof(string))
+			{
+				if (DataObjectHandler.string_types.Contains(type, StringComparer.OrdinalIgnoreCase))
+				{
+					value = GetString(type);
+					if (value != null)
+						return true;
+				}
+			}
+			if (objectType == null || objectType == typeof(Bitmap))
+			{
+				if (DataObjectHandler.image_types.Contains(type, StringComparer.OrdinalIgnoreCase))
+				{
+					value = new Bitmap(GetData(type));
+					return true;
+				}
+			}
+
 			value = null;
 			return false;
 		}
 
 		public void SetObject(object value, string type) => Widget.SetObject(value, type);
-
 		public T GetObject<T>(string type) => Widget.GetObject<T>(type);
+		public object GetObject(string type, Type objectType) => Widget.GetObject(type, objectType);
+		public object GetObject(string type) => Widget.GetObject(type);
 
 		public string[] Types
 		{

--- a/src/Eto.Gtk/Forms/DataObjectHandler.cs
+++ b/src/Eto.Gtk/Forms/DataObjectHandler.cs
@@ -211,8 +211,28 @@ namespace Eto.GtkSharp.Forms
 
 		public bool TrySetObject(object value, string type) => false;
 
-		public bool TryGetObject(string type, out object value)
+		internal static string[] string_types = { "UTF8_STRING", "TEXT", "STRING", "text/html", "text/plain" };
+		internal static string[] image_types = { "image/pixbuf", "image/png", "image/tiff", "image/bmp", "image/jpeg" };
+
+		public bool TryGetObject(string type, Type objectType, out object value)
 		{
+			if (objectType == null || objectType == typeof(string))
+			{
+				if (string_types.Contains(type, StringComparer.OrdinalIgnoreCase))
+				{
+					value = GetString(type);
+					if (value != null)
+						return true;
+				}
+			}
+			if (objectType == null || objectType == typeof(Bitmap))
+			{
+				if (image_types.Contains(type, StringComparer.OrdinalIgnoreCase))
+				{
+					value = new Bitmap(GetData(type));
+					return true;
+				}
+			}
 			value = null;
 			return false;
 		}
@@ -220,6 +240,8 @@ namespace Eto.GtkSharp.Forms
 		public void SetObject(object value, string type) => Widget.SetObject(value, type);
 
 		public T GetObject<T>(string type) => Widget.GetObject<T>(type);
+		public object GetObject(string type, Type objectType) => Widget.GetObject(type, objectType);
+		public object GetObject(string type) => Widget.GetObject(type);
 
 		public string[] Types
 		{

--- a/src/Eto.Mac/Forms/DataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/DataObjectHandler.cs
@@ -195,12 +195,37 @@ namespace Eto.Mac.Forms
 			return Control.GetAvailableTypeFromArray(new[] { type }) != null;
 		}
 
-		public bool TryGetObject(string type, out object value)
+		public bool TryGetObject(string type, Type objectType, out object value)
 		{
-			if (type == NSPasteboard.NSPasteboardTypeColor)
+			if (objectType == null || objectType == typeof(Color))
 			{
-				value = NSColor.FromPasteboard(Control)?.ToEto();
-				return true;
+				if (type == NSPasteboard.NSPasteboardTypeColor)
+				{
+					value = NSColor.FromPasteboard(Control)?.ToEto();
+					return true;
+				}
+			}
+			if (objectType == null || objectType == typeof(string))
+			{
+				if (type == NSPasteboard.NSPasteboardTypeString
+					|| type == NSPasteboard.NSPasteboardTypeTabularText
+					|| type == NSPasteboard.NSPasteboardTypeUrl
+					|| type == NSPasteboard.NSPasteboardTypeFileUrl
+					|| type == NSPasteboard.NSPasteboardTypeRTF
+					|| type == NSPasteboard.NSPasteboardTypeHTML)
+				{
+					value = GetString(type);
+					return true;
+				}
+			}
+			if (objectType == null || objectType == typeof(Bitmap))
+			{
+				if (type == NSPasteboard.NSPasteboardTypeTIFF
+					|| type == NSPasteboard.NSPasteboardTypePNG)
+				{
+					value = new Bitmap(new MemoryStream(GetData(type)));
+					return true;
+				}
 			}
 			value = null;
 			return false;
@@ -219,5 +244,7 @@ namespace Eto.Mac.Forms
 		public void SetObject(object value, string type) => Widget.SetObject(value, type);
 
 		public T GetObject<T>(string type) => Widget.GetObject<T>(type);
+		public object GetObject(string type, Type objectType) => Widget.GetObject(type, objectType);
+		public object GetObject(string type) => Widget.GetObject(type);
 	}
 }

--- a/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/MemoryDataObjectHandler.cs
@@ -193,14 +193,40 @@ namespace Eto.Mac.Forms
 			return false;
 		}
 
-		public bool TryGetObject(string type, out object value)
+		public bool TryGetObject(string type, Type objectType, out object value)
 		{
-			var colorItem = GetDataItem<ColorItem>(type);
-			if (colorItem != null)
+			if (objectType == null || objectType == typeof(Color))
 			{
-				value = colorItem.Value.ToEto();
-				return true;
+				var colorItem = GetDataItem<ColorItem>(type);
+				if (colorItem != null)
+				{
+					value = colorItem.Value.ToEto();
+					return true;
+				}
 			}
+			if (objectType == null || objectType == typeof(string))
+			{
+				if (type == NSPasteboard.NSPasteboardTypeString
+					|| type == NSPasteboard.NSPasteboardTypeTabularText
+					|| type == NSPasteboard.NSPasteboardTypeUrl
+					|| type == NSPasteboard.NSPasteboardTypeFileUrl
+					|| type == NSPasteboard.NSPasteboardTypeRTF
+					|| type == NSPasteboard.NSPasteboardTypeHTML)
+				{
+					value = GetString(type);
+					return true;
+				}
+			}
+			if (objectType == null || objectType == typeof(Bitmap))
+			{
+				if (type == NSPasteboard.NSPasteboardTypeTIFF
+					|| type == NSPasteboard.NSPasteboardTypePNG)
+				{
+					value = new Bitmap(new MemoryStream(GetData(type)));
+					return true;
+				}
+			}
+			
 			value = null;
 			return false;
 		}
@@ -208,5 +234,7 @@ namespace Eto.Mac.Forms
 		public void SetObject(object value, string type) => Widget.SetObject(value, type);
 
 		public T GetObject<T>(string type) => Widget.GetObject<T>(type);
+		public object GetObject(string type, Type objectType) => Widget.GetObject(type, objectType);
+		public object GetObject(string type) => Widget.GetObject(type);
 	}
 }

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -554,5 +554,14 @@ namespace Eto
 		{
 			CLOSE = 0xF060
 		}
+		
+		[DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+		public static extern IntPtr GlobalLock(IntPtr handle);
+
+		[DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+		public static extern bool GlobalUnlock(IntPtr handle);
+
+		[DllImport("kernel32.dll", CharSet = CharSet.Auto)]
+		public static extern int GlobalSize(IntPtr handle);
 	}
 }

--- a/src/Eto.Wpf/Forms/ClipboardHandler.cs
+++ b/src/Eto.Wpf/Forms/ClipboardHandler.cs
@@ -8,6 +8,8 @@ namespace Eto.Wpf.Forms
 			Control = new sw.DataObject();
 		}
 
+		public override sw.IDataObject ReadingDataObject => sw.Clipboard.GetDataObject();
+
 		public override string[] Types => sw.Clipboard.GetDataObject()?.GetFormats();
 
 		protected override void Update()

--- a/src/Eto/Forms/ObjectData.cs
+++ b/src/Eto/Forms/ObjectData.cs
@@ -1,0 +1,93 @@
+using System;
+using System.IO;
+using System.Runtime.Serialization;
+using System.Text;
+
+namespace Eto.Forms;
+
+[DataContract(Name = nameof(ObjectData))]
+class ObjectDataSurrogate
+{
+	[DataMember]
+	public string TypeName { get; set; }
+}
+
+[DataContract]
+class ObjectData
+{
+	internal static bool CanSerialize(Type type) => type == null || type.IsSerializable || type.GetCustomAttribute<DataContractAttribute>() != null;
+	internal static byte[] Serialize(object value, Type baseType)
+	{
+		var data = new ObjectData
+		{
+			TypeName = baseType.AssemblyQualifiedName,
+			Value = value
+		};
+
+		using (var ms = new MemoryStream())
+		{
+			var serializer = new DataContractSerializer(typeof(ObjectData), new [] { baseType });
+			serializer.WriteObject(ms, data);
+			
+			// for debugging
+			// var str = Encoding.UTF8.GetString(ms.ToArray());
+			
+			return ms.ToArray();
+		}
+	}
+
+	internal static object Deserialize(Stream stream, Type objectType)
+	{
+		MemoryStream ms = null;
+
+		// for debugging
+		// var str = new StreamReader(stream).ReadToEnd();
+		// stream.Position = 0;
+
+		if (objectType == null)
+		{
+			// we need to be able to seek so we can read twice
+			if (!stream.CanSeek)
+			{
+				ms = new MemoryStream();
+				stream.CopyTo(ms);
+				stream = ms;
+			}
+			
+			// we don't know the type, read it from the stream first
+			var serializer = new DataContractSerializer(typeof(ObjectDataSurrogate));
+			var dataType = serializer.ReadObject(stream) as ObjectDataSurrogate;
+			if (dataType == null)
+			{
+				ms?.Dispose();
+				return null;
+			}
+			objectType = Type.GetType(dataType.TypeName, false);
+			if (objectType == null)
+			{
+				ms?.Dispose();
+				return null;
+			}
+		}
+
+		{
+			// read again, but with known type populated
+			stream.Position = 0;
+			var serializer = new DataContractSerializer(typeof(ObjectData), new[] { objectType });
+			var data = serializer.ReadObject(stream) as ObjectData;
+
+			ms?.Dispose();
+
+			if (data == null)
+				return null;
+
+			return data.Value;
+		}
+	}
+
+	[DataMember]
+	public string TypeName { get; set; }
+	[DataMember]
+	public object Value { get; set; }
+
+}

--- a/test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
@@ -32,6 +32,12 @@ namespace Eto.Test.Sections.Behaviors
 				clipboard.SetString("my value", "my.custom.type");
 				Update();
 			};
+			var copyObjectButton = new Button { Text = "Copy Object" };
+			copyObjectButton.Click += (sender, e) =>
+			{
+				clipboard.SetObject(new DragDropSection.CustomSerializableType { Name = "Woot" }, "my.custom.object");
+				Update();
+			};
 
 			var pasteTextButton = new Button { Text = "Paste" };
 			pasteTextButton.Click += (sender, e) => Update();
@@ -54,7 +60,7 @@ namespace Eto.Test.Sections.Behaviors
 						Orientation = Orientation.Horizontal, 
 						Spacing = 5,
 						Padding = new Padding(10),
-						Items = { copyTextButton, copyHtmlButton, copyImageButton, copyCustomButton, pasteTextButton, clearButton }
+						Items = { copyTextButton, copyHtmlButton, copyImageButton, copyCustomButton, copyObjectButton, pasteTextButton, clearButton }
 					},
 					new StackLayoutItem(pasteData, expand: true)
 				}
@@ -98,15 +104,20 @@ namespace Eto.Test.Sections.Behaviors
 					var data = clipboard.GetData(type);
 					if (data != null)
 					{
-						panel.Items.Add(string.Format("- Data, Length: {0}", data.Length));
+						panel.Items.Add($"- Data, Length: {data.Length}");
 						var hexString = BitConverter.ToString(data);
 						panel.Items.Add(hexString.Substring(0, Math.Min(hexString.Length, 1000)));
 					}
 					var str = clipboard.GetString(type);
 					if (str != null)
 					{
-						panel.Items.Add(string.Format("- String, Length: {0}", str.Length));
+						panel.Items.Add($"- String, Length: {str.Length}");
 						panel.Items.Add(str);
+					}
+					var obj = clipboard.GetObject(type);
+					if (obj != null)
+					{
+						panel.Items.Add($"- Object, Type: {obj.GetType()}: {obj}");
 					}
 				}
 			}

--- a/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/DragDropSection.cs
@@ -12,6 +12,23 @@ namespace Eto.Test.Sections.Behaviors
 		TextBox innerTextBox;
 		CheckBox writeDataCheckBox;
 		EnumDropDown<DragEffects> allowedEffectDropDown;
+		
+		[DataContract]
+		public class CustomDataContractType
+		{
+			[DataMember]
+			public string Name { get; set; }
+
+			public override string ToString() => Name;
+		}
+		
+		[Serializable]
+		public class CustomSerializableType
+		{
+			public string Name { get; set; }
+
+			public override string ToString() => Name;
+		}
 
 		public DragDropSection()
 		{
@@ -61,6 +78,9 @@ namespace Eto.Test.Sections.Behaviors
 					data.Html = htmlTextArea.Text;
 				if (includeImageCheck.Checked == true)
 					data.Image = TestIcons.Logo;
+					
+				data.SetObject(new CustomDataContractType { Name = "Hello Data Contract!" }, "my.custom.datacontract.type");
+				data.SetObject(new CustomSerializableType { Name = "Hello Serializable!" }, "my.custom.serializable.type");
 
 				return data;
 			}
@@ -445,15 +465,33 @@ namespace Eto.Test.Sections.Behaviors
 					var d = data.GetData(format);
 					if (d != null)
 					{
-						var s = string.Join(",", d.Select(r => r.ToString()).Take(1000));
-						Log.Write(null, $"\t{format}: {s}");
+						var s = string.Join(",", d.Select(r => r.ToString()).Take(10));
+						Log.Write(null, $"\t{format}: data: {d.Length} bytes ({s})");
 					}
 					else
-						Log.Write(null, $"\t{format}: {d}");
+						Log.Write(null, $"\t{format}: data: <null>");
 				}
-				catch
+				catch (Exception ex)
 				{
-
+					Log.Write(null, $"Error getting data for {format}, {ex.Message}");
+				}
+				
+				try
+				{
+					var obj = data.GetObject(format);
+					if (obj != null)
+					{
+						object val = null;
+						if (obj.ToString() != obj.GetType().ToString())
+							val = obj;
+						Log.Write(null, $"\t{format}: object: {obj.GetType()} {val}");
+						if (obj is string[] strings)
+							Log.Write(null, $"\t\tvalues: {string.Join(";", strings)}");
+					}
+				}
+				catch (Exception ex)
+				{
+					Log.Write(null, $"Error getting object for {format}, {ex.Message}");
 				}
 			}
 		}


### PR DESCRIPTION
- Switches out BinarySerializer to DataContractSerializer for GetObject/SetObject
- Support [DataContract] types for GetObject/SetObject (in addition to Serializable)
- Add GetObject() override that takes desired type (vs. having to use a generic method)
- GetObject() returns object for known format types for String, Bitmap, Color (mac)
- Wpf/WinForms: GetData() returns byte data for more types
- Wpf: Prevent crash getting data for FileContents, and return MemoryStream[] with GetObject()