### PR TITLE
Wpf: Fix Scrollable when child size is changed

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
@@ -217,5 +217,11 @@ namespace Eto.Wpf.Forms.Controls
 		public float MinimumZoom { get { return 1f; } set { } }
 
 		public float Zoom { get { return 1f; } set { } }
+
+		public override void OnChildPreferredSizeUpdated()
+		{
+			base.OnChildPreferredSizeUpdated();
+			UpdateScrollSizes();
+		}
 	}
 }


### PR DESCRIPTION
When you change the preferred size of a control, say a Scrollable's content, it does not update the scrollable area unless you manually call `UpdateScrollSizes()`.  Now this is done automatically.