### PR TITLE
Mac: Fix some events not firing properly

### DIFF
--- a/src/Eto.Mac/Forms/MacBase.cs
+++ b/src/Eto.Mac/Forms/MacBase.cs
@@ -38,7 +38,7 @@ namespace Eto.Mac.Forms
 
 		public IntPtr ControlHandle { get; set; }
 
-		public NSObject Control => Runtime.TryGetNSObject(ControlHandle);
+		public NSObject Control => Runtime.GetNSObject(ControlHandle);
 
 		WeakReference handler;
 
@@ -72,9 +72,15 @@ namespace Eto.Mac.Forms
 			var c = Control;
 			if (!hasNotification && c != null)
 			{
+				// Console.WriteLine($"Adding notification center observer for {KeyPath}, Handler: {Handler?.GetType()}, Control: {c.GetType()}");
 				NSNotificationCenter.DefaultCenter.AddObserver(this, selPerformAction, KeyPath, c);
 				hasNotification = true;
 			}
+			else if (!hasNotification)
+			{
+				Debug.WriteLine($"WARNING: Could not add notification center observer for {KeyPath}, Handler: {Handler?.GetType()}. {ControlHandle} points to a null object");
+			}
+			
 		}
 
 		void AddToControl()
@@ -82,9 +88,13 @@ namespace Eto.Mac.Forms
 			var c = Control;
 			if (!hasControl && c != null)
 			{
-				//Console.WriteLine ("{0}: 3. Adding observer! {1}, {2}", ((IRef)this.Handler).WidgetID, this.GetType (), Control.GetHashCode ());
+				// Console.WriteLine($"Adding control observer for {KeyPath}, Handler: {Handler?.GetType()}, Control: {c.GetType()}");
 				c.AddObserver(this, KeyPath, NSKeyValueObservingOptions.New, IntPtr.Zero);
 				hasControl = true;
+			}
+			else if (!hasNotification)
+			{
+				Debug.WriteLine($"WARNING: Could not add control observer for {KeyPath}, Handler: {Handler?.GetType()}. {ControlHandle} points to a null object");
 			}
 		}
 

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -642,7 +642,7 @@ namespace Eto.Mac.Forms
 
 		public virtual IEnumerable<Control> VisualControls => Enumerable.Empty<Control>();
 
-		internal override bool DelayRegisterNotificationCenter => true;
+		internal override bool DelayRegisterNotificationCenter => Widget?.Loaded != true;
 
 		protected virtual Size DefaultMinimumSize => Size.Empty;
 


### PR DESCRIPTION
In some cases, especially when the object being attached such as an `NSScrollView.ContentView` gets GC'd before it gets a chance to register, it would fail causing scroll events to not fire.  This is because we were (incorrectly) using `Runtime.TryGetNSObject()` which will only return an object if it still has a managed instance.  

Additionally if we were to add an event after the control is loaded it wouldn't register it properly so we only delay registration before it has been loaded.

Now we use `Runtime.GetNSObject()` so it'll create an instance if necessary. 

This issue was caused by #2654 as now we only add notification centre observers when the control is loaded, giving more time for the .NET instance to be GC'd if it isn't referenced anywhere.