### PR TITLE
Wpf: Fix issue removing a child from its parent

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/PanelHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/PanelHandler.cs
@@ -12,6 +12,8 @@ namespace Eto.Wpf.Forms.Controls
 			};
 		}
 
+		protected override swc.Border CreateContentBorder() => Control;
+
 		public override Color BackgroundColor
 		{
 			get { return Control.Background.ToEtoColor(); }
@@ -20,7 +22,6 @@ namespace Eto.Wpf.Forms.Controls
 
 		public override void SetContainerContent(sw.FrameworkElement content)
 		{
-			Control.Child = content;
 		}
 	}
 }

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -939,12 +939,9 @@ namespace Eto.Wpf.Forms
 
 		public virtual void SetParent(Container oldParent, Container newParent)
 		{
-			if (newParent == null && Widget.VisualParent != null)
+			if (oldParent?.Handler is IWpfContainer oldContainer)
 			{
-				// don't use GetWpfContainer() extension as we don't want to traverse themed controls
-				var currentParent = Widget.VisualParent.Handler as IWpfContainer;
-				if (currentParent != null)
-					currentParent.Remove(ContainerControl);
+				oldContainer.Remove(ContainerControl);
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/WpfPanel.cs
+++ b/src/Eto.Wpf/Forms/WpfPanel.cs
@@ -7,9 +7,9 @@ namespace Eto.Wpf.Forms
 		where TWidget : Panel
 		where TCallback : Panel.ICallback
 	{
-		Control content;
-		readonly swc.Border border;
-		Size? clientSize;
+		Control _content;
+		swc.Border _border;
+		Size? _clientSize;
 
 		public override bool Enabled
 		{
@@ -19,7 +19,7 @@ namespace Eto.Wpf.Forms
 				base.Enabled = value;
 
 				// some controls (Expander, GroupBox, Scrollable, etc) don't directly affect children for some (strange) reason.
-				border.IsEnabled = value;
+				ContentBorder.IsEnabled = value;
 			}
 		}
 
@@ -28,16 +28,16 @@ namespace Eto.Wpf.Forms
 			get
 			{
 				if (!Control.IsLoaded)
-					return clientSize ?? Size;
+					return _clientSize ?? Size;
 				// when the child of a border is null, it doesn't return the correct size
-				if (border.Child == null)
+				if (ContentBorder.Child == null)
 					return Size;
-				return border.GetSize();
+				return ContentBorder.GetSize();
 			}
 			set
 			{
-				clientSize = value;
-				border.SetSize(value);
+				_clientSize = value;
+				ContentBorder.SetSize(value);
 			}
 		}
 
@@ -50,7 +50,7 @@ namespace Eto.Wpf.Forms
 
 		protected virtual void SetContentScale(bool xscale, bool yscale)
 		{
-			var contentHandler = content.GetWpfFrameworkElement();
+			var contentHandler = _content.GetWpfFrameworkElement();
 			if (contentHandler != null)
 			{
 				contentHandler.SetScale(xscale, yscale);
@@ -70,7 +70,13 @@ namespace Eto.Wpf.Forms
 
 		protected WpfPanel()
 		{
-			border = new swc.Border
+		}
+
+		swc.Border ContentBorder => _border ??= CreateContentBorder();
+
+		protected virtual swc.Border CreateContentBorder()
+		{
+			return new swc.Border
 			{
 				SnapsToDevicePixels = true,
 				Focusable = false,
@@ -80,46 +86,46 @@ namespace Eto.Wpf.Forms
 		protected override void Initialize()
 		{
 			base.Initialize();
-			SetContainerContent(border);
+			SetContainerContent(ContentBorder);
 		}
 
 		public Padding Padding
 		{
-			get { return border.Padding.ToEto(); }
-			set { border.Padding = value.ToWpf(); }
+			get { return ContentBorder.Padding.ToEto(); }
+			set { ContentBorder.Padding = value.ToWpf(); }
 		}
 
 		public Control Content
 		{
-			get { return content; }
+			get { return _content; }
 			set
 			{
-				content = value;
-				if (content != null)
+				_content = value;
+				if (_content != null)
 				{
-					var wpfelement = content.GetWpfFrameworkElement();
+					var wpfelement = _content.GetWpfFrameworkElement();
 					var element = wpfelement.ContainerControl;
 					element.VerticalAlignment = System.Windows.VerticalAlignment.Stretch;
 					element.HorizontalAlignment = System.Windows.HorizontalAlignment.Stretch;
-					border.Child = element;
+					ContentBorder.Child = element;
 					if (Widget.Loaded)
 						SetContentScale(XScale, YScale);
 				}
 				else
-					border.Child = null;
+					ContentBorder.Child = null;
 				Control.InvalidateMeasure();
 				OnChildPreferredSizeUpdated();
 			}
 		}
-
+		
 		public abstract void SetContainerContent(sw.FrameworkElement content);
 
 		public override void Remove(sw.FrameworkElement child)
 		{
-			if (border.Child == child)
+			if (ContentBorder.Child == child)
 			{
-				content = null;
-				border.Child = null;
+				_content = null;
+				ContentBorder.Child = null;
 				OnChildPreferredSizeUpdated();
 			}
 		}

--- a/src/Eto/Forms/Container.cs
+++ b/src/Eto/Forms/Container.cs
@@ -280,11 +280,11 @@ public abstract class Container : Control, IBindableWidgetContainer
 	{
 		if (Handler is IThemedControlHandler)
 		{
-			if (!ReferenceEquals(child, null))
+			if (child is not null)
 				RemoveLogicalParent(child);
 			return;
 		}
-		if (!ReferenceEquals(child, null) && !ReferenceEquals(child.VisualParent, null))
+		if (child is not null && child.VisualParent is not null)
 		{
 #if DEBUG
 			if (!ReferenceEquals(child.VisualParent, this))
@@ -374,24 +374,7 @@ public abstract class Container : Control, IBindableWidgetContainer
 		}
 		if (previousChild is not null && !ReferenceEquals(previousChild, child))
 		{
-#if DEBUG
-			if (!ReferenceEquals(previousChild.VisualParent, this))
-				throw new ArgumentException("The previous child control is not a child of this container. Ensure you only remove children that you own.");
-#endif
-
-			if (previousChild.VisualParent is not null)
-			{
-				if (previousChild.Loaded)
-				{
-					previousChild.TriggerUnLoad(EventArgs.Empty);
-				}
-				previousChild.VisualParent = null;
-			}
-
-			if (ReferenceEquals(previousChild.InternalLogicalParent, this))
-			{
-				previousChild.InternalLogicalParent = null;
-			}
+			RemoveParent(previousChild);
 		}
 		if (child is not null && !ReferenceEquals(child.VisualParent, this))
 		{

--- a/test/Eto.Test.Wpf/UnitTests/ContainerTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/ContainerTests.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Eto.Test.UnitTests;
+using Eto.Wpf.Forms;
+using NUnit.Framework;
+
+namespace Eto.Test.Wpf.UnitTests;
+
+[TestFixture]
+public class ContainerTests : TestBase
+{
+	[Test]
+	public void RemovingChildShouldClearParent() => Invoke(() =>
+	{
+		var container = new Eto.Forms.Panel();
+		var containerHandler = container.Handler as Eto.Wpf.Forms.Controls.PanelHandler;
+		var child = new Eto.Forms.Label { Text = "Child" };
+		var childHandler = child.Handler as Eto.Wpf.Forms.Controls.LabelHandler;
+
+		Assert.That(containerHandler, Is.Not.Null, "#1.1");
+		Assert.That(childHandler, Is.Not.Null, "#1.2");
+
+		container.Content = child;
+
+		var borderField = typeof(WpfPanel<swc.Border, Panel, Panel.ICallback>).GetField("_border", BindingFlags.NonPublic | BindingFlags.Instance);
+		var border = borderField?.GetValue(containerHandler) as swc.Border;
+
+		Assert.That(border, Is.Not.Null, "#2.1");
+		Assert.That(border.Child, Is.EqualTo(childHandler.ContainerControl), "#2.2");
+		Assert.That(container.Content, Is.EqualTo(child), "#2.3");
+		Assert.That(child.Parent, Is.EqualTo(container), "#2.4");
+
+		container.Content = null;
+
+		Assert.That(container.Content, Is.Null, "#3.1");
+		Assert.That(child.Parent, Is.Null, "#3.2");
+
+		Assert.That(containerHandler.Control.Child, Is.Null, "#3.3");
+		Assert.That(childHandler.Control.Parent, Is.Null, "#3.4");
+	});
+
+}

--- a/test/Eto.Test/UnitTests/Forms/ContainerTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ContainerTests.cs
@@ -279,7 +279,8 @@ namespace Eto.Test.UnitTests.Forms
 					radio.EnabledChanged += (sender, e) => label.Text = $"EnabledChanged->radio.Enabled({radio.Enabled})";
 					radio.Enabled = initiallyEnabled;
 					Assert.That(radio.Enabled, Is.EqualTo(initiallyEnabled), "#1.1");
-					check.CheckedChanged += (sender, e) => {
+					check.CheckedChanged += (sender, e) =>
+					{
 						var isChecked = check.Checked == true;
 						radio.Enabled = isChecked;
 						changedCount++;
@@ -305,6 +306,52 @@ namespace Eto.Test.UnitTests.Forms
 			Assert.That(changedCount, Is.GreaterThanOrEqualTo(2), "#2.2 - The check box was not toggled at least twice");
 			Assert.That(initialStateMatchesInitiallyEnabled, Is.True, "#2.3 - initial state of radio button did not match");
 		}
+
+
+		[Test]
+		public void ChildrenShouldAllowRemingAndAddingToAnotherContainer() => ShownAsync(form =>
+		{
+			var content = new Panel { Size = new Size(200, 200) };
+			form.Content = content;
+			return content;			
+		}, async panel =>
+		{
+			var container = new Panel();
+			var control = new TextBox(); // { BackgroundColor = Colors.Blue, Size = new Size(200, 200) };
+			container.Content = control;
+			panel.Content = container;
+
+			await Task.Delay(1000);
+
+			Assert.That(container.Content, Is.EqualTo(control), "#1.1 - Content should be set correctly");
+			Assert.That(control.Parent, Is.EqualTo(container), "#1.2 - Child's parent should be the container");
+
+			var container2 = new TableLayout();
+			container2.Rows.Add(new TableRow(new TableCell(control)));
+			panel.Content = container2;
+
+			await Task.Delay(1000);
+
+			Assert.That(container.Content, Is.Null, "#2.1 - Content should be removed");
+			Assert.That(container2.Rows[0].Cells[0].Control, Is.EqualTo(control), "#2.2 - Content on the second container should be set correctly");
+			Assert.That(control.Parent, Is.EqualTo(container2), "#2.3 - Child's parent should be the second container");
+
+			var container3 = new GroupBox();
+			container3.Content = control;
+			panel.Content = container3;
+
+			await Task.Delay(1000);
+
+			Assert.That(container2.Rows[0].Cells[0].Control, Is.Null, "#3.1 - Content on the second container should be set correctly");
+			Assert.That(container3.Content, Is.EqualTo(control), "#3.2 - Content should be set correctly");
+			Assert.That(control.Parent, Is.EqualTo(container3), "#3.3 - Child's parent should be the second container");
+
+			container3.Content = null;
+
+			await Task.Delay(1000);
+			
+			Assert.That(control.Parent, Is.Null, "#4.2 - Control should not have a parent");
+		}, timeout: 10000);
 
 	}
 }

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -604,7 +604,7 @@ namespace Eto.Test.UnitTests
 			},
 				c =>
 				{
-					test(c);
+					test?.Invoke(c);
 					return Task.CompletedTask;
 				},
 				replay,


### PR DESCRIPTION
When a child gets removed, it would not actually be removed from its container.   This could sometimes lead to exceptions trying to reuse the control in other places, or when rebuilding the UI layout.