### PR TITLE
Mac: Fix regression with Drawable clipping

### DIFF
--- a/src/Eto.Mac/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Mac/Drawing/GraphicsHandler.cs
@@ -83,7 +83,7 @@ namespace Eto.iOS.Drawing
 		}
 
 		#if OSX
-		public GraphicsHandler(NSView view, NSGraphicsContext graphicsContext, float height, CGRect? dirtyRect)
+		public GraphicsHandler(NSView view, NSGraphicsContext graphicsContext, float height, CGRect? clipRect)
 		{
 			DisplayView = view;
 			this.height = height;
@@ -92,8 +92,8 @@ namespace Eto.iOS.Drawing
 			Control = this.graphicsContext.CGContext;
 			
 			// Clip to bounds otherwise you can draw outside the control on macOS Sonoma
-			if (dirtyRect != null)
-				Control.ClipToRect(dirtyRect.Value);
+			if (clipRect != null)
+				Control.ClipToRect(clipRect.Value);
 				
 			InitializeContext(!flipped);
 		}


### PR DESCRIPTION
We were using the flipped dirty rect to clip to when it was expecting a non-flipped rect.  Now we clip to the dirty rect first then flip so we get the right coordinates in PaintEventArgs.ClipRectangle.