### PR TITLE
Fix a crash that can happen when setting SelectFolderDialog.Directory on Mac

### DIFF
--- a/src/Eto.Mac/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Mac/Forms/SelectFolderDialogHandler.cs
@@ -32,7 +32,17 @@ namespace Eto.Mac.Forms
 		public string Directory
 		{
 			get => Control.Url?.Path ?? Control.DirectoryUrl.Path;
-			set => Control.DirectoryUrl = NSUrl.FromFilename(value);
+			set
+			{
+				try
+				{
+					Control.DirectoryUrl = new NSUrl(value, true);
+				}
+				catch
+				{
+					// ignore errors, can crash depending on the value when [NSUrl initFileURLWithPath:isDirectory:] returns nil
+				}
+			}
 		}
 
 	}


### PR DESCRIPTION
`[NSUrl initFileURLWithPath:isDirectory:]` can return null sometimes, causing the .net macOS apis to freak out and throw an exception. I'm not sure exactly when/why, but if it does we should gracefully handle that and not crash.