### PR TITLE
Add WebView.MessageReceived

### DIFF
--- a/src/Eto.Mac/Forms/Controls/WKWebViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/WKWebViewHandler.cs
@@ -10,7 +10,12 @@ namespace Eto.Mac.Forms.Controls
 	{
 		public override NSView ContainerControl { get { return Control; } }
 
-		public wk.WKWebViewConfiguration Configuration { get => Control.Configuration; }
+		public wk.WKWebViewConfiguration Configuration { get; set; }
+
+		public WKWebViewHandler()
+		{
+			Configuration = CreateConfiguration();
+		}
 
 		protected override wk.WKWebView CreateControl()
 		{
@@ -97,7 +102,7 @@ namespace Eto.Mac.Forms.Controls
 			public WKWebViewHandler Handler { get { return (WKWebViewHandler)WeakHandler.Target; } set { WeakHandler = new WeakReference(value); } }
 
 			public EtoWebView(WKWebViewHandler handler)
-				: base(new CGRect(0, 0, 200, 200), handler.CreateConfiguration())
+				: base(new CGRect(0, 0, 200, 200), handler.Configuration)
 			{
 				Handler = handler;
 				UIDelegate = new EtoUIDelegate { Handler = handler };
@@ -262,7 +267,7 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		private wk.WKWebViewConfiguration CreateConfiguration()
+		protected wk.WKWebViewConfiguration CreateConfiguration()
 		{
 			wk.WKUserContentController contentController = new();
 

--- a/src/Eto.Mac/Forms/Controls/WKWebViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/WKWebViewHandler.cs
@@ -10,6 +10,8 @@ namespace Eto.Mac.Forms.Controls
 	{
 		public override NSView ContainerControl { get { return Control; } }
 
+		public wk.WKWebViewConfiguration Configuration { get => Control.Configuration; }
+
 		protected override wk.WKWebView CreateControl()
 		{
 			return new EtoWebView(this);

--- a/src/Eto.Mac/Forms/Controls/WKWebViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/WKWebViewHandler.cs
@@ -112,7 +112,7 @@ namespace Eto.Mac.Forms.Controls
 		class ScriptMessageHandler : wk.WKScriptMessageHandler
 		{
 			private readonly WKWebViewHandler Handler;
-			public ScriptMessageHandler(WKWebViewHandler handler)
+			public ScriptMessageHandler(WKWebViewHandler handler) : base()
 			{
 				Handler = handler;
 			}

--- a/src/Eto.Wpf/Forms/Controls/SwfWebViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/SwfWebViewHandler.cs
@@ -197,7 +197,7 @@ namespace Eto.Wpf.Forms.Controls
 		/// </summary>
 		private void OnDocumentLoadedInjectScript(object sender, EventArgs args)
 		{
-			ExecuteScript(@"window.eto = window.eto || {}; window.eto.postMessage = function(message) { window.external.postMessage(message); };");
+			ExecuteScript(@"window.eto = { postMessage: function(message) { window.external.postMessage(message); } };");
 		}
 
 		public string ExecuteScript(string script)

--- a/src/Eto.Wpf/Forms/Controls/WebView2Handler.cs
+++ b/src/Eto.Wpf/Forms/Controls/WebView2Handler.cs
@@ -479,7 +479,6 @@ public class WebView2Handler : BaseHandler, WebView.IHandler
 		{
 			throw new WebView2InitializationException("Failed to initialize WebView2", e.InitializationException);
 		}
-		InjectScripts();
 
 		// can't actually do anything here, so execute them in the main loop
 		Application.Instance.AsyncInvoke(RunDelayedActions);
@@ -492,6 +491,7 @@ public class WebView2Handler : BaseHandler, WebView.IHandler
 
 		Control.CoreWebView2.DocumentTitleChanged += CoreWebView2_DocumentTitleChanged;
 		Control.CoreWebView2.NewWindowRequested += CoreWebView2_NewWindowRequested;
+		Control.CoreWebView2.DOMContentLoaded += CoreWebView2_DOMContentLoadedInjectScripts;
 		webView2Ready = true;
 
 		if (delayedActions != null)
@@ -664,9 +664,9 @@ public class WebView2Handler : BaseHandler, WebView.IHandler
 	/// <summary>
 	/// Wraps window.chrome.webview.postMessage to window.eto.postMessage for platform consistency
 	/// </summary>
-	private void InjectScripts()
+	private void CoreWebView2_DOMContentLoadedInjectScripts(object sender, CoreWebView2DOMContentLoadedEventArgs e)
 	{
-		CoreWebView2.AddScriptToExecuteOnDocumentCreatedAsync("window.eto = { postMessage: function(message) { window.chrome.webview.postMessage(message); } };");
+		CoreWebView2.ExecuteScriptAsync("window.eto = { postMessage: function(message) { window.chrome.webview.postMessage(message); } };");
 	}
 
 	public Uri Url

--- a/src/Eto.Wpf/Forms/Controls/WebView2Handler.cs
+++ b/src/Eto.Wpf/Forms/Controls/WebView2Handler.cs
@@ -642,13 +642,13 @@ public class WebView2Handler : BaseHandler, WebView.IHandler
 	private void Control_WebMessageReceived(object sender, CoreWebView2WebMessageReceivedEventArgs e)
 	{
 		string content = null;
-		if (!string.IsNullOrEmpty(e.WebMessageAsJson))
-		{
-			content = e.WebMessageAsJson;
-		}
-		else if (e.TryGetWebMessageAsString() is string str && !string.IsNullOrEmpty(str))
+		if (e.TryGetWebMessageAsString() is string str && !string.IsNullOrEmpty(str))
 		{
 			content = str;
+		}
+		else
+		{
+			content = e.WebMessageAsJson;
 		}
 		if (content != null)
 		{

--- a/src/Eto/Forms/Controls/WebView.cs
+++ b/src/Eto/Forms/Controls/WebView.cs
@@ -274,7 +274,7 @@ public class WebView : Control
 	public const string MessageReceivedEvent = "WebView.MessageReceived";
 
 	/// <summary>
-	/// Occurs when the title of the page has change either through navigation or a script.
+	/// Occurs when a message is received from a JS call to window.eto.postMessage(string).
 	/// </summary>
 	public event EventHandler<WebViewMessageEventArgs> MessageReceived
 	{
@@ -283,7 +283,7 @@ public class WebView : Control
 	}
 
 	/// <summary>
-	/// Raises the <see cref="DocumentTitleChanged"/> event.
+	/// Raises the <see cref="MessageReceived"/> event.
 	/// </summary>
 	/// <param name="e">Event arguments.</param>
 	protected virtual void OnMessageReceived(WebViewMessageEventArgs e)

--- a/src/Eto/Forms/Controls/WebView.cs
+++ b/src/Eto/Forms/Controls/WebView.cs
@@ -95,6 +95,27 @@ public class WebViewNewWindowEventArgs : WebViewLoadingEventArgs
 }
 
 /// <summary>
+/// Event arguments for when a message is sent via javascript in the <see cref="WebView"/>
+/// </summary>
+public class WebViewMessageEventArgs : EventArgs
+{
+	/// <summary>
+	/// Gets the received message.
+	/// </summary>
+	/// <value>The message.</value>
+	public string Message { get; private set; }
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Eto.Forms.WebViewMessageEventArgs"/> class.
+	/// </summary>
+	/// <param name="message">The message.</param>
+	public WebViewMessageEventArgs(string message)
+	{
+		this.Message = message;
+	}
+}
+
+/// <summary>
 /// Control to show a browser control that can display html and execute javascript.
 /// </summary>
 /// <remarks>
@@ -246,6 +267,30 @@ public class WebView : Control
 		Properties.TriggerEvent(DocumentTitleChangedEvent, this, e);
 	}
 
+
+	/// <summary>
+	/// Identifier for handlers when attaching the <see cref="MessageReceived"/> event.
+	/// </summary>
+	public const string MessageReceivedEvent = "WebView.MessageReceived";
+
+	/// <summary>
+	/// Occurs when the title of the page has change either through navigation or a script.
+	/// </summary>
+	public event EventHandler<WebViewMessageEventArgs> MessageReceived
+	{
+		add { Properties.AddHandlerEvent(MessageReceivedEvent, value); }
+		remove { Properties.RemoveEvent(MessageReceivedEvent, value); }
+	}
+
+	/// <summary>
+	/// Raises the <see cref="DocumentTitleChanged"/> event.
+	/// </summary>
+	/// <param name="e">Event arguments.</param>
+	protected virtual void OnMessageReceived(WebViewMessageEventArgs e)
+	{
+		Properties.TriggerEvent(MessageReceivedEvent, this, e);
+	}
+
 	#endregion
 
 	static WebView()
@@ -255,6 +300,7 @@ public class WebView : Control
 		EventLookup.Register<WebView>(c => c.OnDocumentLoading(null), WebView.DocumentLoadingEvent);
 		EventLookup.Register<WebView>(c => c.OnDocumentTitleChanged(null), WebView.DocumentTitleChangedEvent);
 		EventLookup.Register<WebView>(c => c.OnOpenNewWindow(null), WebView.OpenNewWindowEvent);
+		EventLookup.Register<WebView>(c => c.OnMessageReceived(null), WebView.MessageReceivedEvent);
 	}
 
 	/// <summary>
@@ -414,6 +460,11 @@ public class WebView : Control
 		/// Raises the document title changed event.
 		/// </summary>
 		void OnDocumentTitleChanged(WebView widget, WebViewTitleEventArgs e);
+
+		/// <summary>
+		/// Raises the message received event.
+		/// </summary>
+		void OnMessageReceived(WebView widget, WebViewMessageEventArgs e);
 	}
 
 	static readonly object callback = new Callback();
@@ -475,6 +526,15 @@ public class WebView : Control
 		{
 			using (widget.Platform.Context)
 				widget.OnDocumentTitleChanged(e);
+		}
+
+		/// <summary>
+		/// Raises the message received event.
+		/// </summary>
+		public void OnMessageReceived(WebView widget, WebViewMessageEventArgs e)
+		{
+			using (widget.Platform.Context)
+				widget.OnMessageReceived(e);
 		}
 	}
 


### PR DESCRIPTION
Hello! Initial draft for discussion.

The goal of this PR is to create a uniform approach to sending events from JS to Eto. Combined with the existing `ExecuteScript` it should allow for bi-directional communication (without polling).

Since each browser implementation significantly differs this approach is intended to keeps it simple by adding a single object /method to the global JavaScript context.

### Example usage:
```JS
function isRunningInEto() {
  return window.eto !== undefined;
}

function onButtonClick() {
   window.eto.postMessage("The button was clicked!");
}
```

### Supported Implementations:
- [x] WebView (legacy) (Wpf and WinForms)
- [x] WebView2 (Wpf and WinForms)
- [x] WebKit.WKWebView (Mac64 and MacOS)

Not implemented:
- [ ] WebKit.WebView (legacy)
- [ ] GTK