### PR TITLE
Wpf: Fix child scaling of explicitly sized panels

### DIFF
--- a/src/Eto.Wpf/Forms/PixelLayoutHandler.cs
+++ b/src/Eto.Wpf/Forms/PixelLayoutHandler.cs
@@ -102,5 +102,17 @@ namespace Eto.Wpf.Forms
 			if (suspended == 0 && Widget.Loaded)
 				base.UpdatePreferredSize();
 		}
+
+		public override void SetScale(bool xscale, bool yscale)
+		{
+			base.SetScale(xscale, yscale);
+			// ensure we propagate down so all controls can set their scale properly
+			foreach (var child in Widget.Controls)
+			{
+				var element = child.GetWpfFrameworkElement();
+				element?.SetScale(false, false);
+			}
+		}
+
 	}
 }

--- a/src/Eto.Wpf/Forms/WpfPanel.cs
+++ b/src/Eto.Wpf/Forms/WpfPanel.cs
@@ -44,7 +44,8 @@ namespace Eto.Wpf.Forms
 		public override void SetScale(bool xscale, bool yscale)
 		{
 			base.SetScale(xscale, yscale);
-			SetContentScale(xscale, yscale);
+			var preferredSize = UserPreferredSize;
+			SetContentScale(xscale || !double.IsNaN(preferredSize.Width), yscale || !double.IsNaN(preferredSize.Height));
 		}
 
 		protected virtual void SetContentScale(bool xscale, bool yscale)

--- a/test/Eto.Test/UnitTests/Forms/Layout/PixelLayoutTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Layout/PixelLayoutTests.cs
@@ -34,7 +34,8 @@ namespace Eto.Test.UnitTests.Forms.Layout
 		[Test, ManualTest]
 		public void LabelsShouldGetCorrectSize()
 		{
-			ManualForm("Labels should end with a period", form => {
+			ManualForm("Labels should end with a period", form =>
+			{
 				// note: this actually failed only when the form was the initial window, as it calculated its size before it was even shown.
 				form.ClientSize = new Size(200, 200);
 
@@ -45,5 +46,32 @@ namespace Eto.Test.UnitTests.Forms.Layout
 				return layout;
 			});
 		}
+		
+		[Test]
+		public void ChildShouldExpandWhenParentAndChildSizeIsExplicitlySet()
+		{
+			ShownAsync(form =>
+			{
+				var childPanel = new Panel { ID = "childPanel", Size = new Size(50, 50), BackgroundColor = Colors.Blue };
+				
+				var panel = new Panel { ID = "panel1", Size = new Size(200, 200), BackgroundColor = Colors.Red };
+				panel.Content = childPanel;
+
+				var layout = new PixelLayout();
+				layout.Add(panel, 0, 0);
+
+				return layout;
+			}, 
+			async layout =>
+			{
+				await Task.Delay(1000);
+				var panel = layout.FindChild("panel1");
+				var childPanel = layout.FindChild("childPanel");
+				Assert.That(childPanel, Is.Not.Null, "#1");
+				Assert.That(childPanel.Width, Is.EqualTo(panel.Width), "#2");
+				Assert.That(childPanel.Height, Is.EqualTo(panel.Width), "#3");
+			});
+		}
+		
 	}
 }


### PR DESCRIPTION
Also fixes issues with scaling child controls of a PixelLayout.

Added a test to verify behaviour.