### PR TITLE
Wpf: Allow DataGrid and Window background to be styled

### DIFF
--- a/src/Eto.Wpf/Forms/ColorDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/ColorDialogHandler.cs
@@ -25,7 +25,6 @@ namespace Eto.Wpf.Forms
 		public XceedColorDialog()
 		{
 			canvas = new xwt.ColorCanvas();
-			SetResourceReference(BackgroundProperty, sw.SystemColors.ControlBrushKey);
 
 			var doneButton = new swc.Button { Content = "OK", IsDefault = true, MinWidth = 80, Margin = new sw.Thickness(5) };
 			doneButton.Click += doneButton_Click;

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -47,7 +47,7 @@ namespace Eto.Wpf.Forms.Controls
 			Loaded += EtoDataGrid_Loaded;
 		}
 
-		private void EtoDataGrid_Loaded(object sender, sw.RoutedEventArgs e)
+				private void EtoDataGrid_Loaded(object sender, sw.RoutedEventArgs e)
 		{
 			var scp = this.FindChild<swc.ScrollContentPresenter>();
 			if (scp != null) scp.RequestBringIntoView += OnRequestBringIntoView;
@@ -146,7 +146,6 @@ namespace Eto.Wpf.Forms.Controls
 				EnableColumnVirtualization = true,
 				EnableRowVirtualization = true,
 			};
-			Control.SetResourceReference(swc.Control.BackgroundProperty, sw.SystemColors.WindowBrushKey);
 		}
 
 		protected ColumnCollection Columns { get; private set; }

--- a/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TreeGridViewHandler.cs
@@ -16,7 +16,6 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			base.Initialize();
 			controller = new TreeController { Handler = this };
-			Control.SetResourceReference(swc.Panel.BackgroundProperty, sw.SystemColors.WindowBrushKey);
 			Control.PreviewKeyDown += Control_PreviewKeyDown;
 		}
 

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -30,6 +30,11 @@ namespace Eto.Wpf.Forms
 		internal static readonly object Icon_Key = new object();
 		internal static readonly object ShowSystemMenu_Key = new object();
 	}
+	
+	public class EtoWindowContent : swc.DockPanel
+	{
+		
+	}
 
 	public abstract class WpfWindow<TControl, TWidget, TCallback> : WpfPanel<TControl, TWidget, TCallback>, Window.IHandler, IWpfWindow, IInputBindingHost
 		where TControl : sw.Window
@@ -99,7 +104,7 @@ namespace Eto.Wpf.Forms
 		{
 			if (IsAttached)
 				return;
-			content = new swc.DockPanel();
+			content = new EtoWindowContent();
 			UseShellDropManager = true;
 
 			base.Initialize();
@@ -109,7 +114,6 @@ namespace Eto.Wpf.Forms
 			main = new swc.DockPanel();
 			menuHolder = new swc.ContentControl { IsTabStop = false };
 			toolBarHolder = new swc.ContentControl { IsTabStop = false };
-			content.SetResourceReference(swc.Panel.BackgroundProperty, sw.SystemColors.ControlBrushKey);
 			swc.DockPanel.SetDock(menuHolder, swc.Dock.Top);
 			swc.DockPanel.SetDock(toolBarHolder, swc.Dock.Top);
 			main.Children.Add(menuHolder);

--- a/src/Eto.Wpf/themes/controls/DataGrid.xaml
+++ b/src/Eto.Wpf/themes/controls/DataGrid.xaml
@@ -1,0 +1,14 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:r="clr-namespace:Eto.Wpf.CustomControls.TreeGridView"
+    xmlns:efc="clr-namespace:Eto.Wpf.Forms.Controls"
+    xmlns:e="clr-namespace:Eto.Wpf"
+    xmlns:s="clr-namespace:System;assembly=mscorlib"
+    xmlns:themes="clr-namespace:Xceed.Wpf.Toolkit.Themes;assembly=Xceed.Wpf.Toolkit"
+    xmlns:local="clr-namespace:Xceed.Wpf.Toolkit;assembly=Xceed.Wpf.Toolkit">
+
+    <Style TargetType="efc:EtoDataGrid">
+        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
+    </Style>
+
+</ResourceDictionary>

--- a/src/Eto.Wpf/themes/controls/Window.xaml
+++ b/src/Eto.Wpf/themes/controls/Window.xaml
@@ -1,0 +1,15 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:r="clr-namespace:Eto.Wpf.CustomControls.TreeGridView"
+    xmlns:efc="clr-namespace:Eto.Wpf.Forms.Controls"
+    xmlns:e="clr-namespace:Eto.Wpf"
+    xmlns:ef="clr-namespace:Eto.Wpf.Forms"
+    xmlns:s="clr-namespace:System;assembly=mscorlib"
+    xmlns:themes="clr-namespace:Xceed.Wpf.Toolkit.Themes;assembly=Xceed.Wpf.Toolkit"
+    xmlns:local="clr-namespace:Xceed.Wpf.Toolkit;assembly=Xceed.Wpf.Toolkit">
+
+    <Style TargetType="ef:EtoWindowContent">
+        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
+    </Style>
+
+</ResourceDictionary>

--- a/src/Eto.Wpf/themes/controls/XceedColorDialog.xaml
+++ b/src/Eto.Wpf/themes/controls/XceedColorDialog.xaml
@@ -1,0 +1,15 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:r="clr-namespace:Eto.Wpf.CustomControls.TreeGridView"
+    xmlns:efc="clr-namespace:Eto.Wpf.Forms.Controls"
+    xmlns:e="clr-namespace:Eto.Wpf"
+    xmlns:ef="clr-namespace:Eto.Wpf.Forms"
+    xmlns:s="clr-namespace:System;assembly=mscorlib"
+    xmlns:themes="clr-namespace:Xceed.Wpf.Toolkit.Themes;assembly=Xceed.Wpf.Toolkit"
+    xmlns:local="clr-namespace:Xceed.Wpf.Toolkit;assembly=Xceed.Wpf.Toolkit">
+
+    <Style TargetType="ef:XceedColorDialog">
+        <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>
+    </Style>
+
+</ResourceDictionary>

--- a/src/Eto.Wpf/themes/generic.xaml
+++ b/src/Eto.Wpf/themes/generic.xaml
@@ -6,9 +6,13 @@
     xmlns:s="clr-namespace:System;assembly=mscorlib">
 
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/wpftoolkit/ButtonSpinner.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/controls/WatermarkTextBox.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/controls/DataGrid.xaml" />
         <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/controls/SearchTextBox.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/controls/WatermarkTextBox.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/controls/Window.xaml" />
+        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/controls/XceedColorDialog.xaml" />
+		
+        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/wpftoolkit/ButtonSpinner.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style TargetType="{x:Type r:TreeToggleButton}">


### PR DESCRIPTION
Using `SetResourceReference()` overrides any WPF styling, so switching to put styles in Eto's default xaml styles instead.