### PR TITLE
Add Grid.RowFormatting event and reset defaults on CellFormatting

### DIFF
--- a/src/Eto.Gtk/Forms/Cells/CheckBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/CheckBoxCellHandler.cs
@@ -28,8 +28,7 @@ namespace Eto.GtkSharp.Forms.Cells
 				get { return item; }
 				set {
 					item = value;
-					if (Handler.FormattingEnabled)
-						Handler.Format(new GtkGridCellFormatEventArgs<Renderer>(this, Handler.Column.Widget, item, Row));
+					Handler.Format(this, item, Row);
 				}
 			}
 

--- a/src/Eto.Gtk/Forms/Cells/ComboBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ComboBoxCellHandler.cs
@@ -32,8 +32,7 @@ namespace Eto.GtkSharp.Forms.Cells
 				set
 				{
 					item = value;
-					if (Handler.FormattingEnabled)
-						Handler.Format(new GtkGridCellFormatEventArgs<Renderer>(this, Handler.Column.Widget, item, Row));
+					Handler.Format(this, item, Row);
 				}
 			}
 			

--- a/src/Eto.Gtk/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/CustomCellHandler.cs
@@ -108,8 +108,7 @@ namespace Eto.GtkSharp.Forms.Cells
 				set
 				{
 					item = value;
-					if (Handler.FormattingEnabled)
-						Handler.Format(new GtkGridCellFormatEventArgs<Renderer>(this, Handler.Column.Widget, item, Row));
+					Handler.Format(this, item, Row);
 				}
 			}
 
@@ -244,6 +243,7 @@ namespace Eto.GtkSharp.Forms.Cells
 			}*/
 #endif
 		}
+
 
 		private int OnGetPreferredWidth(CellEventArgs args)
 		{

--- a/src/Eto.Gtk/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/DrawableCellHandler.cs
@@ -28,8 +28,7 @@ namespace Eto.GtkSharp.Forms.Cells
 				set
 				{
 					item = value;
-					if (Handler.FormattingEnabled)
-						Handler.Format(new GtkGridCellFormatEventArgs<Renderer>(this, Handler.Column.Widget, item, Row));
+					Handler.Format(this, item, Row);
 				}
 			}
 

--- a/src/Eto.Gtk/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ImageTextCellHandler.cs
@@ -31,8 +31,7 @@ namespace Eto.GtkSharp.Forms.Cells
 				set
 				{
 					item = value;
-					if (Handler.FormattingEnabled)
-						Handler.Format(new GtkGridCellFormatEventArgs<ImageRenderer>(this, Handler.Column.Widget, item, Row));
+					Handler.Format(this, item, Row);
 				}
 			}
 		}
@@ -111,7 +110,7 @@ namespace Eto.GtkSharp.Forms.Cells
 			Column.Control.AddAttribute(Control, "text", dataIndex++);
 			base.BindCell(ref dataIndex);
 
-			if (FormattingEnabled)
+			if (CellFormattingEnabled)
 			{
 				Column.Control.AddAttribute(imageCell, "row", Source.RowDataColumn);
 				Column.Control.AddAttribute(imageCell, "item", Source.ItemDataColumn);

--- a/src/Eto.Gtk/Forms/Cells/ImageViewCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ImageViewCellHandler.cs
@@ -27,8 +27,7 @@ namespace Eto.GtkSharp.Forms.Cells
 				set
 				{
 					item = value;
-					if (Handler.FormattingEnabled)
-						Handler.Format(new GtkGridCellFormatEventArgs<Renderer>(this, Handler.Column.Widget, item, Row));
+					Handler.Format(this, item, Row);
 				}
 			}
 

--- a/src/Eto.Gtk/Forms/Cells/ProgressCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ProgressCellHandler.cs
@@ -29,8 +29,7 @@
 				set
 				{
 					item = value;
-					if (Handler.FormattingEnabled)
-						Handler.Format(new GtkGridCellFormatEventArgs<Renderer>(this, Handler.Column.Widget, item, Row));
+					Handler.Format(this, item, Row);
 				}
 			}
 			

