### PR TITLE
Add Control.IsMouseCaptured, CaptureMouse, and ReleaseMouseCapture APIs

### DIFF
--- a/src/Eto.Gtk/NativeMethods.cs
+++ b/src/Eto.Gtk/NativeMethods.cs
@@ -220,6 +220,12 @@ namespace Eto.GtkSharp
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_micro_version();
 
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static void gtk_grab_add(IntPtr widget);
+
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static void gtk_grab_remove(IntPtr widget);
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
 
@@ -439,6 +445,12 @@ namespace Eto.GtkSharp
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_micro_version();
 
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static void gtk_grab_add(IntPtr widget);
+
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static void gtk_grab_remove(IntPtr widget);
+
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
 
@@ -657,6 +669,12 @@ namespace Eto.GtkSharp
 
 			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static uint gtk_get_micro_version();
+
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static void gtk_grab_add(IntPtr widget);
+
+			[DllImport(libgtk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static void gtk_grab_remove(IntPtr widget);
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect);
@@ -986,6 +1004,26 @@ namespace Eto.GtkSharp
 				return NMMac.gtk_get_micro_version();
 			else
 				return NMWindows.gtk_get_micro_version();
+		}
+
+		public static void gtk_grab_add(IntPtr widget)
+		{
+			if (EtoEnvironment.Platform.IsLinux)
+				NMLinux.gtk_grab_add(widget);
+			else if (EtoEnvironment.Platform.IsMac)
+				NMMac.gtk_grab_add(widget);
+			else
+				NMWindows.gtk_grab_add(widget);
+		}
+
+		public static void gtk_grab_remove(IntPtr widget)
+		{
+			if (EtoEnvironment.Platform.IsLinux)
+				NMLinux.gtk_grab_remove(widget);
+			else if (EtoEnvironment.Platform.IsMac)
+				NMMac.gtk_grab_remove(widget);
+			else
+				NMWindows.gtk_grab_remove(widget);
 		}
 
 		public static IntPtr webkit_web_view_new()

--- a/src/Eto.Gtk/NativeMethods.tt
+++ b/src/Eto.Gtk/NativeMethods.tt
@@ -70,7 +70,9 @@ var gtkmethods = new[]
     "IntPtr gtk_button_get_event_window(IntPtr button)",
     "uint gtk_get_major_version()",
     "uint gtk_get_minor_version()",
-    "uint gtk_get_micro_version()"
+    "uint gtk_get_micro_version()",
+	"void gtk_grab_add(IntPtr widget)",
+	"void gtk_grab_remove(IntPtr widget)",
 };
 
 var gdkmethods = new[]

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -196,7 +196,23 @@ namespace Eto.Mac
 				var view = handler.ContainerControl;
 				var pt = theEvent.LocationInWindow;
 				pt = handler.GetAlignmentPointForFramePoint(pt);
-				point = pt.ToEto(view);
+				if (theEvent.Window == null)
+				{
+					// flip to top down first
+					pt.Y = NSScreen.Screens[0].Frame.Height - pt.Y;
+					point = handler.Widget.PointFromScreen(pt.ToEto());
+				}
+				else if (view.Window != theEvent.Window)
+				{
+					var loc = theEvent.Window.Frame.Location.ToEto();
+					pt.X += loc.X;
+					pt.Y += loc.Y;
+					pt.Y = NSScreen.Screens[0].Frame.Height - pt.Y;
+					point = handler.Widget.PointFromScreen(pt.ToEto());
+				}
+				else
+					point = pt.ToEto(view);
+					
 				if (includeWheel)
 					delta = new SizeF((float)theEvent.DeltaX, (float)theEvent.DeltaY);
 				modifiers = theEvent.ModifierFlags.ToEto();

