### PR TITLE
Window OnLoadComplete and GetPreferredSize improvements

### DIFF
--- a/src/Eto.Gtk/Forms/FormHandler.cs
+++ b/src/Eto.Gtk/Forms/FormHandler.cs
@@ -26,6 +26,8 @@ namespace Eto.GtkSharp.Forms
 		{
 			DisableAutoSizeUpdate++;
 			Control.Child.ShowAll();
+			Control.Realize();
+			Callback.OnLoadComplete(Widget, EventArgs.Empty);
 			if (ShowActivated || !Control.AcceptFocus)
 				Control.Show();
 			else

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -21,6 +21,8 @@ namespace Eto.GtkSharp.Forms
 
 		void TriggerMouseEnterIfNeeded();
 		void TriggerMouseLeaveIfNeeded();
+		
+		Control.ICallback Callback { get; }
 	}
 
 	public static class GtkControlExtensions
@@ -1150,8 +1152,12 @@ namespace Eto.GtkSharp.Forms
 		{
 			if (!ContainerControl.IsRealized)
 			{
+				if (ContainerControl is Gtk.Window window)
+					window.Child.ShowAll();
+				else
+					ContainerControl.ShowAll();
+
 				ContainerControl.Realize();
-				ContainerControl.ShowAll();
 			}
 #if GTK3
 			var requestMode = ContainerControl.RequestMode;
@@ -1235,6 +1241,8 @@ namespace Eto.GtkSharp.Forms
 		}
 
 		Control IGtkControl.Widget => Widget;
+
+		Control.ICallback IGtkControl.Callback => Callback;
 
 		public void TriggerMouseEnterIfNeeded() => Connector.TriggerMouseEnterIfNeeded();
 		public void TriggerMouseLeaveIfNeeded() => Connector.TriggerMouseLeaveIfNeeded();

--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -143,6 +143,8 @@ namespace Eto.Mac.Forms
 
 		public virtual void ShowModal()
 		{
+			Control.LayoutIfNeeded();
+			Callback.OnLoadComplete(Widget, EventArgs.Empty);
 			MacView.InMouseTrackingLoop = false;
 			session = null;
 			EnsureOwner();
@@ -160,6 +162,8 @@ namespace Eto.Mac.Forms
 
 		public virtual Task ShowModalAsync()
 		{
+			Control.LayoutIfNeeded();
+			Callback.OnLoadComplete(Widget, EventArgs.Empty);
 			MacView.InMouseTrackingLoop = false;
 			var tcs = new TaskCompletionSource<bool>();
 			session = null;

--- a/src/Eto.Mac/Forms/FormHandler.cs
+++ b/src/Eto.Mac/Forms/FormHandler.cs
@@ -58,6 +58,8 @@ namespace Eto.Mac.Forms
 
 		public virtual void Show()
 		{
+			Control.LayoutIfNeeded();
+			Callback.OnLoadComplete(Widget, EventArgs.Empty);
 			var visible = Control.IsVisible;
 			if (ShowActivated)
 			{

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1343,12 +1343,20 @@ namespace Eto.Mac.Forms
 			// don't use GetMacViewHandler() extension, as that will trigger OnShown for themed controls, which will
 			// trigger Shown multiple times for the same themed control
 			var handler = control.Handler as IMacViewHandler;
-			handler?.Callback.OnShown(control, EventArgs.Empty);
+			var isWindow = control is Window;
+			
+			// Parent controls get shown event first, then children
+			if (!isWindow)
+				handler?.Callback.OnShown(control, EventArgs.Empty);
 
 			foreach (var ctl in control.VisualControls)
 			{
 				FireOnShown(ctl);
 			}
+
+			// Window fires shown after all child controls
+			if (isWindow)
+				handler?.Callback.OnShown(control, EventArgs.Empty);
 		}
 
 		protected virtual void FireOnShown() => FireOnShown(Widget);

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -281,7 +281,9 @@ namespace Eto.Mac.Forms
 					naturalSize.Height = preferredClientSize.Value.Height;
 			}
 
-			return naturalSize;
+			var frame = Control.FrameRectFor(new RectangleF(naturalSize).ToNS());
+
+			return frame.Size.ToEto();
 		}
 
 		public NSMenu MenuBar
@@ -788,7 +790,7 @@ namespace Eto.Mac.Forms
 				if (UserPreferredSize.Height != -1)
 					availableSize.Height = UserPreferredSize.Height - borderSize.Height;
 				var size = GetPreferredSize(availableSize);
-				SetContentSize(size.ToNS());
+				SetSize(size.ToNS());
 			}
 		}
 
