### PR TITLE
Wpf: Fix TextBox.Text so it clears the undo buffer when set

### DIFF
--- a/test/Eto.Test/UnitTests/Forms/Controls/TextBoxTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TextBoxTests.cs
@@ -7,6 +7,34 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		where T: TextBox, new()
 	{
 		[Test, ManualTest]
+		public void SettingTextShouldClearUndoBuffer()
+		{
+			ManualForm("Try typing and undo/redo, then press the button to reset. After reset, it should not undo to previous values", form =>
+			{
+				var textBox = new T();
+				textBox.Text = "Hello";
+				textBox.SelectAll();
+
+				var button = new Button { Text = "Click Me" };
+				button.Click += (sender, e) =>
+				{
+					textBox.Text = "Thanks, now try to undo";
+					textBox.Focus();
+				};
+				
+				return new TableLayout
+				{
+					Spacing = new Size(5, 5),
+					Padding = 10,
+					Rows = {
+						textBox,
+						button
+					}
+				};
+			});
+		}
+		
+		[Test, ManualTest]
 		public void CaretIndexShouldStartInInitialPosition()
 		{
 			ManualForm("Caret should be at index 2, between the 'e' and 'l'.", form =>


### PR DESCRIPTION
Setting the Text property should not add to the undo buffer of the TextBox, like all other platforms.  Also, trigger the TextChanged event _after_ the selection is updated. 