--- a/src/Eto.WinForms/Forms/ApplicationHandler.cs
+++ b/src/Eto.WinForms/Forms/ApplicationHandler.cs
@@ -147,8 +147,9 @@ namespace Eto.WinForms.Forms
 				bubble.AddBubbleMouseEvent((c, cb, e) => cb.OnMouseMove(c, e), null, Win32.WM.MOUSEMOVE);
 				bubble.AddBubbleMouseEvents((c, cb, e) => 
 				{
+					WindowsControl.SkipMouseCapture = false;
 					cb.OnMouseDown(c, e);
-					if (e.Handled && c.Handler is IWindowsControl handler && handler.ShouldCaptureMouse)
+					if (e.Handled && c.Handler is IWindowsControl handler && handler.ShouldCaptureMouse && !WindowsControl.SkipMouseCapture)
 					{
 						handler.ContainerControl.Capture = true;
 						handler.MouseCaptured = true;

--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -623,5 +623,9 @@ namespace Eto.WinForms.Forms
 		public void Print() => throw new NotImplementedException();
 
 		public void UpdateLayout() => throw new NotImplementedException();
+
+		public bool IsMouseCaptured => throw new NotImplementedException();
+		public bool CaptureMouse() => throw new NotImplementedException();
+		public void ReleaseMouseCapture() => throw new NotImplementedException();
 	}
 }

--- a/src/Eto.Wpf/Drawing/GraphicsPathHandler.cs
+++ b/src/Eto.Wpf/Drawing/GraphicsPathHandler.cs
@@ -64,6 +64,8 @@ namespace Eto.Wpf.Drawing
 		public void AddLines(IEnumerable<PointF> points)
 		{
 			var pointsList = points as IList<PointF> ?? points.ToArray();
+			if (pointsList.Count == 0)
+				return;
 			ConnectTo(pointsList.First().ToWpf());
 
 			var wpfPoints = from p in pointsList select p.ToWpf();

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -816,7 +816,7 @@ namespace Eto.Wpf.Forms
 
 			Callback.OnMouseUp(Widget, args);
 			e.Handled = args.Handled;
-			
+
 			// If the mouse was captured intrinsically we need to release capture otherwise it hangs the app
 			// since the caller is overriding default behaviour.
 			if (e.Handled && Control.IsMouseCaptured)
@@ -829,7 +829,7 @@ namespace Eto.Wpf.Forms
 			Callback.OnMouseDoubleClick(Widget, args);
 			e.Handled = args.Handled;
 		}
-		
+
 		protected virtual void HandleLostMouseCapture(object sender, swi.MouseEventArgs e)
 		{
 			if (isMouseCaptured)
@@ -845,8 +845,8 @@ namespace Eto.Wpf.Forms
 
 		protected virtual void HandleMouseDown(object sender, swi.MouseButtonEventArgs e)
 		{
-            isMouseCaptured = false;
-            var args = e.ToEto(ContainerControl);
+			isMouseCaptured = false;
+			var args = e.ToEto(ContainerControl);
 			if (!(Control is swc.Control) && e.ClickCount == 2)
 				Callback.OnMouseDoubleClick(Widget, args);
 			if (!args.Handled)
@@ -884,7 +884,7 @@ namespace Eto.Wpf.Forms
 				SetDefaultScale();
 			}
 		}
-		
+
 		protected virtual void SetDefaultScale() => SetScale(true, true);
 
 		void Control_Loaded(object sender, sw.RoutedEventArgs e)
@@ -973,7 +973,7 @@ namespace Eto.Wpf.Forms
 				return point;
 
 			point = point.LogicalToScreen(Widget.ParentWindow?.Screen);
-			
+
 			if (Win32.IsSystemDpiAware)
 			{
 				var logicalPixelSize = Win32.GetLogicalPixelSize(SwfScreen);
@@ -1000,7 +1000,7 @@ namespace Eto.Wpf.Forms
 		{
 			if (!ContainerControl.IsLoaded)
 				return point;
-			
+
 			// ensure we're connected to a presentation source
 			var presentationSource = sw.PresentationSource.FromVisual(ContainerControl) as HwndSource;
 			if (presentationSource == null)
@@ -1014,7 +1014,7 @@ namespace Eto.Wpf.Forms
 				point = point / systemDpi * logicalPixelSize;
 
 				pt = Win32.ExecuteInDpiAwarenessContext(() => ContainerControl.PointToScreen(point.ToWpf())).ToEto();
-				
+
 				// WPF does not take into account the location of the element in the form..
 				var rootVisual = ContainerControl.GetVisualParents().OfType<sw.UIElement>().Last();
 				var location = ContainerControl.TranslatePoint(new sw.Point(0, 0), rootVisual).ToEto();
@@ -1073,7 +1073,7 @@ namespace Eto.Wpf.Forms
 
 			WpfFrameworkElement.DragSourceControl = null;
 			sw.DragSourceHelper.UnregisterDefaultDragSource(Control);
-			
+
 			var args = new DragEventArgs(Widget, data, allowedAction, PointFromScreen(Mouse.Position), Keyboard.Modifiers, Mouse.Buttons);
 			args.Effects = effects.ToEto();
 			Callback.OnDragEnd(Widget, args);
@@ -1164,5 +1164,13 @@ namespace Eto.Wpf.Forms
 			// update the layout
 			ContainerControl.UpdateLayout();
 		}
+
+		public bool IsMouseCaptured => ContainerControl.IsMouseCaptured;
+		public bool CaptureMouse()
+		{
+			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
+			return ContainerControl.CaptureMouse();
+		}
+		public void ReleaseMouseCapture() => ContainerControl.ReleaseMouseCapture();
 	}
 }

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -864,6 +864,31 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	}
 
 	/// <summary>