@@ -1170,33 +1172,17 @@ namespace Eto.Mac.Forms
 
 		#region IMacContainer implementation
 
-		void SetContentSize(CGSize contentSize)
+		void SetSize(CGSize newSize)
 		{
 			if (MinimumSize != Size.Empty)
 			{
-				contentSize.Width = (nfloat)Math.Max(contentSize.Width, MinimumSize.Width);
-				contentSize.Height = (nfloat)Math.Max(contentSize.Height, MinimumSize.Height);
+				newSize.Width = (nfloat)Math.Max(newSize.Width, MinimumSize.Width);
+				newSize.Height = (nfloat)Math.Max(newSize.Height, MinimumSize.Height);
 			}
 
-			if (Widget.Loaded)
-			{
-				var clientSize = ClientSize;
-				var diffy = clientSize.Height - (int)contentSize.Height;
-				var diffx = clientSize.Width - (int)contentSize.Width;
-				var frame = Control.Frame;
-				if (diffx != 0 || setInitialSize)
-				{
-					frame.Width -= diffx;
-				}
-				if (diffy != 0 || setInitialSize)
-				{
-					frame.Y += diffy;
-					frame.Height -= diffy;
-				}
-				Control.SetFrame(frame, true, AnimateSizeChanges);
-			}
-			else
-				Control.SetContentSize(contentSize);
+			var frame = Control.Frame;
+			frame.Size = newSize;
+			Control.SetFrame(frame, Widget.Loaded, AnimateSizeChanges);
 		}
 
 		#endregion

--- a/src/Eto.WinForms/Forms/WindowHandler.cs
+++ b/src/Eto.WinForms/Forms/WindowHandler.cs
@@ -194,6 +194,8 @@ namespace Eto.WinForms.Forms
 			Control.Size = size;
 			content.MinimumSize = content.MaximumSize = sd.Size.Empty;
 			ContainerContentControl.MinimumSize = sd.Size.Empty;
+
+			Callback.OnLoadComplete(Widget, EventArgs.Empty);
 		}
 
 		public override Size Size

--- a/src/Eto.Wpf/Forms/DialogHandler.cs
+++ b/src/Eto.Wpf/Forms/DialogHandler.cs
@@ -102,6 +102,18 @@ namespace Eto.Wpf.Forms
 			if (owner != null && !owner.HasFocus)
 				owner.Focus();
 
+			if (Control.IsLoaded)
+			{
+				Callback.OnLoadComplete(Widget, EventArgs.Empty);
+				FireOnLoadComplete = false;
+			}
+			else
+			{
+				FireOnLoadComplete = true;
+			}
+
+			var _ = NativeHandle; // ensure SourceInitialized is called to get right size based on style flags
+
 			Control.ShowDialog();
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 

