### PR TITLE
Make Window.Focus() and BringToFront() consistent across platforms

### DIFF
--- a/src/Eto.Gtk/Forms/GtkWindow.cs
+++ b/src/Eto.Gtk/Forms/GtkWindow.cs
@@ -781,17 +781,11 @@ namespace Eto.GtkSharp.Forms
 			}
 		}
 
-		public void BringToFront()
-		{
-			Control.Present();
-		}
+		protected override void GrabFocus() => Control.Present();
 
-		public void SendToBack()
-		{
-			var gdkWindow = Control.GetWindow();
-			if (gdkWindow != null)
-				gdkWindow.Lower();
-		}
+		public void BringToFront() => Control.GetWindow()?.Raise();
+
+		public void SendToBack() => Control.GetWindow()?.Lower();
 
 		public virtual void SetOwner(Window owner)
 		{

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -905,10 +905,7 @@ namespace Eto.Mac.Forms
 			}
 		}
 
-		public override void Focus()
-		{
-			Control.BecomeFirstResponder();
-		}
+		public override void Focus() => Control.MakeKeyAndOrderFront(Control);
 
 		public string Id { get; set; }
 
@@ -1243,7 +1240,6 @@ namespace Eto.Mac.Forms
 		public void BringToFront()
 		{
 			Control.OrderFront(Control);
-			Control.MakeKeyWindow();
 		}
 
 		public void SendToBack()

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -342,7 +342,7 @@ namespace Eto.Mac.Forms
 			if (handler == null)
 				return;
 			handler.Callback.OnGotFocus(handler.Widget, EventArgs.Empty);
-			if (GetHandler(handler.Control.FirstResponder) is IMacViewHandler ctlHandler)
+			if (GetHandler(handler.Control.FirstResponder) is IMacViewHandler ctlHandler && ctlHandler != handler)
 			{
 				ctlHandler.Callback.OnGotFocus(ctlHandler.Widget, EventArgs.Empty);
 			}
@@ -354,7 +354,7 @@ namespace Eto.Mac.Forms
 			if (handler == null)
 				return;
 
-			if (GetHandler(handler.Control.FirstResponder) is IMacViewHandler ctlHandler)
+			if (GetHandler(handler.Control.FirstResponder) is IMacViewHandler ctlHandler && ctlHandler != handler)
 			{
 				ctlHandler.Callback.OnLostFocus(ctlHandler.Widget, EventArgs.Empty);
 			}

--- a/src/Eto.WinForms/Forms/FormHandler.cs
+++ b/src/Eto.WinForms/Forms/FormHandler.cs
@@ -177,6 +177,14 @@ namespace Eto.WinForms.Forms
 			}
 		}
 
+		public override void Focus()
+		{
+			if (!CanFocus)
+				BringToFront();
+			else
+				base.Focus();
+		}
+
 		EtoForm EtoFormControl => Control as EtoForm;
 	}
 }

--- a/src/Eto.WinForms/Forms/WindowHandler.cs
+++ b/src/Eto.WinForms/Forms/WindowHandler.cs
@@ -549,8 +549,10 @@ namespace Eto.WinForms.Forms
 		{
 			if (Control.WindowState == swf.FormWindowState.Minimized)
 				Control.WindowState = swf.FormWindowState.Normal;
-			Control.BringToFront();
-			Control.Activate();
+
+			var hWnd = NativeHandle;
+			if (hWnd != IntPtr.Zero)
+				Win32.SetWindowPos(hWnd, Win32.HWND_TOP, 0, 0, 0, 0, Win32.SWP.NOSIZE | Win32.SWP.NOMOVE | Win32.SWP.NOACTIVATE);
 		}
 
 		public void SendToBack() => Control.SendToBack();

--- a/src/Eto.WinForms/Forms/WindowsControl.cs
+++ b/src/Eto.WinForms/Forms/WindowsControl.cs
@@ -693,7 +693,7 @@ namespace Eto.WinForms.Forms
 			Control.ResumeLayout();
 		}
 
-		public void Focus()
+		public virtual void Focus()
 		{
 			if (Widget.Loaded && Control.IsHandleCreated)
 				Control.Focus();

--- a/src/Eto.Wpf/Forms/FormHandler.cs
+++ b/src/Eto.Wpf/Forms/FormHandler.cs
@@ -71,5 +71,15 @@ namespace Eto.Wpf.Forms
 				SetStyle(Win32.WS.CHILD, !value);
 			}
 		}
