### PR TITLE
Mac: Use InvokeOnMainThread instead of DispatchQueue

### DIFF
--- a/src/Eto.Mac/Forms/ApplicationHandler.cs
+++ b/src/Eto.Mac/Forms/ApplicationHandler.cs
@@ -124,12 +124,12 @@ namespace Eto.Mac.Forms
 			if (NSThread.IsMain)
 				action();
 			else
-				DispatchQueue.MainQueue.DispatchSync(action);
+				Control.InvokeOnMainThread(action);
 		}
 		
 		public void AsyncInvoke(Action action)
 		{
-			DispatchQueue.MainQueue.DispatchAsync(action);
+			Control.BeginInvokeOnMainThread(action);
 		}
 
 		public void Restart()


### PR DESCRIPTION
Looks like this was changed in https://github.com/picoe/Eto/commit/6bc3a3b0cf11581b7b437ba8a9da296bc81bb183 but it doesn't look like a necessary part of the commit?

The DispatchQueue doesn't always work as it ignores the run loop mode (see https://stackoverflow.com/a/9336253/2112909).

Without this change in some cases opening a modal dialog (a common use case for Invoke) caused weird behavior on Mac (empty uninteractible form) while Windows and Linux worked fine.