### PR TITLE
Wpf/WinForms: Fallback to getting raw stream if converting the value to byte data doesn't work

### DIFF
--- a/src/Eto.Wpf/Forms/DataObjectHandler.cs
+++ b/src/Eto.Wpf/Forms/DataObjectHandler.cs
@@ -303,7 +303,7 @@ namespace Eto.WinForms.Forms
 			catch
 			{
 			}
-			
+
 			return null;
 			
 		}
@@ -329,7 +329,7 @@ namespace Eto.WinForms.Forms
 					}
 				}
 
-				return GetAsData(GetObjectData(type));
+				return GetAsData(GetObjectData(type)) ?? GetAsData(GetStream(type));
 			}
 			return null;
 		}


### PR DESCRIPTION
- DataObject.GetData() returns null for FileDrop type (or any other string array)

This is a follow up to #2535