--- a/src/Eto.Gtk/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/TextBoxCellHandler.cs
@@ -4,8 +4,8 @@ namespace Eto.GtkSharp.Forms.Cells
 {
 	interface ITextBoxCellHandler
 	{
-		bool FormattingEnabled { get; }
-		void Format(GridCellFormatEventArgs args);
+		bool CellFormattingEnabled { get; }
+		void Format(Gtk.CellRenderer renderer, object item, int row);
 		AutoSelectMode AutoSelectMode { get; }
 		GridColumnHandler Column { get; }
 		ICellDataSource Source { get; }
@@ -23,16 +23,8 @@ namespace Eto.GtkSharp.Forms.Cells
 			public bool Editing => (bool)GetProperty("editing").Val;
 #endif
 
-			int row;
 			[GLib.Property("row")]
-			public int Row
-			{
-				get { return row; }
-				set
-				{
-					row = value;
-				}
-			}
+			public int Row { get; set; }
 			
 			object item;
 			[GLib.Property("item")]
@@ -42,8 +34,7 @@ namespace Eto.GtkSharp.Forms.Cells
 				set
 				{
 					item = value;
-					if (Handler.FormattingEnabled)
-						Handler.Format(new GtkGridCellFormatEventArgs<Renderer>(this, Handler.Column.Widget, item, Row));
+					Handler.Format(this, item, Row);
 				}
 			}
 

--- a/src/Eto.Gtk/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridColumnHandler.cs
@@ -138,6 +138,8 @@ namespace Eto.GtkSharp.Forms.Controls
 				HandleEvent(Grid.ColumnHeaderClickEvent);
 			if (grid.IsEventHandled(Grid.CellFormattingEvent))
 				HandleEvent(Grid.CellFormattingEvent);
+			if (grid.IsEventHandled(Grid.RowFormattingEvent))
+				HandleEvent(Grid.RowFormattingEvent);
 			if (grid.IsEventHandled(Grid.ColumnWidthChangedEvent))
 				HandleEvent(Grid.ColumnWidthChangedEvent);
 		}

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -142,7 +142,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			Control.QueryTooltip += Control_QueryTooltip;
 			Control.HasTooltip = true;
-
+			
 
 		}
 
@@ -326,6 +326,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				case Grid.CellEditingEvent:
 				case Grid.CellEditedEvent:
 				case Grid.CellFormattingEvent:
+				case Grid.RowFormattingEvent:
 				case Grid.ColumnWidthChangedEvent:
 					SetupColumnEvents();
 					break;
@@ -625,6 +626,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			Callback.OnCellFormatting(Widget, args);
 		}
 
+		public void OnRowFormatting(GridRowFormatEventArgs args) => Callback.OnRowFormatting(Widget, args);
+
 		public void ScrollToRow(int row)
 		{
 			var path = this.GetPathAtRow(row);
@@ -761,6 +764,8 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			Callback.OnColumnWidthChanged(Widget, new GridColumnEventArgs(h.Widget));
 		}
+
+		public abstract int GetRowOfItem(object item);
 	}
 }
 

--- a/src/Eto.Gtk/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridViewHandler.cs
@@ -150,10 +150,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			return new GLib.Value((string)null);
 		}
 
-		public int GetRowOfItem(object item)
-		{
-			return collection != null ? collection.IndexOf(item) : -1;
-		}
+		public override int GetRowOfItem(object item) =>collection?.IndexOf(item) ?? -1;
 
 		public EnumerableChangedHandler<object> Collection
 		{

--- a/src/Eto.Gtk/Forms/Controls/GtkListModel.cs
+++ b/src/Eto.Gtk/Forms/Controls/GtkListModel.cs
@@ -10,7 +10,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		
 		GLib.Value GetColumnValue (TItem item, int column, int row, Gtk.TreeIter iter);
 
-		int GetRowOfItem (TItem item);
+		int GetRowOfItem (object item);
 	}
 
 	public class GtkListModel<TItem> : GLib.Object, ITreeModelImplementor

--- a/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
@@ -473,7 +473,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			// yes, we can get the row.. but it slows down the TreeGridView too much when there are many items
 			// This is only used when formatting the cell, and all other platforms return row=-1 with TreeGridView
 			if (dataColumn == RowDataColumn)
-				return new GLib.Value(row); //model.GetRowIndexOfIter(iter));
+				return new GLib.Value(row); 
+				// return new GLib.Value(model.GetRowIndexOfIter(iter));
 
 			if (dataColumn == ItemDataColumn)
 				return new GLib.Value(item);
@@ -487,9 +488,16 @@ namespace Eto.GtkSharp.Forms.Controls
 			return new GLib.Value((string)null);
 		}
 
