### PR TITLE
Wpf: Fix dispatcher error when cancelling a TextBox TextChanging event

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -304,7 +304,11 @@ namespace Eto.Wpf.Forms.Controls
 					var args = new TextChangingEventArgs(oldText, newText, false);
 					Callback.OnTextChanging(Widget, args);
 					if (args.Cancel)
+					{
+						TextBox.EndChange();
 						return;
+					}
+
 					var needsTextChanged = TextBox.Text == newText;
 
 					// Improve performance when setting text often


### PR DESCRIPTION
This fixes this error "System.InvalidOperationException: Cannot perform this operation while dispatcher processing is suspended." when cancelling changing the Text property of a TextBox.