### PR TITLE
WPF: Fix Window.BackgroundColor when setting Opacity

### DIFF
--- a/src/Eto.Wpf/CustomControls/GlassHelper.cs
+++ b/src/Eto.Wpf/CustomControls/GlassHelper.cs
@@ -95,14 +95,13 @@ namespace Eto.Wpf.CustomControls
 
 		public static bool BlurBehindWindow (sw.Window window)
 		{
-			if (!DwmIsCompositionEnabled ())
+			if (!DwmIsCompositionEnabled())
 				return false;
 
 			var windowInteropHelper = new sw.Interop.WindowInteropHelper (window);
 			IntPtr myHwnd = windowInteropHelper.Handle;
 			var mainWindowSrc = System.Windows.Interop.HwndSource.FromHwnd (myHwnd);
 
-			window.Background = swm.Brushes.Transparent;
 			mainWindowSrc.CompositionTarget.BackgroundColor = swm.Colors.Transparent;
 
 			var blurBehindParameters = new DWM_BLURBEHIND ();

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -1,6 +1,6 @@
 using Eto.Wpf.CustomControls;
-using Eto.Wpf.Forms.Menu;
 using Eto.Wpf.Drawing;
+using Eto.Wpf.Forms.Menu;
 using System.Windows.Input;
 using System.Windows.Threading;
 
@@ -148,7 +148,8 @@ namespace Eto.Wpf.Forms
 			{
 				SetWindowChrome();
 			}
-			
+			SetBlurBehind();
+
 			if (!Minimizable || !Maximizable)
 			{
 				SetResizeMode();
@@ -925,27 +926,20 @@ namespace Eto.Wpf.Forms
 			get { return Control.Opacity; }
 			set
 			{
-				if (Math.Abs(value - 1.0) > 0.01f)
+				Control.Opacity = value;
+				SetBlurBehind();
+				SetWindowTransparency();
+			}
+		}
+
+		private void SetBlurBehind()
+		{
+			if (isSourceInitialized)
+			{
+				if (Math.Abs(Control.Opacity - 1.0) > 0.01f)
 				{
-					if (Control.IsLoaded)
-					{
-						GlassHelper.BlurBehindWindow(Control);
-						//GlassHelper.ExtendGlassFrame (Control);
-						Control.Opacity = value;
-					}
-					else
-					{
-						Control.Loaded += delegate
-						{
-							GlassHelper.BlurBehindWindow(Control);
-							//GlassHelper.ExtendGlassFrame (Control);
-							Control.Opacity = value;
-						};
-					}
-				}
-				else
-				{
-					Control.Opacity = value;
+					GlassHelper.BlurBehindWindow(Control);
+					//GlassHelper.ExtendGlassFrame (Control);
 				}
 			}
 		}
@@ -1008,14 +1002,22 @@ namespace Eto.Wpf.Forms
 		{
 			if (!isSourceInitialized)
 				return;
-			var oldStyle = SaveWindowStyle();
-			var needsCustomWindowChrome = Resizable && WindowStyle == WindowStyle.None;
+			var needsCustomWindowChrome = (Resizable || Opacity < 1) && WindowStyle == WindowStyle.None;
+			
+			if (sw.Shell.WindowChrome.GetWindowChrome(Control) != null && WindowStyle == WindowStyle.None)
+			{
+				// keep window chrome if it is already set, unless WindowStyle is different
+				// E.g. turning off Resizable makes the background opaque if we remove the WindowChrome
+				return;
+			}
 
+			var oldStyle = SaveWindowStyle();
 			if (needsCustomWindowChrome)
 			{
 				var windowChrome = new sw.Shell.WindowChrome
 				{
 					CaptionHeight = 0,
+					GlassFrameThickness = sw.Shell.WindowChrome.GlassFrameCompleteThickness,
 					ResizeBorderThickness = new sw.Thickness(4)
 				};
 				sw.Shell.WindowChrome.SetWindowChrome(Control, windowChrome);
@@ -1067,7 +1069,13 @@ namespace Eto.Wpf.Forms
 		
 		void SetWindowTransparency()
 		{
-			var isTransparent = Control.Background is swm.SolidColorBrush scb && scb.Color.A < 255 && WindowStyle == WindowStyle.None;
+			// Windows doesn't support transparency otherwise..
+			if (WindowStyle != WindowStyle.None)
+				return;
+			var isTransparent =
+				Control.Background is swm.SolidColorBrush scb && scb.Color.A < 255
+				| Control.Opacity < 1.0;
+				
 			if (isSourceInitialized)
 			{
 				if (isTransparent != Control.AllowsTransparency)

--- a/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
@@ -46,7 +46,7 @@ namespace Eto.Test.Sections.Behaviors
 			layout.AddSeparateRow(null, ShowInTaskBar(), CloseableCheckBox(), TopMost(), VisibleCheckbox(), CreateShowActivatedCheckbox(), CreateCanFocus(), null);
 			layout.AddSeparateRow(null, "Type", CreateTypeControl(), "DisplayMode", DisplayModeDropDown(), null);
 			layout.AddSeparateRow(null, "Window Style", WindowStyle(), null);
-			layout.AddSeparateRow(null, "BackgroundColor", CreateBackgroundColorControl(), null);
+			layout.AddSeparateRow(null, "BackgroundColor", CreateBackgroundColorControl(), "Opacity", CreateOpacityControl(), null);
 			layout.AddSeparateRow(null, "Window State", WindowState(), null);
 			layout.AddSeparateRow(null, CreateMenuBarControls(), null);
 			layout.AddSeparateRow(null, CreateInitialLocationControls(), null);
@@ -87,6 +87,7 @@ namespace Eto.Test.Sections.Behaviors
 			public bool? Topmost { get; set; }
 			public WindowStyle WindowStyle { get; set; }
 			public WindowType WindowType { get; set; }
+			public double Opacity { get; set; } = 1;
 			bool setBackgroundColor;
 			public bool SetBackgroundColor
 			{
@@ -220,6 +221,14 @@ namespace Eto.Test.Sections.Behaviors
 			
 			backgroundColor.BindDataContext(c => c.Enabled, enabledBindingElseTrue);
 			return new TableLayout(new TableRow(enableBackgroundColor, backgroundColor));
+		}
+
+		Control CreateOpacityControl()
+		{
+			var opacity = new NumericStepper { MinValue = 0, MaxValue = 1, Increment = 0.1, DecimalPlaces = 2 };
+			opacity.ValueBinding.BindDataContext((SettingsWindow w) => w.Opacity);
+
+			return opacity;
 		}
 
 		Control DisplayModeDropDown()
@@ -589,6 +598,8 @@ namespace Eto.Test.Sections.Behaviors
 				Child.Menu = CreateMenuBar();
 			if (settings.SetBackgroundColor)
 				Child.BackgroundColor = settings.BackgroundColor;
+			if (settings.Opacity < 1)
+				Child.Opacity = settings.Opacity;
 			bringToFrontButton.Enabled = focusButton.Enabled = true;
 			DataContext = Child;
 			show();


### PR DESCRIPTION
Since the BackgroundColor is now set on the Window directly (to allow for transparency), setting opacity shouldn't set it to transparent.  Before, the BackgroundColor of a Window was set to its content so we needed to clear out, but no longer need to do that.