### PR TITLE
Mac: Fix some Open/SaveFileDialog issues

### DIFF
--- a/src/Eto.Mac/Forms/MacFileDialog.cs
+++ b/src/Eto.Mac/Forms/MacFileDialog.cs
@@ -17,11 +17,13 @@ namespace Eto.Mac.Forms
 
 		public override bool ShouldEnableUrl(NSSavePanel panel, NSUrl url)
 		{
-			if (Directory.Exists(url.Path))
+			var h = Handler;
+			if (h == null || url == null || Directory.Exists(url.Path))
 				return true;
 
 			var extension = Path.GetExtension(url.Path).TrimStart(new[] { '.' });
-			if (Handler.MacFilters == null || Handler.MacFilters.Contains(extension, StringComparer.InvariantCultureIgnoreCase))
+			var macFilters = h.MacFilters;
+			if (macFilters == null || macFilters.Contains(extension, StringComparer.InvariantCultureIgnoreCase))
 				return true;
 			return false;
 		}
@@ -41,7 +43,7 @@ namespace Eto.Mac.Forms
 			fileTypes.SelectedIndexChanged += (sender, e) => OnFileTypeChanged();
 		}
 
-		void Create()
+		internal virtual void Create()
 		{
 			if (Widget.Filters.Count > 0)
 			{
@@ -52,6 +54,7 @@ namespace Eto.Mac.Forms
 				layout.Rows.Add(new TableRow(null, fileTypes, null));
 
 				Control.AccessoryView = layout.ToNative(true);
+
 				SetAllowedFileTypes();
 			}
 			else
@@ -137,10 +140,12 @@ namespace Eto.Mac.Forms
 		public virtual DialogResult ShowDialog(Window parent)
 		{
 			//Control.AllowsOtherFileTypes = false;
+			var oldDelegate = Control.Delegate;
 			Control.Delegate = new SavePanelDelegate{ Handler = this };
 			Create();
 
 			int ret = MacModal.Run(Control, parent);
+			Control.Delegate = oldDelegate;
 			
 			if (ret == 1)
 				fileName = null;

--- a/src/Eto.Mac/Forms/OpenFileDialogHandler.cs
+++ b/src/Eto.Mac/Forms/OpenFileDialogHandler.cs
@@ -3,20 +3,28 @@ namespace Eto.Mac.Forms
 	public class OpenFileDialogHandler : MacFileDialog<NSOpenPanel, OpenFileDialog>, OpenFileDialog.IHandler
 	{
 
-		protected override NSOpenPanel CreateControl()
-		{
-			return NSOpenPanel.OpenPanel;
-		}
+		protected override NSOpenPanel CreateControl() => NSOpenPanel.OpenPanel;
 
 		public bool MultiSelect
 		{
-			get { return Control.AllowsMultipleSelection; }
-			set { Control.AllowsMultipleSelection = value; }
+			get => Control.AllowsMultipleSelection;
+			set => Control.AllowsMultipleSelection = value;
 		}
 
-		public IEnumerable<string> Filenames
+		public IEnumerable<string> Filenames => Control.Urls.Select(a => a.Path);
+
+		static readonly Selector selSetAccessoryViewDisclosed = new Selector("setAccessoryViewDisclosed:");
+
+		internal override void Create()
 		{
-			get { return Control.Urls.Select(a => a.Path); }
+			base.Create();
+
+			if (Control.AccessoryView != null && Control.RespondsToSelector(selSetAccessoryViewDisclosed))
+			{
+				// ensure accessory view is always disclosed
+				// only available on NSOpenPanel.
+				Messaging.void_objc_msgSend_bool(Control.Handle, selSetAccessoryViewDisclosed.Handle, true);
+			}
 		}
 	}
 }


### PR DESCRIPTION
- Show accessory view/file type filter for open file dialog by default
- Fix crash after the delegate has been set but handler is GC'd
- Clear out delegate after shown so it doesn't get used for other things