### PR TITLE
Add ability to set up native control when subclassing NativeControlHost

### DIFF
--- a/src/Eto.Gtk/GtkHelpers.cs
+++ b/src/Eto.Gtk/GtkHelpers.cs
@@ -46,7 +46,7 @@ namespace Eto.Forms
 		{
 			if (nativeWidget == null)
 				return null;
-			return new Control(new NativeControlHandler(nativeWidget));
+			return new NativeControlHost(nativeWidget);
 		}
 
 		/// <summary>

--- a/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
@@ -13,9 +13,26 @@
 		{
 		}
 
+		protected override void Initialize()
+		{
+			// don't call any initialize routines as we are hosting a native control
+			base.Initialize();
+		}
+
+		protected override NSView CreateControl()
+		{
+			if (Widget is NativeControlHost host && Callback is NativeControlHost.ICallback callback)
+			{
+				var args = new CreateNativeControlArgs();
+				callback.OnCreateNativeControl(host, args);
+				return CreateHost(args.NativeControl);
+			}
+			return base.CreateControl();
+		}
+
 		public override SizeF GetPreferredSize(SizeF availableSize)
 		{
-			return Control.FittingSize.ToEto();
+			return Control?.FittingSize.ToEto() ?? SizeF.Empty;
 		}
 
 		public NativeControlHandler(NSViewController nativeControl)
@@ -24,27 +41,37 @@
 			Control = controller.View;
 		}
 
-		public override NSView ContainerControl { get { return Control; } }
+		public override NSView ContainerControl => Control;
 		
-		public void Create(object controlObject)
+		public void Create(object nativeControl)
 		{
-			if (controlObject == null)
+			Control = CreateHost(nativeControl);
+		}
+
+		NSView CreateHost(object nativeControl)
+		{
+			if (nativeControl == null)
 			{
-				Control = new NSView();
+				return new NSView();
 			}
-			else if (controlObject is NSView view)
+			else if (nativeControl is NSView view)
 			{
-				Control = view;
+				return view;
 			}
-			else if (controlObject is IntPtr handle)
+			else if (nativeControl is NSViewController viewController)
+			{
+				controller = viewController;
+				return controller.View;
+			}
+			else if (nativeControl is IntPtr handle)
 			{
 				view = Runtime.GetNSObject(handle) as NSView;
 				if (view == null)
 					throw new InvalidOperationException("supplied handle is invalid or does not refer to an object derived from NSView");
-				Control = view;
+				return view;
 			}
 			else
-				throw new NotSupportedException($"controlObject of type {controlObject.GetType()} is not supported by this platform");
+				throw new NotSupportedException($"Native control of type {nativeControl.GetType()} is not supported by this platform");
 		}
 	}
 }

--- a/src/Eto.Mac/MacHelpers.cs
+++ b/src/Eto.Mac/MacHelpers.cs
@@ -66,7 +66,7 @@ namespace Eto.Forms
 		{
 			if (view == null)
 				return null;
-			return new Control(new NativeControlHandler(view));
+			return new NativeControlHost(view);
 		}
 
 		/// <summary>
@@ -78,7 +78,7 @@ namespace Eto.Forms
 		{
 			if (viewController == null)
 				return null;
-			return new Control(new NativeControlHandler(viewController));
+			return new NativeControlHost(viewController);
 		}
 
 		/// <summary>

--- a/src/Eto.WinForms/Forms/WindowsControl.cs
+++ b/src/Eto.WinForms/Forms/WindowsControl.cs
@@ -184,9 +184,9 @@ namespace Eto.WinForms.Forms
 
 		Control.ICallback IWindowsControl.Callback { get { return Callback; } }
 
-		public bool XScale { get; set; }
+		public bool XScale { get; set; } = true;
 
-		public bool YScale { get; set; }
+		public bool YScale { get; set; } = true;
 
 		public virtual Size? GetDefaultSize(Size availableSize) { return null; }// Control.GetPreferredSize(availableSize.ToSD()).ToEto(); }
 
@@ -276,8 +276,6 @@ namespace Eto.WinForms.Forms
 		protected override void Initialize()
 		{
 			base.Initialize();
-			XScale = true;
-			YScale = true;
 			Control.Margin = swf.Padding.Empty;
 			Control.Tag = this;
 		}

--- a/src/Eto.WinForms/WinFormsHelpers.cs
+++ b/src/Eto.WinForms/WinFormsHelpers.cs
@@ -48,7 +48,7 @@ namespace Eto.Forms
 		{
 			if (nativeControl == null)
 				return null;
-			return new Control(new NativeControlHandler(nativeControl));
+			return new NativeControlHost(nativeControl);
 		}
 
 		/// <summary>

--- a/src/Eto/Forms/Controls/NativeControlHost.cs
+++ b/src/Eto/Forms/Controls/NativeControlHost.cs
@@ -1,5 +1,18 @@
 namespace Eto.Forms;
 
