### PR TITLE
Wpf: Don't store RenderTargetBitmap anywhere

### DIFF
--- a/src/Eto.Wpf/Drawing/BitmapHandler.cs
+++ b/src/Eto.Wpf/Drawing/BitmapHandler.cs
@@ -137,6 +137,8 @@ namespace Eto.Wpf.Drawing
 
 		public void SetBitmap(swmi.BitmapSource bitmap)
 		{
+			if (bitmap is swmi.RenderTargetBitmap)
+				bitmap = new swmi.WriteableBitmap(bitmap);
 			Control = bitmap;
 			SetFrozen();
 		}

--- a/src/Eto.Wpf/Drawing/CachedBitmapFrame.cs
+++ b/src/Eto.Wpf/Drawing/CachedBitmapFrame.cs
@@ -38,10 +38,11 @@ namespace Eto.Wpf.Drawing
 			// There's no way to get around it other than just not creating that many and using GC.Collect/WaitForPendingFinalizers.
 			// we can't do it in Eto as it'd be a serious performance hit.
 			var target = new swmi.RenderTargetBitmap(scaledwidth, scaledheight, 96 * scale, 96 * scale, swm.PixelFormats.Default);
-			target.Render(targetVisual);
-			target.Freeze();
+			target.RenderWithCollect(targetVisual);
+			
+			var writable = new swmi.WriteableBitmap(target);
 
-			_cachedFrame = swmi.BitmapFrame.Create(target);
+			_cachedFrame = swmi.BitmapFrame.Create(writable);
 			_cachedFrame.Freeze();
 			_scale = scale;
 			_width = width;


### PR DESCRIPTION
This is a follow up to #2552 and helps keep the limited GDI handles down as each one in memory uses them up.