### PR TITLE
Prevent SubMenuItem action on macOS

### DIFF
--- a/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
@@ -34,7 +34,8 @@ namespace Eto.Mac.Forms.Menu
 		{
 			Enabled = true;
 			Control.Target = new MenuActionHandler{ Handler = this };
-			Control.Action = MenuActionHandler.selActivate;
+			if (Widget is not SubMenuItem)
+				Control.Action = MenuActionHandler.selActivate;
 			base.Initialize();
 		}
 


### PR DESCRIPTION
Click on SubMenuItem will close Context Menu or Main Menu. It is not expected behaviour for macOS.

![Eto submenuitems](https://github.com/picoe/Eto/assets/111512055/26eb2278-15ec-45bc-b26c-f7c9fefb6db8)
