### PR TITLE
Wpf: Don't set GlassFrameThickness unless window uses transparency

### DIFF
--- a/src/Eto.Wpf/CustomControls/GlassHelper.cs
+++ b/src/Eto.Wpf/CustomControls/GlassHelper.cs
@@ -145,8 +145,6 @@ namespace Eto.Wpf.CustomControls
 					throw new InvalidOperationException(string.Format(CultureInfo.CurrentCulture, "The Window must be shown before extending glass."));
 				}
 
-				// Set the background to transparent from both the WPF and Win32 perspectives
-				window.Background = swm.Brushes.Transparent;
 				sw.Interop.HwndSource.FromHwnd (hwnd).CompositionTarget.BackgroundColor = swm.Colors.Transparent;
 
 				var margins = new MARGINS (margin);

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -183,6 +183,8 @@ namespace Eto.Wpf.Forms
 			return IntPtr.Zero;
 		}
 
+		swin.HwndSource HwndSource => sw.PresentationSource.FromVisual(Control) as swin.HwndSource;
+
 		private void Control_Loaded(object sender, sw.RoutedEventArgs e)
 		{
 			SetMinimumSize();
@@ -198,7 +200,7 @@ namespace Eto.Wpf.Forms
 			if (Control.ShowActivated)
 				Control.MoveFocus(new swi.TraversalRequest(swi.FocusNavigationDirection.Next));
 
-			((swin.HwndSource)sw.PresentationSource.FromVisual(Control))?.AddHook(HookProc);
+			HwndSource?.AddHook(HookProc);
 
 			if (FireOnLoadComplete)
 				Callback.OnLoadComplete(Widget, EventArgs.Empty);
@@ -932,14 +934,15 @@ namespace Eto.Wpf.Forms
 			}
 		}
 
+
 		private void SetBlurBehind()
 		{
 			if (isSourceInitialized)
 			{
-				if (Math.Abs(Control.Opacity - 1.0) > 0.01f)
+				if (Control.Opacity < 1 || BackgroundColor.A < 1)
 				{
 					GlassHelper.BlurBehindWindow(Control);
-					//GlassHelper.ExtendGlassFrame (Control);
+					// GlassHelper.ExtendGlassFrame(Control); // this is nice, but the title bar becomes transparent
 				}
 			}
 		}
@@ -1017,7 +1020,7 @@ namespace Eto.Wpf.Forms
 				var windowChrome = new sw.Shell.WindowChrome
 				{
 					CaptionHeight = 0,
-					GlassFrameThickness = sw.Shell.WindowChrome.GlassFrameCompleteThickness,
+					GlassFrameThickness = Control.AllowsTransparency ? sw.Shell.WindowChrome.GlassFrameCompleteThickness : default,
 					ResizeBorderThickness = new sw.Thickness(4)
 				};
 				sw.Shell.WindowChrome.SetWindowChrome(Control, windowChrome);
@@ -1064,9 +1067,10 @@ namespace Eto.Wpf.Forms
 			{
 				Control.Background = value.ToWpfBrush();
 				SetWindowTransparency();
+				SetBlurBehind();
 			}
 		}
-		
+
 		void SetWindowTransparency()
 		{
 			// Windows doesn't support transparency otherwise..
@@ -1075,7 +1079,7 @@ namespace Eto.Wpf.Forms
 			var isTransparent =
 				Control.Background is swm.SolidColorBrush scb && scb.Color.A < 255
 				| Control.Opacity < 1.0;
-				
+
 			if (isSourceInitialized)
 			{
 				if (isTransparent != Control.AllowsTransparency)

--- a/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
@@ -42,6 +42,7 @@ namespace Eto.Test.Sections.Behaviors
 			layout.Styles.Add<Label>(null, l => l.VerticalAlignment = VerticalAlignment.Center);
 
 			layout.AddSpace();
+			layout.AddSeparateRow(null, CreateResetButton(), null);
 			layout.AddSeparateRow(null, Resizable(), AutoSize(), Minimizable(), Maximizable(), MovableByWindowBackground(), null);
 			layout.AddSeparateRow(null, ShowInTaskBar(), CloseableCheckBox(), TopMost(), VisibleCheckbox(), CreateShowActivatedCheckbox(), CreateCanFocus(), null);
 			layout.AddSeparateRow(null, "Type", CreateTypeControl(), "DisplayMode", DisplayModeDropDown(), null);
@@ -60,19 +61,33 @@ namespace Eto.Test.Sections.Behaviors
 
 			Content = layout;
 
-			DataContext = settings = new SettingsWindow();
+			DataContext = settings = TestApplication.Settings.WindowSettings;
 		}
+
+		Control CreateResetButton()
+		{
+			var resetButton = new Button { Text = "Reset Settings" };
+			resetButton.Click += (sender, e) =>
+			{
+				settings = new SettingsWindow();
+				DataContext = settings;
+				TestApplication.Settings.WindowSettings = settings;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(settings)));
+			};
+			return resetButton;
+		}
+
 
 		SettingsWindow settings;
 