+		
+		public override void Focus()
+		{
+			if (!Control.Focusable)
+				BringToFront();
+			else
+				base.Focus();
+		}
+
+		
 	}
 }

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -972,14 +972,9 @@ namespace Eto.Wpf.Forms
 			if (Control.WindowState == sw.WindowState.Minimized)
 				Control.WindowState = sw.WindowState.Normal;
 
-			if (!Control.Focusable)
-			{
-				var hWnd = NativeHandle;
-				if (hWnd != IntPtr.Zero)
-					Win32.SetWindowPos(hWnd, Win32.HWND_TOP, 0, 0, 0, 0, Win32.SWP.NOSIZE | Win32.SWP.NOMOVE);
-			}
-			else
-				Control.Activate();
+			var hWnd = NativeHandle;
+			if (hWnd != IntPtr.Zero)
+				Win32.SetWindowPos(hWnd, Win32.HWND_TOP, 0, 0, 0, 0, Win32.SWP.NOSIZE | Win32.SWP.NOMOVE | Win32.SWP.NOACTIVATE);
 		}
 
 		public void SendToBack()

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -866,7 +866,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// or it can be captured explicitly via <see cref="CaptureMouse"/>.
 	/// </remarks>
 	public bool IsMouseCaptured => Handler.IsMouseCaptured;
-	
+
 	/// <summary>
 	/// Captures all mouse events to this control.
 	/// </summary>
@@ -877,7 +877,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// </remarks>
 	/// <returns><c>true</c> if the mouse was captured, false otherwise.</returns>
 	public bool CaptureMouse() => Handler.CaptureMouse();
-	
+
 	/// <summary>
 	/// Releases the mouse capture after a call to <see cref="CaptureMouse"/>.
 	/// </summary>
@@ -998,10 +998,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// </summary>
 	/// <returns>The parent if found, or null if not found.</returns>
 	/// <param name="id">Identifier of the parent control to find.</param>
-	public new Container FindParent(string id)
-	{
-		return FindParent(null, id);
-	}
+	public new Container FindParent(string id) => FindParent(null, id);
 
 	/// <summary>
 	/// Detaches the control by removing it from its parent