-		public int GetRowOfItem(ITreeGridItem item)
+		public override int GetRowOfItem(object item)
 		{
-			return collection == null ? -1 : collection.IndexOf(item);
+			if (item is ITreeGridItem tgitem)
+			{
+				var iter = model.GetIterFromItem(tgitem, true);
+				if (iter == null)
+					return -1;
+				return model.GetRowIndexOfIter(iter.Value);
+			}
+			return -1;
 		}
 		
 

--- a/src/Eto.Gtk/Forms/Controls/TreeViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TreeViewHandler.cs
@@ -359,9 +359,11 @@ namespace Eto.GtkSharp.Forms.Controls
 			get { return 2; }
 		}
 
-		public int GetRowOfItem(ITreeItem item)
+		public int GetRowOfItem(object item)
 		{
-			return collection != null ? collection.IndexOf(item) : -1;
+			if (item is ITreeItem ti)
+				return collection?.IndexOf(ti) ?? -1;
+			return -1;
 		}
 
 		public void RefreshData()

--- a/src/Eto.Mac/Forms/Cells/ComboBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ComboBoxCellHandler.cs
@@ -189,10 +189,7 @@ namespace Eto.Mac.Forms.Cells
 			}
 		}
 
-		public override Color GetBackgroundColor(NSView view)
-		{
-			return ((EtoPopUpButton)view).Cell.BackgroundColor.ToEto();
-		}
+		public override Color GetBackgroundColor(NSView view) => ((EtoPopUpButton)view).Cell.BackgroundColor.ToEto();
 
 		public override void SetBackgroundColor(NSView view, Color color)
 		{
@@ -201,24 +198,20 @@ namespace Eto.Mac.Forms.Cells
 			field.DrawsBackground = color.A > 0;
 		}
 
-		public override Color GetForegroundColor(NSView view)
-		{
-			return ((EtoCell)((EtoPopUpButton)view).Cell).TextColor.ToEto();
-		}
+		public override Color GetForegroundColor(NSView view) => ((EtoCell)((EtoPopUpButton)view).Cell).TextColor.ToEto();
+		public override void SetForegroundColor(NSView view, Color color) => ((EtoCell)((EtoPopUpButton)view).Cell).TextColor = color.ToNSUI();
 
-		public override void SetForegroundColor(NSView view, Color color)
-		{
-			((EtoCell)((EtoPopUpButton)view).Cell).TextColor = color.ToNSUI();
-		}
+		public override Font GetFont(NSView view) => ((EtoPopUpButton)view).Font.ToEto();
+		public override void SetFont(NSView view, Font font) => ((EtoPopUpButton)view).Font = font.ToNS();
 
-		public override Font GetFont(NSView view)
+		private void SetDefaults(CellView view)
 		{
-			return ((EtoPopUpButton)view).Font.ToEto();
-		}
-
-		public override void SetFont(NSView view, Font font)
-		{
-			((EtoPopUpButton)view).Font = font.ToNS();
+			if (view.Cell is EtoCell cell)
+			{
+				cell.DrawsBackground = false;
+				cell.TextColor = NSColor.ControlText;
+				cell.Font = NSFont.SystemFontOfSize(NSFont.SystemFontSize);
+			}
 		}
 
 		class CellView : EtoPopUpButton
@@ -257,7 +250,6 @@ namespace Eto.Mac.Forms.Cells
 
 					ColumnHandler.DataViewHandler.OnCellEdited(cellArgs);
 					control.ObjectValue = GetObjectValue(item);
-
 				};
 				view.Bind(enabledBinding, tableColumn, "editable", null);
 				view.Menu = menu.Copy() as NSMenu;
@@ -267,6 +259,7 @@ namespace Eto.Mac.Forms.Cells
 
 			view.Tag = row;
 			view.Item = obj;
+			SetDefaults(view);
 			var formatArgs = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(formatArgs);
 			return view;

--- a/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
@@ -129,16 +129,18 @@ namespace Eto.Mac.Forms.Cells
 
 		}
 
-		public override Color GetBackgroundColor(NSView view)
-		{
-			return ((EtoCustomCellView)view).BackgroundColor.ToEto();
-		}
+		public override Color GetBackgroundColor(NSView view) => ((EtoCustomCellView)view).BackgroundColor.ToEto();
 
 		public override void SetBackgroundColor(NSView view, Color color)
 		{
 			var field = ((EtoCustomCellView)view);
 			field.BackgroundColor = color.ToNSUI();
 			field.DrawsBackground = color.A > 0;
+		}
+
+		private void SetDefaults(EtoCustomCellView view)
+		{
+			view.DrawsBackground = false;
 		}
 
 		public override NSView GetViewForItem(NSTableView tableView, NSTableColumn tableColumn, int row, NSObject obj, Func<NSObject, int, object> getItem)
