### PR TITLE
Mac: Implement Keymap.Convert

### DIFF
--- a/src/Eto.Mac/KeyMap.cs
+++ b/src/Eto.Mac/KeyMap.cs
@@ -37,7 +37,7 @@
 
 		public static Keys Convert(string keyEquivalent, NSEventModifierMask modifier)
 		{
-			return Keys.None;
+			return InverseMap.FirstOrDefault(pair => pair.Value == keyEquivalent).Key | modifier.ToEto();
 		}
 
 		public static string KeyEquivalent(Keys key)


### PR DESCRIPTION
This should allow you to retrieve the `Shortcut` of `MenuItem`s again.
I can't verify that this actually works since I'm having difficulties with compiling on Mac, but I'm pretty sure it _should_ work.