### PR TITLE
Fix RectangleF.Contains(pointf)

### DIFF
--- a/src/Eto/Drawing/Rectangle.cs
+++ b/src/Eto/Drawing/Rectangle.cs
@@ -184,7 +184,7 @@ public struct Rectangle : IEquatable<Rectangle>
 	{
 		if (Width == 0 || Height == 0)
 			return false;
-		return (x >= Left && x <= InnerRight && y >= Top && y <= InnerBottom);
+		return x >= Left && x < Right && y >= Top && y < Bottom;
 	}
 
 	/// <summary>

--- a/src/Eto/Drawing/RectangleF.cs
+++ b/src/Eto/Drawing/RectangleF.cs
@@ -149,7 +149,7 @@ public struct RectangleF : IEquatable<RectangleF>
 	{
 		if (Width == 0 || Height == 0)
 			return false;
-		return (x >= Left && x <= InnerRight && y >= Top && y <= InnerBottom);
+		return x >= Left && x < Right && y >= Top && y < Bottom;
 	}
 
 	/// <summary>


### PR DESCRIPTION
`new RectangleF(2f, 2f).Contains(1.5f, 1.5f)` would return false as this is incorrectly using `InnerRight`/`InnerBottom`.  Also changed `Rectangle.Contains()` to not use those as well though it doesn't change their behaviour..