### PR TITLE
Wpf: Isolate resource dictionaries by specifying Version and PublicKey

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,11 +5,26 @@ root = true
 
 # use tabs by default for everything
 [*.cs]
-indent_style = tab
-indent_size = 4
-charset=utf-8
 csharp_new_line_before_open_brace = all
 csharp_indent_braces=false
+csharp_indent_labels = no_change
+csharp_using_directive_placement = outside_namespace:silent
+csharp_prefer_simple_using_statement = true:suggestion
+csharp_prefer_braces = true:silent
+csharp_style_namespace_declarations = block_scoped:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:suggestion
+csharp_prefer_system_threading_lock = true:suggestion
+csharp_style_expression_bodied_methods = false:silent
+csharp_style_expression_bodied_constructors = false:silent
+csharp_style_expression_bodied_operators = false:silent
+csharp_style_expression_bodied_properties = true:silent
+csharp_style_expression_bodied_indexers = true:silent
+csharp_style_expression_bodied_accessors = true:silent
+csharp_style_expression_bodied_lambdas = true:silent
+csharp_style_expression_bodied_local_functions = false:silent
+csharp_space_around_binary_operators = before_and_after
 
 [*.{csproj,vbproj,fsproj,proj,targets,props}]
 indent_style = space
@@ -19,3 +34,62 @@ tab_size = 2
 [*.yml]
 intent_style = space
 indent_size = 2
+
+[*.{cs,vb}]
+# Indentation style/size
+charset=utf-8
+indent_style = tab
+tab_width = 4
+indent_size = 4
+
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ packages/
 .store
 .DS_Store
 *.proj.Backup.tmp
+._.*

--- a/src/Eto.Wpf/AssemblyAbsoluteResourceDictionary.cs
+++ b/src/Eto.Wpf/AssemblyAbsoluteResourceDictionary.cs
@@ -1,0 +1,45 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Eto.Wpf
+{
+	public class AssemblyAbsoluteResourceDictionary : sw.ResourceDictionary, ISupportInitialize
+	{
+		public string AssemblyName { get; set; }
+
+		public string Path { get; set; }
+
+		internal static Uri GetAbsolutePackUri(string path, string assemblyName = null)
+		{
+			// Support having multiple copies of Eto running, potentially with different version and/or public key
+			var assembly = assemblyName != null ? Assembly.Load(assemblyName) : typeof(AssemblyAbsoluteResourceDictionary).Assembly;
+			var name = assembly.GetName();
+
+			var version = "v" + name.Version.ToString() + ";";
+
+			var publicKey = name.GetPublicKey();
+			var publicKeyString = publicKey?.Length > 0 ? BitConverter.ToString(publicKey).Replace("-", "") + ";" : null;
+
+			return new Uri($"pack://application:,,,/{name.Name};{version}{publicKeyString}component/{path}", UriKind.Absolute);
+		}
+
+		void ISupportInitialize.EndInit()
+		{
+			SetupSource();
+
+			base.EndInit();
+		}
+
+		private void SetupSource()
+		{
+			if (Source != null)
+				return;
+			if (string.IsNullOrEmpty(Path))
+				throw new InvalidOperationException("No Path was specified");
+
+			Source = GetAbsolutePackUri(Path, AssemblyName);
+		}
+	}
+}

--- a/src/Eto.Wpf/Forms/ApplicationHandler.cs
+++ b/src/Eto.Wpf/Forms/ApplicationHandler.cs
@@ -67,8 +67,8 @@ public class ApplicationHandler : WidgetHandler<sw.Application, Application, App
 			throw new InvalidOperationException("Could not load Xceed.Wpf.Toolkit");
 
 		// Add themes to our controls
-		var assemblyName = typeof(ApplicationHandler).Assembly.GetName().Name;
-		Control.Resources.MergedDictionaries.Add(new sw.ResourceDictionary { Source = new Uri($"pack://application:,,,/{assemblyName};component/themes/generic.xaml", UriKind.RelativeOrAbsolute) });
+		var uri = AssemblyAbsoluteResourceDictionary.GetAbsolutePackUri("themes/generic.xaml");
+		Control.Resources.MergedDictionaries.Add(new sw.ResourceDictionary { Source = uri });
 	}
 
 	protected override void Initialize()
