### PR TITLE
Add ToolTipSection to test tooltips

### DIFF
--- a/test/Eto.Test/Sections/Behaviors/ToolTipSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ToolTipSection.cs
@@ -1,0 +1,14 @@
+using Eto.Forms;
+namespace Eto.Test.Sections.Behaviors
+{
+	[Section("Behaviors", "ToolTip")]
+	public class ToolTipSection : AllControlsBase
+	{
+		protected override void LogEvents(Control control)
+		{
+			base.LogEvents(control);
+			control.ToolTip = $"ToolTip for {control.GetType().Name}";
+		}
+	}
+}
+


### PR DESCRIPTION
Tooltips stopped working in macOS Sonoma 14.0 or 14.1, and got fixed in Sonoma 14.2.  While there aren't any bugs in Eto, this adds a new section to test the tooltips to ensure they are working.