### PR TITLE
Add NativeControlHost

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/NativeControlHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/NativeControlHandler.cs
@@ -1,10 +1,42 @@
-﻿namespace Eto.GtkSharp.Forms.Controls
+﻿
+namespace Eto.GtkSharp.Forms.Controls
 {
-	public class NativeControlHandler : GtkControl<Gtk.Widget, Control, Control.ICallback>
+	public class NativeControlHandler : GtkControl<Gtk.Widget, Control, Control.ICallback>, NativeControlHost.IHandler
 	{
+
+		Gtk.EventBox _eventBox = new Gtk.EventBox();
+		public override Gtk.Widget ContainerControl => _eventBox;
+				
 		public NativeControlHandler(Gtk.Widget nativeControl)
 		{
 			Control = nativeControl;
+		}
+		
+		public NativeControlHandler()
+		{
+		}
+
+		public void Create(object controlObject)
+		{
+			if (controlObject == null)
+			{
+				Control = _eventBox;
+			}
+			else if (controlObject is Gtk.Widget widget)
+			{
+				Control = widget;
+				_eventBox.Child = widget;
+			}
+			else if (controlObject is IntPtr handle)
+			{
+				widget = GLib.Object.GetObject(handle) as Gtk.Widget;
+				if (widget == null)
+					throw new InvalidOperationException("Could not convert handle to Gtk.Widget");
+				Control = widget;
+				_eventBox.Child = widget;
+			}
+			else
+				throw new NotSupportedException($"controlObject of type {controlObject.GetType()} is not supported by this platform");
 		}
 	}
 }

--- a/src/Eto.Gtk/Platform.cs
+++ b/src/Eto.Gtk/Platform.cs
@@ -220,6 +220,7 @@ namespace Eto.GtkSharp
 			p.Add<DataObject.IHandler>(() => new DataObjectHandler());
 			p.Add<DataFormats.IHandler>(() => new DataFormatsHandler());
 			p.Add<Window.IWindowHandler>(() => new WindowHandler());
+			p.Add<NativeControlHost.IHandler>(() => new NativeControlHandler());
 			if (EtoEnvironment.Platform.IsLinux)
 			{
 				p.Add<TrayIndicator.IHandler>(() => new LinuxTrayIndicatorHandler());

--- a/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
@@ -1,12 +1,16 @@
 ﻿namespace Eto.Mac.Forms.Controls
 {
-	public class NativeControlHandler : MacView<NSView, Control, Control.ICallback>
+	public class NativeControlHandler : MacView<NSView, Control, Control.ICallback>, NativeControlHost.IHandler
 	{
 		NSViewController controller;
 
 		public NativeControlHandler(NSView nativeControl)
 		{
 			Control = nativeControl;
+		}
+		
+		public NativeControlHandler()
+		{
 		}
 
 		public override SizeF GetPreferredSize(SizeF availableSize)
@@ -21,6 +25,27 @@
 		}
 
 		public override NSView ContainerControl { get { return Control; } }
+		
+		public void Create(object controlObject)
+		{
+			if (controlObject == null)
+			{
+				Control = new NSView();
+			}
+			else if (controlObject is NSView view)
+			{
+				Control = view;
+			}
+			else if (controlObject is IntPtr handle)
+			{
+				view = Runtime.GetNSObject(handle) as NSView;
+				if (view == null)
+					throw new InvalidOperationException("supplied handle is invalid or does not refer to an object derived from NSView");
+				Control = view;
+			}
+			else
+				throw new NotSupportedException($"controlObject of type {controlObject.GetType()} is not supported by this platform");
+		}
 	}
 }
 

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -208,6 +208,7 @@ namespace Eto.Mac
 			p.Add<ToggleButton.IHandler>(() => new ToggleButtonHandler());
 			p.Add<PropertyGrid.IHandler>(() => new ThemedPropertyGridHandler());
 			p.Add<CollectionEditor.IHandler>(() => new ThemedCollectionEditorHandler());