@@ -184,6 +186,7 @@ namespace Eto.Mac.Forms.Cells
 				view.Args.SetItem(args.Item);
 			}
 
+			SetDefaults(view);
 			var formatArgs = new MacCellFormatArgs(ColumnHandler.Widget, item, row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(formatArgs);
 			Callback.OnConfigureCell(Widget, view.Args, view.EtoControl);

--- a/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
@@ -87,16 +87,18 @@ namespace Eto.Mac.Forms.Cells
 			return -1; // TODO: Add ability for DrawableCell to provide a preferred width for a specific item.
 		}
 
-		public override Color GetBackgroundColor(NSView view)
-		{
-			return ((EtoCellView)view).BackgroundColor;
-		}
+		public override Color GetBackgroundColor(NSView view) => ((EtoCellView)view).BackgroundColor;
 
 		public override void SetBackgroundColor(NSView view, Color color)
 		{
 			var field = ((EtoCellView)view);
 			field.BackgroundColor = color;
 			field.DrawsBackground = color.A > 0;
+		}
+
+		private void SetDefaults(EtoCellView view)
+		{
+			view.DrawsBackground = false;
 		}
 
 		public override NSObject GetObjectValue(object dataItem)
@@ -202,6 +204,7 @@ namespace Eto.Mac.Forms.Cells
 				view = new EtoCellView { Handler = this, Identifier = tableColumn.Identifier, FocusRingType = NSFocusRingType.Exterior };
 				view.Bind(enabledBinding, tableColumn, "editable", null);
 			}
+			SetDefaults(view);
 			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 			return view;

--- a/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
@@ -40,13 +40,14 @@ namespace Eto.Mac.Forms.Cells
 
 		public override nfloat GetPreferredWidth(object value, CGSize cellSize, int row, object dataItem)
 		{
-			field.TextField.Font = defaultFont;
+			SetDefaults(field);
 			field.SetFrameSize(cellSize);
 
+			field.ObjectValue = value as NSObject;
+			
 			var args = new MacCellFormatArgs(ColumnHandler.Widget, dataItem, row, field);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 
-			field.ObjectValue = value as NSObject;
 			return field.FittingSize.Width;
 		}
 
@@ -64,34 +65,21 @@ namespace Eto.Mac.Forms.Cells
 			}
 		}
 
-		public override Color GetBackgroundColor(NSView view)
-		{
-			return ((CellView)view).BetterBackgroundColor.ToEto();
-		}
+		public override Color GetBackgroundColor(NSView view) => ((CellView)view).BetterBackgroundColor.ToEto();
+		public override void SetBackgroundColor(NSView view, Color color) => ((CellView)view).BetterBackgroundColor = color.ToNSUI();
 
-		public override void SetBackgroundColor(NSView view, Color color)
-		{
-			((CellView)view).BetterBackgroundColor = color.ToNSUI();
-		}
+		public override Color GetForegroundColor(NSView view) => ((CellView)view).TextField.TextColor.ToEto();
+		public override void SetForegroundColor(NSView view, Color color) => ((CellView)view).TextField.TextColor = color.ToNSUI();
 
-		public override Color GetForegroundColor(NSView view)
-		{
-			return ((CellView)view).TextField.TextColor.ToEto();
-		}
+		public override Font GetFont(NSView view) => ((CellView)view).TextField.Font.ToEto();
+		public override void SetFont(NSView view, Font font) => ((CellView)view).TextField.Font = font.ToNS();
 
-		public override void SetForegroundColor(NSView view, Color color)
+		private void SetDefaults(CellView view)
 		{
-			((CellView)view).TextField.TextColor = color.ToNSUI();
-		}
-
-		public override Font GetFont(NSView view)
-		{
-			return ((CellView)view).TextField.Font.ToEto();
-		}
-
-		public override void SetFont(NSView view, Font font)
-		{
-			((CellView)view).TextField.Font = font.ToNS();
+			var field = view.TextField;
+			field.TextColor = NSColor.ControlText;
+			field.Font = NSFont.SystemFontOfSize(NSFont.SystemFontSize);
+			view.BetterBackgroundColor = null;
 		}
 
 		TextAlignment _textAlignment;
@@ -243,6 +231,7 @@ namespace Eto.Mac.Forms.Cells
 
 			view.Tag = row;
 			view.Item = obj;
+			SetDefaults(view);
 			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 			return view;