@@ -1041,7 +1038,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	{
 		if (VisualParent != null)
 			throw new InvalidOperationException("You can only attach a parentless control");
-			
+
 		if (IsAttached)
 			return;
 
@@ -1128,18 +1125,13 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// Gets a value indicating whether this instance has the keyboard input focus.
 	/// </summary>
 	/// <value><c>true</c> if this instance has focus; otherwise, <c>false</c>.</value>
-	public virtual bool HasFocus
-	{
-		get { return Handler.HasFocus; }
-	}
+	public virtual bool HasFocus => Handler.HasFocus;
 
 	/// <summary>
-	/// Attempts to set the keyboard input focus to this control, or the first child that accepts focus
+	/// Attempts to set the keyboard input focus to this control, or the first child that accepts focus.
+	/// For Windows, this will bring it to front and activate it.
 	/// </summary>
-	public virtual void Focus()
-	{
-		Handler.Focus();
-	}
+	public virtual void Focus() => Handler.Focus();
 
 
 	static readonly object SuspendCount_Key = new object();
@@ -1156,7 +1148,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// <seealso cref="SuspendLayout"/>
 	/// <seealso cref="ResumeLayout"/>
 	/// <value><c>true</c> if this instance is suspended; otherwise, <c>false</c>.</value>
-	public bool IsSuspended { get { return SuspendCount > 0; } }
+	public bool IsSuspended => SuspendCount > 0;
 
 	/// <summary>
 	/// Suspends the layout of child controls
@@ -1218,10 +1210,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// </remarks>
 	/// <value>The supported platform commands.</value>
 	/// <seealso cref="MapPlatformCommand"/>
-	public IEnumerable<string> SupportedPlatformCommands
-	{
-		get { return Handler.SupportedPlatformCommands; }
-	}
+	public IEnumerable<string> SupportedPlatformCommands => Handler.SupportedPlatformCommands;
 
 	/// <summary>
 	/// Specifies a command to execute for a platform-specific command
@@ -1248,59 +1237,41 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// <param name="systemCommand">System command</param>
 	/// <param name="command">Command to execute, or null to restore to the default behavior</param>
 	/// <seealso cref="SupportedPlatformCommands"/>
-	public void MapPlatformCommand(string systemCommand, Command command)
-	{
-		Handler.MapPlatformCommand(systemCommand, command);
-	}
+	public void MapPlatformCommand(string systemCommand, Command command) => Handler.MapPlatformCommand(systemCommand, command);
 
 	/// <summary>
 	/// Converts a point from screen space to control space.
 	/// </summary>
 	/// <returns>The point in control space</returns>
 	/// <param name="point">Point in screen space</param>
-	public PointF PointFromScreen(PointF point)
-	{
-		return Handler.PointFromScreen(point);
-	}
+	public PointF PointFromScreen(PointF point) => Handler.PointFromScreen(point);
 
 	/// <summary>
 	/// Converts a point from control space to screen space
 	/// </summary>
 	/// <returns>The point in screen space</returns>
 	/// <param name="point">Point in control space</param>
-	public PointF PointToScreen(PointF point)
-	{
-		return Handler.PointToScreen(point);
-	}
+	public PointF PointToScreen(PointF point) => Handler.PointToScreen(point);
 
 	/// <summary>
 	/// Converts a rectangle from screen space to control space.
 	/// </summary>
 	/// <returns>The rectangle in control space</returns>
 	/// <param name="rect">Rectangle in screen space</param>
-	public RectangleF RectangleToScreen(RectangleF rect)
-	{
-		return new RectangleF(PointToScreen(rect.Location), PointToScreen(rect.EndLocation));
-	}
+	public RectangleF RectangleToScreen(RectangleF rect) => new RectangleF(PointToScreen(rect.Location), PointToScreen(rect.EndLocation));
 
 	/// <summary>
 	/// Converts a rectangle from control space to screen space
 	/// </summary>
 	/// <returns>The rectangle in screen space</returns>
 	/// <param name="rect">Rectangle in control space</param>
-	public RectangleF RectangleFromScreen(RectangleF rect)
-	{
-		return new RectangleF(PointFromScreen(rect.Location), PointFromScreen(rect.EndLocation));
-	}
+	public RectangleF RectangleFromScreen(RectangleF rect) => new RectangleF(PointFromScreen(rect.Location), PointFromScreen(rect.EndLocation));
 
 	/// <summary>
 	/// Gets the bounding rectangle of this control relative to its container
 	/// </summary>
 	/// <value>The bounding rectangle of the control</value>
-	public Rectangle Bounds
-	{
-		get { return new Rectangle(Location, Size); }
-	}
+	public Rectangle Bounds => new Rectangle(Location, Size);
 
 	/// <summary>
 	/// Gets the location of the control as positioned by the container
@@ -1310,10 +1281,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// This can be used to determine where the control is for overlaying floating windows, menus, etc.
 	/// </remarks>
 	/// <value>The current location of the control</value>
-	public Point Location
-	{
-		get { return Handler.Location; }
-	}
+	public Point Location => Handler.Location;
 
 	/// <summary>
 	/// Gets or sets the type of cursor to use when the mouse is hovering over the control
@@ -1435,7 +1403,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// <param name="widget">Widget to style.</param>
 	/// <param name="style">Style of the widget to apply.</param>
 	protected virtual void ApplyStyles(object widget, string style) => Parent?.ApplyStyles(widget, Style);
-		
+
 	/// <summary>
 	/// Shows a print dialog to print the specified control
 	/// </summary>
@@ -1447,7 +1415,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 			dlg.ShowDialog(this, doc);
 		}
 	}
-		
+
 
 	/// <summary>
 	/// Handles the disposal of this control
@@ -2039,7 +2007,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 		/// <param name="availableSize">The available size to determine the preferred size</param>
 		/// <returns>The preferred size this control would like to be, which can be larger than the specified <paramref name="availableSize" />.</returns>
 		SizeF GetPreferredSize(SizeF availableSize);
-			
+
 		/// <summary>
 		/// Updates the layout of this control if necessary.
 		/// </summary>
@@ -2050,7 +2018,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 		/// This is useful when you need to know the dimensions of the control immediately.
 		/// </remarks>
 		void UpdateLayout();
-		
+
 		/// <summary>
 		/// Gets a value indicating this control currently has mouse capture
 		/// </summary>
@@ -2070,7 +2038,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 		/// </remarks>
 		/// <returns><c>true</c> if the mouse was captured, false otherwise.</returns>
 		bool CaptureMouse();
-		
+
 		/// <summary>
 		/// Releases the mouse capture after a call to <see cref="CaptureMouse"/>.
 		/// </summary>

--- a/src/Eto/Forms/Window.cs
+++ b/src/Eto/Forms/Window.cs
@@ -533,20 +533,14 @@ public abstract class Window : Panel
 	}
 
 	/// <summary>
