### PR TITLE
Added a null check to prevent crash on Mac

### DIFF
--- a/src/Eto.Mac/Forms/MacFileDialog.cs
+++ b/src/Eto.Mac/Forms/MacFileDialog.cs
@@ -21,7 +21,7 @@ namespace Eto.Mac.Forms
 			if (h == null || url == null || Directory.Exists(url.Path))
 				return true;
 
-			var extension = Path.GetExtension(url.Path).TrimStart(new[] { '.' });
+			var extension = Path.GetExtension(url.Path)?.TrimStart(new[] { '.' }) ?? string.Empty;
 			var macFilters = h.MacFilters;
 			if (macFilters == null || macFilters.Contains(extension, StringComparer.InvariantCultureIgnoreCase))
 				return true;


### PR DESCRIPTION
I have a crash report for this file at this line and I notice that [Path.GetExtension](https://learn.microsoft.com/en-us/dotnet/api/system.io.path.getextension?view=net-9.0#system-io-path-getextension(system-string)) can return a null string which I gather is the culprit