+
+/// <summary>
+/// Arguments when creating a native control for the <see cref="NativeControlHost"/>
+/// </summary>
+public class CreateNativeControlArgs : EventArgs
+{
+	/// <summary>
+	/// Native control or handle to use. See comments for <see cref="NativeControlHost"/> on what types are supported for each platform.
+	/// </summary>
+	/// 
+	public object NativeControl { get; set; }
+}
+
 /// <summary>
 /// Control to host a native control within Eto
 /// </summary>
@@ -19,21 +32,70 @@ public class NativeControlHost : Control
 	new IHandler Handler => (IHandler)base.Handler;
 
 	/// <summary>
-	/// Initializes a new instance of the native control host with the specified native controlObject
+	/// Initializes a new instance of the native control host with the specified native control
 	/// </summary>
-	/// <param name="controlObject">ControlObject to host, of null to create a native hosting control that the caller can use</param>
-	public NativeControlHost(object controlObject)
+	/// <param name="nativeControl">Native contro to host, of null to create a native hosting control that the caller can use.</param>
+	public NativeControlHost(object nativeControl)
 	{
-		Handler.Create(controlObject);
+		Handler.Create(nativeControl);
 		Initialize();
 	}
 
 	/// <summary>
 	/// Initializes a new instance of the native control host with a native hosting control that the caller can use directly.
 	/// </summary>
-	public NativeControlHost() : this(null)
+	public NativeControlHost()
+	{
+		// derived classes should override OnCreateNativeControl to provide the native control
+		if (!IsSubclass)
+			Handler.Create(null);
+		Initialize();
+	}
+
+	bool IsSubclass => GetType() != typeof(NativeControlHost);
+	
+	/// <summary>
+	/// Called to create the native control.
+	/// </summary>
+	/// <remarks>
+	/// When subclassing, override this method to create your native control and set <see cref="CreateNativeControlArgs.NativeControl"/>
+	/// to one of the supported native control(s) for the platform you are on.
+	/// </remarks>
+	/// <param name="e"></param>
+	protected virtual void OnCreateNativeControl(CreateNativeControlArgs e)
 	{
 	}
+	
+	/// <summary>
+	/// Callback interface for the <see cref="NativeControlHost"/>.
+	/// </summary>
+	public new interface ICallback : Control.ICallback
+	{
+		/// <summary>
+		/// 
+		/// </summary>
+		/// <param name="widget"></param>
+		/// <param name="e"></param>
+		void OnCreateNativeControl(NativeControlHost widget, CreateNativeControlArgs e);
+	}
+
+	/// <summary>
+	/// Callback implementation for the <see cref="NativeControlHost"/>
+	/// </summary>
+	protected new class Callback : Control.Callback, ICallback
+	{
+		/// <inheritdoc/>
+		public void OnCreateNativeControl(NativeControlHost widget, CreateNativeControlArgs e)
+		{
+			using (widget.Platform.Context)
+				widget.OnCreateNativeControl(e);
+		}
+	}
+
+	static readonly object callback = new Callback();
+
+	/// <inheritdoc/>
+	protected override object GetCallback() => callback;
 
 	/// <summary>
 	/// Handler interface for the <see cref="NativeControlHost"/>
@@ -42,9 +104,9 @@ public class NativeControlHost : Control
 	public new interface IHandler : Control.IHandler
 	{
 		/// <summary>
-		/// Initializes a new instance of the native control host with the specified native controlObject
+		/// Initializes a new instance of the native control host with the specified native control
 		/// </summary>
-		/// <param name="controlObject">ControlObject to host, of null to create a native hosting control that the caller can use</param>
-		void Create(object controlObject);
+		/// <param name="nativeControl">Native contro to host, of null to create a native hosting control that the caller can use</param>
+		void Create(object nativeControl);
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/NativeControlHostTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/NativeControlHostTests.cs
@@ -45,5 +45,29 @@ namespace Eto.Test.UnitTests.Forms
 				return scrollable;
 			});
 		}
+		
+		class MyControl : NativeControlHost
+		{
+			public NativeHostTest Test { get; set; }
+
+			protected override void OnCreateNativeControl(CreateNativeControlArgs e)
+			{
+				base.OnCreateNativeControl(e);
+				e.NativeControl = Test.CreateControl();
+			}
+		}
+		
+		[ManualTest]
+		[TestCaseSource(typeof(NativeHostControls), nameof(NativeHostControls.GetNativeHostTests))]
+		public void NetiveHostInSubclassShouldWork(NativeHostTest test)
+		{
+			ManualForm("Control should show something", form =>
+			{
+				form.Resizable = true;
+				var control = new MyControl { Test = test };
+				control.Size = new Size(100, 20);
+				return control;
+			});
+		}
     }
 }


### PR DESCRIPTION
This gives a better pattern for subclassing the `NativeControlHost` and creating the native control using a callback.

A few tweaks to the naming (`controlObject` > `nativeControl`), and ensure the `ToEto()` helpers for each platform uses the `NativeControlHost` instead of hooking up manually.

E.g.
```c#
class MyControl : NativeControlHost
{
	protected override void OnCreateNativeControl(CreateNativeControlArgs e)
	{
		base.OnCreateNativeControl(e);
		e.NativeControl = yourNativeControlOrHandle;
	}
}
```