--- a/src/Eto.Mac/Forms/Cells/ImageViewCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageViewCellHandler.cs
@@ -82,16 +82,14 @@ namespace Eto.Mac.Forms.Cells
 
 		public ImageInterpolation ImageInterpolation { get; set; }
 
-		public override Color GetBackgroundColor(NSView view)
+		public override Color GetBackgroundColor(NSView view) => ((EtoImageView)view).BackgroundColor.ToEto();
+		public override void SetBackgroundColor(NSView view, Color color) => ((EtoImageView)view).BackgroundColor = color.ToNSUI();
+		
+		private void SetDefaults(EtoImageView view)
 		{
-			return ((EtoImageView)view).BackgroundColor.ToEto();
+			view.BackgroundColor = null;
 		}
-
-		public override void SetBackgroundColor(NSView view, Color color)
-		{
-			var field = ((EtoImageView)view);
-			field.BackgroundColor = color.ToNSUI();
-		}
+		
 
 		public override NSView GetViewForItem(NSTableView tableView, NSTableColumn tableColumn, int row, NSObject obj, Func<NSObject, int, object> getItem)
 		{
@@ -100,6 +98,7 @@ namespace Eto.Mac.Forms.Cells
 			{
 				view = new EtoImageView { Identifier = tableColumn.Identifier };
 			}
+			SetDefaults(view);
 			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 			return view;

--- a/src/Eto.Mac/Forms/Cells/ProgressCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ProgressCellHandler.cs
@@ -41,10 +41,7 @@ namespace Eto.Mac.Forms.Cells
 			return field.Cell.CellSizeForBounds(new CGRect(0, 0, nfloat.MaxValue, cellSize.Height)).Width;
 		}
 
-		public override Color GetBackgroundColor(NSView view)
-		{
-			return ((EtoCell)((NSLevelIndicator)view).Cell).BackgroundColor.ToEto();
-		}
+		public override Color GetBackgroundColor(NSView view) => ((EtoCell)((NSLevelIndicator)view).Cell).BackgroundColor.ToEto();
 
 		public override void SetBackgroundColor(NSView view, Color color)
 		{
@@ -53,26 +50,20 @@ namespace Eto.Mac.Forms.Cells
 			field.DrawsBackground = color.A > 0;
 		}
 
-		public override Color GetForegroundColor(NSView view)
-		{
-			return ((EtoCell)((NSLevelIndicator)view).Cell).TextColor.ToEto();
-		}
+		public override Color GetForegroundColor(NSView view) => ((EtoCell)((NSLevelIndicator)view).Cell).TextColor.ToEto();
+		public override void SetForegroundColor(NSView view, Color color) => ((EtoCell)((NSLevelIndicator)view).Cell).TextColor = color.ToNSUI();
 
-		public override void SetForegroundColor(NSView view, Color color)
-		{
-			((EtoCell)((NSLevelIndicator)view).Cell).TextColor = color.ToNSUI();
-		}
+		public override Font GetFont(NSView view) => ((NSLevelIndicator)view).Font.ToEto();
+		public override void SetFont(NSView view, Font font) => ((NSLevelIndicator)view).Font = font.ToNS();
 
-		public override Font GetFont(NSView view)
+		private void SetDefaults(NSLevelIndicator view)
 		{
-			return ((NSLevelIndicator)view).Font.ToEto();
+			if (view.Cell is EtoCell cell)
+			{
+				cell.TextColor = NSColor.ControlText;
+				cell.DrawsBackground = false;
+			}
 		}
-
-		public override void SetFont(NSView view, Font font)
-		{
-			((NSLevelIndicator)view).Font = font.ToNS();
-		}
-
 
 		public override NSView GetViewForItem(NSTableView tableView, NSTableColumn tableColumn, int row, NSObject obj, Func<NSObject, int, object> getItem)
 		{
@@ -85,6 +76,8 @@ namespace Eto.Mac.Forms.Cells
 				view.Enabled = false;
 				view.Cell.LevelIndicatorStyle = NSLevelIndicatorStyle.ContinuousCapacity;
 			}
+			
+			SetDefaults(view);
 			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 			return view;

--- a/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
@@ -11,14 +11,12 @@ namespace Eto.Mac.Forms.Cells
 
 		public override nfloat GetPreferredWidth(object value, CGSize cellSize, int row, object dataItem)
 		{
-			field.Font = defaultFont;
-
+			field.ObjectValue = value as NSObject ?? new NSString(string.Empty);
+			
+			SetDefaults(field);
 			var args = new MacCellFormatArgs(ColumnHandler.Widget, dataItem, row, field);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 
-			if (args.FontSet)
-				field.Font = args.Font.ToNS();
-			field.ObjectValue = value as NSObject ?? new NSString(string.Empty);
 			return field.Cell.CellSizeForBounds(new CGRect(0, 0, nfloat.MaxValue, cellSize.Height)).Width;
 		}
 
