### PR TITLE
Make OperatingSystemPlatform lazy and use newer APIs for OS detection

### DIFF
--- a/src/Eto/OperatingSystemPlatform.cs
+++ b/src/Eto/OperatingSystemPlatform.cs
@@ -11,22 +11,27 @@ public sealed class OperatingSystemPlatform
 	/// <summary>
 	/// Gets a value indicating that the current .NET runtime is mono
 	/// </summary>
-	public bool IsMono { get; private set; }
+	public bool IsMono => _isMono ??= GetIsMono();
 
 	/// <summary>
 	/// Gets a value indicating that the current .NET runtime is .NET Core
 	/// </summary>
-	public bool IsNetCore { get; private set; }
+	public bool IsNetCore => _isNetCore ??= GetIsNetCore();
+
+	/// <summary>
+	/// Gets a value indicating that the current .NET runtime is .NET Core
+	/// </summary>
+	public bool IsNetFramework => _isNetFramework ??= GetIsNetFramework();
 
 	/// <summary>
 	/// Gets a value indicating that the current OS is windows system
 	/// </summary>
-	public bool IsWindows { get; private set; }
+	public bool IsWindows => _isWindows ??= GetIsWindows();
 
 	/// <summary>
 	/// Gets a value indicating that the current OS is a Windows Runtime (WinRT) system.
 	/// </summary>
-	public bool IsWinRT { get; private set; }
+	public bool IsWinRT => _isWinRT ??= GetIsWinRT();
 
 	/// <summary>
 	/// Gets a value indicating that the current OS is a unix-based system
@@ -34,68 +39,42 @@ public sealed class OperatingSystemPlatform
 	/// <remarks>
 	/// This will be true for both Unix (e.g. OS X) and all Linux variants.
 	/// </remarks>
-	public bool IsUnix { get; private set; }
+	public bool IsUnix => !IsWindows;
 
 	/// <summary>
 	/// Gets a value indicating that the current OS is a Mac OS X system
 	/// </summary>
-	public bool IsMac { get; private set; }
+	public bool IsMac => _isMac ??= GetIsMac();
 
 	/// <summary>
 	/// Gets a value indicating that the current OS is a Linux system
 	/// </summary>
-	public bool IsLinux { get; private set; }
+	public bool IsLinux => _isLinux ??= GetIsLinux();
 
-	[DllImport("libc")]
-	static extern int uname(IntPtr buf);
 
-	static string GetUnixType()
-	{
-		IntPtr buf = IntPtr.Zero;
-		string osName = "";
-		try
-		{
-			buf = Marshal.AllocHGlobal(8192);
-			if (uname(buf) == 0)
-				osName = Marshal.PtrToStringAnsi(buf);
-		}
-		// Analysis disable once EmptyGeneralCatchClause
-		catch
-		{
-		}
-		finally
-		{
-			if (buf != IntPtr.Zero)
-				Marshal.FreeHGlobal(buf);
-		}
-		return osName;
-	}
-		
-	/// <summary>
-	/// Initializes a new instance of the OperatingSystemPlatform class
-	/// </summary>
-	public OperatingSystemPlatform()
-	{
-#if NETSTANDARD2_0
-		if (RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase))
-			IsNetCore = true;
-#endif
-		if (Type.GetType("Mono.Runtime", false) != null || Type.GetType("Mono.Interop.IDispatch", false) != null)
-			IsMono = true;
+	bool? _isMono;
+	static bool GetIsMono() => Type.GetType("Mono.Runtime", false) != null || Type.GetType("Mono.Interop.IDispatch", false) != null;
 
-		var winRtType = Type.GetType("Windows.ApplicationModel.DesignMode, Windows, ContentType=WindowsRuntime");
-		IsWinRT = winRtType != null;
+	bool? _isNetCore;
+	static bool GetIsNetCore() =>
+		RuntimeInformation.FrameworkDescription.StartsWith(".NET Core", StringComparison.OrdinalIgnoreCase)
+		|| (
+			RuntimeInformation.FrameworkDescription.StartsWith(".NET ", StringComparison.OrdinalIgnoreCase)
+			&& !RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase)
+		);
 