+			p.Add<NativeControlHost.IHandler>(() => new NativeControlHandler());
 
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/src/Eto.WinForms/Forms/Controls/NativeControlHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/NativeControlHandler.cs
@@ -1,10 +1,55 @@
-﻿namespace Eto.WinForms.Forms.Controls
+﻿
+
+namespace Eto.WinForms.Forms.Controls
 {
-	public class NativeControlHandler : WindowsControl<swf.Control, Control, Control.ICallback>
+	public class NativeControlHandler : WindowsControl<swf.Control, Control, Control.ICallback>, NativeControlHost.IHandler
 	{
+		swf.IWin32Window _win32Window;
 		public NativeControlHandler(swf.Control nativeControl)
 		{
 			Control = nativeControl;
+		}
+		
+		public NativeControlHandler()
+		{
+		}
+		
+
+		public void Create(object controlObject)
+		{
+			if (controlObject == null)
+			{
+				Control = new swf.UserControl();
+			}
+			else if (controlObject is swf.Control control)
+			{
+				Control = control;
+			}
+			else if (controlObject is IntPtr handle)
+			{
+				CreateWithHandle(handle);
+			}
+			else if (controlObject is swf.IWin32Window win32Window)
+			{
+				// keep a reference so it doesn't get GC'd
+				_win32Window = win32Window;
+				CreateWithHandle(win32Window.Handle);
+			}
+			else
+				throw new NotSupportedException($"controlObject of type {controlObject.GetType()} is not supported by this platform");
+		}
+
+		private void CreateWithHandle(IntPtr handle)
+		{
+			Control = new swf.Control();
+			Win32.GetWindowRect(handle, out var rect);
+			Win32.SetParent(handle, Control.Handle);
+			Control.Size = rect.ToSD().Size;
+			Widget.SizeChanged += (sender, e) =>
+			{
+				var size = Control.Size;
+				Win32.SetWindowPos(handle, IntPtr.Zero, 0, 0, size.Width, size.Height, Win32.SWP.NOZORDER);
+			};
 		}
 	}
 }

--- a/src/Eto.WinForms/Platform.cs
+++ b/src/Eto.WinForms/Platform.cs
@@ -115,6 +115,7 @@ namespace Eto.WinForms
 			p.Add<ToggleButton.IHandler>(() => new ToggleButtonHandler());
 			p.Add<PropertyGrid.IHandler>(() => new ThemedPropertyGridHandler());
 			p.Add<CollectionEditor.IHandler>(() => new ThemedCollectionEditorHandler());
+			p.Add<NativeControlHost.IHandler>(() => new NativeControlHandler());
 
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -620,5 +620,17 @@ namespace Eto
 		[DllImport("user32.dll")]
 		[return: MarshalAs(UnmanagedType.Bool)]
 		public static extern bool GetScrollInfo(IntPtr hwnd, int fnBar, ref SCROLLINFO lpsi);