+	/// Gets a value indicating this control currently has mouse capture
+	/// </summary>
+	/// <remarks>
+	/// Mouse capture can happen during a handled MouseDown event until MouseUp,
+	/// or it can be captured explicitly via <see cref="CaptureMouse"/>.
+	/// </remarks>
+	public bool IsMouseCaptured => Handler.IsMouseCaptured;
+	
+	/// <summary>
+	/// Captures all mouse events to this control.
+	/// </summary>
+	/// <remarks>
+	/// This captures all mouse events until <see cref="ReleaseMouseCapture"/> is called.
+	/// 
+	/// Note that not all platforms will allow a mouse capture unless the mouse is currently down.
+	/// </remarks>
+	/// <returns><c>true</c> if the mouse was captured, false otherwise.</returns>
+	public bool CaptureMouse() => Handler.CaptureMouse();
+	
+	/// <summary>
+	/// Releases the mouse capture after a call to <see cref="CaptureMouse"/>.
+	/// </summary>
+	public void ReleaseMouseCapture() => Handler.ReleaseMouseCapture();
+
+	/// <summary>
 	/// Gets or sets the width of the control size.
 	/// </summary>
 	public virtual int Width
@@ -2030,6 +2055,31 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 		/// This is useful when you need to know the dimensions of the control immediately.
 		/// </remarks>
 		void UpdateLayout();
+		
+		/// <summary>
+		/// Gets a value indicating this control currently has mouse capture
+		/// </summary>
+		/// <remarks>
+		/// Mouse capture can happen during a handled MouseDown event until MouseUp,
+		/// or it can be captured explicitly via <see cref="CaptureMouse"/>.
+		/// </remarks>
+		bool IsMouseCaptured { get; }
+
+		/// <summary>
+		/// Captures all mouse events to this control.
+		/// </summary>
+		/// <remarks>
+		/// This captures all mouse events until <see cref="ReleaseMouseCapture"/> is called.
+		/// 
+		/// Note that not all platforms will allow a mouse capture unless the mouse is currently down.
+		/// </remarks>
+		/// <returns><c>true</c> if the mouse was captured, false otherwise.</returns>
+		bool CaptureMouse();
+		
+		/// <summary>
+		/// Releases the mouse capture after a call to <see cref="CaptureMouse"/>.
+		/// </summary>
+		void ReleaseMouseCapture();
 	}
 	#endregion
 }

--- a/src/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/src/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -466,6 +466,13 @@ public class ThemedControlHandler<TControl, TWidget, TCallback> : WidgetHandler<
 	/// <inheritdoc />
 	public void UpdateLayout() => Control.UpdateLayout();
 
