### PR TITLE
Mac: Fix some memory leaks

### DIFF
--- a/src/Eto.Mac/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CellHandler.cs
@@ -84,7 +84,12 @@ namespace Eto.Mac.Forms.Cells
 	public abstract class CellHandler<TWidget, TCallback> : MacObject<NSObject, TWidget, TCallback>, Cell.IHandler, ICellHandler
 		where TWidget: Cell
 	{
-		public IDataColumnHandler ColumnHandler { get; set; }
+		WeakReference _columnHandler;
+		public IDataColumnHandler ColumnHandler
+		{
+			get => _columnHandler?.Target as IDataColumnHandler;
+			set => _columnHandler = new WeakReference(value);
+		}
 
 		public virtual bool Editable { get; set; }
 

--- a/src/Eto.Mac/Forms/Cells/CheckBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CheckBoxCellHandler.cs
@@ -107,15 +107,18 @@ namespace Eto.Mac.Forms.Cells
 				var col = Array.IndexOf(tableView.TableColumns(), tableColumn);
 				view.Activated += (sender, e) =>
 				{
+					var colHandler = ColumnHandler;
+					if (colHandler == null)
+						return;
 					var control = (CellView)sender;
 					var r = (int)control.Tag;
 					var item = getItem(control.Item, r);
-					var ee = MacConversions.CreateCellEventArgs(ColumnHandler.Widget, tableView, r, col, item);
-					ColumnHandler.DataViewHandler.OnCellEditing(ee);
+					var ee = MacConversions.CreateCellEventArgs(colHandler.Widget, tableView, r, col, item);
+					colHandler.DataViewHandler?.OnCellEditing(ee);
 					SetObjectValue(item, control.ObjectValue);
 					control.ObjectValue = GetObjectValue(item);
 
-					ColumnHandler.DataViewHandler.OnCellEdited(ee);
+					colHandler.DataViewHandler?.OnCellEdited(ee);
 				};
 			}
 			view.Tag = row;

--- a/src/Eto.Mac/Forms/Cells/ComboBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ComboBoxCellHandler.cs
@@ -241,14 +241,17 @@ namespace Eto.Mac.Forms.Cells
 				};
 				view.Activated += (sender, e) =>
 				{
+					var colHandler = ColumnHandler;
+					if (colHandler == null)
+						return;
 					var control = (CellView)sender;
 					var r = (int)control.Tag;
 					var item = getItem(control.Item, r);
-					var cellArgs = MacConversions.CreateCellEventArgs(ColumnHandler.Widget, tableView, r, col, item);
-					ColumnHandler.DataViewHandler.OnCellEditing(cellArgs);
+					var cellArgs = MacConversions.CreateCellEventArgs(colHandler.Widget, tableView, r, col, item);
+					colHandler.DataViewHandler?.OnCellEditing(cellArgs);
 					SetObjectValue(item, control.ObjectValue);
 
-					ColumnHandler.DataViewHandler.OnCellEdited(cellArgs);
+					colHandler.DataViewHandler?.OnCellEdited(cellArgs);
 					control.ObjectValue = GetObjectValue(item);
 				};
 				view.Bind(enabledBinding, tableColumn, "editable", null);

