### PR TITLE
Mac: Fix setting background of cells on Sonoma

### DIFF
--- a/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
@@ -59,7 +59,7 @@ namespace Eto.Mac.Forms.Cells
 				if (DrawsBackground && BackgroundColor != null && BackgroundColor.AlphaComponent > 0)
 				{
 					BackgroundColor.Set();
-					NSGraphics.RectFill(dirtyRect);
+					NSGraphics.RectFill(Bounds);
 				}
 				base.DrawRect(dirtyRect);
 			}

--- a/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
@@ -156,13 +156,13 @@ namespace Eto.Mac.Forms.Cells
 				var nscontext = NSGraphicsContext.CurrentContext;
 				var isFirstResponder = Window?.FirstResponder == this;
 
+				var cellFrame = Bounds;
 				if (DrawsBackground)
 				{
 					var context = nscontext.CGContext;
 					context.SetFillColor(BackgroundColor.ToCG());
-					context.FillRect(dirtyRect);
+					context.FillRect(cellFrame);
 				}
-				var cellFrame = Bounds;
 
 				var handler = Handler;
 				if (handler == null)

--- a/src/Eto.Mac/Forms/Cells/ImageViewCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageViewCellHandler.cs
@@ -122,7 +122,7 @@ namespace Eto.Mac.Forms.Cells
 				if (BackgroundColor != null && BackgroundColor.AlphaComponent > 0)
 				{
 					BackgroundColor.Set();
-					NSGraphics.RectFill(dirtyRect);
+					NSGraphics.RectFill(Bounds);
 				}
 				base.DrawRect(dirtyRect);
 			}

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -34,7 +34,7 @@ namespace Eto.Mac.Forms.Controls
 				if (backgroundColor != Colors.Transparent)
 				{
 					backgroundColor.ToNSUI().Set();
-					NSGraphics.RectFill(clipRect);
+					NSGraphics.RectFill(Bounds);
 				}
 				else
 					base.DrawBackground(clipRect);

--- a/src/Eto.Mac/Forms/Controls/MacImageTextView.cs
+++ b/src/Eto.Mac/Forms/Controls/MacImageTextView.cs
@@ -78,16 +78,16 @@
 
         public override void DrawRect(CGRect dirtyRect)
 		{
+			var bounds = Bounds;
             if (BetterBackgroundColor != null)
             {
                 BetterBackgroundColor.SetFill();
-                NSGraphics.RectFill(dirtyRect);
+                NSGraphics.RectFill(bounds);
             }
 
             if (_image != null)
             {
                 var context = NSGraphicsContext.CurrentContext;
-                var bounds = Bounds;
 
                 var imageRect = new CGRect(0, bounds.Y, _imageSize.Width, _imageSize.Height);
                 imageRect.Y += (bounds.Height - _imageSize.Height) / 2;

--- a/src/Eto.Mac/Forms/Controls/TreeViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeViewHandler.cs
@@ -269,7 +269,7 @@ namespace Eto.Mac.Forms.Controls
 					if (backgroundColor != Colors.Transparent)
 					{
 						backgroundColor.ToNSUI().Set();
-						NSGraphics.RectFill(clipRect);
+						NSGraphics.RectFill(Bounds);
 						return;
 					}
 				}


### PR DESCRIPTION
When compiled for Sonoma, we should not use the clip/dirty rect for where to draw the background, but instead always use the bounds of the control.