### PR TITLE
Fix key handling for windows on Mac/Wpf

### DIFF
--- a/src/Eto.Mac/Forms/MacViewTextInput.cs
+++ b/src/Eto.Mac/Forms/MacViewTextInput.cs
@@ -1,6 +1,6 @@
 namespace Eto.Mac.Forms
 {
-	class MacViewTextInput
+	static class MacViewTextInput
 	{
 		internal static IntPtr HasMarkedText_Selector = Selector.GetHandle("hasMarkedText");
 		internal static MarshalDelegates.Func_IntPtr_IntPtr_bool HasMarkedText_Delegate = HasMarkedText;
@@ -57,6 +57,10 @@ namespace Eto.Mac.Forms
 		internal static MarshalDelegates.Action_IntPtr_IntPtr_IntPtr DoCommandBySelector_Delegate = DoCommandBySelector;
 		static void DoCommandBySelector(IntPtr sender, IntPtr sel, IntPtr selector)
 		{
+			var obj = Runtime.GetNSObject(sender);
+			
+			if (obj != null && ObjCExtensions.SuperClassInstancesRespondsToSelector(obj, sel))
+				Messaging.void_objc_msgSendSuper_IntPtr(obj.SuperHandle, sel, selector);
 		}
 
 		internal static IntPtr NSTextInputClientProtocol_Handle = ObjCExtensions.GetProtocolHandle("NSTextInputClient");

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -373,6 +373,8 @@ namespace Eto.Wpf.Forms
 
 		protected virtual sw.FrameworkElement FocusControl => Control;
 
+		protected virtual sw.FrameworkElement KeyEventControl => Control;
+
 		public virtual void Focus()
 		{
 			if (FocusControl.IsLoaded)
@@ -461,20 +463,20 @@ namespace Eto.Wpf.Forms
 				case Eto.Forms.Control.KeyDownEvent:
 					if (UseKeyPreview)
 					{
-						Control.PreviewKeyDown += HandleKeyDown;
-						Control.PreviewTextInput += HandleTextInput;
+						KeyEventControl.PreviewKeyDown += HandleKeyDown;
+						KeyEventControl.PreviewTextInput += HandleTextInput;
 					}
 					else
 					{
-						Control.KeyDown += HandleKeyDown;
-						Control.TextInput += HandleTextInput;
+						KeyEventControl.KeyDown += HandleKeyDown;
+						KeyEventControl.TextInput += HandleTextInput;
 					}
 					break;
 				case Eto.Forms.Control.TextInputEvent:
 					HandleEvent(Eto.Forms.Control.KeyDownEvent);
 					break;
 				case Eto.Forms.Control.KeyUpEvent:
-					Control.KeyUp += HandleKeyUp;
+					KeyEventControl.KeyUp += HandleKeyUp;
 					break;
 				case Eto.Forms.Control.ShownEvent:
 					ContainerControl.IsVisibleChanged += HandleIsVisibleChanged;

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -75,6 +75,8 @@ namespace Eto.Wpf.Forms
 
 		public swc.DockPanel MainPanel { get { return main; } }
 
+		protected override sw.FrameworkElement KeyEventControl => main;
+
 		public bool MovableByWindowBackground
 		{
 			get => Widget.Properties.Get<bool>(WpfWindow.MovableByWindowBackground_Key);

--- a/test/Eto.Test/UnitTests/Forms/MenuItemTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/MenuItemTests.cs
@@ -129,7 +129,25 @@ namespace Eto.Test.UnitTests.Forms
 		[ManualTest]
 		public void DrawableShouldAcceptInputEvenWhenShortcutDefined(bool enabled, Keys key, bool handleKey, bool shouldBeIntrinsic)
 		{
-			ControlShouldAcceptInputEvenWhenShortcutDefined<Drawable>(enabled, key, handleKey, shouldBeIntrinsic, d => d.CanFocus = true);
+			ControlShouldAcceptInputEvenWhenShortcutDefined<Drawable>(enabled, key, handleKey, shouldBeIntrinsic, d =>
+			{
+				d.CanFocus = true;
+				d.BackgroundColor = Colors.Blue;
+				d.KeyDown += (sender, e) =>
+				{
+					if (e.KeyData == key)
+					{
+						d.BackgroundColor = Colors.Green;
+					}
+				};
+				d.KeyUp += (sender, e) =>
+				{
+					if (e.KeyData == key)
+					{
+						d.BackgroundColor = Colors.Blue;
+					}
+				};
+			});
 		}
 		
 		void ControlShouldAcceptInputEvenWhenShortcutDefined<T>(bool enabled, Keys key, bool handleKey, bool shouldBeIntrinsic, Action<T> initialize = null)

--- a/test/Eto.Test/UnitTests/Forms/WindowTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/WindowTests.cs
@@ -200,14 +200,14 @@ public abstract class WindowTests<T> : TestBase
 			var timer = new UITimer { Interval = 0.5 };
 			timer.Elapsed += (sender, e) =>
 		{
-			  var window = Window.FromPoint(Mouse.Position);
-			  content.Content = $"Window: {window?.Title}";
-		  };
+			var window = Window.FromPoint(Mouse.Position);
+			content.Content = $"Window: {window?.Title}";
+		};
 			timer.Start();
 			form.Closed += (sender, e) =>
 		{
-			  timer.Stop();
-		  };
+			timer.Stop();
+		};
 			form.Title = "Test Form";
 			return content;
 		}
@@ -395,4 +395,92 @@ public abstract class WindowTests<T> : TestBase
 		Assert.That(loadComplete, Is.True, "#1.1 - Window should be visible during LoadComplete");
 		Assert.That(shown, Is.True, "#1.2 - Window should be visible during Shown");
 	});