--- a/src/Eto.Wpf/Forms/FormHandler.cs
+++ b/src/Eto.Wpf/Forms/FormHandler.cs
@@ -40,10 +40,21 @@ namespace Eto.Wpf.Forms
 		public virtual void Show()
 		{
 			Control.WindowStartupLocation = sw.WindowStartupLocation.Manual;
-			if (ApplicationHandler.Instance.IsStarted)
+			if (Control.IsLoaded)
 			{
-				Control.Show();
+				Callback.OnLoadComplete(Widget, EventArgs.Empty);
+				FireOnLoadComplete = false;
 			}
+			else
+			{
+				// We should trigger during the Control.Loaded event
+				FireOnLoadComplete = true;
+			}
+			
+			var _ = NativeHandle; // ensure SourceInitialized is called to get right size based on style flags
+			
+			if (ApplicationHandler.Instance.IsStarted)
+				Control.Show();
 			else
 				ApplicationHandler.Instance.DelayShownWindows.Add(Control);
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -529,8 +529,11 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	static readonly object LoadCompleteKey = new object();
 
 	/// <summary>
-	/// Occurs when the load is complete, which happens after the <see cref="Load"/> event
+	/// Occurs when the load is complete, which happens after the <see cref="Load"/> event and before the window/control is shown.
 	/// </summary>
+	/// <remarks>
+	/// This is a good place to reposition a Window before it is shown.
+	/// </remarks>
 	/// <seealso cref="Load"/>
 	/// <seealso cref="PreLoad"/>
 	/// <seealso cref="UnLoad"/>

--- a/src/Eto/Forms/Dialog.cs
+++ b/src/Eto/Forms/Dialog.cs
@@ -213,10 +213,8 @@ public class Dialog : Window
 		{
 			OnPreLoad(EventArgs.Empty);
 			OnLoad(EventArgs.Empty);
-			OnLoadComplete(EventArgs.Empty);
+			Application.Instance.AddWindow(this);
 		}
-
-		Application.Instance.AddWindow(this);
 
 		Handler.ShowModal();
 	}
@@ -246,10 +244,8 @@ public class Dialog : Window
 		{
 			OnPreLoad(EventArgs.Empty);
 			OnLoad(EventArgs.Empty);
-			OnLoadComplete(EventArgs.Empty);
+			Application.Instance.AddWindow(this);
 		}
-
-		Application.Instance.AddWindow(this);
 
 		return Handler.ShowModalAsync();
 	}

--- a/src/Eto/Forms/Form.cs
+++ b/src/Eto/Forms/Form.cs
@@ -88,8 +88,6 @@ public class Form : Window
 		{
 			OnPreLoad(EventArgs.Empty);
 			OnLoad(EventArgs.Empty);
-			OnLoadComplete(EventArgs.Empty);
-
 			Application.Instance.AddWindow(this);
 		}
 

--- a/src/Eto/Forms/Window.cs
+++ b/src/Eto/Forms/Window.cs
@@ -629,6 +629,10 @@ public abstract class Window : Panel
 		/// Raises the logical pixel size changed event.
 		/// </summary>
 		void OnLogicalPixelSizeChanged(Window widget, EventArgs e);
+		/// <summary>
+		/// Raises the load complete event.
+		/// </summary>
+		void OnLoadComplete(Window widget, EventArgs e);
 	}
 
 	/// <summary>
@@ -675,6 +679,14 @@ public abstract class Window : Panel
 		{
 			using (widget.Platform.Context)
 				widget.OnLogicalPixelSizeChanged(e);
+		}
+		/// <summary>
+		/// Raises the load completed event.
+		/// </summary>
+		public void OnLoadComplete(Window widget, EventArgs e)
+		{
+			using (widget.Platform.Context)
+				widget.OnLoadComplete(e);
 		}
 	}
 

--- a/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
@@ -493,6 +493,10 @@ namespace Eto.Test.Sections.Behaviors
 			child.Closed += child_Closed;
 			child.Closing += child_Closing;
 			child.Shown += child_Shown;
+			child.Load += child_Load;
+			child.UnLoad += child_UnLoad;
+			child.LoadComplete += child_LoadComplete;
+			child.LogicalPixelSizeChanged += child_LogicalPixelSizeChanged;
 			child.GotFocus += child_GotFocus;
 			child.LostFocus += child_LostFocus;
 			child.LocationChanged += child_LocationChanged;
@@ -598,6 +602,28 @@ namespace Eto.Test.Sections.Behaviors
 			Log.Write(child, "Shown");
 			OnDataContextChanged(EventArgs.Empty);
 		}
