### PR TITLE
BringToFront() and Focus() should un-minimize the Window

### DIFF
--- a/src/Eto.Gtk/Forms/GtkWindow.cs
+++ b/src/Eto.Gtk/Forms/GtkWindow.cs
@@ -723,6 +723,8 @@ namespace Eto.GtkSharp.Forms
 									Control.Unfullscreen();
 								if (gdkWindow.State.HasFlag(Gdk.WindowState.Iconified))
 									Control.Deiconify();
+								if (gdkWindow.State.HasFlag(Gdk.WindowState.Iconified))
+									Control.Present();
 							}
 							Control.Maximize();
 							break;
@@ -738,6 +740,8 @@ namespace Eto.GtkSharp.Forms
 									Control.Unmaximize();
 								if (gdkWindow.State.HasFlag(Gdk.WindowState.Iconified))
 									Control.Deiconify();
+								if (gdkWindow.State.HasFlag(Gdk.WindowState.Iconified))
+									Control.Present();
 							}
 							break;
 					}
@@ -783,7 +787,18 @@ namespace Eto.GtkSharp.Forms
 
 		protected override void GrabFocus() => Control.Present();
 
-		public void BringToFront() => Control.GetWindow()?.Raise();
+		public void BringToFront()
+		{
+			if (WindowState == WindowState.Minimized)
+			{
+				Control.Deiconify();
+				// if it didn't work, present it
+				if (WindowState == WindowState.Minimized)
+					Control.Present();
+			}
+			
+			Control.GetWindow()?.Raise();
+		}
 
 		public void SendToBack() => Control.GetWindow()?.Lower();
 

--- a/src/Eto.WinForms/Forms/WindowHandler.cs
+++ b/src/Eto.WinForms/Forms/WindowHandler.cs
@@ -547,8 +547,7 @@ namespace Eto.WinForms.Forms
 
 		public virtual void BringToFront()
 		{
-			if (Control.WindowState == swf.FormWindowState.Minimized)
-				Control.WindowState = swf.FormWindowState.Normal;
+			RestoreFromMinimized();
 
 			var hWnd = NativeHandle;
 			if (hWnd != IntPtr.Zero)
@@ -556,6 +555,25 @@ namespace Eto.WinForms.Forms
 		}
 
 		public void SendToBack() => Control.SendToBack();
+
+		public override void Focus()
+		{
+			RestoreFromMinimized();
+
+			base.Focus();
+		}
+
+		private void RestoreFromMinimized()
+		{
+			if (Control.WindowState == swf.FormWindowState.Minimized)
+			{
+				var placement = new Win32.WINDOWPLACEMENT();
+				if (Win32.GetWindowPlacement(NativeHandle, ref placement) && placement.flags.HasFlag(Win32.WPF.RESTORETOMAXIMIZED))
+					Control.WindowState = swf.FormWindowState.Maximized;
+				else
+					Control.WindowState = swf.FormWindowState.Normal;
+			}
+		}
 
 		public virtual void SetOwner(Window owner)
 		{

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -768,5 +768,29 @@ namespace Eto
 		/// <returns>N/A</returns>
 		[DllImport("User32.dll")]
 		public static extern int DestroyIcon(IntPtr hIcon);
+		
+		[DllImport("user32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool GetWindowPlacement(IntPtr hWnd, ref WINDOWPLACEMENT lpwndpl);
+
+		[Flags]
+		public enum WPF : int
+		{
+			SETMINPOSITION = 0x01,
+			RESTORETOMAXIMIZED = 0x02,
+			ASYNCWINDOWPLACEMENT = 0x04
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		public struct WINDOWPLACEMENT
+		{
+			public int length;
+			public WPF flags;
+			public int showCmd;
+			public System.Drawing.Point ptMinPosition;
+			public System.Drawing.Point ptMaxPosition;
+			public System.Drawing.Rectangle rcNormalPosition;
+		}
+		
 	}
 }

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -967,6 +967,13 @@ namespace Eto.Wpf.Forms
 			RestoreWindowStyle(oldStyle);
 		}
 
+		public override void Focus()
+		{
+			if (Control.WindowState == sw.WindowState.Minimized)
+				Control.WindowState = sw.WindowState.Normal;
+			base.Focus();
+		}
+
 		public void BringToFront()
 		{
 			if (Control.WindowState == sw.WindowState.Minimized)


### PR DESCRIPTION
As a follow up to #2646, BringToFront() didn't work if minimized on Gtk, and Focus() didn't work if minimized on WPF/WinForms.