+
+		[DllImport("user32.dll")]
+		public static extern IntPtr SetParent(IntPtr hWndChild, IntPtr hWndNewParent);
+
+		[DllImport("user32.dll")]
+		public static extern IntPtr CreateWindowEx(uint dwExStyle, string lpClassName, string lpWindowName, uint dwStyle, int x, int y, int nWidth, int nHeight, IntPtr hWndParent, IntPtr hMenu, IntPtr hInstance, IntPtr lpParam);
+
+		[DllImport("user32.dll")]
+		public static extern bool DestroyWindow(IntPtr hWnd);
+		
+		[DllImport("User32.dll", SetLastError = true)]
+    	public static extern int SetWindowRgn(IntPtr hWnd, IntPtr hRgn, bool bRedraw);
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/NativeControlHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/NativeControlHandler.cs
@@ -1,22 +1,161 @@
-﻿namespace Eto.Wpf.Forms.Controls
-{
-	public class NativeControlHandler : WpfFrameworkElement<sw.FrameworkElement, Control, Control.ICallback>
-	{
-		public NativeControlHandler(sw.FrameworkElement nativeControl)
-		{
-			Control = nativeControl;
-		}
+using Eto.Forms;
+using System.Windows.Interop;
+using IWin32WindowWinForms = System.Windows.Forms.IWin32Window;
+using IWin32WindowInterop = System.Windows.Interop.IWin32Window;
 
-		public override Eto.Drawing.Color BackgroundColor
+namespace Eto.Wpf.Forms.Controls;
+public class NativeControlHandler : WpfFrameworkElement<sw.FrameworkElement, Control, Control.ICallback>, NativeControlHost.IHandler
+{
+	public override IntPtr NativeHandle
+	{
+		get
 		{
-			get
-			{
-				throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, "You cannot get this property for native controls"));
-			}
-			set
-			{
-				throw new NotSupportedException(string.Format(CultureInfo.CurrentCulture, "You cannot set this property for native controls"));
-			}
+			if (Control is EtoHwndHost host)
+				return host.Handle;
+			return base.NativeHandle;
 		}
 	}
+
+	public NativeControlHandler()
+	{
+	}
+
+	public NativeControlHandler(sw.FrameworkElement nativeControl)
+	{
+		Control = nativeControl;
+	}
+
+	public override Color BackgroundColor
+	{
+		get => throw new NotSupportedException("You cannot get this property for native controls");
+		set => throw new NotSupportedException("You cannot set this property for native controls");
+	}
+
+	public void Create(object controlObject)
+	{
+		if (controlObject == null)
+		{
+			var host = new EtoHwndHost(null);
+			host.GetPreferredSize += () => Size.Round(UserPreferredSize.ToEto() * (Widget.ParentWindow?.Screen?.LogicalPixelSize ?? 1));
+			Control = host;
+		}
+		else if (controlObject is sw.FrameworkElement element)
+		{
+			Control = element;
+		}
+		else if (controlObject is IntPtr handle)
+		{
+			Control = new EtoHwndHost(new HandleRef(this, handle));
+		}
+		else if (controlObject is IWin32WindowWinForms win32Window)
+		{
+			// keep a reference to the win32window object
+			var host = new EtoHwndHost(new HandleRef(win32Window, win32Window.Handle));
+			host.GetPreferredSize += () => Size.Round(UserPreferredSize.ToEto() * (Widget.ParentWindow?.Screen?.LogicalPixelSize ?? 1));
+			Control = host;
+		}
+		else if (controlObject is IWin32WindowInterop win32WindowWpf)
+		{
+			// keep a reference to the win32window object
+			var host = new EtoHwndHost(new HandleRef(win32WindowWpf, win32WindowWpf.Handle));
+			host.GetPreferredSize += () => Size.Round(UserPreferredSize.ToEto() * (Widget.ParentWindow?.Screen?.LogicalPixelSize ?? 1));
+			Control = host;
+		}
+		else
+			throw new NotSupportedException($"controlObject of type {controlObject.GetType()} is not supported by this platform");
+	}
+}
+
+sealed class EtoHwndHost : HwndHost
+{
+	HandleRef? _hwnd;
+	swc.ScrollViewer _parentScrollViewer;
+	sd.Rectangle _regionRect = sd.Rectangle.Empty;
+
+	public Func<Size> GetPreferredSize { get; set; }
+
+	public EtoHwndHost(HandleRef? hwnd)
+	{
+		_hwnd = hwnd;
+	}
+
+	protected override HandleRef BuildWindowCore(HandleRef hwndParent)
+	{
+		if (_hwnd == null)
+		{
+			// create a new WinForms Usercontrol to host whatever we want
+			var size = GetPreferredSize?.Invoke() ?? new Size(100, 100);
+			var ctl = new swf.UserControl();
+			ctl.Size = size.ToSD();
+			_hwnd = new HandleRef(ctl, ctl.Handle);
+		}
+		Win32.SetParent(_hwnd.Value.Handle, hwndParent.Handle);
+		HookParentScrollViewer();
+		return _hwnd.Value;
+	}
+
+	protected override void OnVisualParentChanged(sw.DependencyObject oldParent)
+	{
+		base.OnVisualParentChanged(oldParent);
+		HookParentScrollViewer();
+	}
+
+	void HookParentScrollViewer()
+	{
+		if (_parentScrollViewer != null)
+			_parentScrollViewer.ScrollChanged -= ParentScrollViewerScrollChanged;
+		_regionRect = sd.Rectangle.Empty;
+		_parentScrollViewer = this.GetVisualParent<swc.ScrollViewer>();
+		if (_parentScrollViewer != null)
+			_parentScrollViewer.ScrollChanged += ParentScrollViewerScrollChanged;
+	}
+
+	protected override void DestroyWindowCore(HandleRef hwnd)
+	{
+	}
+
+	private void ParentScrollViewerScrollChanged(object sender, swc.ScrollChangedEventArgs e)
+	{
+		UpdateRegion();
+	}
+
+	double LogicalPixelSize => sw.PresentationSource.FromVisual(this)?.CompositionTarget.TransformToDevice.M11 ?? 1.0;
+
+	sd.Size ScaledSize(double w, double h)
+	{
+		var pixelSize = LogicalPixelSize;
+		return new sd.Size((int)Math.Round(w * pixelSize), (int)Math.Round(h * pixelSize));
+	}
+
+	void UpdateRegion()
+	{
+		if (_parentScrollViewer == null || !IsVisible)
+			return;
+
+		if (_parentScrollViewer.Content is not sw.FrameworkElement content)
+			return;
+
+		var transform = content.TransformToDescendant(this);
+		var offset = transform.Transform(new sw.Point(_parentScrollViewer.HorizontalOffset, _parentScrollViewer.VerticalOffset));
+
+		
+		var loc = ScaledSize(offset.X, offset.Y);
+		var size = ScaledSize(_parentScrollViewer.ViewportWidth, _parentScrollViewer.ViewportHeight);
+
+		var rect = new sd.Rectangle(new sd.Point(loc), size);
+		if (rect != _regionRect)
+		{
+			SetRegion(rect);
+			_regionRect = rect;
+		}
+	}
+
+	private void SetRegion(sd.Rectangle rect)
+	{
+		using (var graphics = sd.Graphics.FromHwnd(Handle))
+			Win32.SetWindowRgn(Handle, new sd.Region(rect).GetHrgn(graphics), true);
+	}
+
+
+
 }

