### PR TITLE
Mac: Add border size to Tree/GridView preferred height

### DIFF
--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -703,24 +703,30 @@ namespace Eto.Mac.Forms.Controls
 			var rowCount = RowCount;
 			var range = new NSRange(0, rowCount);
 			var loaded = loadComplete;
-			var width = ColumnHandlers.Sum(r => loaded ? r.Control.Width : r.GetPreferredWidth(range));
-			if (width == 0)
-				width = 100;
+			var size = new SizeF();
+			size.Width = (float)ColumnHandlers.Sum(r => loaded ? r.Control.Width : r.GetPreferredWidth(range));
+			if (size.Width == 0)
+				size.Width = 100;
 
 			if (Border != BorderType.None)
-				width += ScrollView.FrameSizeForContentSize(new CGSize(0, 0), false, false).Width;
+				size += ScrollView.FrameSizeForContentSize(new CGSize(0, 0), false, false).ToEto();
 
 			var intercellSpacing = Control.IntercellSpacing;
-			width += (Control.ColumnCount - 1) * intercellSpacing.Width;
-			width += GetTableRowInsets();
+			size.Width += (Control.ColumnCount - 1) * (float)intercellSpacing.Width;
+			size.Width += (float)GetTableRowInsets();
 
+			var contentHeight = (float)((RowHeight + intercellSpacing.Height) * rowCount);
 			if (ScrollView.HasVerticalScroller && ScrollView.VerticalScroller.ScrollerStyle == NSScrollerStyle.Legacy)
-				width += NSScroller.GetScrollerWidth(ScrollView.VerticalScroller.ControlSize, ScrollView.VerticalScroller.ScrollerStyle);
+			{
+				if (!float.IsNaN(availableSize.Height) && contentHeight > availableSize.Height)
+					size.Width += (float)NSScroller.GetScrollerWidth(ScrollView.VerticalScroller.ControlSize, ScrollView.VerticalScroller.ScrollerStyle);
+			}
 
-			var height = (int)((RowHeight + intercellSpacing.Height) * rowCount);
+			size.Height += contentHeight;
+
 			if (ShowHeader)
-				height += 2 + (int)Control.HeaderView.Frame.Height;
-			return new SizeF((float)width, height);
+				size.Height += 2 + (int)Control.HeaderView.Frame.Height;
+			return size;
 		}
 
 		public void OnCellFormatting(GridCellFormatEventArgs args)

--- a/test/Eto.Test.Mac/UnitTests/GridViewTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/GridViewTests.cs
@@ -92,20 +92,26 @@ namespace Eto.Test.Mac.UnitTests
 		}
 
 		[ManualTest]
-		[TestCase(NSTableViewStyle.FullWidth, -1, "Some Text", 100)]
-		[TestCase(NSTableViewStyle.FullWidth, -1, "Some Much Longer Text That Should Still Work", 100)]
-		[TestCase(NSTableViewStyle.Inset, -1, "Some Text", 100)]
-		[TestCase(NSTableViewStyle.Inset, -1, "Some Much Longer Text That Should Still Work", 100)]
-		[TestCase(NSTableViewStyle.SourceList, -1, "Some Text", 100)]
-		[TestCase(NSTableViewStyle.SourceList, -1, "Some Much Longer Text That Should Still Work", 100)]
-		[TestCase(NSTableViewStyle.Plain, -1, "Some Text", 100)]
-		[TestCase(NSTableViewStyle.Plain, -1, "Some Much Longer Text That Should Still Work", 100)]
+		[TestCase(NSTableViewStyle.FullWidth, -1, "Some Text", 100, 180)]
+		[TestCase(NSTableViewStyle.FullWidth, -1, "Some Text", 15, -1)]
+		[TestCase(NSTableViewStyle.FullWidth, -1, "Some Much Longer Text That Should Still Work", 100, 180)]
+		[TestCase(NSTableViewStyle.Inset, -1, "Some Text", 100, 180)]
+		[TestCase(NSTableViewStyle.Inset, -1, "Some Text", 15, -1)]
+		[TestCase(NSTableViewStyle.Inset, -1, "Some Much Longer Text That Should Still Work", 100, 180)]
+		[TestCase(NSTableViewStyle.SourceList, -1, "Some Text", 100, 180)]
+		[TestCase(NSTableViewStyle.SourceList, -1, "Some Text", 15, -1)]
+		[TestCase(NSTableViewStyle.SourceList, -1, "Some Much Longer Text That Should Still Work", 100, 180)]
+		[TestCase(NSTableViewStyle.Plain, -1, "Some Text", 100, 180)]
+		[TestCase(NSTableViewStyle.Plain, -1, "Some Text", 15, -1)]
+		[TestCase(NSTableViewStyle.Plain, -1, "Some Much Longer Text That Should Still Work", 100, 180)]
 		[TestCase(NSTableViewStyle.Plain, 20, "Some Text", 100)]
