### PR TITLE
Wpf: Fix GDI handle issues when using resized Bitmaps

### DIFF
--- a/src/Eto.Wpf/Drawing/BitmapHandler.cs
+++ b/src/Eto.Wpf/Drawing/BitmapHandler.cs
@@ -119,8 +119,14 @@ namespace Eto.Wpf.Drawing
 				drawingContext.DrawDrawing(group);
 
 			var resizedImage = new swmi.RenderTargetBitmap(width, height, source.DpiX, source.DpiY, swm.PixelFormats.Default);
-			resizedImage.RenderWithCollect(drawingVisual);
-			Control = resizedImage;
+			resizedImage.Render(drawingVisual);
+
+			// Don't use RenderTargetBitmap directly, it can run out of GDI handles when you have many bitmaps.
+			var writable = new swmi.WriteableBitmap(resizedImage);
+			Control = writable;
+
+			// collect immediately to get rid of the handle use
+			GC.Collect(GC.MaxGeneration, GCCollectionMode.Forced, false);
 		}
 
 		protected override void Initialize()


### PR DESCRIPTION
This fixes an issue if you keep many resized images in memory, each one will use upwards of 4+ GDI handles, and since there's only 10000 available per process this can cause a COMException.  The main takeaway here is we should never be storing a WPF RenderTargetBitmap as it can exhaust GDI handles pretty easily especially when dealing with numerous small bitmaps.

See https://github.com/dotnet/wpf/issues/3067 for more context.