### PR TITLE
Mention documentcontrol in tabcontrol documentation

### DIFF
--- a/src/Eto/Forms/Controls/TabControl.cs
+++ b/src/Eto/Forms/Controls/TabControl.cs
@@ -5,7 +5,7 @@ namespace Eto.Forms;
 /// </summary>
 /// <remarks>
 /// Some platforms (e.g. OS X) have limitations on how many tabs are visible.
-/// It is advised to utilize different methods (e.g. a listbox or combo box) to switch between many sections
+/// It is advised to utilize different methods (e.g. a DocumentControl, listbox or combo box) to switch between many sections
 /// if there are too many tabs.
 /// </remarks>
 [ContentProperty("Pages")]


### PR DESCRIPTION
Noticed that after reading https://github.com/picoe/Eto/issues/2409#issuecomment-2676037983 that DocumentControl wasn't explicitly mentioned in the documentation so made a quick patch.