### PR TITLE
Mac: Fix Drawable clipping to bounds on macOS Sonoma

### DIFF
--- a/src/Eto.Mac/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Mac/Drawing/GraphicsHandler.cs
@@ -83,13 +83,18 @@ namespace Eto.iOS.Drawing
 		}
 
 		#if OSX
-		public GraphicsHandler(NSView view, NSGraphicsContext graphicsContext, float height)
+		public GraphicsHandler(NSView view, NSGraphicsContext graphicsContext, float height, CGRect? dirtyRect)
 		{
 			DisplayView = view;
 			this.height = height;
 			var flipped = view?.IsFlipped ?? false;
 			this.graphicsContext = graphicsContext.IsFlipped ? graphicsContext : NSGraphicsContext.FromCGContext(graphicsContext.CGContext, true);
 			Control = this.graphicsContext.CGContext;
+			
+			// Clip to bounds otherwise you can draw outside the control on macOS Sonoma
+			if (dirtyRect != null)
+				Control.ClipToRect(dirtyRect.Value);
+				
 			InitializeContext(!flipped);
 		}
 

--- a/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
@@ -69,7 +69,7 @@ namespace Eto.Mac.Forms.Cells
 				}
 
 				var handler = Handler;
-				var graphicsHandler = new GraphicsHandler(inView, nscontext, (float)cellFrame.Height);
+				var graphicsHandler = new GraphicsHandler(inView, nscontext, (float)cellFrame.Height, cellFrame);
 				using (var graphics = new Graphics(graphicsHandler))
 				{
 					var state = Highlighted ? CellStates.Selected : CellStates.None;
@@ -167,7 +167,7 @@ namespace Eto.Mac.Forms.Cells
 				var handler = Handler;
 				if (handler == null)
 					return;
-				var graphicsHandler = new GraphicsHandler(this, nscontext, (float)cellFrame.Height);
+				var graphicsHandler = new GraphicsHandler(this, nscontext, (float)cellFrame.Height, cellFrame);
 				using (var graphics = new Graphics(graphicsHandler))
 				{
 					var rowView = this.Superview as NSTableRowView;

--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -36,12 +36,8 @@ namespace Eto.Mac.Forms.Controls
 				
 				if (!IsFlipped)
 					dirty.Y = bounds.Height - dirty.Y - dirty.Height;
-				if (dirty.X % 1.0f > 0f)
-					dirty.Width += 1;
-				if (dirty.Y % 1.0f > 0f)
-					dirty.Height += 1;
 				ApplicationHandler.QueueResizing = true;
-				drawable.DrawRegion(Rectangle.Ceiling(dirty));
+				drawable.DrawRegion(dirty);
 				ApplicationHandler.QueueResizing = false;
 			}
 
@@ -120,14 +116,12 @@ namespace Eto.Mac.Forms.Controls
 			base.Invalidate(rect, invalidateChildren);
 		}
 
-		void DrawRegion(Rectangle rect)
+		void DrawRegion(RectangleF rect)
 		{
 			var context = NSGraphicsContext.CurrentContext;
 			if (context != null)
 			{
-				var handler = new GraphicsHandler(Control, context, (float)Control.Frame.Height);
-				// macOS Sonoma can draw outside the bounds of the NSView, so clip to the drawing rectangle
-				handler.Control.ClipToRect(rect.ToNS());
+				var handler = new GraphicsHandler(Control, context, (float)Control.Frame.Height, rect.ToNS());
 				
 				using (var graphics = new Graphics(handler))
 				{

--- a/src/Eto.Mac/Forms/Printing/PrintDocumentHandler.cs
+++ b/src/Eto.Mac/Forms/Printing/PrintDocumentHandler.cs
@@ -67,7 +67,7 @@ namespace Eto.Mac.Forms.Printing
 				var height = Frame.Height;
 				var pageRect = RectForPage(operation.CurrentPage);
 
-				using (var graphics = new Graphics(new GraphicsHandler(this, context, (float)height)))
+				using (var graphics = new Graphics(new GraphicsHandler(this, context, (float)height, pageRect)))
 				{
 					graphics.TranslateTransform((float)pageRect.X, (float)(height-pageRect.Y-pageRect.Height));
 					Handler.Callback.OnPrintPage(Handler.Widget, new PrintPageEventArgs(graphics, operation.PrintInfo.ImageablePageBounds.Size.ToEto(), (int)operation.CurrentPage - 1));


### PR DESCRIPTION
Some operations with Graphics would reset the clipping region so it would be able to draw outside the bounds of the control.