+		
+		void child_Load(object sender, EventArgs e)
+		{
+			Log.Write(sender, "Load");
+		}
+		
+		void child_LoadComplete(object sender, EventArgs e)
+		{
+			Log.Write(sender, "LoadComplete");
+		}
+
+		void child_UnLoad(object sender, EventArgs e)
+		{
+			Log.Write(sender, "UnLoad");
+		}
+
+		void child_LogicalPixelSizeChanged(object sender, EventArgs e)
+		{
+			var window = sender as Window;
+			Log.Write(sender, $"LogicalPixelSizeChanged: {window?.LogicalPixelSize}");
+		}
+
 
 		static void child_OwnerChanged(object sender, EventArgs e)
 		{

--- a/test/Eto.Test/Sections/UnitTestPanel.cs
+++ b/test/Eto.Test/Sections/UnitTestPanel.cs
@@ -1239,7 +1239,6 @@ namespace Eto.Test.Sections
 
 			if (showLog)
 			{
-				Size = new Size(950, 600);
 				log = new TextArea { Size = new Size(400, 300), ReadOnly = true, Wrap = false };
 
 				base.Content = new Splitter
@@ -1559,6 +1558,7 @@ namespace Eto.Test.Sections
 			public ITest Test { get; set; }
 			public Image Image { get; set; }
 			public ITestFilter Filter { get; set; }
+			public ITestResult Result { get; set; }
 		}
 
 		TreeGridItem ToTree(Assembly assembly, ITest test, ITestFilter filter, IDictionary<object, UnitTestItem> map)
@@ -1588,6 +1588,7 @@ namespace Eto.Test.Sections
 			{
 				Text = name,
 				Test = test,
+				Result = result,
 				Image = GetStateImage(result),
 				Filter = new SingleTestFilter { Test = test, Assembly = assembly }
 			};

--- a/test/Eto.Test/UnitTests/Forms/DialogTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/DialogTests.cs
@@ -3,7 +3,7 @@ using NUnit.Framework;
 namespace Eto.Test.UnitTests.Forms
 {
 	[TestFixture]
-	public class DialogTests : TestBase
+	public class DialogTests : WindowTests<Dialog>
 	{
 		[Test, ManualTest]
 		public void DialogShouldShowContent()
@@ -212,5 +212,12 @@ namespace Eto.Test.UnitTests.Forms
 			);
 		}
 
+		protected override void Test(Action<Dialog> test, int timeout = 4000) => Dialog(test, timeout);
+
+		protected override void ManualTest(string message, Func<Dialog, Control> test) => ManualDialog(message, test);
+
+		protected override void Show(Dialog window) => window.ShowModal();
+
+		protected override Task ShowAsync(Dialog window) => window.ShowModalAsync();
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/FormTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/FormTests.cs
@@ -1,0 +1,124 @@
+using NUnit.Framework;
+namespace Eto.Test.UnitTests.Forms
+{
+	[TestFixture]
+	public class FormTests : WindowTests<Form>
+	{
+		protected override void Test(Action<Form> test, int timeout = 4000) => Form(test, timeout);
+		protected override void ManualTest(string message, Func<Form, Control> test) => ManualForm(message, test);
+		protected override void Show(Form window) => window.Show();
+		protected override Task ShowAsync(Form window)
+		{
+			var tcs = new TaskCompletionSource<bool>();
+			window.Closed += (sender, e) => tcs.TrySetResult(true);
+			window.Show();
+			return tcs.Task;
+		}
+		
+		[Test, ManualTest]
+		public void WindowShouldCloseOnLostFocusWithoutHidingParent()
+		{
+			ManualForm("Click on this window after the child is shown,\nthe form and the main form should not go behind other windows",
+			form =>
+			{
+				var content = new Panel { MinimumSize = new Size(100, 100) };
+				form.Shown += (sender, e) =>
+				{
+					var childForm = new Form
+					{
+						Title = "Child Form",
+						ClientSize = new Size(100, 100),
+						Owner = form
+					};
+					childForm.MouseDown += (s2, e2) => childForm.Close();
+					childForm.LostFocus += (s2, e2) => childForm.Close();
+					childForm.Show();
+				};
+				form.Title = "Test Form";
+				form.Owner = Application.Instance.MainForm;
+				return content;
+			}
+			);
+		}
+		
+		// Hm, this seems useful.. should it be added as an extension method somewhere?
+		static Task EventAsync<TWidget, TEvent>(TWidget control, Action<TWidget, EventHandler<TEvent>> addHandler, Action<TWidget, EventHandler<TEvent>> removeHandler = null)
+			where TWidget : Widget
+		{
+			var mre = new TaskCompletionSource<bool>();
+			void EventTriggered(object sender, TEvent e)
+			{
+				removeHandler?.Invoke(control, EventTriggered);
+				mre.TrySetResult(true);
+			}
+
+			addHandler(control, EventTriggered);
+			return mre.Task;
+		}
+		
+		[Test, ManualTest]
+		public void MultipleChildWindowsShouldGetFocusWhenClicked() => Async(async () =>
+		{
+			var form1 = new Form { ClientSize = new Size(200, 200), Location = new Point(300, 300) };
+			form1.Owner = Application.Instance.MainForm;
+			form1.Title = "Form1";
+			form1.Content = new Label
+			{
+				VerticalAlignment = VerticalAlignment.Center,
+				TextAlignment = TextAlignment.Center,
+				Text = "Click on Form2, it should then get focus and be on top of this form."
+			};
+			// var form1ClosedTask = EventTask<EventArgs>(h => form1.Closed += h);
+			var form1ClosedTask = EventAsync<Form, EventArgs>(form1, (c, h) => c.Closed += h);
+
+			var form2 = new Form { ClientSize = new Size(200, 200), Location = new Point(400, 400) };
+			form2.Owner = Application.Instance.MainForm;
+			form2.Title = "Form2";
+			form2.Content = new Label
+			{
+				VerticalAlignment = VerticalAlignment.Center,
+				TextAlignment = TextAlignment.Center,
+				Text = "Click on Form1, it should then get focus and be on top of this form."
+			};
+			var form2ClosedTask = EventAsync<Form, EventArgs>(form2, (c, h) => c.Closed += h);
+
+			form1.Show();
+
+			form2.Show();
+
+			// wait till both forms are closed..
+			await Task.WhenAll(form1ClosedTask, form2ClosedTask);
+		});
+		
+		public class SubSubForm : SubForm
+		{
+			protected override void OnClosed(EventArgs e)
+			{
+				base.OnClosed(e);
+			}
+		}
+
+		public class SubForm : Form
+		{
+			protected override void OnClosed(EventArgs e)
+			{
+				base.OnClosed(e);
+			}
+		}
+
+		[Test]
+		public void ClosedEventShouldFireOnceWithMultipleSubclasses()
+		{
+			int closed = 0;
+			Form<SubSubForm>(form =>
+			{
+				form.Content = new Panel { Size = new Size(300, 300) };
+				form.Closed += (sender, e) => closed++;
+				form.Shown += (sender, e) => form.Close();
+			});
+			Assert.AreEqual(1, closed, "Closed event should only fire once");
+		}
+		
+	}
+}
+

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -76,12 +76,12 @@ namespace Eto.Test.UnitTests
 		/// <summary>
 		/// Default timeout for form operations
 		/// </summary>
-		const int DefaultTimeout = 4000;
+		protected const int DefaultTimeout = 4000;
 
 		/// <summary>
 		/// Timeout for application initialization
 		/// </summary>
-		const int ApplicationTimeout = 10000;
+		protected const int ApplicationTimeout = 10000;
 
 		/// <summary>
 		/// initializes the application when running unit tests directly through the IDE or NUnit gui.


### PR DESCRIPTION
- OnLoadComplete is now called by Window handler implementations at the appropriate time
- Window.GetPrerredSize() should now be guaranteed to work for a Window during the LoadComplete event on all platforms, and for some platforms before it is shown.
- Gtk still has issues including the window decorations with the preferred size, work is ongoing there.
- Mac now calls Window.Shown after children get the same event, like other platforms.