### PR TITLE
Gtk: Use Gtk.Box vs deprecated HBox/VBox

### DIFF
--- a/src/Eto.Gtk/CustomControls/DateComboBoxDialog.cs
+++ b/src/Eto.Gtk/CustomControls/DateComboBoxDialog.cs
@@ -138,9 +138,7 @@ namespace Eto.GtkSharp.CustomControls
 
 		Gtk.Widget CalendarControls ()
 		{
-			var vbox = new Gtk.VBox { 
-				Spacing = 5
-			};
+			var vbox = new Gtk.Box(Gtk.Orientation.Vertical, 5);
 
 			calendar = new Gtk.Calendar
 			{
@@ -158,8 +156,8 @@ namespace Eto.GtkSharp.CustomControls
 			};
 
 			vbox.PackStart(calendar, false, false, 0);
-			
-			var hbox = new Gtk.HBox (true, 6);
+
+			var hbox = new Gtk.Box(Gtk.Orientation.Horizontal, 6) { Homogeneous = true };
 
 			var todayButton = new Gtk.Button {
 				CanFocus = true,
@@ -217,13 +215,12 @@ namespace Eto.GtkSharp.CustomControls
 		
 		Gtk.Widget ClockControls ()
 		{
-
 #if GTK2
 			var vbox = new Gtk.VBox ();
 			var spinners = new Gtk.HBox ();
 #else
-			var vbox = new Gtk.HBox ();
-			var spinners = new Gtk.VBox ();
+			var vbox = new Gtk.Box(Gtk.Orientation.Vertical, 0);
+			var spinners = new Gtk.Box(Gtk.Orientation.Vertical, 0);
 #endif
 			vbox.Spacing = 6;
 			spinners.Spacing = 6;
@@ -270,8 +267,7 @@ namespace Eto.GtkSharp.CustomControls
 			SkipPagerHint = true;
 			SkipTaskbarHint = true;
 
-			var hbox = new Gtk.HBox {
-				Spacing = 5,
+			var hbox = new Gtk.Box(Gtk.Orientation.Horizontal, 5) {
 				BorderWidth = 3
 			};
 			

--- a/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk3.cs
+++ b/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk3.cs
@@ -89,29 +89,28 @@ namespace Eto.GtkSharp.Forms.Controls
 			var showLabel = !string.IsNullOrEmpty(label.Text);
 			if (showImage && showLabel)
 			{
-				Gtk.VBox vbox;
-				Gtk.HBox hbox;
+				Gtk.Box box;
 				switch (ImagePosition)
 				{
 					case ButtonImagePosition.Above:
-						child = vbox = new Gtk.VBox(false, 2);
-						vbox.PackStart(gtkimage, true, true, 0);
-						vbox.PackEnd(label, false, true, 0);
+						child = box = new Gtk.Box(Gtk.Orientation.Vertical, 2);
+						box.PackStart(gtkimage, true, true, 0);
+						box.PackEnd(label, false, true, 0);
 						break;
 					case ButtonImagePosition.Below:
-						child = vbox = new Gtk.VBox(false, 2);
-						vbox.PackStart(label, false, true, 0);
-						vbox.PackEnd(gtkimage, true, true, 0);
+						child = box = new Gtk.Box(Gtk.Orientation.Vertical, 2);
+						box.PackStart(label, false, true, 0);
+						box.PackEnd(gtkimage, true, true, 0);
 						break;
 					case ButtonImagePosition.Left:
-						child = hbox = new Gtk.HBox(false, 2);
-						hbox.PackStart(gtkimage, false, true, 0);
-						hbox.PackStart(label, true, true, 0);
+						child = box = new Gtk.Box(Gtk.Orientation.Horizontal, 2);
+						box.PackStart(gtkimage, false, true, 0);
+						box.PackStart(label, true, true, 0);
 						break;
 					case ButtonImagePosition.Right:
-						child = hbox = new Gtk.HBox(false, 2);
-						hbox.PackStart(label, true, true, 0);
-						hbox.PackEnd(gtkimage, false, true, 0);
+						child = box = new Gtk.Box(Gtk.Orientation.Horizontal, 2);
+						box.PackStart(label, true, true, 0);
+						box.PackEnd(gtkimage, false, true, 0);
 						break;
 					case ButtonImagePosition.Overlay:
 #if GTK2

--- a/src/Eto.Gtk/Forms/Controls/CalendarHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/CalendarHandler.cs
@@ -57,7 +57,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				suppressRangeChanged--;
 
 				if (box == null)
-					box = new Gtk.HBox();
+					box = new Gtk.Box(Gtk.Orientation.Horizontal, 0);
 				else
 					box.Remove(endCalendar);
 				box.PackStart(Control, true, true, 0);

--- a/src/Eto.Gtk/Forms/Controls/DocumentPageHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DocumentPageHandler.cs
@@ -1,12 +1,12 @@
 using Eto.GtkSharp.Drawing;
 namespace Eto.GtkSharp.Forms.Controls
 {
-	public class DocumentPageHandler : GtkPanel<Gtk.VBox, DocumentPage, DocumentPage.ICallback>, DocumentPage.IHandler
+	public class DocumentPageHandler : GtkPanel<Gtk.Box, DocumentPage, DocumentPage.ICallback>, DocumentPage.IHandler
 	{
 		Gtk.Label label;
 
 		internal Gtk.Button closeButton;
-		readonly Gtk.HBox tab;
+		readonly Gtk.Box tab;
 		Gtk.Image gtkimage;
 		Image image;
 		public static Size MaxImageSize = new Size(16, 16);
@@ -27,8 +27,8 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public DocumentPageHandler()
 		{
-			Control = new Gtk.VBox();
-			tab = new Gtk.HBox();
+			Control = new Gtk.Box(Gtk.Orientation.Vertical, 0);
+			tab = new Gtk.Box(Gtk.Orientation.Horizontal, 0);
 			closeButton = new Gtk.Button();
 			closeButton.Relief = Gtk.ReliefStyle.None;
 			closeButton.CanFocus = false;

--- a/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
@@ -3,7 +3,7 @@ namespace Eto.GtkSharp.Forms.Controls
 {
 	public class DrawableHandler : GtkPanel<Gtk.EventBox, Drawable, Drawable.ICallback>, Drawable.IHandler
 	{
-		Gtk.VBox content;
+		Gtk.Box content;
 
 		public bool SupportsCreateGraphics { get { return true; } }
 
@@ -17,7 +17,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			Control.CanDefault = true;
 			Control.Events |= Gdk.EventMask.ButtonPressMask;
 
-			content = new Gtk.VBox();
+			content = new Gtk.Box(Gtk.Orientation.Vertical, 0);
 
 			Control.Add(content);
 		}

--- a/src/Eto.Gtk/Forms/Controls/FilePickerHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/FilePickerHandler.cs
@@ -4,7 +4,7 @@ namespace Eto.GtkSharp.Forms.Controls
 	{
 		FileAction action;
 		Gtk.FileChooserButton filebutton;
-		Gtk.HBox savebox;
+		Gtk.Box savebox;
 		Gtk.Entry saveentry;
 		Gtk.Button savebutton;
 
@@ -17,7 +17,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			// Save is not a valid option for FileChooserButton, therefore
 			// we need to create our own, or use the ThemedFilePickerHandler
-			savebox = new Gtk.HBox();
+			savebox = new Gtk.Box(Gtk.Orientation.Horizontal, 0);
 			saveentry = new Gtk.Entry();
 			savebox.PackStart(saveentry, true, true, 0);
 			savebutton = new Gtk.Button();

--- a/src/Eto.Gtk/Forms/Controls/PanelHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/PanelHandler.cs
@@ -18,7 +18,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		public PanelHandler()
 		{
 			Control = new Gtk.EventBox();
-			box = new Gtk.VBox();
+			box = new Gtk.Box(Gtk.Orientation.Vertical, 0);
 			Control.Add(box);
 		}
 

--- a/src/Eto.Gtk/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ScrollableHandler.cs
@@ -3,8 +3,8 @@ namespace Eto.GtkSharp.Forms.Controls
 	public class ScrollableHandler : GtkPanel<Gtk.ScrolledWindow, Scrollable, Scrollable.ICallback>, Scrollable.IHandler
 	{
 		readonly Gtk.Viewport vp;
-		readonly Gtk.HBox hbox;
-		readonly Gtk.VBox vbox;
+		readonly Gtk.Box hbox;
+		readonly Gtk.Box vbox;
 		BorderType border;
 		bool expandWidth = true;
 		bool expandHeight = true;
@@ -64,8 +64,11 @@ namespace Eto.GtkSharp.Forms.Controls
 #endif
 		}
 
-		public class EtoVBox : Gtk.VBox
+		public class EtoVBox : Gtk.Box
 		{
+			public EtoVBox() : base(Gtk.Orientation.Vertical, 0)
+			{
+			}
 #if GTK3
 			protected override void OnAdjustSizeRequest(Gtk.Orientation orientation, out int minimum_size, out int natural_size)
 			{
@@ -86,7 +89,7 @@ namespace Eto.GtkSharp.Forms.Controls
 				Control.SetSizeRequest(10, 10);
 #endif
 			// ensure things are top-left and not centered
-			hbox = new Gtk.HBox();
+			hbox = new Gtk.Box(Gtk.Orientation.Horizontal, 0);
 
 			vbox = new EtoVBox();
 			vbox.PackStart(hbox, true, true, 0);

--- a/src/Eto.Gtk/Forms/Controls/SliderHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/SliderHandler.cs
@@ -6,12 +6,13 @@ namespace Eto.GtkSharp.Forms.Controls
 		int max = 100;
 		int tick = 1;
 		Gtk.Scale scale;
+		Orientation orientation;
 
 		public SliderHandler()
 		{
 			this.Control = new Gtk.EventBox();
 			//Control.VisibleWindow = false;
-			scale = new Gtk.HScale(min, max, 1);
+			scale = new Gtk.Scale(Gtk.Orientation.Horizontal, min, max, 1);
 			this.Control.Child = scale;
 		}
 
@@ -107,14 +108,12 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public Orientation Orientation
 		{
-			get
-			{
-				return (scale is Gtk.HScale) ? Orientation.Horizontal : Orientation.Vertical;
-			}
+			get => orientation;
 			set
 			{
 				if (Orientation != value)
 				{
+					orientation = value;
 					scale.ValueChanged -= Connector.HandleScaleValueChanged;
 					Control.Remove(scale);
 #if !GTKCORE
@@ -122,9 +121,9 @@ namespace Eto.GtkSharp.Forms.Controls
 #endif
 					scale.Dispose();
 					if (value == Orientation.Horizontal)
-						scale = new Gtk.HScale(min, max, 1);
+						scale = new Gtk.Scale(Gtk.Orientation.Horizontal, min, max, 1);
 					else
-						scale = new Gtk.VScale(min, max, 1);
+						scale = new Gtk.Scale(Gtk.Orientation.Vertical, min, max, 1);
 					scale.ValueChanged += Connector.HandleScaleValueChanged;
 					Control.Child = scale;
 					scale.ShowAll();

--- a/src/Eto.Gtk/Forms/Controls/SplitterHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/SplitterHandler.cs
@@ -39,9 +39,13 @@ namespace Eto.GtkSharp.Forms.Controls
 			return width1 + width2 + SplitterWidth;
 		}
 
-		class EtoHPaned : Gtk.HPaned
+		class EtoHPaned : Gtk.Paned
 		{
 			WeakReference handler;
+
+			public EtoHPaned() : base(Gtk.Orientation.Horizontal)
+			{
+			}
 
 			public SplitterHandler Handler
 			{
@@ -98,9 +102,13 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
-		class EtoVPaned : Gtk.VPaned
+		class EtoVPaned : Gtk.Paned
 		{
 			WeakReference handler;
+
+			public EtoVPaned() : base(Gtk.Orientation.Vertical)
+			{
+			}
 
 			public SplitterHandler Handler
 			{
@@ -551,7 +559,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		static Gtk.Widget EmptyContainer()
 		{
-			var bin = new Gtk.VBox();
+			var bin = new Gtk.Box(Gtk.Orientation.Horizontal, 0);
 			bin.Visible = false;
 			bin.NoShowAll = true;
 			return bin;

--- a/src/Eto.Gtk/Forms/Controls/TabPageHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TabPageHandler.cs
@@ -2,18 +2,18 @@ using Eto.GtkSharp.Drawing;
 
 namespace Eto.GtkSharp.Forms.Controls
 {
-	public class TabPageHandler : GtkPanel<Gtk.VBox, TabPage, TabPage.ICallback>, TabPage.IHandler
+	public class TabPageHandler : GtkPanel<Gtk.Box, TabPage, TabPage.ICallback>, TabPage.IHandler
 	{
 		Gtk.Label label;
-		readonly Gtk.HBox tab;
+		readonly Gtk.Box tab;
 		Gtk.Image gtkimage;
 		Image image;
 		public static Size MaxImageSize = new Size(16, 16);
 
 		public TabPageHandler()
 		{
-			Control = new Gtk.VBox();
-			tab = new Gtk.HBox();
+			Control = new Gtk.Box(Gtk.Orientation.Vertical, 0);
+			tab = new Gtk.Box(Gtk.Orientation.Horizontal, 0);
 			label = new Gtk.Label();
 			tab.PackEnd(label, true, true, 0);
 			tab.ShowAll();

--- a/src/Eto.Gtk/Forms/CursorHandler.cs
+++ b/src/Eto.Gtk/Forms/CursorHandler.cs
@@ -5,7 +5,7 @@ namespace Eto.GtkSharp.Forms
 
 		public void Create(CursorType cursor)
 		{
-			Control = new Gdk.Cursor(cursor.ToGdk());
+			Control = new Gdk.Cursor(Gdk.Display.Default, cursor.ToGdk());
 		}
 
 		public void Create(Bitmap image, PointF hotspot)

--- a/src/Eto.Gtk/Forms/DialogHandler.cs
+++ b/src/Eto.Gtk/Forms/DialogHandler.cs
@@ -20,7 +20,7 @@ namespace Eto.GtkSharp.Forms
 			base.Initialize();
 			Control.KeyPressEvent += Connector.Control_KeyPressEvent;
 
-			var vbox = new EtoVBox { Handler = this };
+			var vbox = new EtoBox(Gtk.Orientation.Vertical, 0) { Handler = this };
 			vbox.PackStart(WindowActionControl, false, true, 0);
 			vbox.PackStart(WindowContentControl, true, true, 0);
 

--- a/src/Eto.Gtk/Forms/EtoControls.cs
+++ b/src/Eto.Gtk/Forms/EtoControls.cs
@@ -200,7 +200,7 @@ namespace Eto.GtkSharp.Forms
 
     }
     
-    public partial class EtoVBox : Gtk.VBox
+    public partial class EtoBox : Gtk.Box
     {
         WeakReference _handler;
         public IGtkControl Handler
@@ -208,6 +208,11 @@ namespace Eto.GtkSharp.Forms
             get => _handler?.Target as IGtkControl;
             set => _handler = new WeakReference(value);
         }
+	public EtoBox(Gtk.Orientation orientation, int spacing)
+		: base(orientation, spacing)
+	{
+		
+	}
         
 #if GTK3        
         protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)

--- a/src/Eto.Gtk/Forms/EtoControls.tt
+++ b/src/Eto.Gtk/Forms/EtoControls.tt
@@ -9,7 +9,7 @@ using Eto;
 namespace Eto.GtkSharp.Forms
 {
 <#
-var controls = new[] { "Fixed", "EventBox", "VBox", "ScrolledWindow" };
+var controls = new[] { "Fixed", "EventBox", "Box", "ScrolledWindow" };
 
 foreach (var control in controls)
 {
@@ -22,6 +22,18 @@ foreach (var control in controls)
             get => _handler?.Target as IGtkControl;
             set => _handler = new WeakReference(value);
         }
+<#
+	if (control == "Box")
+	{
+#>
+	public EtoBox(Gtk.Orientation orientation, int spacing)
+		: base(orientation, spacing)
+	{
+		
+	}
+<#
+	}
+#>
         
 #if GTK3        
         protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)

--- a/src/Eto.Gtk/Forms/FormHandler.cs
+++ b/src/Eto.Gtk/Forms/FormHandler.cs
@@ -16,7 +16,7 @@ namespace Eto.GtkSharp.Forms
 			Resizable = true;
 			Control.SetPosition(Gtk.WindowPosition.Center);
 
-			var vbox = new EtoVBox { Handler = this };
+			var vbox = new EtoBox(Gtk.Orientation.Vertical, 0) { Handler = this };
 			vbox.PackStart(WindowActionControl, false, true, 0);
 			vbox.PackStart(WindowContentControl, true, true, 0);
 			Control.Child = vbox;

--- a/src/Eto.Gtk/Forms/GtkWindow.cs
+++ b/src/Eto.Gtk/Forms/GtkWindow.cs
@@ -13,11 +13,12 @@ namespace Eto.GtkSharp.Forms
 		Size UserPreferredSize { get; }
 	}
 
-	public class GtkShrinkableVBox : Gtk.VBox
+	public class GtkShrinkableVBox : Gtk.Box
 	{
 		public bool Resizable { get; set; }
 
 		public GtkShrinkableVBox()
+			: base(Gtk.Orientation.Vertical, 0)
 		{
 		}
 
@@ -69,8 +70,8 @@ namespace Eto.GtkSharp.Forms
 		where TWidget : Window
 		where TCallback : Window.ICallback
 	{
-		Gtk.VBox vbox;
-		readonly Gtk.VBox actionvbox;
+		Gtk.Box vbox;
+		readonly Gtk.Box actionvbox;
 		readonly Gtk.Box topToolbarBox;
 		Gtk.Box menuBox;
 		GtkShrinkableVBox containerBox;
@@ -90,17 +91,17 @@ namespace Eto.GtkSharp.Forms
 
 		protected GtkWindow()
 		{
-			vbox = new Gtk.VBox();
-			actionvbox = new Gtk.VBox();
+			vbox = new Gtk.Box(Gtk.Orientation.Vertical, 0);
+			actionvbox = new Gtk.Box(Gtk.Orientation.Vertical, 0);
 
-			menuBox = new Gtk.HBox();
-			topToolbarBox = new Gtk.VBox();
+			menuBox = new Gtk.Box(Gtk.Orientation.Horizontal, 0);
+			topToolbarBox = new Gtk.Box(Gtk.Orientation.Vertical, 0);
 
 			containerBox = new GtkShrinkableVBox();
 			containerBox.Resizable = true;
 			containerBox.Visible = true;
 
-			bottomToolbarBox = new Gtk.VBox();
+			bottomToolbarBox = new Gtk.Box(Gtk.Orientation.Vertical, 0);
 
 			actionvbox.PackStart(menuBox, false, false, 0);
 			actionvbox.PackStart(topToolbarBox, false, false, 0);

--- a/src/Eto.Gtk/Forms/PixelLayoutHandler.cs
+++ b/src/Eto.Gtk/Forms/PixelLayoutHandler.cs
@@ -11,8 +11,12 @@ namespace Eto.GtkSharp.Forms
 		}
 
 #if GTK3
-		class EtoVBox : Gtk.VBox
+		class EtoVBox : Gtk.Box
 		{
+			public EtoVBox() : base(Gtk.Orientation.Vertical, 0)
+			{
+			}
+			
 			protected override void OnAdjustSizeRequest(Gtk.Orientation orientation, out int minimum_size, out int natural_size)
 			{
 				base.OnAdjustSizeRequest(orientation, out minimum_size, out natural_size);

--- a/src/Eto.Gtk/Forms/Printing/PrintDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/Printing/PrintDialogHandler.cs
@@ -6,13 +6,12 @@ namespace Eto.GtkSharp.Forms.Printing
 
 		public PrintDocument Document { get; set; }
 
-		public class CustomOptions : Gtk.VBox
+		public class CustomOptions : Gtk.Box
 		{
 			public Gtk.CheckButton SelectionOnly { get; private set; }
 
-			public CustomOptions()
+			public CustomOptions() : base(Gtk.Orientation.Vertical, 10)
 			{
-				this.Spacing = 10;
 				SelectionOnly = new Gtk.CheckButton { Label = "Selection Only" };
 				this.PackStart(SelectionOnly, false, false, 10);
 			}

--- a/src/Eto.Gtk/Forms/TableLayoutHandler.gtk2.cs
+++ b/src/Eto.Gtk/Forms/TableLayoutHandler.gtk2.cs
@@ -164,7 +164,7 @@ namespace Eto.GtkSharp.Forms
 				controls[y, x] = null;
 				var blankWidget = blank[y, x];
 				if (blankWidget == null)
-					blankWidget = blank[y, x] = new Gtk.VBox();
+					blankWidget = blank[y, x] = new Gtk.Box(Gtk.Orientation.Vertical, 0);
 				else if (blankWidget.Parent != null)
 					Control.Remove(blankWidget);
 				Control.Attach(blankWidget, (uint)x, (uint)x + 1, (uint)y, (uint)y + 1, GetColumnOptions(x), GetRowOptions(y), 0, 0);
@@ -184,7 +184,7 @@ namespace Eto.GtkSharp.Forms
 						var widget = child.GetContainerWidget();
 						Control.Remove(widget);
 
-						var blankWidget = blank[y, x] = new Gtk.VBox();
+						var blankWidget = blank[y, x] = new Gtk.Box(Gtk.Orientation.Vertical, 0);
 						Control.Attach(blankWidget, (uint)x, (uint)x + 1, (uint)y, (uint)y + 1, GetColumnOptions(x), GetRowOptions(y), 0, 0);
 						return;
 					}

--- a/src/Eto.Gtk/Forms/TableLayoutHandler.gtk3.cs
+++ b/src/Eto.Gtk/Forms/TableLayoutHandler.gtk3.cs
@@ -140,7 +140,7 @@ namespace Eto.GtkSharp.Forms
 				controls[y, x] = null;
 				var blankWidget = blank[y, x];
 				if (blankWidget == null)
-					blankWidget = blank[y, x] = new Gtk.VBox();
+					blankWidget = blank[y, x] = new Gtk.Box(Gtk.Orientation.Vertical, 0);
 				else if (blankWidget.Parent != null)
 					Control.Remove(blankWidget);
 				SetExpand(blankWidget, x, y);
@@ -165,7 +165,7 @@ namespace Eto.GtkSharp.Forms
 						var widget = child.GetContainerWidget();
 						Control.Remove(widget);
 
-						var blankWidget = blank[y, x] = new Gtk.VBox();
+						var blankWidget = blank[y, x] = new Gtk.Box(Gtk.Orientation.Vertical, 0);
 						SetExpand(blankWidget, x, y);
 						Control.Attach(blankWidget, x, y, 1, 1);
 
@@ -183,7 +183,7 @@ namespace Eto.GtkSharp.Forms
 				var blankWidget = blank[y, x];
 				if (blankWidget == null)
 				{
-					blankWidget = blank[y, x] = new Gtk.VBox();
+					blankWidget = blank[y, x] = new Gtk.Box(Gtk.Orientation.Vertical, 0);
 					Control.Attach(blankWidget, x, y, 1, 1);
 				}
 				else if (blankWidget.Parent != null)


### PR DESCRIPTION
HBox/VBox are obsolete, and in some distributions cause crashes trying to use HBox/VBox.