### PR TITLE
Mac: Make MacCell/RowGridFormatEventArgs public

### DIFF
--- a/src/Eto.Mac/Forms/Cells/CheckBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CheckBoxCellHandler.cs
@@ -115,7 +115,7 @@ namespace Eto.Mac.Forms.Cells
 			view.Tag = row;
 			view.Item = obj;
 			SetDefaults(view);
-			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
+			var args = new MacGridCellFormatEventArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 			return view;
 		}

--- a/src/Eto.Mac/Forms/Cells/ComboBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ComboBoxCellHandler.cs
@@ -155,7 +155,7 @@ namespace Eto.Mac.Forms.Cells
 
 		public override nfloat GetPreferredWidth(object value, CGSize cellSize, int row, object dataItem)
 		{
-			var args = new MacCellFormatArgs(ColumnHandler.Widget, dataItem, row, field);
+			var args = new MacGridCellFormatEventArgs(ColumnHandler.Widget, dataItem, row, field);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 
 			field.Font = defaultFont;
@@ -263,7 +263,7 @@ namespace Eto.Mac.Forms.Cells
 			view.Tag = row;
 			view.Item = obj;
 			SetDefaults(view);
-			var formatArgs = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
+			var formatArgs = new MacGridCellFormatEventArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(formatArgs);
 			return view;
 		}

--- a/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CustomCellHandler.cs
@@ -197,7 +197,7 @@ namespace Eto.Mac.Forms.Cells
 			}
 
 			SetDefaults(view);
-			var formatArgs = new MacCellFormatArgs(ColumnHandler.Widget, item, row, view);
+			var formatArgs = new MacGridCellFormatEventArgs(ColumnHandler.Widget, item, row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(formatArgs);
 			Callback.OnConfigureCell(Widget, view.Args, view.EtoControl);
 			return view;

--- a/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/DrawableCellHandler.cs
@@ -205,7 +205,7 @@ namespace Eto.Mac.Forms.Cells
 				view.Bind(enabledBinding, tableColumn, "editable", null);
 			}
 			SetDefaults(view);
-			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
+			var args = new MacGridCellFormatEventArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 			return view;
 		}

--- a/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageTextCellHandler.cs
@@ -45,7 +45,7 @@ namespace Eto.Mac.Forms.Cells
 
 			field.ObjectValue = value as NSObject;
 			
-			var args = new MacCellFormatArgs(ColumnHandler.Widget, dataItem, row, field);
+			var args = new MacGridCellFormatEventArgs(ColumnHandler.Widget, dataItem, row, field);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 
 			return field.FittingSize.Width;
@@ -232,7 +232,7 @@ namespace Eto.Mac.Forms.Cells
 			view.Tag = row;
 			view.Item = obj;
 			SetDefaults(view);
-			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
+			var args = new MacGridCellFormatEventArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 			return view;
 		}

--- a/src/Eto.Mac/Forms/Cells/ImageViewCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ImageViewCellHandler.cs
@@ -99,7 +99,7 @@ namespace Eto.Mac.Forms.Cells
 				view = new EtoImageView { Identifier = tableColumn.Identifier };
 			}
 			SetDefaults(view);
-			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
+			var args = new MacGridCellFormatEventArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 			return view;
 		}

--- a/src/Eto.Mac/Forms/Cells/ProgressCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/ProgressCellHandler.cs
@@ -33,7 +33,7 @@ namespace Eto.Mac.Forms.Cells
 
 		public override nfloat GetPreferredWidth(object value, CGSize cellSize, int row, object dataItem)
 		{
-			var args = new MacCellFormatArgs(ColumnHandler.Widget, dataItem, row, field);
+			var args = new MacGridCellFormatEventArgs(ColumnHandler.Widget, dataItem, row, field);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 
 			field.Font = args.Font.ToNS() ?? NSFont.BoldSystemFontOfSize(NSFont.SystemFontSize);
@@ -78,7 +78,7 @@ namespace Eto.Mac.Forms.Cells
 			}
 			
 			SetDefaults(view);
-			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
+			var args = new MacGridCellFormatEventArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 			return view;
 		}

--- a/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
@@ -14,7 +14,7 @@ namespace Eto.Mac.Forms.Cells
 			field.ObjectValue = value as NSObject ?? new NSString(string.Empty);
 			
 			SetDefaults(field);
-			var args = new MacCellFormatArgs(ColumnHandler.Widget, dataItem, row, field);
+			var args = new MacGridCellFormatEventArgs(ColumnHandler.Widget, dataItem, row, field);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 
 			return field.Cell.CellSizeForBounds(new CGRect(0, 0, nfloat.MaxValue, cellSize.Height)).Width;
@@ -190,7 +190,7 @@ namespace Eto.Mac.Forms.Cells
 			view.Item = obj;
 			view.Tag = row;
 			SetDefaults(view);
-			var args = new MacCellFormatArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
+			var args = new MacGridCellFormatEventArgs(ColumnHandler.Widget, getItem(obj, row), row, view);
 			ColumnHandler.DataViewHandler.OnCellFormatting(args);
 			return view;
 		}


### PR DESCRIPTION
This is useful when you need access to whether the properties are set or not