### PR TITLE
Mac: Fix some memory leaks

### DIFF
--- a/src/Eto.Mac/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Mac/Drawing/GraphicsHandler.cs
@@ -111,6 +111,11 @@ namespace Eto.iOS.Drawing
 
 		protected override void Dispose(bool disposing)
 		{
+			if (disposing)
+			{
+				_formattedText?.Dispose();
+				_formattedText = null;
+			}
 			base.Dispose(disposing);
 		}
 

--- a/src/Eto.Mac/Forms/MacBase.cs
+++ b/src/Eto.Mac/Forms/MacBase.cs
@@ -57,7 +57,6 @@ namespace Eto.Mac.Forms
 			if (!isNotification && c != null)
 			{
 				NSNotificationCenter.DefaultCenter.AddObserver(this, selPerformAction, KeyPath, c);
-				c.DangerousRetain();
 				isNotification = true;
 			}
 		}
@@ -69,12 +68,10 @@ namespace Eto.Mac.Forms
 			{
 				//Console.WriteLine ("{0}: 3. Adding observer! {1}, {2}", ((IRef)this.Handler).WidgetID, this.GetType (), Control.GetHashCode ());
 				c.AddObserver(this, KeyPath, NSKeyValueObservingOptions.New, IntPtr.Zero);
-				c.DangerousRetain();
 				isControl = true;
 			}
 		}
 
-		static readonly IntPtr selRelease_Handle = Selector.GetHandle("release");
 		static readonly IntPtr selRemoveObserverForKeyPath_Handle = Selector.GetHandle("removeObserver:forKeyPath:");
 
 		public void Remove()
@@ -83,7 +80,6 @@ namespace Eto.Mac.Forms
 			if (isNotification)
 			{
 				NSNotificationCenter.DefaultCenter.RemoveObserver(this);
-				Messaging.void_objc_msgSend(ControlHandle, selRelease_Handle);
 
 				isNotification = false;
 			}
@@ -91,7 +87,6 @@ namespace Eto.Mac.Forms
 			{
 				//Console.WriteLine ("{0}: 4. Removing observer! {1}, {2}", ((IRef)this.Handler).WidgetID, Handler.GetType (), Control.GetHashCode ());
 				Messaging.void_objc_msgSend_IntPtr_IntPtr(ControlHandle, selRemoveObserverForKeyPath_Handle, Handle, KeyPath.Handle);
-				Messaging.void_objc_msgSend(ControlHandle, selRelease_Handle);
 				isControl = false;
 			}
 		}

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -1071,15 +1071,21 @@ namespace Eto.Mac.Forms
 		{
 			base.Initialize();
 
-			// need to send Got/LostFocus to child when window Got/LostFocus is called
-			HandleEvent(Window.LostFocusEvent);
-			HandleEvent(Window.GotFocusEvent);
+			if (!Widget.IsAttached)
+			{
+				// need to send Got/LostFocus to child when window Got/LostFocus is called
+				HandleEvent(Window.LostFocusEvent);
+				HandleEvent(Window.GotFocusEvent);
+			}
 		}
 
 		public override void OnLoad(EventArgs e)
 		{
-			PerformAutoSize();
-			PositionWindow();
+			if (!Widget.IsAttached)
+			{
+				PerformAutoSize();
+				PositionWindow();
+			}
 			base.OnLoad(e);
 		}
 
@@ -1097,14 +1103,17 @@ namespace Eto.Mac.Forms
 		public override void OnLoadComplete(EventArgs e)
 		{
 			base.OnLoadComplete(e);
-			if (initialState != null)
+			if (!Widget.IsAttached)
 			{
-				WindowState = initialState.Value;
-				initialState = null;
-				Callback.OnSizeChanged(Widget, EventArgs.Empty);
+				if (initialState != null)
+				{
+					WindowState = initialState.Value;
+					initialState = null;
+					Callback.OnSizeChanged(Widget, EventArgs.Empty);
+				}
+				else if (!setInitialSize)
+					Callback.OnSizeChanged(Widget, EventArgs.Empty);
 			}
-			else if (!setInitialSize)
-				Callback.OnSizeChanged(Widget, EventArgs.Empty);
 		}
 
 		protected virtual void PositionWindow()

--- a/src/Eto.Mac/MacHelpers.cs
+++ b/src/Eto.Mac/MacHelpers.cs
@@ -94,7 +94,7 @@ namespace Eto.Forms
 			if (window is IMacControl macControl && macControl.WeakHandler?.Target is IMacWindow macWindow)
 				return macWindow.Widget;
 
-			return new Form(new NativeFormHandler(window));
+			return NativeFormHandler.CreateWrapper(null, window);
 		}
 
 		/// <summary>
@@ -106,7 +106,7 @@ namespace Eto.Forms
 		{
 			if (windowController == null)
 				return null;
-			return new Form(new NativeFormHandler(windowController));
+			return NativeFormHandler.CreateWrapper(windowController, null);
 		}
 
 		/// <summary>


### PR DESCRIPTION
- EtoLayoutManager wouldn't GC as it wasn't weak referencing the handler
- Observers don't need an extra retain/release
- When a window is attached, don't do some extra logic
- Cache window instances returned with MacHelpers.ToEtoWindow
- Dispose shared FormattedText when disposing GraphicsHandler