### PR TITLE
Mac/WinForms/Wpf: Wire up DataObject.NativeHandle

### DIFF
--- a/src/Eto.Mac/Forms/DataObjectHandler.cs
+++ b/src/Eto.Mac/Forms/DataObjectHandler.cs
@@ -33,6 +33,8 @@ namespace Eto.Mac.Forms
 	{
 		nint _changeCount;
 
+		public override IntPtr NativeHandle => Control.Handle;
+
 		void ClearIfNeeded()
 		{
 			if (Control.ChangeCount != _changeCount)

--- a/src/Eto.Wpf/Forms/DataObjectHandler.cs
+++ b/src/Eto.Wpf/Forms/DataObjectHandler.cs
@@ -105,6 +105,8 @@ namespace Eto.WinForms.Forms
 
 		public virtual sw.IDataObject ReadingDataObject => Control;
 
+		public override IntPtr NativeHandle => Marshal.GetComInterfaceForObject(Control, typeof(System.Runtime.InteropServices.ComTypes.IDataObject));
+
 		public DataObjectHandler()
 		{
 		}


### PR DESCRIPTION
This allows better interop with native code, when needed.