### PR TITLE
Mac: Fix firing LocationChanged event when only size changes

### DIFF
--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -401,6 +401,14 @@ namespace Eto.Mac.Forms
 								handler.Callback.OnSizeChanged(handler.Widget, EventArgs.Empty);
 								oldSize = newSize;
 							}
+							var old = handler.oldLocation;
+							handler.oldLocation = null;
+							var newLocation = handler.Location;
+							if (old != newLocation)
+							{
+								handler.oldLocation = newLocation;
+								handler.Callback.OnLocationChanged(handler.Widget, EventArgs.Empty);
+							}
 						});
 					}
 					break;


### PR DESCRIPTION
If you change the size of window from the top, it wouldn't fire the LocationChanged event as on Mac the location is based on the lower left vs. upper left.  We now fire the location changed event when the size is changed, if the location is different than last.