### PR TITLE
Wpf: Set blur behind only once, and protect against having an zero hwnd

### DIFF
--- a/src/Eto.Wpf/CustomControls/GlassHelper.cs
+++ b/src/Eto.Wpf/CustomControls/GlassHelper.cs
@@ -100,6 +100,9 @@ namespace Eto.Wpf.CustomControls
 
 			var windowInteropHelper = new sw.Interop.WindowInteropHelper (window);
 			IntPtr myHwnd = windowInteropHelper.Handle;
+			if (myHwnd == IntPtr.Zero)
+				return false;
+				
 			var mainWindowSrc = System.Windows.Interop.HwndSource.FromHwnd (myHwnd);
 
 			mainWindowSrc.CompositionTarget.BackgroundColor = swm.Colors.Transparent;

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -31,6 +31,7 @@ namespace Eto.Wpf.Forms
 		internal static readonly object Resizable_Key = new object();
 		internal static readonly object Icon_Key = new object();
 		internal static readonly object ShowSystemMenu_Key = new object();
+		internal static readonly object DidBlurBehindWindow_Key = new object();
 	}
 	
 	public class EtoWindowContent : swc.DockPanel
@@ -937,9 +938,12 @@ namespace Eto.Wpf.Forms
 
 		private void SetBlurBehind()
 		{
-			if (isSourceInitialized)
+			if (!isSourceInitialized)
+				return;
+				
+			if (Control.Opacity < 1 || BackgroundColor.A < 1)
 			{
-				if (Control.Opacity < 1 || BackgroundColor.A < 1)
+				if (Widget.Properties.TrySet(WpfWindow.DidBlurBehindWindow_Key, true))
 				{
 					GlassHelper.BlurBehindWindow(Control);
 					// GlassHelper.ExtendGlassFrame(Control); // this is nice, but the title bar becomes transparent


### PR DESCRIPTION
If for example you set the Opacity to fade the window in a timer, it now calls the blur behind each time even though it is only required to be set once.