### PR TITLE
Unsaved indicator for DocumentControl

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/DocumentPageHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DocumentPageHandler.cs
@@ -89,6 +89,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			set { closeButton.Visible = value; }
 		}
 
+		public bool HasUnsavedChanges { get; set; }
+
 		public Image Image
 		{
 			get { return image; }

--- a/src/Eto/Forms/Controls/DocumentPage.cs
+++ b/src/Eto/Forms/Controls/DocumentPage.cs
@@ -1,4 +1,4 @@
-﻿namespace Eto.Forms;
+namespace Eto.Forms;
 
 /// <summary>
 /// Control for a page in a <see cref="DocumentControl"/>
@@ -78,6 +78,16 @@ public class DocumentPage : Panel
 	}
 
 	/// <summary>
+	/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.DocumentPage"/> has unsaved changes.
+	/// </summary>
+	/// <value><c>true</c> if page has unsaved changes; otherwise, <c>false</c>.</value>
+	public bool HasUnsavedChanges
+	{
+		get { return Handler.HasUnsavedChanges; }
+		set { Handler.HasUnsavedChanges = value; }
+	}
+
+	/// <summary>
 	/// Gets or sets the image of the page.
 	/// </summary>
 	/// <remarks>
@@ -112,6 +122,12 @@ public class DocumentPage : Panel
 		/// </summary>
 		/// <value><c>true</c> if closable; otherwise, <c>false</c>.</value>
 		bool Closable { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.DocumentPage"/> has unsaved changes.
+		/// </summary>
+		/// <value><c>true</c> if page has unsaved changes; otherwise, <c>false</c>.</value>
+		bool HasUnsavedChanges { get; set; }
 
 		/// <summary>
 		/// Gets or sets the image of the page.

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -779,8 +779,12 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 			var closeMargin = (int)tab.CloseRect.Height / 4;
 			var closeForegroundRect = RectangleF.Inset(tab.CloseRect, new PaddingF(closeMargin));
 			var closeForeground = Enabled ? closeSelected ? CloseHighlightForegroundColor : CloseForegroundColor : DisabledForegroundColor;
+
+			g.SaveTransform();
+			g.PixelOffsetMode = PixelOffsetMode.Half;
 			g.DrawLine(closeForeground, closeForegroundRect.TopLeft, closeForegroundRect.BottomRight);
 			g.DrawLine(closeForeground, closeForegroundRect.TopRight, closeForegroundRect.BottomLeft);
+			g.RestoreTransform();
 		}
 	}
 

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -696,33 +696,35 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		}
 	}
 
-	void CalculateTab(ThemedDocumentPageHandler tab, int i, ref float posx)
+	void CalculateTab(ThemedDocumentPageHandler tab, int i, ref float posX)
 	{
-		var tabPadding = TabPadding;
-		var textSize = string.IsNullOrEmpty(tab.Text) ? Size.Empty : Size.Ceiling(Font.MeasureString(tab.Text));
-		var size = textSize;
-		var prevnextsel = mousePos.X > nextPrevWidth || i == -1;
-		var textoffset = 0;
-		if (tab.Image != null)
-		{
-			textoffset = maxImageSize.Width + tabPadding.Left;
-			size.Width += textoffset;
-		}
-
-		var closesize = (int)Math.Floor(tabDrawable.Height * 0.6);
-		var tabRect = new RectangleF(posx, 0, size.Width + (tab.Closable ? closesize + tabPadding.Horizontal + tabPadding.Right : tabPadding.Horizontal), tabDrawable.Height);
-
+		var tabLocation = new PointF(posX, 0);
 		if (i == selectedIndex && draggingLocation != null)
 		{
-			tabRect.Offset(mousePos.X - draggingLocation.Value.X, 0);
+			tabLocation.Offset(mousePos.X - draggingLocation.Value.X, 0);
 		}
 
-		tab.Rect = tabRect;
+		var imageLocation = new PointF(tabLocation.X + TabPadding.Left, (tabDrawable.Height - maxImageSize.Height) / 2f);
+		var imageSize = tab.Image is null ? Size.Empty : maxImageSize;
+		tab.ImageRect = new RectangleF(imageLocation, imageSize);
 
-		tab.CloseRect = new RectangleF(tabRect.X + tab.Rect.Width - tabPadding.Right - closesize, (tabDrawable.Height - closesize) / 2, closesize, closesize);
-		tab.TextRect = new RectangleF(tabRect.X + tabPadding.Left + textoffset, (tabDrawable.Height - size.Height) / 2, textSize.Width, textSize.Height);
+		var textSize = string.IsNullOrEmpty(tab.Text) ? Size.Empty : Size.Ceiling(Font.MeasureString(tab.Text));
+		var textLocation = new PointF(tab.ImageRect.Right + (imageSize.IsEmpty ? 0 : TabPadding.Left), (tabDrawable.Height - textSize.Height) / 2);
+		tab.TextRect = new RectangleF(textLocation, textSize);
 
-		posx += tab.Rect.Width;
+		var unsavedSize = tab.HasUnsavedChanges ? new Size(6, 6) : Size.Empty;
+		var unsavedLocation = new PointF(tab.TextRect.Right + (tab.HasUnsavedChanges ? TabPadding.Right : 0), (tabDrawable.Height - unsavedSize.Height) / 2);
+		tab.UnsavedRect = new RectangleF(unsavedLocation, unsavedSize);
+
+		var closeSize = tab.Closable
+			? (int)Math.Floor(tabDrawable.Height * 0.6)
+			: 0;
+		var closeLocation = new PointF(tab.UnsavedRect.Right + (tab.Closable ? TabPadding.Right : 0), (tabDrawable.Height - closeSize) / 2);
+		tab.CloseRect = new RectangleF(closeLocation, new SizeF(closeSize, closeSize));
+
+		tab.Rect = new RectangleF(tabLocation, new SizeF(tab.CloseRect.Right + TabPadding.Right - tabLocation.X, tabDrawable.Height));
+
+		posX += tab.Rect.Width;
 	}
 
 	bool IsCloseSelected(ThemedDocumentPageHandler tab)
