### PR TITLE
Improve DocumentControl styling capabilities

### DIFF
--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -190,9 +190,9 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	}
 
 	/// <summary>
-	/// Gets or sets the highlight background color for the highlighted (or active) tab.
+	/// Gets or sets the highlight background color for the highlighted or selected tab.
 	/// </summary>
-	/// <value>The highlight background color for the highlighted (or active) tab.</value>
+	/// <value>The highlight background color for the highlighted or selected tab.</value>
 	public Color TabHighlightBackgroundColor
 	{
 		get { return tabHighlightBackgroundColor; }
@@ -232,9 +232,9 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	}
 
 	/// <summary>
-	/// Gets or sets the highlight foreground color for the highlighted (or active) tab.
+	/// Gets or sets the highlight foreground color for the highlighted or selected tab.
 	/// </summary>
-	/// <value>The foreground color for the highlighted (or active) tab.</value>
+	/// <value>The foreground color for the highlighted or selected tab.</value>
 	public Color TabHighlightForegroundColor
 	{
 		get { return tabHighlightForegroundColor; }

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -523,7 +523,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 					}
 					else
 						SelectedIndex = i;
-						
+
 					break;
 				}
 			}
@@ -691,8 +691,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		var tabRect = tab.Rect;
 		var textRect = tab.TextRect;
 		var closerect = tab.CloseRect;
-		var closemargin =  closerect.Height / 3;
-		var size = tabRect.Size;
+		var closemargin = closerect.Height / 3;
 
 		var textcolor = Enabled ? TabForegroundColor : DisabledForegroundColor;
 		var backcolor = TabBackgroundColor;
@@ -725,7 +724,6 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 			g.DrawLine(closeForeground, closerect.X + closemargin, closerect.Y + closemargin, closerect.X + closerect.Width - 1 - closemargin, closerect.Y + closerect.Height - 1 - closemargin);
 			g.DrawLine(closeForeground, closerect.X + closemargin, closerect.Y + closerect.Height - 1 - closemargin, closerect.X + closerect.Width - 1 - closemargin, closerect.Y + closemargin);
 		}
-
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -21,6 +21,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	Panel contentPanel;
 	Font font;
 
+	Color backgroundColor;
 	Color disabledForegroundColor;
 	Color closeBackgroundColor;
 	Color closeHighlightBackgroundColor;
@@ -72,6 +73,17 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		{
 			font = value;
 			Calculate();
+		}
+	}
+
+	/// <inheritdoc />
+	public override Color BackgroundColor
+	{
+		get => backgroundColor;
+		set
+		{
+			backgroundColor = value;
+			tabDrawable.Invalidate();
 		}
 	}
 
@@ -229,6 +241,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		nextPrevWidth = 0;
 		startx = 0;
 		font = SystemFonts.Default();
+		backgroundColor = SystemColors.Control;
 		disabledForegroundColor = SystemColors.DisabledText;
 		closeBackgroundColor = SystemColors.Control;
 		closeHighlightBackgroundColor = SystemColors.Highlight;
@@ -596,7 +609,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	{
 		var g = e.Graphics;
 
-		g.Clear(SystemColors.Control);
+		g.Clear(BackgroundColor);
 
 		var posx = nextPrevWidth + startx;
 

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -693,7 +693,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 			size.Width += textoffset;
 		}
 
-		var closesize = UseFixedTabHeight ? minImageSquareSide : tabDrawable.Height / 2;
+		var closesize = (int)Math.Floor(tabDrawable.Height * 0.6);
 		var tabRect = new RectangleF(posx, 0, size.Width + (tab.Closable ? closesize + tabPadding.Horizontal + tabPadding.Right : tabPadding.Horizontal), tabDrawable.Height);
 
 		if (i == selectedIndex && draggingLocation != null)
@@ -703,7 +703,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 
 		tab.Rect = tabRect;
 
-		tab.CloseRect = new RectangleF(tabRect.X + tab.Rect.Width - tabPadding.Right - closesize, tabDrawable.Height / 4, closesize, closesize);
+		tab.CloseRect = new RectangleF(tabRect.X + tab.Rect.Width - tabPadding.Right - closesize, (tabDrawable.Height - closesize) / 2, closesize, closesize);
 		tab.TextRect = new RectangleF(tabRect.X + tabPadding.Left + textoffset, (tabDrawable.Height - size.Height) / 2, textSize.Width, textSize.Height);
 
 		posx += tab.Rect.Width;
