### PR TITLE
Mac: Fix universal binary build

### DIFF
--- a/src/Eto.Mac/build/BundleDotNetCore.targets
+++ b/src/Eto.Mac/build/BundleDotNetCore.targets
@@ -30,7 +30,7 @@
     
     <ItemGroup>
       <UnifiedFiles Include="$(BaseOutputAppPath)%(MacBundleRuntimeIdentifiers.Identity)\$(MacBundleName).app\**" RuntimeIdentifier="%(MacBundleRuntimeIdentifiers.Identity)" BasePath="$(BaseOutputAppPath)%(MacBundleRuntimeIdentifiers.Identity)\$(MacBundleName).app\" />
-      <UnifiedFiles TargetPath="$([System.String]::Copy('%(Identity)').TrimStart('%(BasePath)'))" />
+      <UnifiedFiles TargetPath="$([System.String]::Copy('^%(Identity)').Replace('^%(BasePath)', '').TrimStart('^'))" />
     </ItemGroup>
     
     <!-- <Message Importance="high" Text="%(UnifiedFiles.RelativeDir)%(UnifiedFiles.FileName)%(UnifiedFiles.Extension) > %(UnifiedFiles.TargetPath)" /> -->


### PR DESCRIPTION
My MacOS universal binary builds were corrupted when the C# project name contained some combination of letters. I went digging in and found the culprit. The `TrimStart()` method does not trim the specified parameter from the string start, but actually trims as much chars from the front of the string as possible as long as the given parameter contains all those chars ([reference](https://learn.microsoft.com/en-us/dotnet/api/system.string.trimstart?view=net-8.0#system-string-trimstart(system-char()))). This is used to trim the leading relative path of a file, so as a consequence the path gets corrupted.

For example, if my project name was `MYPROJECT` trimming `bin/Debug/net6.0/osx-arm64/MYPROJECT.app/` from `bin/Debug/net6.0/osx-arm64/MYPROJECT.app/Contents/MacOS/MYPROJECT` would result in a corrupted path of `cOS/MYPROJECT` instead of the expected `Contents/MacOS/MYPROJECT`. Then my universal binary `MYPROJECT.app` would actually contain a subdirectory `cOS` with `MYPROJECT` binary.