@@ -734,11 +736,6 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	void DrawTab(Graphics g, ThemedDocumentPageHandler tab, int i)
 	{
 		var prevnextsel = mousePos.X > nextPrevWidth || i == -1;
-		var closeSelected = IsCloseSelected(tab);
-		var tabRect = tab.Rect;
-		var textRect = tab.TextRect;
-		var closerect = tab.CloseRect;
-		var closemargin = closerect.Height / 4;
 
 		var textcolor = Enabled ? TabForegroundColor : DisabledForegroundColor;
 		var backcolor = TabBackgroundColor;
@@ -747,33 +744,43 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 			textcolor = Enabled ? TabHighlightForegroundColor : DisabledForegroundColor;
 			backcolor = TabHighlightBackgroundColor;
 		}
-		else if (draggingLocation == null && tabRect.Contains(mousePos) && prevnextsel && Enabled)
+		else if (draggingLocation == null && tab.Rect.Contains(mousePos) && prevnextsel && Enabled)
 		{
 			textcolor = TabHoverForegroundColor;
 			backcolor = TabHoverBackgroundColor;
 		}
 
-		g.FillRectangle(backcolor, tabRect);
-		if (tab.Image != null)
+		g.FillRectangle(backcolor, tab.Rect);
+		g.DrawText(Font, textcolor, tab.TextRect.Location, tab.Text);
+
+		if (tab.Image is not null)
 		{
 			g.SaveTransform();
 			g.ImageInterpolation = ImageInterpolation.High;
-			g.DrawImage(tab.Image, tabRect.X + TabPadding.Left, (tabDrawable.Height - maxImageSize.Height) / 2, maxImageSize.Width, maxImageSize.Height);
+			g.DrawImage(tab.Image, tab.ImageRect);
 			g.RestoreTransform();
 		}
-		g.DrawText(Font, textcolor, textRect.Location, tab.Text);
+
+		if (tab.HasUnsavedChanges)
+		{
+			g.FillEllipse(UnsavedBackgroundColor, tab.UnsavedRect);
+		}
 
 		if (tab.Closable)
 		{
+			var closeSelected = IsCloseSelected(tab);
+
 			var closeBackground = closeSelected ? CloseHighlightBackgroundColor : CloseBackgroundColor;
 			if (closeCornerRadius > 0)
-				g.FillPath(closeBackground, GraphicsPath.GetRoundRect(closerect, closeCornerRadius));
+				g.FillPath(closeBackground, GraphicsPath.GetRoundRect(tab.CloseRect, closeCornerRadius));
 			else
-				g.FillRectangle(closeBackground, closerect);
+				g.FillRectangle(closeBackground, tab.CloseRect);
 
+			var closeMargin = (int)tab.CloseRect.Height / 4;
+			var closeForegroundRect = RectangleF.Inset(tab.CloseRect, new PaddingF(closeMargin));
 			var closeForeground = Enabled ? closeSelected ? CloseHighlightForegroundColor : CloseForegroundColor : DisabledForegroundColor;
-			g.DrawLine(closeForeground, closerect.X + closemargin, closerect.Y + closemargin, closerect.X + closerect.Width - 1 - closemargin, closerect.Y + closerect.Height - 1 - closemargin);
-			g.DrawLine(closeForeground, closerect.X + closemargin, closerect.Y + closerect.Height - 1 - closemargin, closerect.X + closerect.Width - 1 - closemargin, closerect.Y + closemargin);
+			g.DrawLine(closeForeground, closeForegroundRect.TopLeft, closeForegroundRect.BottomRight);
+			g.DrawLine(closeForeground, closeForegroundRect.TopRight, closeForegroundRect.BottomLeft);
 		}
 	}
 

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentControlHandler.cs
@@ -33,6 +33,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	Color tabForegroundColor;
 	Color tabHighlightForegroundColor;
 	Color tabHoverForegroundColor;
