### PR TITLE
Allow disposing multiple times

### DIFF
--- a/src/Eto/Widget.cs
+++ b/src/Eto/Widget.cs
@@ -539,7 +539,7 @@ public abstract class Widget : IHandlerSource, IDisposable, ICallbackSource
 	{
 		if (disposing)
 		{
-			if (Handler is IDisposable handler)
+			if (!IsDisposed && Handler is IDisposable handler)
 				handler.Dispose();
 			IsDisposed = true;
 			Handler = null;


### PR DESCRIPTION
I use dependency injection.

As per Disposable pattern `Dispose` method can be called multiple times however, once DependencyInjection calls `Wiget.Dispose` it crashes, because Handler property checks if it's already disposed.

As I understand Application disposes all of it's widgets and cannot be called 2nd time which is done by DependencyInjection.