### PR TITLE
Mac: Fix issue updating items in a GridView

### DIFF
--- a/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
@@ -11,6 +11,42 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		}
 
 		[Test, ManualTest]
+		public void MultipleChangesShouldWork() => ManualForm(
+			"Scroll while the collection is updated,\nand ensure all items are correct and not duplicated.",
+			form =>
+			{
+
+				var collection = new ObservableCollection<GridItem>();
+				for (int i = 0; i < 20; i++)
+				{
+					collection.Add(new GridItem(true, $"Item {i}"));
+				}
+
+				var gv = new GridView
+				{
+					DataStore = collection,
+					Size = new Size(200, 200),
+					Columns = {
+						new GridColumn { HeaderText = "Check", DataCell = new CheckBoxCell(0) },
+						new GridColumn { HeaderText = "Text", DataCell = new TextBoxCell(1) }
+					},
+				};
+
+				Application.Instance.AsyncInvoke(async () =>
+				{
+					for (int i = 0; i < collection.Count; i++)
+					{
+						if (!form.Loaded)
+							return;
+						// gv.SelectedRow = i;
+						await Task.Delay(1000);
+						collection[i] = new GridItem(true, $"Changed {i}");
+					}
+				});
+				return gv;
+			});
+
+		[Test, ManualTest]
 		public void CellClickShouldHaveMouseInformation()
 		{
 			Exception exception = null;


### PR DESCRIPTION
When certain collection updates happen, such as replacing an item or a range of items happen, then the visual state of the GridView could get out of whack as it could be reloading using the wrong item.  

This happens because on Mac one must call `NSTableView.BeginUpdates()` before all updates are registered, then `NSTableView.EndUpdates()` after.  Since the collection isn't actually changed when it called `RemoveItem`, then `InsertItem`, it could refresh the view using invalid state of the collection.

Now there are new virtual methods in `CollectionChangedHandler` for `BeginUpdates()` and `EndUpdates()` which can be forwarded to handlers in the case that the collection changed event causes multiple methods to be called.

Additionally, there are also `ReplaceItem` and `ReplaceRange` overrides in the case that replacing a single item can just refresh that row making it more efficient, and in the case of Mac will no longer make the refreshed item "slide down".