-	/// Brings the window in front of all other windows in the z-order.
+	/// Brings the window in front of all other windows in the z-order.  This should not activate/focus the window.
 	/// </summary>
-	public void BringToFront()
-	{
-		Handler.BringToFront();
-	}
+	public void BringToFront() => Handler.BringToFront();
 
 	/// <summary>
-	/// Sends the window behind all other windows in the z-order.
+	/// Sends the window behind all other windows in the z-order, and will remain active if it has focus.
 	/// </summary>
-	public void SendToBack()
-	{
-		Handler.SendToBack();
-	}
+	public void SendToBack() => Handler.SendToBack();
 
 	/// <summary>
 	/// Raises the <see cref="BindableWidget.DataContextChanged"/> event

--- a/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
@@ -7,6 +7,7 @@ namespace Eto.Test.Sections.Behaviors
 	{
 		Window child;
 		Button bringToFrontButton;
+		Button focusButton;
 		EnumRadioButtonList<WindowStyle> styleCombo;
 		EnumRadioButtonList<WindowState> stateCombo;
 		EnumRadioButtonList<WindowType> typeRadio;
@@ -41,7 +42,7 @@ namespace Eto.Test.Sections.Behaviors
 			layout.AddSeparateRow(null, CreateMinimumSizeControls(), null);
 			layout.AddSeparateRow(null, CreateCancelClose(), null);
 			layout.AddSeparateRow(null, CreateChildWindowButton(), null);
-			layout.AddSeparateRow(null, BringToFrontButton(), null);
+			layout.AddSeparateRow(null, BringToFrontButton(), SetFocusButton(), null);
 			layout.Add(null);
 
 			Content = layout;
@@ -527,7 +528,7 @@ namespace Eto.Test.Sections.Behaviors
 				child.Owner = ParentWindow;
 			if (createMenuBar.Checked ?? false)
 				child.Menu = CreateMenuBar();
-			bringToFrontButton.Enabled = true;
+			bringToFrontButton.Enabled = focusButton.Enabled = true;
 			DataContext = child;
 			show();
 			//visibleCheckBox.Checked = child?.Visible == true; // child will be null after it is shown
@@ -548,7 +549,7 @@ namespace Eto.Test.Sections.Behaviors
 			child.LostFocus -= child_LostFocus;
 			child.LocationChanged -= child_LocationChanged;
 			child.SizeChanged -= child_SizeChanged;
-			bringToFrontButton.Enabled = false;
+			bringToFrontButton.Enabled = focusButton.Enabled = false;
 			child.Unbind();
 			child = null;
 			// write out number of open windows after the closed event is called
@@ -616,37 +617,32 @@ namespace Eto.Test.Sections.Behaviors
 			control.Click += (sender, e) => CreateChild();
 			return control;
 		}
+		
+		Control SetFocusButton()
+		{
+			var control = focusButton = new Button { Text = "Focus", Enabled = false };
+			control.Click += (sender, e) => child?.Focus();
+			return control;
+		}
 
 		Control BringToFrontButton()
 		{
-			var control = bringToFrontButton = new Button { Text = "Bring to Front", Enabled = false };
-			control.Click += (sender, e) =>
-			{
-				if (child != null)
-					child.BringToFront();
-			};
+			var control = bringToFrontButton = new Button { Text = "BringToFront", Enabled = false };
+			control.Click += (sender, e) => child?.BringToFront();
 			return control;
 		}
 
 		Control CloseButton()
 		{
 			var control = new Button { Text = "Close Window" };
-			control.Click += (sender, e) =>
-			{
-				if (child != null)
-					child.Close();
-			};
+			control.Click += (sender, e) => child?.Close();
 			return control;
 		}
 
 		Control SendToBackButton()
 		{
-			var control = new Button { Text = "Send to Back" };
-			control.Click += (sender, e) =>
-			{
-				if (child != null)
-					child.SendToBack();
-			};
+			var control = new Button { Text = "SendToBack" };
+			control.Click += (sender, e) => child?.SendToBack();
 			return control;
 		}
 


### PR DESCRIPTION
- Mac: Fix Window.Focus()
- Mac: Don't fire GotFocus/LostFocus on a Window twice when the first responder is the window itself.
- Focus() should bring to front and make active (set keyboard focus)
- BringToFront() should not make window active, just change z-order
- Focus() is the same as BringToFront() when CanFocus = false