@@ -722,7 +722,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		var tabRect = tab.Rect;
 		var textRect = tab.TextRect;
 		var closerect = tab.CloseRect;
-		var closemargin = UseFixedTabHeight ? 3 : closerect.Height / 3;
+		var closemargin = closerect.Height / 4;
 
 		var textcolor = Enabled ? TabForegroundColor : DisabledForegroundColor;
 		var backcolor = TabBackgroundColor;

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -29,6 +29,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	Color closeHighlightForegroundColor;
 	Color tabBackgroundColor;
 	Color tabHighlightBackgroundColor;
+	Color tabHoverBackgroundColor;
 	Color tabForegroundColor;
 	Color tabHighlightForegroundColor;
 
@@ -172,15 +173,29 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	}
 
 	/// <summary>
-	/// Gets or sets the highlight background color for the highlighted  tab.
+	/// Gets or sets the highlight background color for the highlighted (or active) tab.
 	/// </summary>
-	/// <value>The highlight background color for the close highlighted tab.</value>
+	/// <value>The highlight background color for the highlighted (or active) tab.</value>
 	public Color TabHighlightBackgroundColor
 	{
 		get { return tabHighlightBackgroundColor; }
 		set
 		{
 			tabHighlightBackgroundColor = value;
+			tabDrawable.Invalidate();
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the background color for the tab under mouse.
+	/// </summary>
+	/// <value>The background color for the tab under mouse.</value>
+	public Color TabHoverBackgroundColor
+	{
+		get { return tabHoverBackgroundColor; }
+		set
+		{
+			tabHoverBackgroundColor = value;
 			tabDrawable.Invalidate();
 		}
 	}
@@ -249,6 +264,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		closeHighlightForegroundColor = SystemColors.HighlightText;
 		tabBackgroundColor = SystemColors.Control;
 		tabHighlightBackgroundColor = SystemColors.Highlight;
+		tabHoverBackgroundColor = new Color(SystemColors.Highlight, 0.8f);
 		tabForegroundColor = SystemColors.ControlText;
 		tabHighlightForegroundColor = SystemColors.HighlightText;
 
@@ -684,13 +700,12 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		{
 			textcolor = Enabled ? TabHighlightForegroundColor : DisabledForegroundColor;
 			backcolor = TabHighlightBackgroundColor;
-			backcolor.A *= 0.8f;
 		}
 
 		if (draggingLocation == null && tabRect.Contains(mousePos) && prevnextsel && !closeSelected && Enabled)
 		{
 			textcolor = TabHighlightForegroundColor;
-			backcolor = TabHighlightBackgroundColor;
+			backcolor = TabHoverBackgroundColor;
 		}
 
 		g.FillRectangle(backcolor, tabRect);

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -34,10 +34,12 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	Color tabHighlightForegroundColor;
 	Color tabHoverForegroundColor;
 
+	int closeCornerRadius;
+
 	static Padding DefaultTabPadding = 6;
 
 	static readonly object TabPadding_Key = new object();
-	private int minImageSquareSide = 16;
+	int minImageSquareSide = 16;
 
 	/// <summary>
 	/// Gets or sets the padding inside each tab around the text.
@@ -127,6 +129,20 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		set
 		{
 			closeHighlightBackgroundColor = value;
+			tabDrawable.Invalidate();
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the corner radius of the close button.
+	/// </summary>
+	/// <value>The corner radius of the close button.</value>
+	public int CloseCornerRadius
+	{
+		get { return closeCornerRadius; }
+		set
+		{
+			closeCornerRadius = value;
 			tabDrawable.Invalidate();
 		}
 	}
@@ -733,7 +749,12 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 
 		if (tab.Closable)
 		{
-			g.FillRectangle(closeSelected ? CloseHighlightBackgroundColor : CloseBackgroundColor, closerect);
+			var closeBackground = closeSelected ? CloseHighlightBackgroundColor : CloseBackgroundColor;
+			if (closeCornerRadius > 0)
+				g.FillPath(closeBackground, GraphicsPath.GetRoundRect(closerect, closeCornerRadius));
+			else
+				g.FillRectangle(closeBackground, closerect);
+
 			var closeForeground = Enabled ? closeSelected ? CloseHighlightForegroundColor : CloseForegroundColor : DisabledForegroundColor;
 			g.DrawLine(closeForeground, closerect.X + closemargin, closerect.Y + closemargin, closerect.X + closerect.Width - 1 - closemargin, closerect.Y + closerect.Height - 1 - closemargin);
 			g.DrawLine(closeForeground, closerect.X + closemargin, closerect.Y + closerect.Height - 1 - closemargin, closerect.X + closerect.Width - 1 - closemargin, closerect.Y + closemargin);

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -715,8 +715,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 			textcolor = Enabled ? TabHighlightForegroundColor : DisabledForegroundColor;
 			backcolor = TabHighlightBackgroundColor;
 		}
-
-		if (draggingLocation == null && tabRect.Contains(mousePos) && prevnextsel && !closeSelected && Enabled)
+		else if (draggingLocation == null && tabRect.Contains(mousePos) && prevnextsel && Enabled)
 		{
 			textcolor = TabHoverForegroundColor;
 			backcolor = TabHoverBackgroundColor;

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -677,7 +677,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 			size.Width += textoffset;
 		}
 
-		var closesize = tabDrawable.Height / 2;
+		var closesize = UseFixedTabHeight ? minImageSquareSide : tabDrawable.Height / 2;
 		var tabRect = new RectangleF(posx, 0, size.Width + (tab.Closable ? closesize + tabPadding.Horizontal + tabPadding.Right : tabPadding.Horizontal), tabDrawable.Height);
 
 		if (i == selectedIndex && draggingLocation != null)
@@ -706,7 +706,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		var tabRect = tab.Rect;
 		var textRect = tab.TextRect;
 		var closerect = tab.CloseRect;
-		var closemargin = closerect.Height / 3;
+		var closemargin = UseFixedTabHeight ? 3 : closerect.Height / 3;
 
 		var textcolor = Enabled ? TabForegroundColor : DisabledForegroundColor;
 		var backcolor = TabBackgroundColor;

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -32,6 +32,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	Color tabHoverBackgroundColor;
 	Color tabForegroundColor;
 	Color tabHighlightForegroundColor;
+	Color tabHoverForegroundColor;
 
 	static Padding DefaultTabPadding = 6;
 
@@ -215,9 +216,9 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	}
 
 	/// <summary>
-	/// Gets or sets the highlight foreground color for the close button.
+	/// Gets or sets the highlight foreground color for the highlighted (or active) tab.
 	/// </summary>
-	/// <value>The highlight foreground color for the close button.</value>
+	/// <value>The foreground color for the highlighted (or active) tab.</value>
 	public Color TabHighlightForegroundColor
 	{
 		get { return tabHighlightForegroundColor; }
@@ -228,6 +229,19 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		}
 	}
 
+	/// <summary>
+	/// Gets or sets the foreground color for the tab under mouse.
+	/// </summary>
+	/// <value>The foreground color for the tab under mouse.</value>
+	public Color TabHoverForegroundColor
+	{
+		get { return tabHoverForegroundColor; }
+		set
+		{
+			tabHoverForegroundColor = value;
+			tabDrawable.Invalidate();
+		}
+	}
 
 	/// <summary>
 	/// Gets or sets a value indicating whether to use a fixed tab height.
@@ -267,6 +281,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		tabHoverBackgroundColor = new Color(SystemColors.Highlight, 0.8f);
 		tabForegroundColor = SystemColors.ControlText;
 		tabHighlightForegroundColor = SystemColors.HighlightText;
+		tabHoverForegroundColor = SystemColors.HighlightText;
 
 		tabDrawable = new Drawable();
 
@@ -703,7 +718,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 
 		if (draggingLocation == null && tabRect.Contains(mousePos) && prevnextsel && !closeSelected && Enabled)
 		{
-			textcolor = TabHighlightForegroundColor;
+			textcolor = TabHoverForegroundColor;
 			backcolor = TabHoverBackgroundColor;
 		}
 


### PR DESCRIPTION
This PR makes it possible to adjust the following styling aspects of `DocumentControl`:

- Set custom `BackgroundColor` of the `DocumentControl`;
- Set custom `TabHoverBackgroundColor` and `TabHoverForegroundColorfor` for the tab in Hover state;
- Set rounded corners of certain `CloseCornerRadius` for `X` Close tab button.

Changes in look/default behavior:

- Removes forced 80% opacity of the tab in Hover state (yet retains previous behavior by default);
- Makes `Highlighted` tab colors winning vs `Hover` colors (as this is how most of the tab controls look);
- Adjusts the size of the close button to balance it with the size of the tab icon (16x16).