### PR TITLE
WPF/WinForms: Performance updates for Tree/GridView

### DIFF
--- a/src/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/TreeGridViewHandler.cs
@@ -126,7 +126,7 @@ namespace Eto.WinForms.Forms.Controls
 				if (e.Action == NotifyCollectionChangedAction.Add
 					|| e.Action == NotifyCollectionChangedAction.Reset
 					|| e.Action == NotifyCollectionChangedAction.Replace)
-					AutoSizeColumns(e.Action != NotifyCollectionChangedAction.Reset);
+					AutoSizeColumns(true);
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/Controls/EtoGridCollectionView.cs
+++ b/src/Eto.Wpf/Forms/Controls/EtoGridCollectionView.cs
@@ -1,0 +1,94 @@
+namespace Eto.Wpf.Forms.Controls
+{
+	class EtoGridCollectionView : IList, INotifyCollectionChanged
+	{
+		IList _collection;
+		swc.DataGrid _grid;
+		swcp.DataGridRowsPresenter _presenter;
+
+		public static IEnumerable Create(IEnumerable collection, swc.DataGrid grid)
+		{
+			if (collection is IList list && collection is INotifyCollectionChanged)
+				return new EtoGridCollectionView(list, grid);
+			return collection;
+		}
+
+		public EtoGridCollectionView(IList collection, swc.DataGrid grid)
+		{
+			_collection = collection;
+			if (_collection is INotifyCollectionChanged collectionChanged)
+				collectionChanged.CollectionChanged += OnCollectionChanged;
+			_grid = grid;
+		}
+
+		public void Unregister()
+		{
+			if (_collection is INotifyCollectionChanged collectionChanged)
+				collectionChanged.CollectionChanged -= OnCollectionChanged;
+		}
+
+		public object this[int index]
+		{
+			get => _collection[index];
+			set => _collection[index] = value;
+		}
+
+		public bool IsReadOnly => _collection.IsReadOnly;
+		public bool IsFixedSize => _collection.IsFixedSize;
+		public int Count => _collection.Count;
+		public object SyncRoot => _collection.SyncRoot;
+		public bool IsSynchronized => _collection.IsSynchronized;
+
+		public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+		public int Add(object value) => _collection.Add(value);
+
+		public void Clear() => _collection.Clear();
+
+		public bool Contains(object value) => _collection.Contains(value);
+
+		public void CopyTo(Array array, int index) => _collection.CopyTo(array, index);
+
+		public IEnumerator GetEnumerator() => _collection.GetEnumerator();
+
+		public int IndexOf(object value) => _collection.IndexOf(value);
+
+		public void Insert(int index, object value) => _collection.Insert(index, value);
+
+		public void Remove(object value) => _collection.Remove(value);
+
+		public void RemoveAt(int index) => _collection.RemoveAt(index);
+
+		static readonly FieldInfo s_queueField = typeof(swc.ItemContainerGenerator).GetField("_recyclableContainers", BindingFlags.Instance | BindingFlags.NonPublic);
+
+		void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
+		{
+			if (args.Action == NotifyCollectionChangedAction.Reset && s_queueField != null)
+			{
+				_presenter ??= _grid.FindChild<swcp.DataGridRowsPresenter>();
+				if (_presenter != null)
+				{
+					var existingRows = new List<sw.DependencyObject>();
+
+					IList list = _presenter.Children;
+					for (int i = 0; i < list.Count; i++)
+					{
+						if (list[i] is sw.DependencyObject child)
+							existingRows.Add(child);
+					}
+					CollectionChanged?.Invoke(this, args);
+
+					if (s_queueField.GetValue(_grid.ItemContainerGenerator) is Queue<sw.DependencyObject> queue)
+					{
+						for (int i = 0; i < existingRows.Count; i++)
+						{
+							queue.Enqueue(existingRows[i]);
+						}
+						return;
+					}
+				}
+			}
+			CollectionChanged?.Invoke(this, args);
+		}
+	}
+}

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -2,7 +2,7 @@ using Eto.Wpf.Forms.Cells;
 using Eto.Wpf.Forms.Menu;
 using Eto.Wpf.Drawing;
 using Eto.Wpf.CustomControls.TreeGridView;
-using System.Windows;
+
 namespace Eto.Wpf.Forms.Controls
 {
 	public class EtoDataGrid : swc.DataGrid
@@ -143,6 +143,8 @@ namespace Eto.Wpf.Forms.Controls
 				RowHeaderWidth = 0,
 				SelectionMode = swc.DataGridSelectionMode.Single,
 				GridLinesVisibility = swc.DataGridGridLinesVisibility.None,
+				EnableColumnVirtualization = true,
+				EnableRowVirtualization = true,
 			};
 			Control.SetResourceReference(swc.Control.BackgroundProperty, sw.SystemColors.WindowBrushKey);
 		}
@@ -351,7 +353,7 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
-		private void Control_Loaded(object sender, RoutedEventArgs e)
+		private void Control_Loaded(object sender, sw.RoutedEventArgs e)
 		{
 			// expanded columns don't get autosized, so we flip to star width after they are auto sized.
 			foreach (var col in Widget.Columns)
@@ -1078,7 +1080,7 @@ namespace Eto.Wpf.Forms.Controls
 			}
 
 			var height = Control.ActualHeight;
-			if (scrollViewer.ComputedHorizontalScrollBarVisibility == Visibility.Visible)
+			if (scrollViewer.ComputedHorizontalScrollBarVisibility == sw.Visibility.Visible)
 			{
 				var child = scrollViewer.FindChild<swcp.ScrollBar>("PART_HorizontalScrollBar");
 				height -= child.ActualHeight;

--- a/src/Eto.Wpf/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridViewHandler.cs
@@ -169,10 +169,13 @@ namespace Eto.Wpf.Forms.Controls
 			get { return store; }
 			set
 			{
+				if (store is EtoGridCollectionView coll)
+					coll.Unregister();
+
 				store = value;
 				// must use observable collection for editing and collection update notifications
 				if (store is INotifyCollectionChanged)
-					Control.ItemsSource = store;
+					Control.ItemsSource = EtoGridCollectionView.Create(store, Control);
 				else
 					Control.ItemsSource = store != null ? new ObservableCollection<object>(store) : null;
 				EnsureSelection();

--- a/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -148,8 +148,12 @@ namespace Eto.Wpf.Forms.Controls
 			get { return controller.Store; }
 			set
 			{
+				if (Control.ItemsSource is EtoGridCollectionView collectionView)
+					collectionView.Unregister();
+
 				controller.InitializeItems(value);
-				Control.ItemsSource = controller;
+
+				Control.ItemsSource = EtoGridCollectionView.Create(controller, Control);
 				EnsureSelection();
 			}
 		}


### PR DESCRIPTION
Improve performance of GridView and especially TreeGridView when the collection resets, e.g. when expanding/collapsing rows.  This works around a WPF issue where when the collection resets it throws away all realized rows instead of caching and re-using them.

For WinForms, it no longer auto sizes to all columns on expand/collapse as for large datasets that slows things down considerably.