### PR TITLE
Don't clear out owner when hiding a form

### DIFF
--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -1114,17 +1114,17 @@ namespace Eto.Wpf.Forms
 			{
 				if (value)
 				{
-					// set owner back if we weren't visible beforehand
-					SetOwner(Widget.Owner);
 					Control.Show();
 				}
 				else
 				{
-					// hiding will hide entire owner chain, so clear that out before making it invisible.
-					SetOwner(null);
-					Control.Hide();
+					// hiding when it has focus can hide entire owner chain, so set focus to owner first
+					if (HasFocus)
+						Widget.Owner?.Focus();
+
+					Control.Hide();	
+				}
 			}
-		}
 	}
 }
 }


### PR DESCRIPTION
When clearing out the owner, forms will show up in alt+tab menu on windows, which is not desired nor intended.

This was broken in #2690, which was trying to ensure that hiding a form wouldn't make the owner go behind other application windows.  Instead, a better fix appears to focus the owner _then_ hide the child form.