@@ -45,34 +43,20 @@ namespace Eto.Mac.Forms.Cells
 			}
 		}
 
-		public override Color GetBackgroundColor(NSView view)
-		{
-			return ((CellView)view).Cell.BetterBackgroundColor.ToEto();
-		}
+		public override Color GetBackgroundColor(NSView view) => ((CellView)view).Cell.BetterBackgroundColor.ToEto();
+		public override void SetBackgroundColor(NSView view, Color color) => ((CellView)view).Cell.BetterBackgroundColor = color.ToNSUI();
 
-		public override void SetBackgroundColor(NSView view, Color color)
-		{
-			((CellView)view).Cell.BetterBackgroundColor = color.ToNSUI();
-		}
+		public override Color GetForegroundColor(NSView view) => ((CellView)view).TextColor.ToEto();
+		public override void SetForegroundColor(NSView view, Color color) => ((CellView)view).TextColor = color.ToNSUI();
 
-		public override Color GetForegroundColor(NSView view)
-		{
-			return ((CellView)view).TextColor.ToEto();
-		}
+		public override Font GetFont(NSView view) => ((CellView)view).Font.ToEto();
+		public override void SetFont(NSView view, Font font) => ((CellView)view).Font = font.ToNS();
 
-		public override void SetForegroundColor(NSView view, Color color)
+		private void SetDefaults(CellView view)
 		{
-			((CellView)view).TextColor = color.ToNSUI();
-		}
-
-		public override Font GetFont(NSView view)
-		{
-			return ((CellView)view).Font.ToEto();
-		}
-
-		public override void SetFont(NSView view, Font font)
-		{
-			((CellView)view).Font = font.ToNS();
+			var field = view.Cell.BetterBackgroundColor = null; 
+			view.TextColor = NSColor.ControlText;
+			view.Font = defaultFont;
 		}
 
 		TextAlignment _textAlignment;
@@ -187,6 +171,7 @@ namespace Eto.Mac.Forms.Cells
 
 			view.Item = obj;
 			view.Tag = row;
+			SetDefaults(view);
 			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 			return view;

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -989,6 +989,26 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
+		class RowFormatEventArgs : GridRowFormatEventArgs
+		{
+			NSTableRowView _rowView;
+			public RowFormatEventArgs(NSTableRowView rowView, object item, int row) : base(item, row)
+			{
+				_rowView = rowView;
+			}
+
+			public override Color BackgroundColor
+			{
+				get => _rowView.BackgroundColor.ToEto();
+				set => _rowView.BackgroundColor = value.ToNSUI();
+			}
+		}
+
+		protected virtual void OnDidAddRowView(NSTableRowView rowView, nint row)
+		{
+			var item = GetItem((int)row);
+			Callback.OnRowFormatting(Widget, new RowFormatEventArgs(rowView, item, (int)row));
+		}
 	}
 }
 

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -413,6 +413,11 @@ namespace Eto.Mac.Forms.Controls
 				return tableView.MakeView(tableColumn.Identifier, this);
 			}
 
+			public override void DidAddRowView(NSTableView tableView, NSTableRowView rowView, nint row)
+			{
+				Handler?.OnDidAddRowView(rowView, row);
+			}
+
 			public override void DidRemoveRowView(NSTableView tableView, NSTableRowView rowView, nint row)
 			{
 				foreach (var col in Handler.ColumnHandlers)
@@ -472,6 +477,8 @@ namespace Eto.Mac.Forms.Controls
 					// Handled in EtoTableView
 					break;
 				case Grid.CellFormattingEvent:
+					break;
+				case Grid.RowFormattingEvent:
 					break;
 				case Eto.Forms.Control.DragOverEvent:
 				case Eto.Forms.Control.DragDropEvent:

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -266,6 +266,11 @@ namespace Eto.Mac.Forms.Controls
 				return outlineView.MakeView(tableColumn?.Identifier ?? string.Empty, this);
 			}
 
