### PR TITLE
Mac: Fix turning off TextArea.Wrap with Right or Center alignment

### DIFF
--- a/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -306,7 +306,11 @@ namespace Eto.Mac.Forms.Controls
 				{
 					Control.HorizontallyResizable = true;
 					Control.TextContainer.WidthTracksTextView = false;
-					Control.TextContainer.ContainerSize = new CGSize(float.MaxValue, float.MaxValue);
+					
+					// anything greater then selection isn't shown when alignment isn't Left
+					// even though the default size is 10000000, setting it to that doesn't work.
+					// must be some weird magic going on behind the scenes..
+					Control.TextContainer.Size = new CGSize(9999999, float.MaxValue); 
 				}
 			}
 		}


### PR DESCRIPTION
When you would turn wrapping on, it would make the TextArea completely blank when TextAlignment was anything other than Left, at least on macOS Sequoia 15.1.1.

This has been tested on macOS 12 and later and appears to make it work as expected in all cases.