### PR TITLE
Fix some tests with Splitter, EnsureUIThread, and NativeControl

### DIFF
--- a/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NativeControlHandler.cs
@@ -52,7 +52,7 @@
 		{
 			if (nativeControl == null)
 			{
-				return new NSView();
+				return new MacPanelView();
 			}
 			else if (nativeControl is NSView view)
 			{

--- a/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/SplitterHandler.cs
@@ -225,6 +225,11 @@ namespace Eto.Mac.Forms.Controls
 				}
 			}
 
+			if (newFrame.Width <= 0)
+				panel1Rect.Width = panel1Rect.X = panel2Rect.Width = panel2Rect.X = 0;
+			if (newFrame.Height <= 0)
+				panel1Rect.Height = panel1Rect.Y = panel2Rect.Height = panel2Rect.Y = 0;
+
 			splitView.Subviews[0].Frame = panel1Rect;
 			splitView.Subviews[1].Frame = panel2Rect;
 			//Console.WriteLine($"Splitter resize: frame: {splitView.Frame.Size}, position: {position}, panel1({panel1?.Visible}): {panel1Rect}, panel2({panel2?.Visible}): {panel2Rect}");

--- a/src/Eto/Forms/Application.cs
+++ b/src/Eto/Forms/Application.cs
@@ -22,9 +22,7 @@ public enum UIThreadCheckMode
 /// <summary>
 /// Exception thrown when a control method is accessed in a non-UI thread using <see cref="Application.EnsureUIThread"/>.
 /// </summary>
-#if NETSTANDARD2_0_OR_GREATER
 [System.Serializable]
-#endif
 public class UIThreadAccessException : System.Exception
 {
 	/// <summary>
@@ -42,7 +40,6 @@ public class UIThreadAccessException : System.Exception
 	/// <param name="message">Message for the exception</param>
 	/// <param name="inner">Inner exception</param>
 	public UIThreadAccessException(string message, System.Exception inner) : base(message, inner) { }
-#if NETSTANDARD2_0_OR_GREATER
 	/// <summary>
 	/// Initializes a new instance of the UIThreadAccessException class from serialization
 	/// </summary>
@@ -51,7 +48,6 @@ public class UIThreadAccessException : System.Exception
 	protected UIThreadAccessException(
 		System.Runtime.Serialization.SerializationInfo info,
 		System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
-#endif
 }
 
 /// <summary>
@@ -65,9 +61,7 @@ public class UIThreadAccessException : System.Exception
 [Handler(typeof(Application.IHandler))]
 public class Application : Widget
 {
-#if NETSTANDARD2_0_OR_GREATER
 	Thread mainThread;
-#endif
 	LocalizeEventArgs localizeArgs;
 	readonly object localizeLock = new object();
 	static readonly object ApplicationKey = new object();
@@ -313,9 +307,7 @@ public class Application : Widget
 		: this(InitializePlatform(platform))
 	{
 		Instance = this;
-#if NETSTANDARD2_0_OR_GREATER
 		mainThread = System.Threading.Thread.CurrentThread;
-#endif
 	}
 
 	Application(InitHelper init)
@@ -350,7 +342,6 @@ public class Application : Widget
 	/// </summary>
 	public void EnsureUIThread()
 	{
-#if NETSTANDARD2_0_OR_GREATER
 		if (UIThreadCheckMode == UIThreadCheckMode.None)
 			return;
 		if (mainThread == Thread.CurrentThread)
@@ -359,7 +350,6 @@ public class Application : Widget
 			System.Diagnostics.Trace.WriteLine("Warning: Accessing UI object from a non-UI thread. UI objects can only be used from the main thread.");
 		else if (UIThreadCheckMode == UIThreadCheckMode.Error)
 			throw new UIThreadAccessException();
-#endif
 	}
 
 	/// <summary>

--- a/test/Eto.Test.Mac/UnitTests/ButtonTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/ButtonTests.cs
@@ -30,7 +30,7 @@ namespace Eto.Test.Mac.UnitTests
 				
 				var b = new EtoButton(NSButtonType.MomentaryPushIn);
 				var originalSize = b.GetAlignmentRectForFrame(new CGRect(CGPoint.Empty, b.FittingSize)).Size;
-				Assert.AreEqual(defaultButtonHeight, originalSize.Height, "#2.1");
+				Assert.AreEqual((nfloat)defaultButtonHeight, originalSize.Height, "#2.1");
 
 				var preferred = handler.GetPreferredSize(SizeF.PositiveInfinity);
 				Assert.AreEqual(originalSize.Height, preferred.Height, "#2.1");

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -353,6 +353,14 @@ namespace Eto.Test.UnitTests
 								form.Close();
 							}
 						};
+						form.KeyDown += (sender, e) =>
+						{
+							if (e.KeyData == Keys.Escape)
+							{
+								failButton.PerformClick();
+								e.Handled = true;
+							}
+						};
 						row.Cells.Add(failButton);
 					}
 
@@ -361,6 +369,15 @@ namespace Eto.Test.UnitTests
 						var passButton = new Button { Text = "Pass" };
 						passButton.Click += (sender, e) => form.Close();
 						row.Cells.Add(passButton);
+						
+						form.KeyDown += (sender, e) =>
+						{
+							if (e.KeyData == Keys.Enter)
+							{
+								passButton.PerformClick();
+								e.Handled = true;
+							}
+						};
 					}
 					layout.Items.Add(new StackLayoutItem(table, HorizontalAlignment.Center));
 				}
@@ -458,6 +475,8 @@ namespace Eto.Test.UnitTests
 
 				var passButton = new Button { Text = "Pass" };
 				passButton.Click += (sender, e) => dialog.Close();
+				dialog.DefaultButton = passButton;
+				dialog.AbortButton = failButton;
 
 				dialog.Content = new StackLayout
 				{


### PR DESCRIPTION
- When the NativeControl is used with an Eto-supplied native control, use MacPanelView vs. NSView so events will work
- Prevent silly debug messages for Splitter when it has zero width or height
- Application.EnsureUIThread didn't work for .NET 7 build

Also added keyboard shortcuts for manual tests to more quickly go through them.  Enter = pass, Escape = fail.