### PR TITLE
Wpf: Fix memory leak with Screen.GetImage()

### DIFF
--- a/src/Eto.WinForms/Win32.gdi.cs
+++ b/src/Eto.WinForms/Win32.gdi.cs
@@ -86,5 +86,8 @@ namespace Eto
 			g.Dispose();
 			return fontRanges;
 		}
+		
+		[DllImport("gdi32.dll")]
+		public static extern bool DeleteObject(IntPtr hObject);
 	}
 }

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -101,6 +101,9 @@ You do not need to use any of the classes of this assembly (unless customizing t
     <Compile Include="..\Eto.WinForms\Win32.dpi.cs">
       <Link>Win32.dpi.cs</Link>
     </Compile>
+    <Compile Include="..\Eto.WinForms\Win32.gdi.cs">
+      <Link>Win32.gdi.cs</Link>
+    </Compile>
     <Compile Include="..\Eto.WinForms\WinConversions.shared.cs">
       <Link>WinConversions.shared.cs</Link>
     </Compile>

--- a/src/Eto.Wpf/Forms/ScreenHandler.cs
+++ b/src/Eto.Wpf/Forms/ScreenHandler.cs
@@ -56,16 +56,24 @@ namespace Eto.Wpf.Forms
 				using (var bmpGraphics = sd.Graphics.FromImage(screenBmp))
 				{
 					bmpGraphics.CopyFromScreen(realRect.X, realRect.Y, 0, 0, realRect.Size.ToSD());
-					var bitmapSource = sw.Interop.Imaging.CreateBitmapSourceFromHBitmap(
-						screenBmp.GetHbitmap(),
-						IntPtr.Zero,
-						sw.Int32Rect.Empty,
-						sw.Media.Imaging.BitmapSizeOptions.FromEmptyOptions());
+					var hbmp = screenBmp.GetHbitmap();
+					try
+					{
+						var bitmapSource = sw.Interop.Imaging.CreateBitmapSourceFromHBitmap(
+							hbmp,
+							IntPtr.Zero,
+							sw.Int32Rect.Empty,
+							sw.Media.Imaging.BitmapSizeOptions.FromEmptyOptions());
+							
+						if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
+							Win32.SetThreadDpiAwarenessContextSafe(oldDpiAwareness);
 
-					if (oldDpiAwareness != Win32.DPI_AWARENESS_CONTEXT.NONE)
-						Win32.SetThreadDpiAwarenessContextSafe(oldDpiAwareness);
-
-					return new Bitmap(new BitmapHandler(bitmapSource));
+						return new Bitmap(new BitmapHandler(bitmapSource));
+					}
+					finally
+					{
+						Win32.DeleteObject(hbmp);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Fixes #2674