### PR TITLE
Wpf: Don't create source for windows when setting Focusable property

### DIFF
--- a/src/Eto.Wpf/Forms/FormHandler.cs
+++ b/src/Eto.Wpf/Forms/FormHandler.cs
@@ -88,11 +88,25 @@ public class FormHandler : WpfWindow<sw.Window, Form, Form.ICallback>, Form.IHan
 		set
 		{
 			Control.Focusable = value;
-			SetStyleEx(Win32.WS_EX.NOACTIVATE, !value);
-			SetStyle(Win32.WS.CHILD, !value);
+			if (IsSourceInitialized)
+			{
+				SetStyleEx(Win32.WS_EX.NOACTIVATE, !value);
+				SetStyle(Win32.WS.CHILD, !value);
+			}
 		}
 	}
-	
+
+	protected override void OnSourceInitialized()
+	{
+		base.OnSourceInitialized();
+		var focusable = Control.Focusable;
+		if (!focusable)
+		{
+			SetStyleEx(Win32.WS_EX.NOACTIVATE, !focusable);
+			SetStyle(Win32.WS.CHILD, !focusable);
+		}
+	}
+
 	public override void Focus()
 	{
 		if (!Control.Focusable)

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -55,6 +55,8 @@ namespace Eto.Wpf.Forms
 		Point? initialLocation;
 		bool isSourceInitialized;
 
+		public bool IsSourceInitialized => isSourceInitialized;
+
 		protected virtual bool IsAttached => false;
 
 		sw.Interop.WindowInteropHelper windowInterop;
@@ -126,7 +128,7 @@ namespace Eto.Wpf.Forms
 			main.Children.Add(toolBarHolder);
 			main.Children.Add(content);
 			Control.Content = main;
-			Control.SourceInitialized += Control_SourceInitialized;
+			Control.SourceInitialized += (sender, e) => OnSourceInitialized();
 			Control.Loaded += Control_Loaded;
 			Control.PreviewKeyDown += (sender, e) =>
 			{
@@ -141,7 +143,7 @@ namespace Eto.Wpf.Forms
 			HandleEvent(Window.ClosingEvent);
 		}
 
-		private void Control_SourceInitialized(object sender, EventArgs e)
+		protected virtual void OnSourceInitialized()
 		{
 			isSourceInitialized = true;
 


### PR DESCRIPTION
This would cause the window to show blank briefly before it is fully loaded.