### PR TITLE
WPF: Fix calling GC.TryStartNoCGRegion when already set

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -315,7 +315,8 @@ namespace Eto.Wpf.Forms.Controls
 
 				try
 				{
-					endNoGCRegion &= GC.TryStartNoGCRegion(1000000); // is this magic number reasonable??
+					if (endNoGCRegion)
+						endNoGCRegion &= GC.TryStartNoGCRegion(1000000); // is this magic number reasonable??
 				}
 				catch
 				{


### PR DESCRIPTION
`&=` will still execute the right side even if the left is already false.. 🤦‍♂️