+			public override void DidAddRowView(NSOutlineView outlineView, NSTableRowView rowView, nint row)
+			{
+				Handler?.OnDidAddRowView(rowView, row);
+			}
+
 			public override void DidRemoveRowView(NSOutlineView outlineView, NSTableRowView rowView, nint row)
 			{
 				foreach (var col in Handler.ColumnHandlers)
@@ -725,6 +730,10 @@ namespace Eto.Mac.Forms.Controls
 				case Grid.CellClickEvent:
 					// Handled in EtoOutlineView
 					break;
+				case Grid.CellFormattingEvent:
+					break;
+				case Grid.RowFormattingEvent:
+					break;
 				case Eto.Forms.Control.DragOverEvent:
 				case Eto.Forms.Control.DragDropEvent:
 					// handled in EtoDataSource
@@ -973,14 +982,23 @@ namespace Eto.Mac.Forms.Controls
 			{
 				var items = CustomSelectedItems;
 				if (items != null)
-				{
-					return CustomSelectedItems.Select(r => (int)Control.RowForItem(GetCachedItem(r)));
-				}
+					return GetRowsForItems(items);
+					
 				return base.SelectedRows;
 			}
 			set
 			{
 				base.SelectedRows = value;
+			}
+		}
+
+		private IEnumerable<int> GetRowsForItems(IEnumerable<object> items)
+		{
+			foreach (var item in items)
+			{
+				var cachedItem = GetCachedItem(item);
+				if (cachedItem != null)
+					yield return (int)Control.RowForItem(cachedItem);
 			}
 		}
 

--- a/src/Eto.WinForms/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.WinForms/Forms/Cells/ImageTextCellHandler.cs
@@ -104,7 +104,7 @@ namespace Eto.WinForms.Forms.Cells
 						using (var background = new sd.SolidBrush(cellState.HasFlag(swf.DataGridViewElementStates.Selected) ? cellStyle.SelectionBackColor : cellStyle.BackColor))
 							graphics.FillRectangle(background, cellBounds);
 					graphics.InterpolationMode = InterpolationMode;
-					graphics.DrawImage(img, new sd.Rectangle(cellBounds.X + IconPadding, cellBounds.Y + (cellBounds.Height - Math.Min(img.Height, cellBounds.Height)) / 2, IconSize, IconSize));
+					graphics.DrawImage(img, new sd.Rectangle(cellBounds.X + IconPadding, cellBounds.Y + (cellBounds.Height - Math.Min(IconSize, cellBounds.Height)) / 2, IconSize, IconSize));
 					graphics.EndContainer(container);
 					cellBounds.X += IconSize + IconPadding * 2;
 					cellBounds.Width -= IconSize + IconPadding * 2;

--- a/src/Eto.WinForms/Forms/Controls/GridHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GridHandler.cs
@@ -244,11 +244,11 @@ namespace Eto.WinForms.Forms.Controls
 			DisableAutoSizeToggle--;
 		}
 
-		class FormattingArgs : GridCellFormatEventArgs
+		class CellFormattingArgs : GridCellFormatEventArgs
 		{
 			public swf.DataGridViewCellFormattingEventArgs Args { get; private set; }
 
-			public FormattingArgs(swf.DataGridViewCellFormattingEventArgs args, GridColumn column, object item, int row)
+			public CellFormattingArgs(swf.DataGridViewCellFormattingEventArgs args, GridColumn column, object item, int row)
 				: base(column, item, row)
 			{
 				this.Args = args;
@@ -258,10 +258,7 @@ namespace Eto.WinForms.Forms.Controls
 
 			public override Font Font
 			{
-				get
-				{
-					return font ?? (font = new Font(new FontHandler(Args.CellStyle.Font)));
-				}
+				get => font ?? (font = new Font(new FontHandler(Args.CellStyle.Font)));
 				set
 				{
 					font = value;
@@ -280,6 +277,22 @@ namespace Eto.WinForms.Forms.Controls
 				get { return Args.CellStyle.ForeColor.ToEto(); }
 				set { Args.CellStyle.ForeColor = value.ToSD(); }
 			}
+		}
+
+		class RowFormattingArgs : GridRowFormatEventArgs
+		{
+			swf.DataGridViewCellFormattingEventArgs _args;
+			public RowFormattingArgs(swf.DataGridViewCellFormattingEventArgs args, object item, int row) : base(item, row)
+			{
+				_args = args;
+			}
+
+			public override Color BackgroundColor
+			{
+				get => _args.CellStyle.BackColor.ToEto();
+				set => _args.CellStyle.BackColor = value.ToSD();
+			}
+
 		}
 
 		public override void AttachEvent(string id)
@@ -333,6 +346,9 @@ namespace Eto.WinForms.Forms.Controls
 				case Grid.SelectionChangedEvent:
 					// handled automatically
 					break;
+				case Grid.RowFormattingEvent:
+					HandleEvent(Grid.CellFormattingEvent);
+					break;
 				case Grid.CellFormattingEvent:
 					Control.CellFormatting += HandleCellFormatting;
 					break;
@@ -361,7 +377,8 @@ namespace Eto.WinForms.Forms.Controls
 					cell.ToolTipText = column.CellToolTipBinding.GetValue(item);
 				}
 			}
