### PR TITLE
Work around bug in WPF when running in .NET Core

### DIFF
--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -632,5 +632,8 @@ namespace Eto
 		
 		[DllImport("User32.dll", SetLastError = true)]
     	public static extern int SetWindowRgn(IntPtr hWnd, IntPtr hRgn, bool bRedraw);
+
+		[DllImport("kernel32.dll")]
+		public static extern void SetLastError(uint dwErrCode);
 	}
 }

--- a/src/Eto.Wpf/Forms/FormHandler.cs
+++ b/src/Eto.Wpf/Forms/FormHandler.cs
@@ -1,33 +1,32 @@
 namespace Eto.Wpf.Forms
 {
-	public class FormHandler : WpfWindow<sw.Window, Form, Form.ICallback>, Form.IHandler
+	public class EtoFormWindow : EtoWindow
 	{
-		public class EtoWindow : sw.Window
+		public EtoFormWindow()
 		{
-
-			public EtoWindow()
-			{
-				AllowDrop = true;
-			}
-
-			protected override void OnActivated(EventArgs e)
-			{
-				if (!Focusable)
-					return;
-				base.OnActivated(e);
-			}
-
-			protected override void OnPreviewGotKeyboardFocus(swi.KeyboardFocusChangedEventArgs e)
-			{
-				if (!Focusable)
-				{
-					e.Handled = true;
-					return;
-				}
-				base.OnPreviewGotKeyboardFocus(e);
-			}
+			AllowDrop = true;
 		}
 
+		protected override void OnActivated(EventArgs e)
+		{
+			if (!Focusable)
+				return;
+			base.OnActivated(e);
+		}
+
+		protected override void OnPreviewGotKeyboardFocus(swi.KeyboardFocusChangedEventArgs e)
+		{
+			if (!Focusable)
+			{
+				e.Handled = true;
+				return;
+			}
+			base.OnPreviewGotKeyboardFocus(e);
+		}
+	}
+	
+	public class FormHandler : WpfWindow<sw.Window, Form, Form.ICallback>, Form.IHandler
+	{
 		public FormHandler(sw.Window window)
 		{
 			Control = window;
@@ -35,7 +34,7 @@ namespace Eto.Wpf.Forms
 
 		public FormHandler()
 		{
-			Control = new EtoWindow();
+			Control = new EtoFormWindow();
 		}
 
 		public virtual void Show()


### PR DESCRIPTION
WPF can cause crashes with the following stack trace, seemingly in random places:

```
System.ComponentModel.Win32Exception (87): The parameter is incorrect.
   at MS.Win32.UnsafeNativeMethods.GetWindowText(HandleRef hWnd, StringBuilder lpString, Int32 nMaxCount)
   at System.Windows.Automation.Peers.WindowAutomationPeer.GetNameCore()
   at System.Windows.Automation.Peers.AutomationPeer.UpdateSubtree()
   at System.Windows.Automation.Peers.AutomationPeer.UpdatePeer(Object arg)
   at System.Windows.Threading.ExceptionWrapper.InternalRealCall(Delegate callback, Object args, Int32 numArgs)
   at System.Windows.Threading.ExceptionWrapper.TryCatchWhen(Object source, Delegate callback, Object args, Int32 numArgs, Delegate catchHandler)
```

It has been fixed in the WPF repo, see https://github.com/dotnet/wpf/issues/4181 and https://github.com/dotnet/wpf/pull/7345, but hasn't been merged into a release yet so we override the automation peer and catch the exception there.