### PR TITLE
Gtk fix various treeview bugs

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -534,7 +534,20 @@ namespace Eto.GtkSharp.Forms.Controls
 		public bool AllowMultipleSelection
 		{
 			get { return Control.Selection.Mode == Gtk.SelectionMode.Multiple; }
-			set { Control.Selection.Mode = value ? Gtk.SelectionMode.Multiple : Gtk.SelectionMode.Browse; }
+			set
+			{
+				if (value)
+				{
+					Control.Selection.Mode = Gtk.SelectionMode.Multiple;
+				}
+				else
+				{
+					Control.GetCursor(out var cursorRow, out _);
+					Control.Selection.Mode = Gtk.SelectionMode.None;
+					Control.Selection.Mode = Gtk.SelectionMode.Single;
+					Control.Selection.SelectPath(cursorRow);
+				}
+			}
 		}
 
 		public virtual IEnumerable<int> SelectedRows

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -725,7 +725,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				{
 					(true, true) => Gtk.SelectionMode.Multiple,
 					(true, false) => Gtk.SelectionMode.Single,
-					(false, true) => Gtk.SelectionMode.Multiple, // Handled by SelectFunction
+					(false, true) => Gtk.SelectionMode.Multiple, // Handled by Selection Changed event in Initialize().
 					(false, false) => Gtk.SelectionMode.Browse
 				};
 
@@ -733,16 +733,17 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				// Workaround to not lose the ability to select after switching to Multi, unselecting everything,
 				// then switching back to Single or Browse. Cause unknown but reproduced in GtkSharp.
-				if (currentMode == Gtk.SelectionMode.Multiple && newMode != Gtk.SelectionMode.Multiple)
+				if (currentMode == Gtk.SelectionMode.Multiple
+				    && newMode is Gtk.SelectionMode.Single or Gtk.SelectionMode.Browse)
 				{
-					var anyWereSelected = Control.Selection.CountSelectedRows() > 0;
+					Control.GetCursor(out var cursorRowPath, out _);
+					var cursorWasSelected = Control.Selection.PathIsSelected(cursorRowPath);
 
 					Control.Selection.Mode = Gtk.SelectionMode.None;
 					Control.Selection.Mode = newMode;
-					if (anyWereSelected)
+					if (cursorWasSelected)
 					{
-						Control.GetCursor(out var cursorRow, out _);
-						Control.Selection.SelectPath(cursorRow);
+						Control.Selection.SelectPath(cursorRowPath);
 					}
 				}
 				Control.Selection.Mode = newMode;

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -746,7 +746,10 @@ namespace Eto.GtkSharp.Forms.Controls
 						Control.Selection.SelectPath(cursorRowPath);
 					}
 				}
-				Control.Selection.Mode = newMode;
+				else
+				{
+					Control.Selection.Mode = newMode;
+				}
 			}
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -145,7 +145,10 @@ namespace Eto.GtkSharp.Forms.Controls
 				if (!AllowEmptySelection && AllowMultipleSelection && Control.Selection.CountSelectedRows() == 0)
 				{
 					Control.GetCursor(out var cursorRow, out _);
-					Control.Selection.SelectPath(cursorRow);
+					if (cursorRow != null)
+					{
+						Control.Selection.SelectPath(cursorRow);
+					}
 				}
 			};
 
@@ -737,11 +740,12 @@ namespace Eto.GtkSharp.Forms.Controls
 				    && newMode is Gtk.SelectionMode.Single or Gtk.SelectionMode.Browse)
 				{
 					Control.GetCursor(out var cursorRowPath, out _);
-					var cursorWasSelected = Control.Selection.PathIsSelected(cursorRowPath);
+					var mustReselectCursor = cursorRowPath != null && Control.Selection.PathIsSelected(cursorRowPath);
 
 					Control.Selection.Mode = Gtk.SelectionMode.None;
 					Control.Selection.Mode = newMode;
-					if (cursorWasSelected)
+
+					if (mustReselectCursor)
 					{
 						Control.Selection.SelectPath(cursorRowPath);
 					}

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -168,7 +168,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			Control.HasTooltip = true;
 
 			//Control.Selection.SelectFunction = SelectFunction;
-			Control.Selection.Changed += (sender, args) =>
+			/*Control.Selection.Changed += (sender, args) =>
 			{
 				//if (!AllowEmptySelection && AllowMultipleSelection)
 				{
@@ -178,7 +178,7 @@ namespace Eto.GtkSharp.Forms.Controls
 						Control.Selection.SelectPath(cursorRow);
 					}
 				}
-			};
+			};*/
 		}
 
 		private void Control_QueryTooltip(object o, Gtk.QueryTooltipArgs args)
