### PR TITLE
Failed to initialize WebView2 error message spelling

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/WebView2Handler.cs
+++ b/src/Eto.Wpf/Forms/Controls/WebView2Handler.cs
@@ -477,7 +477,7 @@ public class WebView2Handler : BaseHandler, WebView.IHandler
 	{
 		if (!e.IsSuccess)
 		{
-			throw new WebView2InitializationException("Failed to initialze WebView2", e.InitializationException);
+			throw new WebView2InitializationException("Failed to initialize WebView2", e.InitializationException);
 		}
 
 		// can't actually do anything here, so execute them in the main loop


### PR DESCRIPTION
I was messing around with leveraging WebView2 in my Eto application and noticed this while attempting to get WebView2 to properly load.  

I was getting this error due to `Eto.Wpf.Forms.Controls.WebView2InitializationException: Failed to initialze WebView2 ---> System.UnauthorizedAccessException: Access is denied.` which was caused by not setting an accesible cache location for `WEBVIEW2_USER_DATA_FOLDER`.