@@ -169,7 +169,7 @@ public class ApplicationHandler : WidgetHandler<sw.Application, Application, App
 	{
 		var size = Size.Round(new SizeF(14, 14) * scale);
 		var bmp = new Bitmap(size, PixelFormat.Format32bppRgba);
-		
+
 		using (var graphics = new Graphics(bmp))
 		{
 			var font = SystemFonts.Bold(6 * scale);

--- a/src/Eto.Wpf/themes/controls/DataGrid.xaml
+++ b/src/Eto.Wpf/themes/controls/DataGrid.xaml
@@ -3,9 +3,7 @@
     xmlns:r="clr-namespace:Eto.Wpf.CustomControls.TreeGridView"
     xmlns:efc="clr-namespace:Eto.Wpf.Forms.Controls"
     xmlns:e="clr-namespace:Eto.Wpf"
-    xmlns:s="clr-namespace:System;assembly=mscorlib"
-    xmlns:themes="clr-namespace:Xceed.Wpf.Toolkit.Themes;assembly=Xceed.Wpf.Toolkit"
-    xmlns:local="clr-namespace:Xceed.Wpf.Toolkit;assembly=Xceed.Wpf.Toolkit">
+    xmlns:s="clr-namespace:System;assembly=mscorlib">
 
     <Style TargetType="DataGridRowsPresenter">
         <!-- Avoid endless loop in WPF due to the following:

--- a/src/Eto.Wpf/themes/controls/ToggleButton.xaml
+++ b/src/Eto.Wpf/themes/controls/ToggleButton.xaml
@@ -3,9 +3,7 @@
     xmlns:r="clr-namespace:Eto.Wpf.CustomControls.TreeGridView"
     xmlns:efc="clr-namespace:Eto.Wpf.Forms.Controls"
     xmlns:e="clr-namespace:Eto.Wpf"
-    xmlns:s="clr-namespace:System;assembly=mscorlib"
-    xmlns:themes="clr-namespace:Xceed.Wpf.Toolkit.Themes;assembly=Xceed.Wpf.Toolkit"
-    xmlns:local="clr-namespace:Xceed.Wpf.Toolkit;assembly=Xceed.Wpf.Toolkit">
+    xmlns:s="clr-namespace:System;assembly=mscorlib">
 
     <SolidColorBrush x:Key="ToggleButton.Checked.Background" Color="#FFBBDDEE"/>
     <SolidColorBrush x:Key="ToggleButton.Checked.Border" Color="#FF255A83"/>

--- a/src/Eto.Wpf/themes/controls/Window.xaml
+++ b/src/Eto.Wpf/themes/controls/Window.xaml
@@ -4,9 +4,7 @@
     xmlns:efc="clr-namespace:Eto.Wpf.Forms.Controls"
     xmlns:e="clr-namespace:Eto.Wpf"
     xmlns:ef="clr-namespace:Eto.Wpf.Forms"
-    xmlns:s="clr-namespace:System;assembly=mscorlib"
-    xmlns:themes="clr-namespace:Xceed.Wpf.Toolkit.Themes;assembly=Xceed.Wpf.Toolkit"
-    xmlns:local="clr-namespace:Xceed.Wpf.Toolkit;assembly=Xceed.Wpf.Toolkit">
+    xmlns:s="clr-namespace:System;assembly=mscorlib">
 
     <Style TargetType="ef:EtoWindowContent">
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>

--- a/src/Eto.Wpf/themes/controls/XceedColorDialog.xaml
+++ b/src/Eto.Wpf/themes/controls/XceedColorDialog.xaml
@@ -4,9 +4,7 @@
     xmlns:efc="clr-namespace:Eto.Wpf.Forms.Controls"
     xmlns:e="clr-namespace:Eto.Wpf"
     xmlns:ef="clr-namespace:Eto.Wpf.Forms"
-    xmlns:s="clr-namespace:System;assembly=mscorlib"
-    xmlns:themes="clr-namespace:Xceed.Wpf.Toolkit.Themes;assembly=Xceed.Wpf.Toolkit"
-    xmlns:local="clr-namespace:Xceed.Wpf.Toolkit;assembly=Xceed.Wpf.Toolkit">
+    xmlns:s="clr-namespace:System;assembly=mscorlib">
 
     <Style TargetType="ef:XceedColorDialog">
         <Setter Property="Background" Value="{DynamicResource {x:Static SystemColors.ControlBrushKey}}"/>

--- a/src/Eto.Wpf/themes/generic.xaml
+++ b/src/Eto.Wpf/themes/generic.xaml
@@ -6,13 +6,13 @@
     xmlns:s="clr-namespace:System;assembly=mscorlib">
 
     <ResourceDictionary.MergedDictionaries>
-        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/controls/DataGrid.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/controls/SearchTextBox.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/controls/WatermarkTextBox.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/controls/Window.xaml" />
-        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/controls/XceedColorDialog.xaml" />
+        <e:AssemblyAbsoluteResourceDictionary Path="themes/controls/DataGrid.xaml" />
+        <e:AssemblyAbsoluteResourceDictionary Path="themes/controls/SearchTextBox.xaml" />
+        <e:AssemblyAbsoluteResourceDictionary Path="themes/controls/WatermarkTextBox.xaml" />
+        <e:AssemblyAbsoluteResourceDictionary Path="themes/controls/Window.xaml" />
+        <e:AssemblyAbsoluteResourceDictionary Path="themes/controls/XceedColorDialog.xaml" />
 		
-        <ResourceDictionary Source="pack://application:,,,/Eto.Wpf;Component/themes/wpftoolkit/ButtonSpinner.xaml" />
+        <e:AssemblyAbsoluteResourceDictionary Path="themes/wpftoolkit/ButtonSpinner.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
     <Style TargetType="{x:Type r:TreeToggleButton}">


### PR DESCRIPTION
This allows multiple copies of Eto to be loaded (with different versions) and still load the correct resources.