--- a/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
@@ -129,28 +129,46 @@ namespace Eto.Mac.Forms.Cells
 				var col = Array.IndexOf(tableView.TableColumns(), tableColumn);
 				view.BecameFirstResponder += (sender, e) =>
 				{
+					var colHandler = ColumnHandler;
+					if (colHandler == null)
+						return;
+					var table = colHandler.DataViewHandler?.Table;
+					if (table == null)
+						return;
 					var control = (CellView)sender;
 					var r = (int)control.Tag;
 					var item = getItem(control.Item, r);
-					var ee = MacConversions.CreateCellEventArgs(ColumnHandler.Widget, tableView, r, col, item);
-					ColumnHandler.DataViewHandler.OnCellEditing(ee);
+					var ee = MacConversions.CreateCellEventArgs(colHandler.Widget, table, r, col, item);
+					colHandler.DataViewHandler?.OnCellEditing(ee);
 				};
 				view.EditingEnded += (sender, e) =>
 				{
+					var colHandler = ColumnHandler;
+					if (colHandler == null)
+						return;
+					var table = colHandler.DataViewHandler?.Table;
+					if (table == null)
+						return;
 					var notification = (NSNotification)sender;
 					var control = (CellView)notification.Object;
 					var r = (int)control.Tag;
 					var item = getItem(control.Item, r);
 					SetObjectValue(item, control.ObjectValue);
 
-					var ee = MacConversions.CreateCellEventArgs(ColumnHandler.Widget, tableView, r, col, item);
-					ColumnHandler.DataViewHandler.OnCellEdited(ee);
+					var ee = MacConversions.CreateCellEventArgs(colHandler.Widget, table, r, col, item);
+					colHandler.DataViewHandler?.OnCellEdited(ee);
 					control.ObjectValue = GetObjectValue(item) ?? new NSString(string.Empty);
 				};
 				bool isResigning = false;
 				view.ResignedFirstResponder += (sender, e) =>
 				{
+					var colHandler = ColumnHandler;
+					if (colHandler == null)
+						return;
 					if (isResigning)
+						return;
+					var table = colHandler.DataViewHandler?.Table;
+					if (table == null)
 						return;
 					isResigning = true;
 					var control = (CellView)sender;
@@ -158,8 +176,8 @@ namespace Eto.Mac.Forms.Cells
 					var item = getItem(control.Item, r);
 					SetObjectValue(item, control.ObjectValue);
 
-					var ee = MacConversions.CreateCellEventArgs(ColumnHandler.Widget, tableView, r, col, item);
-					ColumnHandler.DataViewHandler.OnCellEdited(ee);
+					var ee = MacConversions.CreateCellEventArgs(colHandler.Widget, table, r, col, item);
+					colHandler.DataViewHandler?.OnCellEdited(ee);
 					isResigning = false;
 				};
 				view.Bind(editableBinding, tableColumn, "editable", null);

--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -76,8 +76,8 @@ namespace Eto.Mac.Forms.Controls
 			public EtoTableView(GridViewHandler handler)
 			{
 				FocusRingType = NSFocusRingType.None;
-				DataSource = new EtoTableViewDataSource { Handler = handler };
-				Delegate = new EtoTableDelegate { Handler = handler };
+				WeakDataSource = new EtoTableViewDataSource { Handler = handler };
+				WeakDelegate = new EtoTableDelegate { Handler = handler };
 				ColumnAutoresizingStyle = NSTableViewColumnAutoresizingStyle.Uniform;
 				SetDraggingSourceOperationMask(NSDragOperation.All, true);
 				SetDraggingSourceOperationMask(NSDragOperation.All, false);

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -646,8 +646,8 @@ namespace Eto.Mac.Forms.Controls
 
 			public EtoOutlineView(TreeGridViewHandler handler)
 			{
-				Delegate = new EtoOutlineDelegate { Handler = handler };
-				DataSource = new EtoDataSource { Handler = handler };
+				WeakDelegate = new EtoOutlineDelegate { Handler = handler };
+				WeakDataSource = new EtoDataSource { Handler = handler };
 				//HeaderView = null,
 				AutoresizesOutlineColumn = false;
 				//AllowsColumnResizing = false,

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -642,6 +642,8 @@ namespace Eto.Mac.Forms
 
 		public virtual IEnumerable<Control> VisualControls => Enumerable.Empty<Control>();
 
+		internal override bool DelayRegisterNotificationCenter => true;
+
 		protected virtual Size DefaultMinimumSize => Size.Empty;
 
 		public virtual Size MinimumSize
@@ -1201,6 +1203,7 @@ namespace Eto.Mac.Forms
 
 		public virtual void OnLoad(EventArgs e)
 		{
+			RegisterDelayedNotifications();
 			if (Widget.VisualParent?.Loaded != false && !(Widget is Window))
 			{
 				// adding dynamically or loading without a parent (e.g. embedding into a native app)
@@ -1224,6 +1227,7 @@ namespace Eto.Mac.Forms
 		public virtual void OnUnLoad(EventArgs e)
 		{
 			mouseDelegate?.FireMouseLeaveIfNeeded(false);
+			RemoveNotificationCenterObservers();
 		}
 
 		public virtual void OnKeyDown(KeyEventArgs e) => Callback.OnKeyDown(Widget, e);


### PR DESCRIPTION
- NotificationCenter observers are now added during OnLoad, removed during OnUnLoad
- Use weak references for handlers in cell views