### PR TITLE
Mac: Don't call SizeChanged if disposed

### DIFF
--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -281,7 +281,7 @@ namespace Eto.Mac.Forms
 			var obj = Runtime.GetNSObject(sender);
 			Messaging.void_objc_msgSendSuper_SizeF(obj.SuperHandle, sel, size);
 
-			if (MacBase.GetHandler(obj) is IMacViewHandler handler)
+			if (MacBase.GetHandler(obj) is IMacViewHandler handler && !handler.Widget.IsDisposed)
 			{
 				handler.OnSizeChanged(EventArgs.Empty);
 				handler.Callback.OnSizeChanged(handler.Widget, EventArgs.Empty);


### PR DESCRIPTION
Sometimes this event gets called even after the control is disposed, causing crashes.