### PR TITLE
Wpf: Focus the family text box when showing the FontDialog

### DIFF
--- a/src/Eto.Wpf/CustomControls/FontDialog/fontchooser.xaml.cs
+++ b/src/Eto.Wpf/CustomControls/FontDialog/fontchooser.xaml.cs
@@ -226,6 +226,12 @@ namespace Eto.Wpf.CustomControls.FontDialog
 			// Schedule background updates.
 			_populated = true;
 			ScheduleUpdate ();
+
+			// Make using the keyboard easier by setting focus initially and selecting all
+			sizeTextBox.GotFocus += (sender, e) => sizeTextBox.SelectAll();
+			fontFamilyTextBox.GotFocus += (sender, e) => fontFamilyTextBox.SelectAll();
+
+			fontFamilyTextBox.Focus();
 		}
 
         #endregion


### PR DESCRIPTION
Also select all when the size or font family is focused so it is easier to find other fonts.