### PR TITLE
Mac: Open/SaveFileDialog fixes

### DIFF
--- a/src/Eto.Mac/Forms/OpenFileDialogHandler.cs
+++ b/src/Eto.Mac/Forms/OpenFileDialogHandler.cs
@@ -8,8 +8,6 @@ namespace Eto.Mac.Forms
 			return NSOpenPanel.OpenPanel;
 		}
 
-		protected override bool DisposeControl { get { return false; } }
-
 		public bool MultiSelect
 		{
 			get { return Control.AllowsMultipleSelection; }

--- a/src/Eto.Mac/Forms/OpenWithDialogHandler.cs
+++ b/src/Eto.Mac/Forms/OpenWithDialogHandler.cs
@@ -6,11 +6,14 @@
 
 		public DialogResult ShowDialog(Window parent)
 		{
-			Control = new NSOpenPanel();
-			Control.ReleasedWhenClosed = true;
-			Control.DirectoryUrl = new NSUrl("/Applications");
-			Control.Prompt = "Choose Application";
+			Control = NSOpenPanel.OpenPanel;
+			Control.DirectoryUrl = NSUrl.FromFilename("/Applications");
+			Control.Prompt = Application.Instance.Localize(Widget, "Choose Application");
+#if MACOS_NET
+			Control.AllowedContentTypes = new [] { UniformTypeIdentifiers.UTTypes.Application };
+#else
 			Control.AllowedFileTypes = new[] { "app" };
+#endif
 
 			if (Control.RunModal() == 1)
 				Process.Start("open", "-a \"" + Control.Url.Path +  "\" \"" + FilePath + "\"");

--- a/src/Eto.Mac/Forms/SaveFileDialogHandler.cs
+++ b/src/Eto.Mac/Forms/SaveFileDialogHandler.cs
@@ -15,6 +15,7 @@ namespace Eto.Mac.Forms
 				var name = value;
 				if (!string.IsNullOrEmpty(name))
 				{
+					SetAllowedFileTypes();
 					var dir = Path.GetDirectoryName(name);
 					if (!string.IsNullOrEmpty(dir) && System.IO.Directory.Exists(dir))
 						Directory = new Uri(dir);
@@ -25,8 +26,6 @@ namespace Eto.Mac.Forms
 			}
 		}
 
-		protected override bool DisposeControl { get { return false; } }
-
 		protected override NSSavePanel CreateControl()
 		{
 			return NSSavePanel.SavePanel;
@@ -34,6 +33,7 @@ namespace Eto.Mac.Forms
 
 		protected override void Initialize()
 		{
+			Control.ExtensionHidden = false;
 			Control.AllowsOtherFileTypes = true;
 			Control.CanSelectHiddenExtension = true;
 			base.Initialize();
@@ -49,6 +49,18 @@ namespace Eto.Mac.Forms
 			}
 
 			return result;
+		}
+
+		protected override void OnFileTypeChanged()
+		{
+			base.OnFileTypeChanged();
+			var extension = Widget.CurrentFilter?.Extensions?.FirstOrDefault()?.TrimStart('*', '.');
+			if (!string.IsNullOrEmpty(extension))
+			{
+				var fileName = Control.NameFieldStringValue;
+				if (fileName != null)
+					Control.NameFieldStringValue = $"{Path.GetFileNameWithoutExtension(fileName)}.{extension}";
+			}			
 		}
 	}
 }

--- a/test/Eto.Test/Sections/Dialogs/FileDialogSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/FileDialogSection.cs
@@ -104,12 +104,12 @@ namespace Eto.Test.Sections.Dialogs
 				{
 					Filters =
 					{
-						new FileFilter("All Formats", "png", "jpg", "jpeg", "gif", "tiff"),
+						new FileFilter("All Formats", ".png", ".jpg", ".jpeg", ".gif", ".tiff"),
 						new FileFilter("All Files", "*"),
-						"PNG Files|png",
-						new FileFilter("JPeg Files", "jpg", "jpeg"),
-						new FileFilter("GIF Files", "gif"),
-						new FileFilter("TIFF Files", "tiff"),
+						"PNG Files|.png",
+						new FileFilter("JPeg Files", ".jpg", ".jpeg"),
+						new FileFilter("GIF Files", ".gif"),
+						new FileFilter("TIFF Files", ".tiff"),
 					}
 				};
 				SetAttributes(dialog);
@@ -135,17 +135,14 @@ namespace Eto.Test.Sections.Dialogs
 						new FileFilter("JPeg Files", ".jpg", ".jpeg"),
 						new FileFilter("GIF Files", ".gif"),
 						new FileFilter("TIFF Files", ".tiff"),
+						new FileFilter("CS Files", ".cs"),
 					}
 				};
 				SetAttributes(dialog);
 
 				var result = dialog.ShowDialog(ParentWindow);
-				if (result == DialogResult.Ok)
-				{
-					Log.Write(dialog, "Result: {0}, CurrentFilter: {1}, FileName: {2}", result, dialog.CurrentFilter, dialog.FileName);
-				}
-				else
-					Log.Write(dialog, "Result: {0}", result);
+				Log.Write(dialog, "Result: {0}, CurrentFilter: {1}, FileName: {2}", result, dialog.CurrentFilter, dialog.FileName);
+				dialog.Dispose();
 			};
 			return button;
 		}
@@ -158,12 +155,8 @@ namespace Eto.Test.Sections.Dialogs
 				var dialog = new SaveFileDialog();
 				SetAttributes(dialog);
 				var result = dialog.ShowDialog(ParentWindow);
-				if (result == DialogResult.Ok)
-				{
-					Log.Write(dialog, "Result: {0}, FileName: {1}", result, dialog.FileName);
-				}
-				else
-					Log.Write(dialog, "Result: {0}", result);
+				Log.Write(dialog, "Result: {0}, FileName: {1}", result, dialog.FileName);
+				dialog.Dispose();
 			};
 			return button;
 		}


### PR DESCRIPTION
This fixes the following:
- Changing the file type for the SaveFileDialog will now change the extension of the file name
- The extension will be shown by default for the entered name
- The file type drop down is now centered
- Removed Format label so it doesn't have to be translated
- Setting the FileName with an extension that is known won't double up the extension
- Use newer AllowedContentTypes API on macOS platform, requires macOS 11+