### PR TITLE
WinForms: Handle MainForm changes

### DIFF
--- a/src/Eto.WinForms/Forms/ApplicationHandler.cs
+++ b/src/Eto.WinForms/Forms/ApplicationHandler.cs
@@ -8,6 +8,7 @@ namespace Eto.WinForms.Forms
 		bool quitting;
 		readonly Thread mainThread;
 		SynchronizationContext context;
+		swf.ApplicationContext applicationContext = new swf.ApplicationContext();
 		public static bool EnableScrollingUnderMouse = true;
 		public static bool BubbleMouseEvents = true;
 		public static bool BubbleKeyEvents = true;
@@ -115,10 +116,7 @@ namespace Eto.WinForms.Forms
 
 				if (!quitting)
 				{
-					if (Widget.MainForm != null && Widget.MainForm.Loaded)
-						swf.Application.Run((swf.Form)Widget.MainForm.ControlObject);
-					else
-						swf.Application.Run();
+					swf.Application.Run(applicationContext);
 				}
 			}
 			else
@@ -230,6 +228,7 @@ namespace Eto.WinForms.Forms
 
 		public void OnMainFormChanged()
 		{
+			applicationContext.MainForm = (swf.Form)Widget.MainForm.ControlObject;
 		}
 
 		public void Quit()


### PR DESCRIPTION
This allows the former MainForm to be closed without the application shutting down.

Running with a swf.ApplicationContext with a form is equivalent to just running with the form ([reference source](https://referencesource.microsoft.com/#System.Windows.Forms/winforms/Managed/System/WinForms/Application.cs,1485)), and allows that form to be changed later.

I'm pretty sure the MainForm.Loaded check is unnecessary as the form should always be loaded when it gets to this point of the Eto.Application.Run flow.