### PR TITLE
Mac: Fix double extension for unknown file types

### DIFF
--- a/src/Eto.Mac/Forms/SaveFileDialogHandler.cs
+++ b/src/Eto.Mac/Forms/SaveFileDialogHandler.cs
@@ -41,11 +41,11 @@ namespace Eto.Mac.Forms
 
 		public override DialogResult ShowDialog(Window parent)
 		{
+			hasShown = true;
 			var result = base.ShowDialog(parent);
 			if (result == DialogResult.Ok)
 			{
 				selectedFileName = null;
-				hasShown = true;
 			}
 
 			return result;
@@ -54,12 +54,30 @@ namespace Eto.Mac.Forms
 		protected override void OnFileTypeChanged()
 		{
 			base.OnFileTypeChanged();
-			var extension = Widget.CurrentFilter?.Extensions?.FirstOrDefault()?.TrimStart('*', '.');
-			if (!string.IsNullOrEmpty(extension))
+			var extensions = Widget.CurrentFilter?.Extensions;
+			if (extensions == null)
+				return;
+
+			var currentExtension = Path.GetExtension(Control.NameFieldStringValue);
+
+			// If the new file type supports the extension, don't change it
+			if (extensions.Select(r => r.TrimStart('*')).Any(r => r == currentExtension))
+			{
+				if (!hasShown)
+				{
+					// need to reset the value, otherwise for unknown file types it doubles up the extension
+					var name = Control.NameFieldStringValue;
+					Control.NameFieldStringValue = string.Empty;
+					Control.NameFieldStringValue = name;
+				}
+				return;
+			}
+			var newExtension = extensions.FirstOrDefault()?.TrimStart('*', '.');
+			if (!string.IsNullOrEmpty(newExtension))
 			{
 				var fileName = Control.NameFieldStringValue;
 				if (fileName != null)
-					Control.NameFieldStringValue = $"{Path.GetFileNameWithoutExtension(fileName)}.{extension}";
+					Control.NameFieldStringValue = $"{Path.GetFileNameWithoutExtension(fileName)}.{newExtension}";
 			}			
 		}
 	}

--- a/test/Eto.Test/UnitTests/Forms/FileDialogTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/FileDialogTests.cs
@@ -10,6 +10,19 @@ namespace Eto.Test.UnitTests.Forms
 	[TestFixture]
 	public class SaveFileDialogTests : FileDialogTests<SaveFileDialog>
 	{
+		[Test, ManualTest, InvokeOnUI]
+		public void FileNameShouldNotHaveDoubleExtension()
+		{
+			// this can only be replicated on macOS when the extension is unknown
+			// and we set the filename first
+			var fd = new SaveFileDialog();
+			fd.FileName = "NoDoubleExt.eto";
+			fd.Directory = new Uri(EtoEnvironment.GetFolderPath(EtoSpecialFolder.Downloads));
+			fd.Filters.Clear();
+			fd.Filters.Add(new FileFilter("ETO Files", ".eto"));
+			fd.Filters.Add(new FileFilter("Text Files", ".txt"));
+			fd.ShowDialog(null);
+		}
 	}
 
 	public class FileDialogTests<T> : TestBase


### PR DESCRIPTION
Follow up to #2738, if you set the FileName of a file with an unknown extension, then set the filters, it will double up the extension.  E.g. it would have `NoDoubleExt.eto.eto` in the file name.  

See `SaveFileDialogTests.FileNameShouldNotHaveDoubleExtension` for repro.