@@ -778,21 +778,26 @@ namespace Eto.GtkSharp.Forms.Controls
 				if (currentMode == SelectionMode.Multiple && newMode != SelectionMode.Multiple)
 				{
 					// Workaround to not lose the ability to select after switching to Multi then back to Single or Browse.
+					//var firstSelectedRow = Control.Selection.GetSelectedRows().FirstOrDefault();//Control.Selection.CountSelectedRows() > 0 ? Control.Selection.GetSelectedRows()[0] : null;
+					var anyWereSelected = Control.Selection.CountSelectedRows() > 0;
+
 					Control.Selection.Mode = Gtk.SelectionMode.None;
 					Control.Selection.Mode = newMode;
-					//if (Control.Selection.CountSelectedRows() == 0)
+					if (anyWereSelected)
 					{
+						//SkipSelectedChange = true;
 						Control.GetCursor(out var cursorRow, out _);
 						Control.Selection.SelectPath(cursorRow);
+						//SkipSelectedChange = false;
 					}
 				}
 				Control.Selection.Mode = newMode;
 			}
-			if (!allowEmptySelection && Control.Selection.CountSelectedRows() == 0)
+			/*if (!allowEmptySelection && Control.Selection.CountSelectedRows() == 0)
 			{
 				Control.GetCursor(out var cursorRow, out _);
 				Control.Selection.SelectPath(cursorRow);
-			}
+			}*/
 
 			//EnsureSelection();
 		}

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridViewSelectTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridViewSelectTests.cs
@@ -124,5 +124,36 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				Assert.AreEqual(initialCount / 4, selectionChangedCount, "SelectionChanged event should fire for each selected item removed");
 			});
 		}
+
+		[Test]
+		public void UnselectingInMultipleModeThenSwitchingToSingleModeShouldNotBreakSelection()
+		{
+			TestBase.Shown(form =>
+			{
+				form.Content = grid;
+			}, () =>
+			{
+				grid.AllowEmptySelection = true;
+				grid.AllowMultipleSelection = true;
+				grid.UnselectAll();
+				grid.AllowMultipleSelection = false;
+				grid.SelectRow(1);
+				Assert.AreEqual(1, grid.SelectedRow);
+			});
+		}
+
+		[Test]
+		public void SwitchingToSingleModeDoesNotBreakUnselecting()
+		{
+			TestBase.Invoke(() =>
+			{
+				grid.AllowEmptySelection = true;
+				grid.AllowMultipleSelection = true;
+				grid.SelectRow(1);
+				grid.AllowMultipleSelection = false;
+				grid.UnselectAll();
+				Assert.AreEqual(-1, grid.SelectedRow);
+			});
+		}
 	}
 }


### PR DESCRIPTION
**Fix a couple of selection related bugs in the Grid**

If you switched to Multi mode, unselected everything, and switched back to Single then you could no longer select anything. I reproduced this in raw GtkSharp but I can't find the cause so this is a workaround. I don't think this would break anything if the underlying issue were fixed.

If you switched to Multi and back to Single you could no longer unselect anything. This was due to AllowMultipleSelection starting in Single but setting Browse.

---

**Fix inability to select bottom row of GridView**

This was caused by the header height not being taken into consideration. I did the fixes for the above issues in such a way as to remove the need for the mouse click handler altogether. That handler didn't account for unselecting with the keyboard anyway.

---

These fixes also address (I believe):
https://github.com/picoe/Eto/issues/2335
https://github.com/picoe/Eto/issues/2401
https://github.com/picoe/Eto/issues/2443

and potentially some others but there are too many for me to check.

There are many inconsistencies between the platforms for what happens to the selection on switching modes or which events fire under which conditions. I've just tried to be sensible for what was already happening between Eto, Eto.Gtk, and GtkSharp and any other issues need to be addressed separately.