--- a/src/Eto.Wpf/Platform.cs
+++ b/src/Eto.Wpf/Platform.cs
@@ -144,6 +144,7 @@ namespace Eto.Wpf
 			p.Add<ToggleButton.IHandler>(() => new ToggleButtonHandler());
 			p.Add<PropertyGrid.IHandler>(() => new ThemedPropertyGridHandler());
 			p.Add<CollectionEditor.IHandler>(() => new ThemedCollectionEditorHandler());
+			p.Add<NativeControlHost.IHandler>(() => new NativeControlHandler());
 
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());

--- a/src/Eto.Wpf/WpfHelpers.cs
+++ b/src/Eto.Wpf/WpfHelpers.cs
@@ -54,7 +54,7 @@ namespace Eto.Forms
 		{
 			if (nativeControl == null)
 				return null;
-			return new Control(new NativeControlHandler(nativeControl));
+			return new NativeControlHost(nativeControl);
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/Controls/NativeControlHost.cs
+++ b/src/Eto/Forms/Controls/NativeControlHost.cs
@@ -1,0 +1,50 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Control to host a native control within Eto
+/// </summary>
+/// <remarks>
+/// This can be used as a cross platform way to convert a native control to an eto control without having to reference
+/// Eto's platform-specific assemblies and using its ToNatve() method or creating custom handlers.
+/// 
+/// The type of the supplied controlObject supported depends on the platform you are running on.
+/// - Wpf:         FrameworkElement, HWND (IntPtr), System.Windows.Forms.Control, or IWin32Window
+/// - WinForms:    HWND, System.Windows.Forms.Control, or IWin32Window
+/// - Mac64/macOS: AppKit.NSView, handle to NSView (IntPtr)
+/// - Gtk:         Gtk.Widget, or handle to Gtk.Widget (IntPtr)
+/// </remarks>
+[Handler(typeof(IHandler))]
+public class NativeControlHost : Control
+{
+	new IHandler Handler => (IHandler)base.Handler;
+
+	/// <summary>
+	/// Initializes a new instance of the native control host with the specified native controlObject
+	/// </summary>
+	/// <param name="controlObject">ControlObject to host, of null to create a native hosting control that the caller can use</param>
+	public NativeControlHost(object controlObject)
+	{
+		Handler.Create(controlObject);
+		Initialize();
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the native control host with a native hosting control that the caller can use directly.
+	/// </summary>
+	public NativeControlHost() : this(null)
+	{
+	}
+
+	/// <summary>
+	/// Handler interface for the <see cref="NativeControlHost"/>
+	/// </summary>
+	[AutoInitialize(false)]
+	public new interface IHandler : Control.IHandler
+	{
+		/// <summary>
+		/// Initializes a new instance of the native control host with the specified native controlObject
+		/// </summary>
+		/// <param name="controlObject">ControlObject to host, of null to create a native hosting control that the caller can use</param>
+		void Create(object controlObject);
+	}
+}

--- a/test/Eto.Test.Gtk/NativeHostControls.cs
+++ b/test/Eto.Test.Gtk/NativeHostControls.cs
@@ -1,0 +1,11 @@
+namespace Eto.Test.Gtk;
+
+class NativeHostControls : INativeHostControls
+{
+	public IEnumerable<NativeHostTest> GetNativeHostTests()
+	{
+		yield return new NativeHostTest("Gtk.Button", () => new global::Gtk.Button { Child = new global::Gtk.Label { Text = "A Gtk.Button" } });
+		yield return new NativeHostTest("IntPtr", () => new global::Gtk.Button { Child = new global::Gtk.Label { Text = "An IntPtr handle button" } }.Handle);
+	}
+}
+

--- a/test/Eto.Test.Gtk/Startup.cs
+++ b/test/Eto.Test.Gtk/Startup.cs
@@ -7,9 +7,10 @@ namespace Eto.Test.Gtk
 		[STAThread]
 		static void Main(string[] args)
 		{
-			var generator = new Eto.GtkSharp.Platform();
+			var platform = new Eto.GtkSharp.Platform();
+			platform.Add<INativeHostControls>(() => new NativeHostControls());
 			
-			var app = new TestApplication(generator);
+			var app = new TestApplication(platform);
 			app.TestAssemblies.Add(typeof(Startup).Assembly);
 			app.Run();
 		}

--- a/test/Eto.Test.Mac/NativeHostControls.cs
+++ b/test/Eto.Test.Mac/NativeHostControls.cs
@@ -1,0 +1,12 @@
+namespace Eto.Test.Mac
+{
+	class NativeHostControls : INativeHostControls
+	{
+		public IEnumerable<NativeHostTest> GetNativeHostTests()
+		{
+			yield return new NativeHostTest("NSView", () => new NSButton { Title = "A NSButton"});
+			yield return new NativeHostTest("IntPtr", () => new NSButton { Title = "An IntPtr handle button"}.Handle);
+		}
+	}
+}
+

--- a/test/Eto.Test.Mac/Startup.cs
+++ b/test/Eto.Test.Mac/Startup.cs
@@ -13,6 +13,7 @@ namespace Eto.Test.Mac
 			var stopwatch = new Stopwatch();
 			stopwatch.Start();
 			var platform = new Eto.Mac.Platform();
+			platform.Add<INativeHostControls>(() => new NativeHostControls());
 			stopwatch.Stop();
 			
 			var app = new TestApplication(platform);

--- a/test/Eto.Test.WinForms/NativeHostControls.cs
+++ b/test/Eto.Test.WinForms/NativeHostControls.cs
@@ -1,0 +1,12 @@
+namespace Eto.Test.WinForms
+{
+	class NativeHostControls : INativeHostControls
+	{
+		public IEnumerable<NativeHostTest> GetNativeHostTests()
+		{
+			yield return new NativeHostTest("HWND", () => new swf.UserControl { AutoScaleMode = swf.AutoScaleMode.Dpi, Controls = { new swf.Button { Text = "A HWND button" } } }.Handle);
+			yield return new NativeHostTest("WinForms", () => new swf.Button { Text = "A WinForms button" });
+		}
+	}
+}
+

--- a/test/Eto.Test.WinForms/Startup.cs
+++ b/test/Eto.Test.WinForms/Startup.cs
@@ -9,6 +9,8 @@ namespace Eto.Test.WinForms
 		static void Main(string[] args)
 		{
 			var platform = new Eto.WinForms.Platform();
+			platform.Add<INativeHostControls>(() => new NativeHostControls());
+
 			var app = new TestApplication(platform);
 			app.TestAssemblies.Add(typeof(Startup).Assembly);
 			app.Run();

--- a/test/Eto.Test.Wpf/NativeHostControls.cs
+++ b/test/Eto.Test.Wpf/NativeHostControls.cs
@@ -1,0 +1,13 @@
+namespace Eto.Test.Wpf
+{
+	class NativeHostControls : INativeHostControls
+	{
+		public IEnumerable<NativeHostTest> GetNativeHostTests()
+		{
+			yield return new NativeHostTest("FrameworkElement", () => new System.Windows.Controls.Button { Content = "A WPF button"});
+			yield return new NativeHostTest("HWND", () => new System.Windows.Forms.Button { Text = "A HWND button"}.Handle);
+			yield return new NativeHostTest("WinForms", () => new System.Windows.Forms.Button { Text = "A WinForms button"});
+		}
+	}
+}
+

--- a/test/Eto.Test.Wpf/Startup.cs
+++ b/test/Eto.Test.Wpf/Startup.cs
@@ -9,6 +9,7 @@ namespace Eto.Test.Wpf
 		static void Main(string[] args)
 		{
 			var platform = new Eto.Wpf.Platform();
+			platform.Add<INativeHostControls>(() => new NativeHostControls());
 
 			// optional - enables GDI text display mode
 			/**

--- a/test/Eto.Test/NativeHostControls.cs
+++ b/test/Eto.Test/NativeHostControls.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Eto.Test
+{
+	public interface INativeHostControls
+	{
+		public IEnumerable<NativeHostTest> GetNativeHostTests();
+	}
+	
+	public class NativeHostTest
+	{
+		Func<object> _createControl;
+		
+		public NativeHostTest(string name, Func<object> create)
+		{
+			Name = name;
+			_createControl = create;
+		}
+		public string Name { get; }
+		public object CreateControl() => _createControl();
+
+		public override string ToString() => Name;
+	}
+	
+    public static class NativeHostControls
+    {
+		static INativeHostControls Handler => Platform.Instance.CreateShared<INativeHostControls>();
+
+		public static IEnumerable<NativeHostTest> GetNativeHostTests() => Handler.GetNativeHostTests();
+    }
+}

--- a/test/Eto.Test/UnitTests/Forms/NativeControlHostTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/NativeControlHostTests.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography.X509Certificates;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms
+{
+	[TestFixture]
+    public class NativeControlHostTests : TestBase
+    {
+		
+		[ManualTest]
+		[TestCaseSource(typeof(NativeHostControls), nameof(NativeHostControls.GetNativeHostTests))]
+		public void NativeHostShouldShowControl(NativeHostTest test)
+		{
+			ManualForm("Control should show something", form =>
+			{
+				form.Resizable = true;
+				return new NativeControlHost(test.CreateControl());
+			});
+		}
+        
+		[ManualTest]
+		[TestCaseSource(typeof(NativeHostControls), nameof(NativeHostControls.GetNativeHostTests))]
+		public void NativeHostInScrollableShouldBeClipped(NativeHostTest test)
+		{
+			ManualForm("Native control should not show when scrolled out of view", form =>
+			{
+				form.Resizable = true;
+				var scrollable = new Scrollable
+				{
+					Size = new Size(400, 400),
+					Content = new TableLayout
+					{
+						Rows = {
+						new Panel { Content = "Before", Size = new Size(600, 400) },
+						new NativeControlHost(test.CreateControl()),
+						new Panel { Content = "After", Size = new Size(600, 400) },
+					}
+					}
+				};
+
+				return scrollable;
+			});
+		}
+    }
+}


### PR DESCRIPTION
This adds an easier way to host a native control within Eto without having to reference each of the platform-specific assemblies.  You can pass the native object/handle to the `NativeControlHost` constructor, or if it is omitted then it will create a native control for you, along with a NativeHandle to do with what you wish.

Fixes #2167