### PR TITLE
Wpf: Drawable updates for large canvases in a scrollable

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
@@ -109,7 +109,6 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			get
 			{
-				EnsureLoaded();
 				return new Point((int)scroller.HorizontalOffset, (int)scroller.VerticalOffset);
 			}
 			set
@@ -124,7 +123,6 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			get
 			{
-				EnsureLoaded();
 				return new Size((int)scroller.ExtentWidth, (int)scroller.ExtentHeight);
 			}
 			set
@@ -149,7 +147,6 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				if (!Widget.Loaded)
 					return Size;
-				EnsureLoaded();
 				var info = scroller.GetScrollInfo();
 				return info != null ? new Size((int)info.ViewportWidth, (int)info.ViewportHeight) : Size.Empty;
 			}

--- a/test/Eto.Test/Sections/Controls/DrawableSection.cs
+++ b/test/Eto.Test/Sections/Controls/DrawableSection.cs
@@ -92,9 +92,9 @@ namespace Eto.Test.Sections.Controls
 
 		Control LargeCanvas()
 		{
-			var control = new Drawable
+			var control = new Drawable(true)
 			{
-				Size = new Size(1000, 1000),
+				Size = new Size(2000, 2000),
 				BackgroundColor = Colors.Blue
 			};
 			var image = TestIcons.TestImage;


### PR DESCRIPTION
This changes the behavior of passing `largeCanvas: true` to the `Drawable` constructor.  Instead of tiling which creates edge artifacts and sporadic performance, it now will only update the visible area of the drawable within a Scrollable, and update when it is scrolled.

Additionally, this fixes issues getting the VisibleRect/ClientSize of a Scrollable during a paint event.