### PR TITLE
Wpf: Fix startup when attaching to a WPF application

### DIFF
--- a/src/Eto.Wpf/Forms/ApplicationHandler.cs
+++ b/src/Eto.Wpf/Forms/ApplicationHandler.cs
@@ -88,6 +88,11 @@ namespace Eto.Wpf.Forms
 			{
 				Control = new sw.Application { ShutdownMode = sw.ShutdownMode.OnExplicitShutdown };
 				sw.Forms.Application.EnableVisualStyles();
+				Control.Startup += (s, e) => HandleStartup();
+			}
+			else
+			{
+				HandleStartup();
 			}
 
 			// Prevent race condition with volatile font collection field in WPF when measuring a window the first time
@@ -97,7 +102,6 @@ namespace Eto.Wpf.Forms
 
 			dispatcher = sw.Application.Current.Dispatcher ?? Dispatcher.CurrentDispatcher;
 			instance = this;
-			Control.Startup += HandleStartup;
 			ApplyThemes();
 			base.Initialize();
 		}
@@ -114,7 +118,7 @@ namespace Eto.Wpf.Forms
 			Callback.OnUnhandledException(Widget, unhandledExceptionArgs);
 		}
 
-		void HandleStartup(object sender, sw.StartupEventArgs e)
+		void HandleStartup()
 		{
 			IsStarted = true;
 			IsActive = Win32.ApplicationIsActivated();


### PR DESCRIPTION
When attaching to an existing WPF application the System.Windows.Application.Startup event is not called, so we now assume it has already started and set everything up directly.

This fixes issues showing new windows as they were being added to a delayed list of windows to show and would never be shown.