### PR TITLE
Further fixes removing controls from TableLayout

### DIFF
--- a/src/Eto.WinForms/Forms/TableLayoutHandler.cs
+++ b/src/Eto.WinForms/Forms/TableLayoutHandler.cs
@@ -272,7 +272,7 @@ namespace Eto.WinForms.Forms
 			if (childControl.Parent == Control)
 			{
 				var pos = Control.GetCellPosition(childControl);
-				if (views != null)
+				if (views != null && ReferenceEquals(views[pos.Column, pos.Row], child))
 					views[pos.Column, pos.Row] = null;
 				childControl.Parent = null;
 				SetEmptyCell(pos.Column, pos.Row);

--- a/src/Eto.Wpf/Forms/TableLayoutHandler.cs
+++ b/src/Eto.Wpf/Forms/TableLayoutHandler.cs
@@ -423,10 +423,20 @@ namespace Eto.Wpf.Forms
 
 		public override void Remove(sw.FrameworkElement child)
 		{
+			// ensure this is actually a child of this table
+			if (child.Parent != Control)
+				return;
+
+			// row and column could be for a different table
 			var x = swc.Grid.GetColumn(child);
 			var y = swc.Grid.GetRow(child);
 			Control.Children.Remove(child);
-			controls[x, y] = null;
+			if (controls != null
+				&& x >= 0 && x < controls.GetLength(0)
+				&& y >= 0 && y < controls.GetLength(1)
+				&& ReferenceEquals(controls[x,y]?.GetContainerControl(), child)
+				)
+				controls[x, y] = null;
 			OnChildPreferredSizeUpdated();
 		}
 	}


### PR DESCRIPTION
Further to #2591 this fixes some additional issues when recreating table layouts when the controls already exist in another layout.