+	/// <inheritdoc />
+	public bool IsMouseCaptured => Control.IsMouseCaptured;
+	/// <inheritdoc />
+	public bool CaptureMouse() => Control.CaptureMouse();
+	/// <inheritdoc />
+	public void ReleaseMouseCapture() => Control.ReleaseMouseCapture();
+
 	#endregion
 
 }

--- a/test/Eto.Test/UnitTests/Forms/Behaviors/MouseTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Behaviors/MouseTests.cs
@@ -103,10 +103,10 @@ namespace Eto.Test.UnitTests.Forms.Behaviors
 					child.BackgroundColor = child.BackgroundColor == Colors.Blue ? Colors.Green : Colors.Blue;
 					e.Handled = true;
 				};
-				
+
 				return new StackLayout(parent);
 			}
-			
+
 			var section1 = CreateClickableBox();
 
 			var section2 = CreateClickableBox();
@@ -119,5 +119,170 @@ namespace Eto.Test.UnitTests.Forms.Behaviors
 				Padding = 8
 			};
 		});
+
+		[Test, ManualTest]
+		public void MouseShouldBeCapturedByOtherControl()
+		{
+			bool wasCaptured = false;
+			bool isMouseCaptured = false;
+			bool parent1Entered = false;
+			bool parent2Entered = false;
+			bool parent2ShouldBeEntered = false;
+			bool parent1ShouldNotBeEntered = false;
+			bool panel1ShouldNeverBeCaptured = false;
+			bool panel2ShouldNeverHaveMouseMoveWithoutCapturing = false;
+			var points = new List<PointF>();
+			ManualForm("Click and drag on panel 1, events should go to panel 2.\nThen click and drag on panel 2, it should remain green", form =>
+			{
+				var panel2 = new Drawable
+				{
+					CanFocus = true,
+					Size = new Size(200, 200),
+					BackgroundColor = Colors.Green,
+					Content = "Panel 2"
+				};
+
+				var panel1 = new Drawable
+				{
+					CanFocus = true,
+					Size = new Size(200, 200),
+					BackgroundColor = Colors.Blue,
+					Content = "Panel 1"
+				};
+				panel1.MouseEnter += (sender, e) => Debug.WriteLine("Panel1.MouseEnter");
+				panel1.MouseLeave += (sender, e) => Debug.WriteLine("Panel1.MouseLeave");
+				panel1.MouseUp += (sender, e) => Debug.WriteLine("Panel1.MouseUp");
+				panel1.MouseMove += (sender, e) =>
+				{
+					if (panel1.IsMouseCaptured)
+					{
+						panel1.BackgroundColor = Colors.Red;
+						panel1ShouldNeverBeCaptured = true;
+						form.Close();
+					}
+					Debug.WriteLine("Panel1.MouseMove");
+				};
+				panel1.MouseDown += (sender, e) =>
+				{
+					Debug.WriteLine("Panel1.MouseDown");
+					wasCaptured = panel2.CaptureMouse();
+					isMouseCaptured = panel2.IsMouseCaptured;
+					if (!wasCaptured || !isMouseCaptured)
+						form.Close();
+					e.Handled = true;
+					points = new List<PointF>();
+				};
+				panel1.KeyDown += (sender, e) =>
+				{
+					Debug.WriteLine("Panel1.KeyDown");
+					if (panel2.IsMouseCaptured)
+					{
+						panel2.ReleaseMouseCapture();
+					}
+					else
+					{
+						wasCaptured = panel2.CaptureMouse();
+						isMouseCaptured = panel2.IsMouseCaptured;
+						if (!wasCaptured || !isMouseCaptured)
+							form.Close();
+						points = new List<PointF>();
+					}
+					e.Handled = true;
+				};
+
+				panel2.MouseEnter += (sender, e) => Debug.WriteLine("Panel2.MouseEnter");
+				panel2.MouseLeave += (sender, e) => Debug.WriteLine("Panel2.MouseLeave");
+				panel2.MouseDown += (sender, e) =>
+				{
+					Debug.WriteLine("Panel2.MouseDown");
+					// wasCaptured = panel2.CaptureMouse();
+					// isMouseCaptured = panel2.IsMouseCaptured;
+					points = new List<PointF>
+					{
+						e.Location
+					};
+					panel2.Invalidate();
+					// if (!wasCaptured || !isMouseCaptured)
+					// 	form.Close();
+					e.Handled = true; // should capture the mouse
+				};
+				panel2.MouseUp += (sender, e) =>
+				{
+					Debug.WriteLine("Panel2.MouseUp");
+					panel2.ReleaseMouseCapture();
+				};
+				panel2.MouseMove += (sender, e) =>
+				{
+					Debug.WriteLine("Panel2.MouseMove");
+					if (panel2.IsMouseCaptured)
+					{
+						// note: WinForms does not bubble enter/leave events currently
+						if (!parent2Entered && !Platform.Instance.IsWinForms)
+						{
+							form.Close();
+							return;
+						}
+						parent2ShouldBeEntered = true;
+						if (parent1Entered && !Platform.Instance.IsWinForms)
+						{
+							form.Close();
+							return;
+						}
+						parent1ShouldNotBeEntered = true;
+						points.Add(e.Location);
+						panel2.Invalidate();
+					}
+					else if (e.Buttons != MouseButtons.None)
+					{
+						panel2.BackgroundColor = Colors.Red;
+						panel2ShouldNeverHaveMouseMoveWithoutCapturing = true;
+						form.Close();
+					}
+				};
+				panel2.Paint += (sender, e) =>
+				{
+					if (points.Count > 1)
+						e.Graphics.DrawLines(Colors.White, points);
+				};
+
+
+				var parent1 = new Panel { Content = panel1 };
+				parent1.MouseEnter += (sender, e) =>
+				{
+					parent1Entered = true;
+					Debug.WriteLine($"parent1.MouseEnter");
+				};
+				parent1.MouseLeave += (sender, e) =>
+				{
+					parent1Entered = false;
+					Debug.WriteLine($"parent1.MouseLeave");
+				};
+
+				var parent2 = new Panel { Content = panel2 };
+				parent2.MouseEnter += (sender, e) =>
+				{
+					parent2Entered = true;
+					Debug.WriteLine($"parent2.MouseEnter");
+				};
+				parent2.MouseLeave += (sender, e) =>
+				{
+					parent2Entered = false;
+					Debug.WriteLine($"parent2.MouseLeave");
+				};
+
+				var layout = new TableLayout(
+					new TableRow(null, parent1, null, parent2, null)
+				);
+
+				form.Shown += (sender, e) => panel1.Focus();
+				return layout;
+			});
+			Assert.IsTrue(wasCaptured, "#1 - Mouse was not able to be captured");
+			Assert.IsTrue(isMouseCaptured, "#2 - Control.IsMouseCaptured should be true after CaptureMouse() is successful");
+			Assert.IsTrue(parent2ShouldBeEntered, "#3 - Parent2 should be entered when mouse is captured on Panel2");
+			Assert.IsTrue(parent1ShouldNotBeEntered, "#4 - Parent1 should not be entered when mouse is captured on Panel2");
+			Assert.IsFalse(panel1ShouldNeverBeCaptured, "#5 - Panel2 should never be captured");
+			Assert.IsFalse(panel2ShouldNeverHaveMouseMoveWithoutCapturing, "#6 - Panel2 should not have a MouseMove with a button down without being captured");
+		}
 	}
 }


### PR DESCRIPTION
This adds the ability to capture the mouse to a particular control/window until `ReleaseMouseCapture` is called.  You can also tell if the mouse is captured during a mouse down/drag/mouse up operation with the `IsMouseCaptured` property.

New APIs:
```
class Control
{
  public bool IsMouseCaptured { get; }
  public bool CaptureMouse();
  public void ReleaseMouseCapture();
}
```