### PR TITLE
Wpf: Use public key token for WPF resources instead of full key

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -98,6 +98,7 @@
 			"request": "launch",
 			"preLaunchTask": "build-wpf",
             "program": "${workspaceFolder}/artifacts/test/Eto.Test.Wpf/${config:var.configuration}/net48/Eto.Test.Wpf.exe",
+			"targetArchitecture": "x86_64",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart",

--- a/src/Eto.Wpf/AssemblyAbsoluteResourceDictionary.cs
+++ b/src/Eto.Wpf/AssemblyAbsoluteResourceDictionary.cs
@@ -19,7 +19,7 @@ namespace Eto.Wpf
 
 			var version = "v" + name.Version.ToString() + ";";
 
-			var publicKey = name.GetPublicKey();
+			var publicKey = name.GetPublicKeyToken();
 			var publicKeyString = publicKey?.Length > 0 ? BitConverter.ToString(publicKey).Replace("-", "") + ";" : null;
 
 			return new Uri($"pack://application:,,,/{name.Name};{version}{publicKeyString}component/{path}", UriKind.Absolute);


### PR DESCRIPTION
Using the full public key works with .NET Core, but not .NET Framework.  Use the token instead so things load as expected.