### PR TITLE
Don't attach a dialog when launched from an NSPanel

### DIFF
--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -137,7 +137,7 @@ namespace Eto.Mac.Forms
 					return false;
 
 				// if the owner can't become main (e.g. NSPanel), show as attached
-				return !owner.CanBecomeMainWindow;
+				return !owner.CanBecomeMainWindow && owner is not NSPanel;
 			}
 		}
 


### PR DESCRIPTION
When showing a Dialog from an NSPanel on macOS, we shouldn't attach the dialog as NSPanels are not really intended to be used that way.  You can still override this behaviour by setting the DisplayMode of the dialog explicitly.

For example, a FloatingForm (NSPanel) should never really automatically use an attached dialog unless it has been explicitly set.