### PR TITLE
Mac: Fix layout of controls when constrained to a larger width

### DIFF
--- a/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
@@ -202,7 +202,7 @@ namespace Eto.Mac.Forms.Controls
 				else if (availableSize.Height < 0)
 					availableSize.Height = float.PositiveInfinity;
 
-				var preferred = (Content?.GetPreferredSize(availableSize) ?? Size.Empty);
+				var preferred = Content?.GetPreferredSize(availableSize) ?? Size.Empty;
 
 				if (availableSize.Width < 0)
 					size.Width = preferred.Width;
@@ -212,6 +212,24 @@ namespace Eto.Mac.Forms.Controls
 			else
 			{
 				var preferred = (Content?.GetPreferredSize(SizeF.PositiveInfinity) ?? Size.Empty) + Padding.Size;
+
+				if ((ExpandContentWidth && preferred.Width < clientSize.Width)
+					|| (ExpandContentHeight && preferred.Height < clientSize.Height))
+				{
+					var availableSize = SizeF.PositiveInfinity;
+					if (ExpandContentWidth && preferred.Width < clientSize.Width)
+						availableSize.Width = clientSize.Width;
+					if (ExpandContentHeight && preferred.Height < clientSize.Height)
+						availableSize.Height = clientSize.Height;
+
+					preferred = (Content?.GetPreferredSize(availableSize) ?? Size.Empty) + Padding.Size;
+
+					if (ExpandContentWidth && preferred.Width < clientSize.Width)
+						preferred.Width = clientSize.Width;
+					if (ExpandContentHeight && preferred.Height < clientSize.Height)
+						preferred.Height = clientSize.Height;
+				}					
+				
 				var vbar = preferred.Height > clientSize.Height;
 				var hbar = preferred.Width > clientSize.Width;
 				if (hbar || vbar)
@@ -230,17 +248,24 @@ namespace Eto.Mac.Forms.Controls
 			if (ctl == null)
 				return;
 			
-			var size = Content.GetPreferredSize(SizeF.PositiveInfinity).ToNS();
-
 			var padding = Padding;
 			var clientSize = ContentControl.Frame.Size.ToEto() - padding.Size;
+			
+			SizeF availableSize = SizeF.PositiveInfinity;
+			if (ExpandContentWidth)
+				availableSize.Width = clientSize.Width;
+			if (ExpandContentHeight)
+				availableSize.Height = clientSize.Height;
+			
+			var size = (Content?.GetPreferredSize(availableSize - Padding.Size) ?? Size.Empty) + Padding.Size;
+
 
 			if (ExpandContentWidth)
-				size.Width = (nfloat)Math.Max(clientSize.Width, size.Width);
+				size.Width = (float)Math.Max(clientSize.Width, size.Width);
 			if (ExpandContentHeight)
-				size.Height = (nfloat)Math.Max(clientSize.Height, size.Height);
+				size.Height = (float)Math.Max(clientSize.Height, size.Height);
 
-			var clientFrame = new CGRect(new CGPoint(padding.Left, (nfloat)(padding.Bottom + clientSize.Height - size.Height)), size);
+			var clientFrame = new CGRect(new CGPoint(padding.Left, (nfloat)(padding.Bottom + clientSize.Height - size.Height)), size.ToNS());
 
 			ctl.Frame = clientFrame;
 		}

--- a/src/Eto.Mac/Forms/MacPanel.cs
+++ b/src/Eto.Mac/Forms/MacPanel.cs
@@ -132,7 +132,15 @@ namespace Eto.Mac.Forms
 		protected override SizeF GetNaturalSize(SizeF availableSize)
 		{
 			if (content != null && content.Visible)
+			{
+				var preferredSize = UserPreferredSize;
+				if (preferredSize.Width >= 0 && double.IsPositiveInfinity(availableSize.Width))
+					availableSize.Width = preferredSize.Width;
+				if (preferredSize.Height >= 0 && double.IsPositiveInfinity(availableSize.Height))
+					availableSize.Height = preferredSize.Height;
+				
 				return content.GetPreferredSize(SizeF.Max(SizeF.Empty, availableSize - Padding.Size)) + Padding.Size;
+			}
 			
 			return Padding.Size;
 		}

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -772,9 +772,9 @@ namespace Eto.Mac.Forms
 			// only get natural size if the size isn't explicitly set.
 			if (preferredSize.Width == -1 || preferredSize.Height == -1)
 			{
-				if (preferredSize.Width >= 0)
+				if (preferredSize.Width >= 0 && double.IsPositiveInfinity(availableSize.Width))
 					availableSize.Width = preferredSize.Width;
-				if (preferredSize.Height >= 0)
+				if (preferredSize.Height >= 0 && double.IsPositiveInfinity(availableSize.Height))
 					availableSize.Height = preferredSize.Height;
 				size = GetNaturalSize(availableSize);
 			}

