### PR TITLE
Wpf: Maintain focus of TreeGridView after calling ReloadItem

### DIFF
--- a/src/Eto.WinForms/CustomControls/TreeController.cs
+++ b/src/Eto.WinForms/CustomControls/TreeController.cs
@@ -3,11 +3,11 @@ namespace Eto.CustomControls
 	public interface ITreeHandler
 	{
 		ITreeGridItem SelectedItem { get; }
-		void SelectRow (int row);
+		void SelectRow(int row);
 		bool AllowMultipleSelection { get; }
 
-		void PreResetTree ();
-		void PostResetTree ();
+		bool PreResetTree(object item = null, int row = -1);
+		void PostResetTree(object item = null, int row = -1);
 	}
 
 	public class TreeController : ITreeGridStore<ITreeGridItem>, IList, INotifyCollectionChanged
@@ -316,11 +316,9 @@ namespace Eto.CustomControls
 
 		void ResetCollection ()
 		{
-			if (parent == null)
-				Handler.PreResetTree ();
-			OnTriggerCollectionChanged (new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Reset));
-			if (parent == null)
-				Handler.PostResetTree ();
+			var doPost = parent == null && Handler.PreResetTree();
+			OnTriggerCollectionChanged(new NotifyCollectionChangedEventArgs (NotifyCollectionChangedAction.Reset));
+			if (doPost) Handler.PostResetTree ();
 		}
 
 		public void ReloadItem(ITreeGridItem item)
@@ -328,8 +326,10 @@ namespace Eto.CustomControls
 			var row = IndexOf(item);
 			if (row < 0)
 				return;
+			var doPost = parent == null && Handler.PreResetTree(item, row);
 			OnTriggerCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Remove, item, row));
 			OnTriggerCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item, row));
+			if (doPost) Handler.PostResetTree(item, row);
 		}
 
 		public bool CollapseRow (int row)

--- a/src/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
@@ -351,11 +351,12 @@ namespace Eto.WinForms.Forms.Controls
 			}
 		}
 
-		void ITreeHandler.PreResetTree()
+		bool ITreeHandler.PreResetTree(object item, int row)
 		{
+			return false;
 		}
 
-		void ITreeHandler.PostResetTree()
+		void ITreeHandler.PostResetTree(object item, int row)
 		{
 		}
 

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -939,7 +939,15 @@ namespace Eto.Wpf.Forms.Controls
 
 		public void ReloadData(IEnumerable<int> rows)
 		{
+			SkipSelectionChanged = true;
+			SaveFocus();
+
 			Control.Items.Refresh();
+			
+			DisableAutoScrollToSelection = true;
+			RestoreFocus();
+			SkipSelectionChanged = false;
+			DisableAutoScrollToSelection = false;
 		}
 
 		swc.DataGridRow GetCurrentRow()

--- a/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -189,13 +189,16 @@ namespace Eto.Wpf.Forms.Controls
 			return new TreeTogglePanel(defaultContent, controller);
 		}
 
-		void ITreeHandler.PreResetTree()
+		bool ITreeHandler.PreResetTree(object item, int row)
 		{
+			if (item != null && Control.CurrentItem != item)
+				return false;
 			SkipSelectionChanged = true;
 			SaveFocus();
+			return true;
 		}
 
-		void ITreeHandler.PostResetTree()
+		void ITreeHandler.PostResetTree(object item, int row)
 		{
 			DisableAutoScrollToSelection = true;
 			RestoreFocus();


### PR DESCRIPTION
Same as when `ReloadData()` is called, if the item that is reloaded has focus then we lose focus altogether which is not expected. 