+	Color unsavedBackgroundColor;
 
 	int closeCornerRadius;
 
@@ -260,6 +261,20 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 	}
 
 	/// <summary>
+	/// Gets or sets the background color for the unsaved changes indicator.
+	/// </summary>
+	/// <value>The background color for the unsaved changes indicator.</value>
+	public Color UnsavedBackgroundColor
+	{
+		get { return unsavedBackgroundColor; }
+		set
+		{
+			unsavedBackgroundColor = value;
+			tabDrawable.Invalidate();
+		}
+	}
+
+	/// <summary>
 	/// Gets or sets a value indicating whether to use a fixed tab height.
 	/// </summary>
 	/// <value><c>true</c> to use a fixed tab height.</value>
@@ -298,6 +313,7 @@ public class ThemedDocumentControlHandler : ThemedContainerHandler<TableLayout, 
 		tabForegroundColor = SystemColors.ControlText;
 		tabHighlightForegroundColor = SystemColors.HighlightText;
 		tabHoverForegroundColor = SystemColors.HighlightText;
+		unsavedBackgroundColor = SystemColors.ControlText;
 
 		tabDrawable = new Drawable();
 

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentPageHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentPageHandler.cs
@@ -129,9 +129,13 @@ public class ThemedDocumentPageHandler : ThemedContainerHandler<Panel, DocumentP
 
 	internal RectangleF Rect { get; set; }
 
+	internal RectangleF UnsavedRect { get; set; }
+
 	internal RectangleF CloseRect { get; set; }
 
 	internal RectangleF TextRect { get; set; }
+
+	internal RectangleF ImageRect { get; set; }
 
 	void Update() => DocControl?.Update(this);
 }

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentPageHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentPageHandler.cs
@@ -9,6 +9,7 @@ public class ThemedDocumentPageHandler : ThemedContainerHandler<Panel, DocumentP
 	bool closable;
 	string text;
 	Image image;
+	bool hasUnsavedChanges;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="T:Eto.Forms.ThemedControls.ThemedDocumentPageHandler"/> class.
@@ -101,6 +102,21 @@ public class ThemedDocumentPageHandler : ThemedContainerHandler<Panel, DocumentP
 		set
 		{
 			text = value;
+			Update();
+		}
+	}
+
+
+	/// <summary>
+	/// Gets or sets a value indicating whether this <see cref="T:Eto.Forms.ThemedControls.ThemedDocumentPageHandler"/> has unsaved changes.
+	/// </summary>
+	/// <value><c>true</c> if page has unsaved changes; otherwise, <c>false</c>.</value>
+	public bool HasUnsavedChanges
+	{
+		get { return hasUnsavedChanges; }
+		set
+		{
+			hasUnsavedChanges = value;
 			Update();
 		}
 	}


### PR DESCRIPTION
This PR adds possibility to mark individual document page as one having unsaved changes (`HasUnsavedChanges`). Such page would then be rendered with a little round indicator after the name of the document. The color can be configured using `UnsavedBackgroundColor` property.

Also, the calculations and drawing for each tab in `ThemedDocumentControlHandler` have been refactored:
- Introduce `ImageRect` and `UsavedRect`;
- Calculate rectangles once in `CalculateTab` (except for
`closeForegroundRect` which is calculated while drawing it);
- Restructure calculations element by element;
- Each of the element has valid location and size (even though it can be
 empty);
- (Hopefully) simplify calculations by using `PointF` and `RectangleF`
methods;
- Simplify drawing of the close button.