### PR TITLE
Localization updates

### DIFF
--- a/src/Eto.Mac/Forms/Menu/MenuBarHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/MenuBarHandler.cs
@@ -79,9 +79,9 @@ namespace Eto.Mac.Forms.Menu
 			yield return new Command((sender, e) => NSApplication.SharedApplication.Hide(NSApplication.SharedApplication))
 			{ 
 				ID = "mac_hide", 
-				MenuText = Application.Instance.Localize(Widget, string.Format("Hide {0}", appName)),
+				MenuText = string.Format(Application.Instance.Localize(Widget, "Hide {0}"), appName),
 				ToolBarText = Application.Instance.Localize(Widget, "Hide"),
-				ToolTip = Application.Instance.Localize(Widget, string.Format("Hides the main {0} window", appName)), 
+				ToolTip = string.Format(Application.Instance.Localize(Widget, "Hides the main {0} window"), appName), 
 				Shortcut = Keys.H | Keys.Application
 			};
 

--- a/src/Eto/Forms/Key.cs
+++ b/src/Eto/Forms/Key.cs
@@ -343,16 +343,17 @@
 	  {
 		  var sb = new StringBuilder();
 		  if (key.HasFlag(Keys.Application))
-			  AppendSeparator(sb, separator, 
+			  AppendSeparator(sb, separator,
+			  	Application.Instance.Localize(key, 
 				  EtoEnvironment.Platform.IsMac ? "\x2318" : 
 				  EtoEnvironment.Platform.IsWindows ? "Win" :
-				  "App");
+				  "App"));
 		  if (key.HasFlag(Keys.Control))
-			  AppendSeparator(sb, separator, EtoEnvironment.Platform.IsMac ? "^" : "Ctrl");
+			  AppendSeparator(sb, separator, Application.Instance.Localize(key, EtoEnvironment.Platform.IsMac ? "^" : "Ctrl"));
 		  if (key.HasFlag(Keys.Shift))
-			  AppendSeparator(sb, separator, EtoEnvironment.Platform.IsMac ? "\x21e7" : "Shift");
+			  AppendSeparator(sb, separator, Application.Instance.Localize(key, EtoEnvironment.Platform.IsMac ? "\x21e7" : "Shift"));
 		  if (key.HasFlag(Keys.Alt))
-			  AppendSeparator(sb, separator, EtoEnvironment.Platform.IsMac ? "\x2325" : "Alt");
+			  AppendSeparator(sb, separator, Application.Instance.Localize(key, EtoEnvironment.Platform.IsMac ? "\x2325" : "Alt"));
 
 		  var mainKey = key & Keys.KeyMask;
 		  string val;

--- a/src/Eto/Forms/ThemedControls/ThemedPropertyGridHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedPropertyGridHandler.cs
@@ -752,9 +752,9 @@ public class ThemedPropertyGrid : Panel, IValueTypeWrapperHost
 			if (s_defaultSize != null)
 				Size = s_defaultSize.Value;
 
-			var cancelButton = new Button { Text = Application.Instance.Localize(this, "Cancel") };
+			var cancelButton = new Button { Text = Application.Instance.Localize(editor, "Cancel") };
 			cancelButton.Click += CancelButton_Click;
-			var okButton = new Button { Text = Application.Instance.Localize(this, Platform.IsMac ? "Apply" : "OK") };
+			var okButton = new Button { Text = Application.Instance.Localize(editor, Platform.IsMac ? "Apply" : "OK") };
 			okButton.Click += OkButton_Click;
 			DefaultButton = okButton;
 			AbortButton = cancelButton;
@@ -869,9 +869,9 @@ public class ThemedPropertyGrid : Panel, IValueTypeWrapperHost
 			if (s_defaultSize != null)
 				Size = s_defaultSize.Value;
 
-			var cancelButton = new Button { Text = Application.Instance.Localize(this, "Cancel") };
+			var cancelButton = new Button { Text = Application.Instance.Localize(editor, "Cancel") };
 			cancelButton.Click += CancelButton_Click;
-			var okButton = new Button { Text = Application.Instance.Localize(this, Platform.IsMac ? "Apply" : "OK") };
+			var okButton = new Button { Text = Application.Instance.Localize(editor, Platform.IsMac ? "Apply" : "OK") };
 			okButton.Click += OkButton_Click;
 			DefaultButton = okButton;
 			AbortButton = cancelButton;


### PR DESCRIPTION
- Key.ToShortcutString() strings can now be localized
- Reference public instead of private types for ThemedPropertyGrid localizations
- Localized strings with placeholders should keep placeholder when passing to localization