### PR TITLE
Mac: Fix crash when setting background color on some controls and size changes to zero

### DIFF
--- a/src/Eto.Mac/ColorizeView.cs
+++ b/src/Eto.Mac/ColorizeView.cs
@@ -28,14 +28,14 @@
 			var size = controlView.Frame.Size;
 			if (size.Width <= 0 || size.Height <= 0)
 			{
+				_image?.Dispose();
+				_image = null;
 				return;
 			}
 			
 			if (_image == null || size != _image.Size)
 			{
-				if (_image != null)
-					_image.Dispose();
-
+				_image?.Dispose();
 				_image = new NSImage(size);
 			}
 


### PR DESCRIPTION
If a control such as a `TextBox`, `Button`, or `DropDown` is colorized by setting its background color, then subsequently its size is set to zero it would try to call `NSImage.UnlockFocus()` when it never got locked to begin with causing a crash.