+
+	[Test]
+	[ManualTest]
+	public void HandlingTextInputOnWindowShouldNotPreventShortcuts()
+	{
+		bool? copyCalled = null;
+		bool? keyDownInControl = null;
+		bool? keyDownInWindow = null;
+		ManualTest(Platform.Instance.IsMac ? "Press CMD+C" : "Press Ctrl+C", form =>
+		{
+			// var ctl = new Drawable { CanFocus = true, Size = new Size(200, 200), BackgroundColor = Colors.Blue };
+			var ctl = new WebView { Size = new Size(200, 200) };
+			ctl.KeyDown += (sender, e) =>
+			{
+				if (e.KeyData == (Application.Instance.CommonModifier | Keys.C))
+				{
+					keyDownInControl = true;
+				}
+			};
+			ctl.TextInput += (sender, e) =>
+			{
+				Log.Write(ctl, "TextInput called!");
+			};
+
+			form.KeyDown += (sender, e) =>
+			{
+				if (e.KeyData == (Application.Instance.CommonModifier | Keys.C))
+				{
+					keyDownInWindow = true;
+				}
+			};
+			form.TextInput += (sender, e) =>
+			{
+				Log.Write(form, "TextInput called!");
+			};
+
+			void Close(object sender, EventArgs e)
+			{
+				form.Close();
+			}
+
+			void Copy(object sender, EventArgs e)
+			{
+				Log.Write(null, "Copy called!");
+				copyCalled = true;
+				form.Close();
+			}
+
+			ctl.DocumentLoaded += (sender, e) =>
+			{
+				ctl.Focus();
+			};
+			ctl.LoadHtml("<html><body><p>Test</p></body></html>");
+
+			var bar = new MenuBar
+			{
+				IncludeSystemItems = MenuBarSystemItems.Quit,
+				Items = {
+					new SubMenuItem { Text = "Close", Items = {
+							new ButtonMenuItem(Close) { Text = "Close", Shortcut = Application.Instance.CommonModifier | Keys.W }
+						}
+					},
+					new SubMenuItem { Text = "Edit", Items = {
+							new ButtonMenuItem(Copy) { Text = "Copy", Shortcut = Application.Instance.CommonModifier | Keys.C }
+						}
+					}
+				}
+			};
+
+			form.Menu = bar;
+
+
+			return ctl;
+		});
+		Assert.That(copyCalled, Is.True, "#1 - Copy menuItem was not called");
+		if (Platform.Instance.IsMac || Platform.Instance.IsGtk)
+		{
+			// in case this gets "fixed" later to behave like other platforms.
+			// Gtk and Mac prioritize menu shortcuts over control key events
+			Assert.That(keyDownInControl, Is.Null, "#2 - KeyDown is not called on control on Mac or Gtk with a menu shortcut");
+			Assert.That(keyDownInWindow, Is.Null, "#3 - KeyDown is not called on Window on Mac or Gtk with a menu shortcut");
+		}
+		else
+		{
+			Assert.That(keyDownInControl, Is.True, "#2 - KeyDown was not called in control");
+			Assert.That(keyDownInWindow, Is.True, "#3 - KeyDown was not called in window");
+		}
+	}
 }


### PR DESCRIPTION
Mac: Fix certain shortcuts when handling the Window.TextInput events
Wpf: Key events should fire on Window even if there are menu items with the shortcut

On Mac, handling the TextInput event on a Form/Dialog would make certain keyboard shortcuts not fire even if they were defined in the menu.

On Wpf, KeyDown was not firing on the Window before the menu shortcuts.