### PR TITLE
Wpf: Only expand/collapse/go to parent on left key when not editing

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -22,7 +22,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		private void Control_PreviewKeyDown(object sender, sw.Input.KeyEventArgs e)
 		{
-			if (e.Handled || swi.Keyboard.Modifiers != swi.ModifierKeys.None)
+			if (e.Handled || swi.Keyboard.Modifiers != swi.ModifierKeys.None || IsEditing)
 				return;
 
 			// handle expanding/collapsing via the keyboard


### PR DESCRIPTION
If you are editing a text box in a TreeGridView, pressing the left key should not collapse the node or go to parent node.