### PR TITLE
Add usings back to project templates

### DIFF
--- a/src/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.cs
+++ b/src/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.cs
@@ -1,4 +1,8 @@
 #if (UseCode || UseCodePreview)
+using System;
+using Eto.Forms;
+using Eto.Drawing;
+
 namespace EtoApp._1
 {
 	public partial class MainForm : Form

--- a/src/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.eto.cs
+++ b/src/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.eto.cs
@@ -1,4 +1,8 @@
 #if (UseCodePreview)
+using System;
+using Eto.Forms;
+using Eto.Drawing;
+
 namespace EtoApp._1
 {
 	partial class MainForm : Form

--- a/src/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.jeto.cs
+++ b/src/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.jeto.cs
@@ -1,4 +1,8 @@
 ﻿#if (UseJeto)
+using System;
+using System.Collections.Generic;
+using Eto.Forms;
+using Eto.Drawing;
 using Eto.Serialization.Json;
 
 namespace EtoApp._1

--- a/src/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.xeto.cs
+++ b/src/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/MainForm.xeto.cs
@@ -1,4 +1,8 @@
 ﻿#if (UseXeto)
+using System;
+using System.Collections.Generic;
+using Eto.Forms;
+using Eto.Drawing;
 using Eto.Serialization.Xaml;
 
 namespace EtoApp._1

--- a/src/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/Program.cs
+++ b/src/Eto.Forms.Templates/content/App-CSharp/EtoApp.1/Program.cs
@@ -1,4 +1,8 @@
-﻿namespace EtoApp._1
+﻿using System;
+using Eto.Forms;
+using Eto.Drawing;
+
+namespace EtoApp._1
 {
 	class Program
 	{

--- a/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.Gtk/Program.cs
+++ b/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.Gtk/Program.cs
@@ -1,4 +1,7 @@
-﻿namespace EtoApp._1.Gtk
+﻿using System;
+using Eto.Forms;
+
+namespace EtoApp._1.Gtk
 {
 	class Program
 	{

--- a/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.Mac/Program.cs
+++ b/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.Mac/Program.cs
@@ -1,4 +1,7 @@
-﻿namespace EtoApp._1.Mac
+﻿using System;
+using Eto.Forms;
+
+namespace EtoApp._1.Mac
 {
 	class Program
 	{

--- a/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.MacOS/Program.cs
+++ b/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.MacOS/Program.cs
@@ -1,4 +1,7 @@
-﻿namespace EtoApp._1.Mac
+﻿using System;
+using Eto.Forms;
+
+namespace EtoApp._1.Mac
 {
 	class Program
 	{

--- a/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.WinForms/Program.cs
+++ b/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.WinForms/Program.cs
@@ -1,4 +1,7 @@
-﻿namespace EtoApp._1.WinForms
+﻿using System;
+using Eto.Forms;
+
+namespace EtoApp._1.WinForms
 {
 	class Program
 	{

--- a/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.Wpf/Program.cs
+++ b/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.Wpf/Program.cs
@@ -1,4 +1,7 @@
-﻿namespace EtoApp._1.Wpf
+﻿using System;
+using Eto.Forms;
+
+namespace EtoApp._1.Wpf
 {
 	class Program
 	{

--- a/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.XamMac/Program.cs
+++ b/src/Eto.Forms.Templates/content/App-CSharp/Separate/EtoApp.1.XamMac/Program.cs
@@ -1,4 +1,6 @@
 ﻿using AppKit;
+using Eto.Forms;
+
 namespace EtoApp._1.XamMac
 {
 	class Program

--- a/src/Eto.Forms.Templates/content/App-FSharp/Separate/EtoApp.1.Wpf/Program.cs
+++ b/src/Eto.Forms.Templates/content/App-FSharp/Separate/EtoApp.1.Wpf/Program.cs
@@ -1,4 +1,7 @@
-﻿namespace EtoApp._1.Wpf
+﻿using System;
+using Eto.Forms;
+
+namespace EtoApp._1.Wpf
 {
 	class Program
 	{

--- a/src/Eto.Forms.Templates/content/App-VisualBasic/Separate/EtoApp.1.MacOS/Program.cs
+++ b/src/Eto.Forms.Templates/content/App-VisualBasic/Separate/EtoApp.1.MacOS/Program.cs
@@ -1,4 +1,7 @@
-﻿namespace EtoApp._1.Mac
+﻿using System;
+using Eto.Forms;
+
+namespace EtoApp._1.Mac
 {
 	class Program
 	{

--- a/src/Eto.Forms.Templates/content/App-VisualBasic/Separate/EtoApp.1.XamMac/Program.cs
+++ b/src/Eto.Forms.Templates/content/App-VisualBasic/Separate/EtoApp.1.XamMac/Program.cs
@@ -1,4 +1,6 @@
 ﻿using AppKit;
+using Eto.Forms;
+
 namespace EtoApp._1.XamMac
 {
 	class Program

--- a/src/Eto.Forms.Templates/content/File-CSharp/MainForm.cs
+++ b/src/Eto.Forms.Templates/content/File-CSharp/MainForm.cs
@@ -1,4 +1,8 @@
 #if (UseCode || UseCodePreview)
+using System;
+using Eto.Forms;
+using Eto.Drawing;
+
 namespace EtoApp._1
 {
 	public partial class MainForm : Form

--- a/src/Eto.Forms.Templates/content/File-CSharp/MainForm.eto.cs
+++ b/src/Eto.Forms.Templates/content/File-CSharp/MainForm.eto.cs
@@ -1,4 +1,8 @@
 #if (UseCodePreview)
+using System;
+using Eto.Forms;
+using Eto.Drawing;
+
 namespace EtoApp._1
 {
 	partial class MainForm : Form

--- a/src/Eto.Forms.Templates/content/File-CSharp/MainForm.jeto.cs
+++ b/src/Eto.Forms.Templates/content/File-CSharp/MainForm.jeto.cs
@@ -1,4 +1,8 @@
 ﻿#if (UseJeto)
+using System;
+using System.Collections.Generic;
+using Eto.Forms;
+using Eto.Drawing;
 using Eto.Serialization.Json;
 
 namespace EtoApp._1

--- a/src/Eto.Forms.Templates/content/File-CSharp/MainForm.xeto.cs
+++ b/src/Eto.Forms.Templates/content/File-CSharp/MainForm.xeto.cs
@@ -1,4 +1,8 @@
 ﻿#if (UseXeto)
+using System;
+using System.Collections.Generic;
+using Eto.Forms;
+using Eto.Drawing;
 using Eto.Serialization.Xaml;
 
 namespace EtoApp._1


### PR DESCRIPTION
These were inadvertently removed when using global usings for other files, but should remain for the project templates.

Fixes #2619