-		enum WindowType
+		public enum WindowType
 		{
 			Form,
 			FloatingForm,
 			Dialog
 		}
 
-		class SettingsWindow : INotifyPropertyChanged
+		public class SettingsWindow : INotifyPropertyChanged
 		{
 			public bool ThreeState => true; // enable three state for these settings
 			public bool? AutoSize { get; set; }
@@ -85,6 +100,7 @@ namespace Eto.Test.Sections.Behaviors
 			public bool? ShowInTaskbar { get; set; }
 			public bool? ShowActivated { get; set; }
 			public bool? Topmost { get; set; }
+			public bool SetOwner { get; set; }
 			public WindowStyle WindowStyle { get; set; }
 			public WindowType WindowType { get; set; }
 			public double Opacity { get; set; } = 1;
@@ -182,8 +198,17 @@ namespace Eto.Test.Sections.Behaviors
 		Control CreateSetOwnerCheckBox()
 		{
 			setOwnerCheckBox = new CheckBox { Text = "Set Owner" };
+			setOwnerCheckBox.BindDataContext(c => c.Checked, Binding.Delegate<object, bool?>((object w) =>
+			{
+				if (w is SettingsWindow settingsWindow)
+					return settingsWindow.SetOwner;
+				if (w is Window window)
+					return window.Owner != null;
+				return false;
+			}));
 			setOwnerCheckBox.CheckedChanged += (sender, e) =>
 			{
+				settings.SetOwner = setOwnerCheckBox.Checked ?? false;
 				if (Child != null)
 					Child.Owner = setOwnerCheckBox.Checked ?? false ? ParentWindow : null;
 			};
@@ -611,7 +636,6 @@ namespace Eto.Test.Sections.Behaviors
 		void child_Closed(object sender, EventArgs e)
 		{
 			Log.Write(Child, "Closed");
-			DataContext = settings;
 			Child.OwnerChanged -= child_OwnerChanged;
 			Child.WindowStateChanged -= child_WindowStateChanged;
 			Child.Closed -= child_Closed;
@@ -624,6 +648,7 @@ namespace Eto.Test.Sections.Behaviors
 			bringToFrontButton.Enabled = focusButton.Enabled = false;
 			Child.Unbind();
 			Child = null;
+			DataContext = settings;
 			// write out number of open windows after the closed event is called
 			Application.Instance.AsyncInvoke(() => Log.Write(null, "Open Windows: {0}", Application.Instance.Windows.Count()));
 		}

--- a/test/Eto.Test/Settings.cs
+++ b/test/Eto.Test/Settings.cs
@@ -1,4 +1,7 @@
-﻿namespace Eto.Test
+﻿
+using Eto.Test.Sections.Behaviors;
+
+namespace Eto.Test
 {
 	public class Settings
 	{
@@ -33,6 +36,8 @@
 		public List<bool> GridViewSection_ColumnAutoSize { get; set; }
 		public List<int> GridViewSection_DisplayIndexes { get; set; }
 		public List<bool> GridViewSection_VisibleIndexes { get; set; }
+		public WindowsSection.SettingsWindow WindowSettings { get; set; } = new WindowsSection.SettingsWindow();
+
 
 		public static Settings Load()
 		{


### PR DESCRIPTION
When the GlassFrameThickness is set, then any ElementHost will not display correctly.  This was introduced in #2777.

Also now save window section settings, setting them each time you run the test app is very tiring.

I also tested using GlassHelper.ExtendGlassFrame which makes the window fully transparent (e.g. no grey background) even with a title bar, but unfortunately the title bar itself is also transparent so it doesn't quite work.