-		if (Environment.NewLine == "\r\n")
-			IsWindows = true;
-		else
-		{
-			IsUnix = true;
+	bool? _isNetFramework;
+	static bool GetIsNetFramework() => RuntimeInformation.FrameworkDescription.StartsWith(".NET Framework", StringComparison.OrdinalIgnoreCase);
 
-			if (GetUnixType().ToUpperInvariant() == "DARWIN")
-				IsMac = true;
-			else
-				IsLinux = true;
-		}
-	}
+	bool? _isWindows;
+	static bool GetIsWindows() => RuntimeInformation.IsOSPlatform(OSPlatform.Windows);
+
+	bool? _isWinRT;
+	static bool GetIsWinRT() => Type.GetType("Windows.ApplicationModel.DesignMode, Windows, ContentType=WindowsRuntime", false) != null;
+
+	bool? _isMac;
+	static bool GetIsMac() => RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+	bool? _isLinux;
+	static bool GetIsLinux() => RuntimeInformation.IsOSPlatform(OSPlatform.Linux);
 }

--- a/test/Eto.Test/Sections/Behaviors/OperatingSystemPlatformSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/OperatingSystemPlatformSection.cs
@@ -1,0 +1,49 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Eto.Test.Sections.Behaviors
+{
+	[Section("Behaviors", "OperatingSystemPlatform")]
+    public class OperatingSystemPlatformSection : Scrollable
+    {
+        public OperatingSystemPlatformSection()
+		{
+			var platform = EtoEnvironment.Platform;
+			
+			var layout = new DynamicLayout
+			{
+				DefaultSpacing = new Size(10, 10)
+			};
+			layout.BeginCentered(yscale: true, xscale: true);
+
+			layout.Add(new Label { Text = "OperatingSystemPlatform", Font = SystemFonts.Bold(SystemFonts.Bold().Size + 2) });
+			
+			layout.BeginVertical();
+			layout.AddRow("IsNetCore:", platform.IsNetCore.ToString());
+			layout.AddRow("IsNetFramework:", platform.IsNetFramework.ToString());
+			layout.AddRow("IsMono:", platform.IsMono.ToString());
+			layout.AddRow("IsWinRT:", platform.IsWinRT.ToString());
+			layout.AddRow("IsWindows:", platform.IsWindows.ToString());
+			layout.AddRow("IsMac:", platform.IsMac.ToString());
+			layout.AddRow("IsUnix:", platform.IsUnix.ToString());
+			layout.AddRow("IsLinux:", platform.IsLinux.ToString());
+			layout.EndVertical();
+
+			layout.Add(new Label { Text = "RuntimeInformation", Font = SystemFonts.Bold(SystemFonts.Bold().Size + 2) });
+			layout.BeginVertical();
+			layout.AddRow("FrameworkDescription: ", RuntimeInformation.FrameworkDescription);
+			layout.AddRow("OSArchitecture: ", RuntimeInformation.OSArchitecture.ToString());
+			layout.AddRow("OSDescription: ", RuntimeInformation.OSDescription);
+			layout.AddRow("ProcessArchitecture: ", RuntimeInformation.ProcessArchitecture.ToString());
+#if NET
+			layout.AddRow("RuntimeIdentifier: ", RuntimeInformation.RuntimeIdentifier);
+#endif
+			layout.EndVertical();
+
+			layout.EndCentered();
+			Content = layout;
+		}
+    }
+}


### PR DESCRIPTION
Now uses `RuntimeInformation.IsOSPlatform()` to detect Windows, Linux, and Mac.

All properties are now lazy so it doesn't have to figure out everything during construction, only when actually needed.

For example. Using `Type.GetType()` can have a performance impact on startup so it is now only invoked when necessary.