### PR TITLE
Always recurse style changed to children

### DIFF
--- a/src/Eto/Forms/Container.cs
+++ b/src/Eto/Forms/Container.cs
@@ -152,7 +152,7 @@ public abstract class Container : Control, IBindableWidgetContainer
 	protected override void OnStyleChanged(EventArgs e)
 	{
 		base.OnStyleChanged(e);
-		if (Loaded && Handler.RecurseToChildren)
+		if (Loaded)
 		{
 			foreach (Control control in VisualControls)
 			{


### PR DESCRIPTION
When triggering style changes, it should recurse to children regardless of the `Handler.RecurseToChildren` value.