### PR TITLE
Mac: Re-add obsolete ToEto(NSColor, bool) apis

### DIFF
--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -28,6 +28,9 @@ namespace Eto.Mac
 				: NSColor.FromDeviceRgba(color.R, color.G, color.B, color.A);
 		}
 
+		[Obsolete("Use ToEtoWithAppearance(NSColor) instead")]
+		public static Color ToEtoWithAppearance(this NSColor color, bool calibrated) => ToEtoWithAppearance(color);
+		
 		public static Color ToEtoWithAppearance(this NSColor color)
 		{
 			if (color == null)
@@ -46,13 +49,16 @@ namespace Eto.Mac
 			return result;
 		}
 
+		[Obsolete("Use ToEto(NSColor) instead")]
+		public static Color ToEto(this NSColor color, bool calibrated) => ToEto(color);
+
 		public static Color ToEto(this NSColor color)
 		{
 			if (color == null)
 				return Colors.Transparent;
 
 			var colorspace = NSColorSpace.DeviceRGBColorSpace;
-			
+
 			var converted = color.UsingColorSpace(colorspace);
 			if (converted == null)
 			{


### PR DESCRIPTION
These have been used in the wild, and while we don't necessarily ensure that platform-specific assemblies maintain any ABI compatibility, adding these back in are pretty easy so here they are.