--- a/test/Eto.Test/UnitTests/Forms/ClipboardTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ClipboardTests.cs
@@ -381,16 +381,16 @@ namespace Eto.Test.UnitTests.Forms
 		}
 
 		[Test]
-		public void DisposedClipboardShouldNotBreak() => Async(async () =>
+		public void DisposedClipboardShouldNotBreak() => Async(() =>
 		{
 			var clipboard1 = new Clipboard();
 			clipboard1.Text = "Hello";
 			Assert.That(clipboard1.Text, Is.EqualTo("Hello"), "#1");
 			clipboard1.Dispose();
-			
+
 			GC.Collect();
 			GC.WaitForPendingFinalizers();
-			
+
 			var clipboard2 = new Clipboard();
 			Assert.That(clipboard2.Text, Is.EqualTo("Hello"), "#1");
 			clipboard2.Text = "Hello2";
@@ -399,10 +399,11 @@ namespace Eto.Test.UnitTests.Forms
 
 			GC.Collect();
 			GC.WaitForPendingFinalizers();
-			
+
 			using var clipboard3 = new Clipboard();
 			Assert.That(clipboard3.Text, Is.EqualTo("Hello2"), "#1");
 			clipboard3.Dispose();
+			return Task.CompletedTask;
 		});
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/Layout/LayoutTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Layout/LayoutTests.cs
@@ -39,7 +39,7 @@ namespace Eto.Test.UnitTests.Forms.Layout
 				// Gtk is annoying and returns 1,1 for size at this stage, others return 0,0.
 				Assert.That(control.Width, Is.LessThanOrEqualTo(1), "#2.1");
 				Assert.That(control.Height, Is.LessThanOrEqualTo(1), "#2.2");
-				
+
 				// macOS gives us a "flipped" view of the location at this point..
 				// the value of Location isn't valid here anyway.
 				if (!Platform.Instance.IsMac)
@@ -52,7 +52,7 @@ namespace Eto.Test.UnitTests.Forms.Layout
 					// Gtk, Wpf, and Mac all use deferred layouts so it still isn't set up here.
 					Assert.That(control.Width, Is.LessThanOrEqualTo(1), "#3.1");
 					Assert.That(control.Height, Is.LessThanOrEqualTo(1), "#3.2");
-					
+
 					if (!Platform.Instance.IsMac)
 						Assert.That(control.Location, Is.EqualTo(new Point(0, 0)), "#3.3");
 				}
@@ -75,5 +75,52 @@ namespace Eto.Test.UnitTests.Forms.Layout
 				Assert.That(Point.Round(table.PointFromScreen(control.PointToScreen(PointF.Empty))), Is.EqualTo(new Point(100, 100)), "#4.4");
 			});
 		}
+		
+		[Test]
+		public void LabelShouldGetProperSizeWhenContainerSizeIsSetInScrollable()
+		{
+			Label label = null;
+			ShownAsync(form =>
+			{
+				label = new Label { Text = "This label should be fully visible, but then mucks up the scroll size way too much", Wrap = WrapMode.Word };
+				var container = new Panel { Content = label, Width = 10 };
+				container.BackgroundColor = Colors.Blue;
+				var scrollable = new Scrollable
+				{
+					Size = new Size(300, 300),
+					Content = container
+				};
+				return scrollable;
+			},
+			async scrollable =>
+			{
+				await Task.Delay(100); // wait to see the results
+				Assert.That(label.Width, Is.GreaterThan(20), "#1");
+				Assert.That(scrollable.Content.Size, Is.EqualTo(scrollable.ClientSize), "#2");
+			});	
+		}		
+		[Test]
+		public void LabelShouldGetProperSizeWhenContainerSizeIsSet()
+		{
+			Label label = null;
+			ShownAsync(form =>
+			{
+				label = new Label { Text = "This label should be fully visible, but then mucks up the scroll size way too much", Wrap = WrapMode.Word };
+				var container = new Panel { Content = label, Width = 10 };
+				container.BackgroundColor = Colors.Blue;
+				var panel = new Panel
+				{
+					Size = new Size(300, 300),
+					Content = container
+				};
+				return panel;
+			},
+			async panel =>
+			{
+				await Task.Delay(100); // wait to see the results
+				Assert.That(label.Width, Is.GreaterThan(20), "#1");
+				Assert.That(panel.Content.Size, Is.EqualTo(panel.ClientSize), "#2");
+			});	
+		}		
 	}
 }

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -761,7 +761,7 @@ namespace Eto.Test.UnitTests
 				test = PropertyTest<T>(() => ctl, properties);
 				test.Run();
 				return ctl as Control;
-			}, async ctl => test.Run());
+			}, ctl => test.Run());
 		}
 
 		public class PropertyTestInfo


### PR DESCRIPTION
If a container with labels has a size set to a small size, but its parent expands its width due to its layout, the calculated preferred size of the label would be incorrect in that it would assume the smaller size for wrapping.

This is a common pattern for ensuring a Scrollable does not scroll horizontally until a particular size, and make labels wrap until it gets to that size.