### PR TITLE
Wpf: Fix issue that could cause an endless loop with Tree/GridView

### DIFF
--- a/src/Eto.Wpf/themes/controls/DataGrid.xaml
+++ b/src/Eto.Wpf/themes/controls/DataGrid.xaml
@@ -7,6 +7,13 @@
     xmlns:themes="clr-namespace:Xceed.Wpf.Toolkit.Themes;assembly=Xceed.Wpf.Toolkit"
     xmlns:local="clr-namespace:Xceed.Wpf.Toolkit;assembly=Xceed.Wpf.Toolkit">
 
+    <Style TargetType="DataGridRowsPresenter">
+        <!-- Avoid endless loop in WPF due to the following:
+        https://github.com/dotnet/wpf/issues/9944
+        -->
+        <Setter Property="UseLayoutRounding" Value="False"/>
+    </Style>
+
     <Style TargetType="efc:EtoDataGrid">
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.WindowBrushKey}}"/>
     </Style>


### PR DESCRIPTION
Setting focus to the TreeGridView/GridView can sometimes cause the application to hang due to a bug in WPF with layout rounding turned on.  See https://github.com/dotnet/wpf/issues/9944 for more details.