### PR TITLE
Mac: Don't order window to front when it has an owner

### DIFF
--- a/src/Eto.Mac/Forms/FormHandler.cs
+++ b/src/Eto.Mac/Forms/FormHandler.cs
@@ -92,9 +92,12 @@ namespace Eto.Mac.Forms
 				{
 					if (value != Visible)
 					{
-						Control.OrderFront(ApplicationHandler.Instance.AppDelegate);
+						if (!EnsureOwner())
+						{
+							// only order front when there is no owner as it'll bring the owner above any existing non-child windows
+							Control.OrderFront(ApplicationHandler.Instance.AppDelegate);
+						}
 						FireOnShown();
-						EnsureOwner();
 					}
 				}
 				else


### PR DESCRIPTION
This is the same when calling Show() for the first time, where it would make the parent window come to front. 