-		[TestCase(NSTableViewStyle.Plain, 3, "Some Text", 100)]
-		[TestCase(NSTableViewStyle.Plain, 0, "Some Much Longer Text That Should Still Work", 100)]
-		public void AutoSizedColumnShouldChangeSizeOfControl(NSTableViewStyle style, int intercellSpacing, string text, int rows)
+		[TestCase(NSTableViewStyle.Plain, 20, "Some Text", 15, -1)]
+		[TestCase(NSTableViewStyle.Plain, 3, "Some Text", 100, 180)]
+		[TestCase(NSTableViewStyle.Plain, 3, "Some Text", 15, -1)]
+		[TestCase(NSTableViewStyle.Plain, 0, "Some Much Longer Text That Should Still Work", 100, 180)]
+		public void AutoSizedColumnShouldChangeSizeOfControl(NSTableViewStyle style, int intercellSpacing, string text, int rows, int height)
 		{
-			BaseGridTests.AutoSizedColumnShouldChangeSizeOfControl(text, rows, grid => {
+			BaseGridTests.AutoSizedColumnShouldChangeSizeOfControl(text, rows, height, grid => {
 				SetParameters(style, intercellSpacing, grid);
 			});
 		}

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
@@ -396,22 +396,27 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		}
 
 		[ManualTest]
-		[TestCase("Some Text", 1)]
-		[TestCase("Some Text", 100)]
-		[TestCase("Some Much Longer Text That Should Still Work", 1)]
-		[TestCase("Some Much Longer Text That Should Still Work", 100)]
-		[TestCase("Short", 1)]
-		[TestCase("Short", 100)]
-		public void AutoSizedColumnShouldChangeSizeOfControl(string text, int rows) => AutoSizedColumnShouldChangeSizeOfControl(text, rows, null);
+		[TestCase("Some Text", 1, 180)]
+		[TestCase("Some Text", 15, -1)]
+		[TestCase("Some Text", 100, 180)]
+		[TestCase("Some Much Longer Text That Should Still Work", 1, 180)]
+		[TestCase("Some Much Longer Text That Should Still Work", 15, -1)]
+		[TestCase("Some Much Longer Text That Should Still Work", 100, 180)]
+		[TestCase("Short", 1, 180)]
+		[TestCase("Short", 15, -1)]
+		[TestCase("Short", 100, 180)]
+		public void AutoSizedColumnShouldChangeSizeOfControl(string text, int rows, int height) => AutoSizedColumnShouldChangeSizeOfControl(text, rows, height, null);
 		
-		public void AutoSizedColumnShouldChangeSizeOfControl(string text, int rows, Action<T> customize)
+		public void AutoSizedColumnShouldChangeSizeOfControl(string text, int rows, int height, Action<T> customize)
 		{
-			ManualForm("GridView should auto size to the\ncolumn content and not scroll horizontally", form =>
+			ManualForm($"GridView should auto size to the\ncolumn content and not scroll horizontally{(height == -1 ? " or vertically" : "")}", form =>
 			{
-				var gridView = new T
-				{
-					Height = 180,
-				};
+				var gridView = new T();
+				if (height > 0)
+					gridView.Height = height;
+
+				gridView.ShowHeader = false;
+					
 				customize?.Invoke(gridView);
 				gridView.Columns.Add(new GridColumn
 				{
@@ -420,7 +425,6 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				});
 				
 				var collection = new TreeGridItemCollection();
-				SetDataStore(gridView, collection);
 				DataItem mainItem = null;
 				for (int i = 0; i < rows; i++)
 				{
@@ -429,6 +433,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					if (mainItem == null)
 						mainItem = item;
 				}
+				SetDataStore(gridView, collection);
 
 				var textBox = new TextBox();
 				textBox.Focus();
@@ -451,11 +456,5 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				return layout;
 			});
 		}
-
-		[Test, ManualTest]
-		public void AutoSizedColumnShouldReportCorrectPreferredSize()
-		{
-		}
-
 	}
 }


### PR DESCRIPTION
Also only add scrollbar width if content height is greater than available size