### PR TITLE
Mac: Don't show gridlines in TreeGridView when elastically scrolling horizontally.

### DIFF
--- a/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridViewHandler.cs
@@ -21,25 +21,11 @@ namespace Eto.Mac.Forms.Controls
 				set { WeakHandler = new WeakReference(value); }
 			}
 
-			/// <summary>
-			/// The area to the right and below the rows is not filled with the background
-			/// color. This fixes that. See http://orangejuiceliberationfront.com/themeing-nstableview/
-			/// </summary>
-			public override void DrawBackground(CGRect clipRect)
+			public override void DrawGrid(CGRect clipRect)
 			{
-				var h = Handler;
-				if (h == null)
-					return;
-				var backgroundColor = h.BackgroundColor;
-				if (backgroundColor != Colors.Transparent)
-				{
-					backgroundColor.ToNSUI().Set();
-					NSGraphics.RectFill(Bounds);
-				}
-				else
-					base.DrawBackground(clipRect);
+				// Only draw gridlines for rows/columns with data, not for the empty space
 			}
-
+			
 			public override void RightMouseDown(NSEvent theEvent)
 			{
 				if (Handler?.HandleMouseEvent(theEvent) == true)

--- a/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeGridViewHandler.cs
@@ -672,6 +672,11 @@ namespace Eto.Mac.Forms.Controls
 				SetDraggingSourceOperationMask(NSDragOperation.All, false);
 			}
 
+			public override void DrawGrid(CGRect clipRect)
+			{
+				// Only draw gridlines for rows/columns with data, not for the empty space
+			}
+			
 			public override void Layout()
 			{
 				// layout must occur after autosizing columns otherwise expanders don't show for some reason..


### PR DESCRIPTION
This fixes this issue with the GridView/TreeGridView when scrolling horizontally, and removes an old hack to make the background color work properly on GridView which is no longer needed.

<img width="118" alt="Screenshot 2025-05-01 at 11 18 17 AM" src="https://github.com/user-attachments/assets/6cdc5e5c-04f6-41fc-b005-037b8328cf58" />