-			Callback.OnCellFormatting(Widget, new FormattingArgs(e, column, item, e.RowIndex));
+			Callback.OnRowFormatting(Widget, new RowFormattingArgs(e, item, e.RowIndex));
+			Callback.OnCellFormatting(Widget, new CellFormattingArgs(e, column, item, e.RowIndex));
 		}
 
 		private void HandleColumnWidthChanged(object sender, swf.DataGridViewColumnEventArgs e)

--- a/test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/TreeGridViewSection.cs
@@ -21,7 +21,7 @@ namespace Eto.Test.Sections.Controls
 
 		protected override void SetDataStore(TreeGridView grid)
 		{
-			var item = CreateItem(4, "Item", 0, 100);
+			var item = CreateItem(4, "Item", 0, 1000);
 			// var item = await Task.Run(() => CreateItem(0, "Item", 0, 1000));
 			grid.DataStore = item;
 		}

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
@@ -7,6 +7,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		class GridTestItem : TreeGridItem
 		{
 			public string Text { get; set; }
+			public bool? BooleanValue { get; set; }
 			
 			public Image Image { get; set; }
 
@@ -136,7 +137,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			for (int i = 0; i < rows; i++)
 			{
 				Image image = i % 2 == 0 ? (Image)TestIcons.Logo : (Image)TestIcons.TestImage;
-				list.Add(new GridTestItem { Text = $"Item {i}", Image = image, Values = new[] { $"col {i}.2", $"col {i}.3", $"col {i}.4", $"col {i}.5" } });
+				bool? boolValue = i % 3 == 0 ? true : i % 3 == 1 ? false : null;
+				list.Add(new GridTestItem { Text = $"Item {i}", BooleanValue = boolValue, Image = image, Values = new[] { $"col {i}.2", $"col {i}.3", $"col {i}.4", $"col {i}.5" } });
 			}
 			return list;
 		}
@@ -301,6 +303,39 @@ namespace Eto.Test.UnitTests.Forms.Controls
 
 			return grid;
 		});
+
+		[Test, ManualTest]
+		public void RowFormattingShouldWork() => ManualDialog(
+			"Should be background",
+			dlg => {
+				
+				dlg.Resizable = true;
+				
+				var grid = new T();
+				grid.Height = 500;
+				grid.RowHeight = 32;
+				grid.CellFormatting += (sender, e) =>
+				{
+					if (e.Row % 4 == 0)
+						e.BackgroundColor = Colors.Green;
+				};
+				grid.RowFormatting += (sender, e) =>
+				{
+					if (e.Row % 3 == 0)
+						e.BackgroundColor = Colors.Blue;
+				};
+				grid.Columns.Add(new GridColumn { DataCell = new ImageTextCell { TextBinding = Binding.Property((GridTestItem m) => m.Text), ImageBinding = Binding.Property((GridTestItem m) => m.Image) } });
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(1) });
+				grid.Columns.Add(new GridColumn { DataCell = new CheckBoxCell { Binding = Binding.Property((GridTestItem m) => m.BooleanValue) } });
+				grid.Columns.Add(new GridColumn { DataCell = new DrawableCell { }, Width = 20 });
+				grid.Columns.Add(new GridColumn { DataCell = new CustomCell { CreateCell = d => new Panel() }, Width = 20 });
+				grid.Columns.Add(new GridColumn { DataCell = new ImageViewCell { Binding = Binding.Property((GridTestItem m) => m.Image) }});
+				
+				SetDataStore(grid, CreateDataStore(500));
+
+				return grid;
+			}
+		);
 
 		[Test, ManualTest]
 		public void CustomCellShouldGetMouseEvents()


### PR DESCRIPTION
This adds the ability to full-row highlight certain rows without affecting selection colors or having gaps between cells on macOS/WPF due to cell margins.

Also all formatting is reset you don't have to set the values back to defaults for reused cells,  which is not always easy to do in a platform agnostic way.