### PR TITLE
Mac: Fix disabled menu items with a Dialog

### DIFF
--- a/src/Eto.Mac/AppDelegate.cs
+++ b/src/Eto.Mac/AppDelegate.cs
@@ -29,7 +29,10 @@ namespace Eto.Mac
 		{
 			var handler = Application.Instance.Handler as ApplicationHandler;
 			if (handler != null)
+			{
+				handler.InitialMenu = Messaging.IntPtr_objc_msgSend(NSApplication.SharedApplication.Handle, MacWindow.selMainMenu);
 				handler.Initialize(this);
+			}
 		}
 
 		public override NSApplicationTerminateReply ApplicationShouldTerminate(NSApplication sender)

--- a/src/Eto.Mac/Forms/ApplicationHandler.cs
+++ b/src/Eto.Mac/Forms/ApplicationHandler.cs
@@ -15,6 +15,9 @@ namespace Eto.Mac.Forms
 
 		public bool AllowClosingMainForm { get; set; }
 
+		// pointer to the initial menu so we know whether we want to keep it or not for the main form
+		internal IntPtr InitialMenu { get; set; }
+
 		/// <summary>
 		/// Gets or sets a value indicating whether native macOS crash reports are generated for uncaught .NET exceptions.
 		/// </summary>
@@ -193,7 +196,7 @@ namespace Eto.Mac.Forms
 
 
 				EtoBundle.Init();
-
+				
 				EtoFontManager.Install();
 
 				if (Control.Delegate == null)

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -787,6 +787,9 @@ namespace Eto.Mac.Forms
 				if (oldMenu == IntPtr.Zero)
 				{
 					oldMenu = Messaging.IntPtr_objc_msgSend(NSApplication.SharedApplication.Handle, MacWindow.selMainMenu);
+					// don't save the initial menu which macOS creates on startup
+					if (oldMenu == ApplicationHandler.Instance.InitialMenu)
+						oldMenu = IntPtr.Zero;
 					if (oldMenu != IntPtr.Zero)
 					{
 						// remember old native menu so we can restore it later


### PR DESCRIPTION
On Mac, if you define a Menu on a Dialog all of its items (except system items) end up being disabled without having to add a native style to set `MenuItemHandler.EnabledWhenModal` to true.

Now when you define a menu for a Dialog, and it is the current dialog, all of those items will be enabled.

Also, macOS now creates a blank menu on startup instead of leaving it null, so we now ensure we don't remember that so other dialogs/forms don't get a completely blank menu.