### PR TITLE
WPF: Don't force layout when child preferred size changes

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
@@ -221,7 +221,8 @@ namespace Eto.Wpf.Forms.Controls
 		public override void OnChildPreferredSizeUpdated()
 		{
 			base.OnChildPreferredSizeUpdated();
-			UpdateScrollSizes();
+			if (ExpandContentWidth || ExpandContentHeight)
+				UpdateSizes();
 		}
 	}
 }


### PR DESCRIPTION
Fix performance regression with Scrollable as instead of just invalidating the layout when a child preferred size changes, it also forced an update by using `UpdateScrollSizes()` which was introduced in #2709.  

This method is only meant to be used if you need the sizes calculated immediately after.  In the case where many child controls are updated, it could cause the entire scrollable layout to recalculate many times causing the performance issue. 