### PR TITLE
WinForms: Show icon when set in Dialog

### DIFF
--- a/src/Eto.WinForms/Forms/WindowHandler.cs
+++ b/src/Eto.WinForms/Forms/WindowHandler.cs
@@ -457,6 +457,11 @@ namespace Eto.WinForms.Forms
 			{
 				icon = value;
 				Control.Icon = ((IWindowsIconSource)icon.Handler).GetIcon();
+				if (!Control.ShowIcon)
+				{
+					// For dialogs we don't show an icon by default and need to enable it here
+					Control.ShowIcon = true;
+				}
 			}
 		}
 


### PR DESCRIPTION
In DialogHandler ShowIcon is set to false:
https://github.com/picoe/Eto/blob/5fb78c03d5c55043b95951640d69030e93c94eeb/src/Eto.WinForms/Forms/DialogHandler.cs#L18

If an icon is manually set it should be displayed.

Using an "if" instead of just setting to true to avoid unnecessary redrawing.