### PR TITLE
Reparent TableRow and TableCell when added from one table to another

### DIFF
--- a/src/Eto/Forms/Container.cs
+++ b/src/Eto/Forms/Container.cs
@@ -295,9 +295,10 @@ public abstract class Container : Control, IBindableWidgetContainer
 				child.TriggerUnLoad(EventArgs.Empty);
 			}
 			child.VisualParent = null;
-			if (ReferenceEquals(child.InternalLogicalParent, this))
-				child.InternalLogicalParent = null;
 		}
+		
+		if (ReferenceEquals(child.InternalLogicalParent, this))
+			child.InternalLogicalParent = null;
 	}
 
 	/// <summary>
@@ -397,7 +398,7 @@ public abstract class Container : Control, IBindableWidgetContainer
 			// Detach so parent can remove from controls collection if necessary.
 			// prevents UnLoad from being called more than once when containers think a control is still a child
 			// no-op if there is no parent (handled in detach)
-			child.Detach();
+			child.Detach(); //.VisualParent?.Remove(child);
 
 			if (ReferenceEquals(child.InternalLogicalParent, null))
 				SetLogicalParent(child);

--- a/src/Eto/Forms/Layout/TableRow.cs
+++ b/src/Eto/Forms/Layout/TableRow.cs
@@ -155,39 +155,46 @@ public class TableRow
 		return new TableCell(new TableLayout(row));
 	}
 
-	internal void SetLayout(TableLayout layout)
+	internal void SetLayout(TableLayout layout, bool shouldRemove)
 	{
-		((TableCellCollection)Cells).SetLayout(layout);
+		((TableCellCollection)Cells).SetLayout(this, layout, shouldRemove);
 	}
 }
 
 class TableRowCollection : Collection<TableRow>, IList
 {
-	TableLayout layout;
+	internal TableLayout _layout;
 	public TableRowCollection(TableLayout layout)
 	{
-		this.layout = layout;
+		_layout = layout;
 	}
 
 	public TableRowCollection(TableLayout layout, IEnumerable<TableRow> list)
 		: base(list.Select(r => r ?? new TableRow { ScaleHeight = true }).ToList())
 	{
-		this.layout = layout;
+		_layout = layout;
 		foreach (var item in this)
-			item?.SetLayout(layout);
+			item?.SetLayout(layout, true);
+	}
+	
+	internal void RemoveItemWithoutLayoutUpdate(TableRow row)
+	{
+		var index = IndexOf(row);
+		if (index >= 0)
+			base.RemoveItem(index);
 	}
 
 	protected override void RemoveItem(int index)
 	{
 		var item = this[index];
-		item?.SetLayout(null);
+		item?.SetLayout(null, false);
 		base.RemoveItem(index);
 	}
 
 	protected override void ClearItems()
 	{
 		foreach (var item in this)
-			item?.SetLayout(null);
+			item?.SetLayout(null, false);
 		base.ClearItems();
 	}
 
@@ -195,17 +202,17 @@ class TableRowCollection : Collection<TableRow>, IList
 	{
 		if (item == null)
 			item = new TableRow { ScaleHeight = true };
-		item?.SetLayout(layout);
+		item?.SetLayout(_layout, true);
 		base.InsertItem(index, item);
 	}
 
 	protected override void SetItem(int index, TableRow item)
 	{
 		var old = this[index];
-		old?.SetLayout(null);
+		old?.SetLayout(null, false);
 		if (item == null)
 			item = new TableRow { ScaleHeight = true };
-		item?.SetLayout(layout);
+		item?.SetLayout(_layout, true);
 		base.SetItem(index, item);
 	}
 

--- a/test/Eto.Test/UnitTests/Forms/Layout/TableLayoutTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Layout/TableLayoutTests.cs
@@ -189,6 +189,88 @@ namespace Eto.Test.UnitTests.Forms.Layout
 				Assert.Greater(label.Height, 0, "Label didn't get correct height!");
 			});
 		}
+
+		[Test]
+		public void DestroyingChildShouldRemoveFromParent()
+		{
+			TableLayout layout = null;
+			Label child = null;
+			Shown(form =>
+			{
+				child = new Label { Text = "I should not be shown" };
+				layout = new TableLayout
+				{
+					Rows = {
+						new TableRow(child)
+					}
+				};
+				child.Dispose();
+				form.Content = layout;
+			}, () =>
+			{
+				Assert.IsTrue(child.IsDisposed);
+				Assert.IsNull(child.Parent);
+				CollectionAssert.DoesNotContain(layout.Children, child);
+			});
+		}
+
+		[Test, ManualTest]
+		public void CopyingRowsShouldReparentChildren()
+		{
+			ManualForm("Label above should show", form =>
+			{
+				var child = new Label { Text = "I should be shown!" };
+
+				var layout1 = new TableLayout { ID = "layout1" };
+				layout1.Rows.Add(child);
+				Assert.AreEqual(child.Parent, layout1, "#1.1 Child's parent should now be the 2nd table");
+				Assert.AreEqual(child.LogicalParent, layout1, "#1.2 Child's logical parent should now be the 2nd table");
+
+				// copy rows to a new layout
+				var layout2 = new TableLayout { ID = "layout2" };
+				foreach (var row in layout1.Rows.ToList())
+					layout2.Rows.Add(row);
+
+				Assert.AreEqual(0, layout1.Rows.Count, "#2.1 All rows should now be in the 2nd table");
+				Assert.AreEqual(child.Parent, layout2, "#2.2 Child's parent should now be the 2nd table");
+				Assert.AreEqual(child.LogicalParent, layout2, "#2.3 Child's logical parent should now be the 2nd table");
+				return layout2;
+			});
+		}
+
+		[Test, ManualTest]
+		public void CopyingCellsShouldReparentChildren()
+		{
+			ManualForm("Label above should show", form =>
+			{
+				var child = new Label { Text = "I should be shown!" };
+
+				var layout1 = new TableLayout { ID = "layout1" };
+				var cell1 = new TableCell(child);
+				var row1 = new TableRow(child);
+				layout1.Rows.Add(row1);
+				Assert.AreEqual(child.Parent, layout1, "#1.1 Child's parent should now be the 2nd table");
+				Assert.AreEqual(child.LogicalParent, layout1, "#1.2 Child's logical parent should now be the 2nd table");
+
+				// copy rows to a new layout
+				var layout2 = new TableLayout { ID = "layout2" };
+				var row2 = new TableRow();
+				foreach (var row in layout1.Rows.ToList())
+				{
+					foreach (var cell in row.Cells.ToList())
+						row2.Cells.Add(cell);
+				}
+				layout2.Rows.Add(row2);
+
+				Assert.AreEqual(1, layout1.Rows.Count, "#2.1 Should still have a single row");
+				Assert.AreEqual(0, layout1.Rows[0].Cells.Count, "#2.2 Cells should be removed from old table");
+				Assert.AreEqual(1, layout2.Rows.Count, "#2.3 2nd table should have a single row");
+				Assert.AreEqual(1, layout2.Rows[0].Cells.Count, "#2.4 All cells should now be in the 2nd table");
+				Assert.AreEqual(child.Parent, layout2, "#2.5 Child's parent should now be the 2nd table");
+				Assert.AreEqual(child.LogicalParent, layout2, "#2.6 Child's logical parent should now be the 2nd table");
+				return layout2;
+			});
+		}
 	}
 }
 


### PR DESCRIPTION
Now when you add a TableRow or TableCell to a new TableLayout that have already been added to an existing TableLayout, it will be removed from the original TableLayout and the controls will be reparented.