### PR TITLE
Wpf: protect against errors in GridView.SelectedRows

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -642,7 +642,12 @@ namespace Eto.Wpf.Forms.Controls
 						Control.SelectedItems.Clear();
 						foreach (int row in value)
 						{
-							Control.SelectedItems.Add(list[row]);
+							// protect against any incorrect info
+							if (row >= list.Count)
+								continue;
+							var item = list[row];
+							if (item != null)
+								Control.SelectedItems.Add(item);
 						}
 
 						Control.EndUpdateSelectedItems();


### PR DESCRIPTION
Passing incorrect info to Tree/GridView.SelectedRows can cause crashes, instead let's just go on our merry way.