### PR TITLE
Add UseMnemonic and AlwaysShowMnemonic properties

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk3.cs
+++ b/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk3.cs
@@ -12,6 +12,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		where TCallback : Button.ICallback
 	{
 		readonly Gtk.AccelLabel label;
+		string _text;
 
 		Gtk.Image gtkimage;
 
@@ -22,6 +23,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		public ButtonHandler()
 		{
 			label = new Gtk.AccelLabel(string.Empty);
+			label.UseUnderline = true;
 			label.Ellipsize = Pango.EllipsizeMode.End;
 			label.Show();
 		}
@@ -52,10 +54,14 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public override string Text
 		{
-			get { return label.Text.ToEtoMnemonic(); }
+			get => _text;
 			set
 			{
-				label.TextWithMnemonic = value.ToPlatformMnemonic();
+				_text = value;
+				if (label.UseUnderline)
+					label.TextWithMnemonic = _text.ToPlatformMnemonic();
+				else
+					label.Text = _text;
 				SetImagePosition();
 			}
 		}
@@ -176,6 +182,25 @@ namespace Eto.GtkSharp.Forms.Controls
 					Control.QueueResize(); 
 				}
 			}
+		}
+
+		public bool UseMnemonic
+		{
+			get => label.UseUnderline;
+			set
+			{
+				if (value == label.UseUnderline)
+					return; // no change
+				var text = Text;
+				label.UseUnderline = value;
+				Text = text;
+			}
+		}
+		
+		public bool AlwaysShowMnemonic
+		{
+			get => false;
+			set { /* not supported in GTK */ }
 		}
 
 		protected override void SetSize(Size size)

--- a/src/Eto.Gtk/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/CheckBoxHandler.cs
@@ -1,6 +1,3 @@
-using Eto.GtkSharp.Drawing;
-using Gtk;
-
 namespace Eto.GtkSharp.Forms.Controls
 {
 	public class CheckBoxHandler : GtkControl<Gtk.CheckButton, CheckBox, CheckBox.ICallback>, CheckBox.IHandler
@@ -13,7 +10,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public CheckBoxHandler()
 		{
-			Control = new Gtk.CheckButton();
+			Control = new Gtk.CheckButton { UseUnderline = true };
 			box = new Gtk.EventBox { Child = Control };
 		}
 
@@ -66,7 +63,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			get { return Control.Label.ToEtoMnemonic(); }
 			set {
 				var needsFont = Control.Child == null && Widget.Properties.ContainsKey(GtkControl.Font_Key);
-				Control.Label = value.ToPlatformMnemonic();
+				Control.Label = Control.UseUnderline ? value.ToPlatformMnemonic() : value;
 				if (needsFont)
 					Control.Child?.SetFont(Font.ToPango());
 			}
@@ -116,6 +113,25 @@ namespace Eto.GtkSharp.Forms.Controls
 				child.SetForeground(value, GtkStateFlags.Active);
 				child.SetForeground(value, GtkStateFlags.Prelight);
 			}
+		}
+
+		public bool UseMnemonic
+		{
+			get => Control.UseUnderline;
+			set
+			{
+				if (value == Control.UseUnderline)
+					return; // no change
+				var text = Text;
+				Control.UseUnderline = value;
+				Text = text;
+			}
+		}
+		
+		public bool AlwaysShowMnemonic
+		{
+			get => false;
+			set { /* not supported in GTK */ }
 		}
 
 		public override void AttachEvent(string id)

--- a/src/Eto.Gtk/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/LabelHandler.cs
@@ -4,6 +4,7 @@ namespace Eto.GtkSharp.Forms.Controls
 {
 	public class LabelHandler : GtkControl<LabelHandler.EtoLabel, Label, Label.ICallback>, Label.IHandler
 	{
+		string _text;
 		readonly Gtk.EventBox eventBox;
 		TextAlignment horizontalAlign = TextAlignment.Left;
 		VerticalAlignment verticalAlign = VerticalAlignment.Top;
@@ -119,6 +120,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			eventBox.ResizeMode = Gtk.ResizeMode.Immediate;
 #endif
 			Control = new EtoLabel();
+			Control.UseUnderline = true;
 			Control.Xalign = 0;
 			Control.Yalign = 0;
 			eventBox.Child = Control;
@@ -188,11 +190,15 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public override string Text
 		{
-			get { return Control.Text.ToEtoMnemonic(); }
+			get => _text;
 			set
 			{
 				Control.ResetWidth();
-				Control.TextWithMnemonic = value.ToPlatformMnemonic();
+				_text = value;
+				if (Control.UseUnderline)
+					Control.TextWithMnemonic = _text.ToPlatformMnemonic();
+				else
+					Control.Text = _text;
 				InvalidateMeasure();
 			}
 		}
@@ -237,6 +243,25 @@ namespace Eto.GtkSharp.Forms.Controls
 				base.Font = value;
 				Control.Attributes = value != null ? ((FontHandler)value.Handler).Attributes : null;
 			}
+		}
+
+		public bool UseMnemonic
+		{
+			get => Control.UseUnderline;
+			set
+			{
+				if (value == Control.UseUnderline)
+					return; // no change
+				var text = Text;
+				Control.UseUnderline = value;
+				Text = text;
+			}
+		}
+
+		public bool AlwaysShowMnemonic
+		{
+			get => false;
+			set { /* not supported in GTK */ }
 		}
 	}
 }

--- a/src/Eto.Gtk/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/RadioButtonHandler.cs
@@ -2,18 +2,13 @@ namespace Eto.GtkSharp.Forms.Controls
 {
 	public class RadioButtonHandler : GtkControl<Gtk.RadioButton, RadioButton, RadioButton.ICallback>, RadioButton.IHandler
 	{
-		Gtk.EventBox box;
-		Gtk.AccelLabel label;
+		Gtk.EventBox _box;
+		Gtk.AccelLabel _label;
+		string _text;
 
-		protected override Gtk.Widget FontControl
-		{
-			get { return label; }
-		}
+		protected override Gtk.Widget FontControl => _label;
 
-		public override Gtk.Widget ContainerControl
-		{
-			get { return box; }
-		}
+		public override Gtk.Widget ContainerControl => _box;
 
 		public void Create(RadioButton controller)
 		{
@@ -26,28 +21,32 @@ namespace Eto.GtkSharp.Forms.Controls
 				var inactive = new Gtk.RadioButton(Control);
 				inactive.Active = true;
 			}
-			label = new Gtk.AccelLabel("");
-			Control.Add(label);
+			_label = new Gtk.AccelLabel("");
+			_label.UseUnderline = true;
+			Control.Add(_label);
 			Control.Realized += Connector.Control_Realized;
 
 			Control.Toggled += Connector.HandleCheckedChanged;
-			box = new Gtk.EventBox();
-			box.Child = Control;
+			_box = new Gtk.EventBox();
+			_box.Child = Control;
 		}
 
 		void UpdateLabel()
 		{
 			// if Text present show label, otherwise hide it.
-			if (label.Text != null && label.Text != string.Empty){
-				label.Visible = true;
-			} else {
-				label.Visible = false;
+			if (_label.Text != null && _label.Text != string.Empty)
+			{
+				_label.Visible = true;
+			}
+			else
+			{
+				_label.Visible = false;
 			}
 		}
 
-		void Control_Realized (object sender, EventArgs e)
+		void Control_Realized(object sender, EventArgs e)
 		{
-			UpdateLabel ();
+			UpdateLabel();
 		}
 
 		protected new RadioButtonConnector Connector { get { return (RadioButtonConnector)base.Connector; } }
@@ -68,10 +67,15 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public override string Text
 		{
-			get { return label.Text.ToEtoMnemonic(); }
-			set {
-				label.TextWithMnemonic = value.ToPlatformMnemonic();
-				UpdateLabel ();
+			get => _text;
+			set
+			{
+				_text = value;
+				if (_label.UseUnderline)
+					_label.TextWithMnemonic = _text.ToPlatformMnemonic();
+				else
+					_label.Text = _text;
+				UpdateLabel();
 			}
 		}
 
@@ -83,13 +87,32 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public Color TextColor
 		{
-			get { return label.GetForeground(); }
+			get { return _label.GetForeground(); }
 			set
 			{
-				label.SetForeground(value, GtkStateFlags.Normal);
-				label.SetForeground(value, GtkStateFlags.Active);
-				label.SetForeground(value, GtkStateFlags.Prelight);
+				_label.SetForeground(value, GtkStateFlags.Normal);
+				_label.SetForeground(value, GtkStateFlags.Active);
+				_label.SetForeground(value, GtkStateFlags.Prelight);
 			}
+		}
+
+		public bool UseMnemonic
+		{
+			get => _label.UseUnderline;
+			set
+			{
+				if (value == _label.UseUnderline)
+					return; // no change
+				var text = Text;
+				_label.UseUnderline = value;
+				Text = text;
+			}
+		}
+
+		public bool AlwaysShowMnemonic
+		{
+			get => false;
+			set { /* not supported in GTK */ }
 		}
 	}
 }

--- a/src/Eto.Gtk/Platform.cs
+++ b/src/Eto.Gtk/Platform.cs
@@ -51,7 +51,7 @@ namespace Eto.GtkSharp
 		public override string ID => "Gtk3";
 #endif
 
-		public override PlatformFeatures SupportedFeatures => PlatformFeatures.DrawableWithTransparentContent;
+		public override PlatformFeatures SupportedFeatures => PlatformFeatures.DrawableWithTransparentContent | PlatformFeatures.Mnemonics;
 
 #endif
 		public Platform()

--- a/src/Eto.Mac/Forms/Controls/MacButton.cs
+++ b/src/Eto.Mac/Forms/Controls/MacButton.cs
@@ -1,47 +1,76 @@
 namespace Eto.Mac.Forms.Controls
 {
 	public abstract class MacButton<TControl, TWidget, TCallback> : MacControl<TControl, TWidget, TCallback>, TextControl.IHandler
-		where TControl: NSButton
-		where TWidget: Control
-		where TCallback: Control.ICallback
+		where TControl : NSButton
+		where TWidget : Control
+		where TCallback : Control.ICallback
 	{
-		static readonly object textKey = new object();
+		MacMnemonicString _str;
+
+		MacMnemonicString MnemonicString => _str ??= new();
 
 		public virtual string Text
 		{
-			get { return Widget.Properties.Get<string>(textKey); }
+			get { return _str?.Text ?? string.Empty; }
 			set
 			{
-				Widget.Properties[textKey] = value;
-				SetText(value);
+				MnemonicString.Text = value;
+				SetAttributes();
 				InvalidateMeasure();
 			}
 		}
 
-		static readonly object textColorKey = new object();
-
 		public virtual Color TextColor
 		{
-			get { return Widget.Properties.Get<Color?>(textColorKey) ?? NSColor.ControlText.ToEto(); }
-			set {
+			get { return _str?.TextColor ?? NSColor.ControlText.ToEto(); }
+			set
+			{
 				if (value != TextColor)
 				{
-					Widget.Properties[textColorKey] = value;
-					SetText(Text);
+					MnemonicString.TextColor = value;
+					SetAttributes();
 				}
 			}
 		}
-
-		void SetText(string text)
+		
+		public bool UseMnemonic
 		{
-			Control.Title = MacConversions.StripAmpersands(text ?? string.Empty);
-			var color = Widget.Properties.Get<Color?>(textColorKey);
-			if (color != null)
+			get => _str.UseMnemonic;
+			set
 			{
-				var attr = NSDictionary.FromObjectAndKey(color.Value.ToNSUI(), NSStringAttributeKey.ForegroundColor);
-				var str = new NSMutableAttributedString(Control.AttributedTitle);
-				str.AddAttributes(attr, new NSRange(0, str.Length));
-				Control.AttributedTitle = str;
+				MnemonicString.UseMnemonic = value;
+				SetAttributes();
+			}
+		}
+		
+		public bool AlwaysShowMnemonic
+		{
+			get => _str.AlwaysShowMnemonic;
+			set
+			{
+				MnemonicString.AlwaysShowMnemonic = value;
+				SetAttributes();
+			}
+		}
+		
+		public override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+			SetAttributes(true);
+		}
+
+		protected override SizeF GetNaturalSize(SizeF availableSize)
+		{
+			if (!Widget.Loaded)
+				SetAttributes(true);
+			return base.GetNaturalSize(availableSize);
+		}
+
+		void SetAttributes(bool force = false)
+		{
+			if (Widget.Loaded || force)
+			{
+				Control.AttributedTitle = _str?.AttributedString ?? new NSAttributedString();
 			}
 		}
 	}

--- a/src/Eto.Mac/Forms/Controls/MacLabel.cs
+++ b/src/Eto.Mac/Forms/Controls/MacLabel.cs
@@ -78,26 +78,17 @@ namespace Eto.Mac.Forms.Controls
 		}
 	}
 
-	static class MacLabel
-	{
-		public static readonly object InSizingKey = new object();
-
-		public static readonly object FontKey = new object();
-
-		public static readonly object TextColorKey = new object();
-	}
-
 	public abstract class MacLabel<TControl, TWidget, TCallback> : MacView<TControl, TWidget, TCallback>
 		where TControl: NSTextField
 		where TWidget: Control
 		where TCallback: Control.ICallback
 	{
-		readonly NSMutableAttributedString str;
-		readonly NSMutableParagraphStyle paragraphStyle;
-		int underlineIndex;
-		Size availableSizeCached;
-
+		readonly MacMnemonicString _str = new();
+		Size _availableSizeCached;
+		
 		public override NSView ContainerControl => Control;
+
+		protected override bool DefaultUseAlignmentFrame => true;
 
 		protected override SizeF GetNaturalSize(SizeF availableSize)
 		{
@@ -112,8 +103,13 @@ namespace Eto.Mac.Forms.Controls
 
 				var width = UserPreferredSize.Width;
 				if (width < 0) width = int.MaxValue;
-				var size = Control.Cell.CellSizeForBounds(new CGRect(0, 0, width, int.MaxValue)).ToEto();
-				NaturalSizeInfinity = Size.Ceiling(size);
+				if (UseAlignmentFrame && width < int.MaxValue)
+					width = (int)Control.GetFrameForAlignmentRect(new CGRect(0, 0, width, int.MaxValue)).Size.Width;
+				var size = Control.Cell.CellSizeForBounds(new CGRect(0, 0, width, int.MaxValue));
+				if (UseAlignmentFrame)
+					size = Control.GetAlignmentRectForFrame(new CGRect(CGPoint.Empty, size)).Size;
+				
+				NaturalSizeInfinity = Size.Ceiling(size.ToEto());
 				return NaturalSizeInfinity.Value;
 			}
 
@@ -130,11 +126,17 @@ namespace Eto.Mac.Forms.Controls
 			}
 
 			var availableSizeTruncated = availableSize.TruncateInfinity();
-			if (NaturalSize == null || availableSizeCached != availableSizeTruncated)
+			if (NaturalSize == null || _availableSizeCached != availableSizeTruncated)
 			{
-				var size = Control.Cell.CellSizeForBounds(new CGRect(CGPoint.Empty, availableSizeTruncated.ToNS())).ToEto();
-				NaturalSize = Size.Ceiling(size);
-				availableSizeCached = availableSizeTruncated;
+				// var size = _str.AttributedString.BoundingRectWithSize(availableSizeTruncated.ToNS(), 0).Size;
+				if (UseAlignmentFrame)
+					availableSizeTruncated = Control.GetFrameForAlignmentRect(new CGRect(CGPoint.Empty, availableSizeTruncated.ToNS())).Size.ToEtoSize();
+				var size = Control.Cell.CellSizeForBounds(new CGRect(CGPoint.Empty, availableSizeTruncated.ToNS()));
+				if (UseAlignmentFrame)
+					size = Control.GetAlignmentRectForFrame(new CGRect(CGPoint.Empty, size)).Size;
+					
+				NaturalSize = Size.Ceiling(size.ToEto());
+				_availableSizeCached = availableSizeTruncated;
 			}
 
 			return NaturalSize.Value;
@@ -142,11 +144,7 @@ namespace Eto.Mac.Forms.Controls
 
 		protected MacLabel()
 		{
-			paragraphStyle = new NSMutableParagraphStyle();
-			str = new NSMutableAttributedString();
-
-			underlineIndex = -1;
-			paragraphStyle.LineBreakMode = NSLineBreakMode.ByWordWrapping;
+			_str.Wrap = WrapMode.Word;
 		}
 
 		protected override void Initialize()
@@ -162,10 +160,10 @@ namespace Eto.Mac.Forms.Controls
 
 		public Color TextColor
 		{
-			get { return Widget.Properties.Get<Color?>(MacLabel.TextColorKey) ?? SystemColors.ControlText; }
+			get => _str.TextColor ?? SystemColors.ControlText;
 			set
 			{
-				Widget.Properties[MacLabel.TextColorKey] = value;
+				_str.TextColor = value;
 				SetAttributes();
 			}
 		}
@@ -184,30 +182,10 @@ namespace Eto.Mac.Forms.Controls
 
 		public WrapMode Wrap
 		{
-			get
-			{
-				if (paragraphStyle.LineBreakMode == NSLineBreakMode.Clipping)
-					return WrapMode.None;
-				if (paragraphStyle.LineBreakMode == NSLineBreakMode.ByWordWrapping)
-					return WrapMode.Word;
-				return WrapMode.Character;
-			}
+			get => _str.Wrap;
 			set
 			{
-				switch (value)
-				{
-					case WrapMode.None:
-						paragraphStyle.LineBreakMode = NSLineBreakMode.Clipping;
-						break;
-					case WrapMode.Word:
-						paragraphStyle.LineBreakMode = NSLineBreakMode.ByWordWrapping;
-						break;
-					case WrapMode.Character:
-						paragraphStyle.LineBreakMode = NSLineBreakMode.CharWrapping;
-						break;
-					default:
-						throw new NotSupportedException();
-				}
+				_str.Wrap = value;
 				SetAttributes();
 				InvalidateMeasure();
 			}
@@ -215,32 +193,10 @@ namespace Eto.Mac.Forms.Controls
 
 		public string Text
 		{
-			get { return str.Value; }
+			get => _str.Text;
 			set
 			{
-				if (string.IsNullOrEmpty(value))
-				{
-					str.SetString(new NSMutableAttributedString());
-				}
-				else
-				{
-					var match = Regex.Match(value, @"(?<=([^&](?:[&]{2})*)|^)[&](?![&])");
-					if (match.Success)
-					{
-						var val = value.Remove(match.Index, match.Length).Replace("&&", "&");
-
-						var matches = Regex.Matches(value, @"[&][&]");
-						var prefixCount = matches.Cast<Match>().Count(r => r.Index < match.Index);
-
-						str.SetString(new NSAttributedString(val));
-						underlineIndex = match.Index - prefixCount;
-					}
-					else
-					{
-						str.SetString(new NSAttributedString(value.Replace("&&", "&")));
-						underlineIndex = -1;
-					}
-				}
+				_str.Text = value;
 				SetAttributes();
 				InvalidateMeasure();
 			}
@@ -248,10 +204,10 @@ namespace Eto.Mac.Forms.Controls
 
 		public TextAlignment TextAlignment
 		{
-			get { return paragraphStyle.Alignment.ToEto(); }
+			get { return _str.Alignment; }
 			set
 			{
-				paragraphStyle.Alignment = value.ToNS();
+				_str.Alignment = value;
 				SetAttributes();
 				InvalidateMeasure();
 			}
@@ -259,15 +215,12 @@ namespace Eto.Mac.Forms.Controls
 
 		public virtual Font Font
 		{
-			get
-			{
-				return Widget.Properties.Create<Font>(MacLabel.FontKey, () => new Font(new FontHandler(Control.Font)));
-			}
+			get => _str.Font ??= new Font(new FontHandler(Control.Font));
 			set
 			{
-				if (Widget.Properties.Get<Font>(MacLabel.FontKey) != value)
+				if (_str.Font != value)
 				{
-					Widget.Properties[MacLabel.FontKey] = value;
+					_str.Font = value;
 					SetAttributes();
 					InvalidateMeasure();
 				}
@@ -284,44 +237,44 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		protected virtual void SetAttributes()
-		{
-			SetAttributes(false);
-		}
+		protected virtual void SetAttributes() => SetAttributes(false);
 
 		void SetAttributes(bool force)
 		{
 			if (Widget.Loaded || force)
 			{
-				if (str.Length > 0)
-				{
-					var range = new NSRange(0, (int)str.Length);
-					var attr = new NSMutableDictionary();
-					Widget.Properties.Get<Font>(MacLabel.FontKey).Apply(attr);
-					// need a copy of the paragraph style otherwise they don't get applied correctly when changed
-					attr.Add(NSStringAttributeKey.ParagraphStyle, (NSParagraphStyle)paragraphStyle.Copy());
-					var col = CurrentColor;	
-					if (col != null)
-						attr.Add(NSStringAttributeKey.ForegroundColor, col);
-					str.SetAttributes(attr, range);
-					if (underlineIndex >= 0)
-					{
-						var num = (NSNumber)str.GetAttribute(NSStringAttributeKey.UnderlineStyle, underlineIndex, out range);
-						var newStyle = (num != null && (NSUnderlineStyle)num.Int64Value == NSUnderlineStyle.Single) ? NSUnderlineStyle.Double : NSUnderlineStyle.Single;
-						str.AddAttribute(NSStringAttributeKey.UnderlineStyle, new NSNumber((int)newStyle), new NSRange(underlineIndex, 1));
-					}
-				}
-				Control.AttributedStringValue = str;
+				Control.AttributedStringValue = _str.AttributedString;
+			}
+		}
+		
+		public bool UseMnemonic
+		{
+			get => _str.UseMnemonic;
+			set
+			{
+				_str.UseMnemonic = value;
+				SetAttributes();
+			}
+		}
+		
+		public bool AlwaysShowMnemonic
+		{
+			get => _str.AlwaysShowMnemonic;
+			set
+			{
+				_str.AlwaysShowMnemonic = value;
+				SetAttributes();
 			}
 		}
 
 		protected virtual NSColor CurrentColor
 		{
-			get { 
-				var col = Widget.Properties.Get<Color?>(MacLabel.TextColorKey);
+			get
+			{
+				var col = _str.TextColor;
 				if (col != null)
 					return col.Value.ToNSUI();
-				return null; 
+				return null;
 			}
 		}
 

--- a/src/Eto.Mac/Forms/Controls/MacMnemonicString.cs
+++ b/src/Eto.Mac/Forms/Controls/MacMnemonicString.cs
@@ -1,0 +1,160 @@
+using Eto.Mac.Drawing;
+
+namespace Eto.Mac.Forms.Controls
+{
+	class MacMnemonicString
+	{
+		string _text;
+		private bool _alwaysShowMnemonic;
+		NSMutableAttributedString _str;
+		NSMutableParagraphStyle _paragraphStyle;
+		Color? _textColor;
+		Font _font;
+		bool _useMnemonic = true;
+
+		public string Text
+		{
+			get => _text;
+			set
+			{
+				_text = value;
+				_str = null;
+			}
+		}
+
+		public bool UseMnemonic
+		{
+			get => _useMnemonic;
+			set
+			{
+				_useMnemonic = value;
+				_str = null;
+			}
+		}
+		
+		public bool AlwaysShowMnemonic
+		{
+			get => _alwaysShowMnemonic;
+			set
+			{
+				_alwaysShowMnemonic = value;
+				_str = null;
+			}
+		}
+
+
+		public Color? TextColor
+		{
+			get => _textColor;
+			set
+			{
+				_textColor = value;
+				_str = null;
+			}
+		}
+
+		public Font Font
+		{
+			get => _font;
+			set
+			{
+				_font = value;
+				_str = null;
+			}
+		}
+
+		private NSMutableParagraphStyle ParagraphStyle => _paragraphStyle ??= new();
+
+		public NSAttributedString AttributedString
+		{
+			get
+			{
+				if (_str == null)
+				{
+					Build();
+				}
+				return _str;
+			}
+		}
+
+		public WrapMode Wrap
+		{
+			get => _paragraphStyle?.LineBreakMode switch
+			{
+				NSLineBreakMode.Clipping => WrapMode.None,
+				NSLineBreakMode.ByWordWrapping => WrapMode.Word,
+				_ => WrapMode.Character
+			};
+			set
+			{
+				ParagraphStyle.LineBreakMode = value switch
+				{
+					WrapMode.None => NSLineBreakMode.Clipping,
+					WrapMode.Word => NSLineBreakMode.ByWordWrapping,
+					WrapMode.Character => NSLineBreakMode.CharWrapping,
+					_ => throw new NotSupportedException()
+				};
+				_str = null;
+			}
+		}
+		
+		public TextAlignment Alignment
+		{
+			get => _paragraphStyle?.Alignment.ToEto() ?? TextAlignment.Left;
+			set
+			{
+				ParagraphStyle.Alignment = value.ToNS();
+				_str = null;
+			}
+		}
+
+		private void Build()
+		{
+			var text = _text ?? string.Empty;
+
+			int mnemonicIndex = -1;
+			if (UseMnemonic)
+			{
+				// find mnemonic starting with '&'
+				var match = Regex.Match(text, @"(?<=([^&](?:[&]{2})*)|^)[&](?![&])");
+				if (match.Success)
+				{
+					var val = text.Remove(match.Index, match.Length).Replace("&&", "&");
+
+					var matches = Regex.Matches(text, @"[&][&]");
+					var prefixCount = matches.Cast<Match>().Count(r => r.Index < match.Index);
+					
+					if (AlwaysShowMnemonic)
+						mnemonicIndex = match.Index - prefixCount;
+					text = val;
+				}
+				else
+					text = text.Replace("&&", "&");
+			}
+
+			_str = new NSMutableAttributedString(text);
+			var strRange = new NSRange(0, _str.Length);
+			if (_paragraphStyle != null)
+			{
+				_str.AddAttribute(NSStringAttributeKey.ParagraphStyle, _paragraphStyle.Copy(), strRange);
+			}
+			if (_font != null)
+			{
+				var attr = new NSMutableDictionary();
+				_font.Apply(attr);
+				_str.AddAttributes(attr, strRange);
+			}
+			if (mnemonicIndex >= 0 && mnemonicIndex < _str.Length)
+			{
+				var range = new NSRange(mnemonicIndex, 1);
+				_str.AddAttribute(NSStringAttributeKey.UnderlineStyle, NSNumber.FromInt32((int)NSUnderlineStyle.Single), range);
+			}
+			if (_textColor != null)
+			{
+				var attr = NSDictionary.FromObjectAndKey(_textColor.Value.ToNSUI(), NSStringAttributeKey.ForegroundColor);
+				_str.AddAttributes(attr, strRange);
+			}
+		}
+	}
+}
+

--- a/src/Eto.WinForms/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/ButtonHandler.cs
@@ -129,5 +129,17 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			return !intrinsicEvents.Contains((Win32.WM)msg.Msg) && base.ShouldBubbleEvent(msg);
 		}
+
+		public bool UseMnemonic
+		{
+			get => Control.UseMnemonic;
+			set => Control.UseMnemonic = value;
+		}
+
+		public bool AlwaysShowMnemonic
+		{
+			get => false;
+			set { /* not supported */ }
+		}
 	}
 }

--- a/src/Eto.WinForms/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/CheckBoxHandler.cs
@@ -45,5 +45,17 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			return !intrinsicEvents.Contains((Win32.WM)msg.Msg) && base.ShouldBubbleEvent(msg);
 		}
+
+		public bool UseMnemonic
+		{
+			get => Control.UseMnemonic;
+			set => Control.UseMnemonic = value;
+		}
+
+		public bool AlwaysShowMnemonic
+		{
+			get => false;
+			set { /* not supported */ }
+		}
 	}
 }

--- a/src/Eto.WinForms/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/LabelHandler.cs
@@ -37,6 +37,19 @@ namespace Eto.WinForms.Forms.Controls
 					BeginInvoke(new Action(Handler.SizeChanged));
 				}
 			}
+			
+			public new bool UseMnemonic
+			{
+				get => base.UseMnemonic;
+				set
+				{
+					base.UseMnemonic = value;
+					if (value)
+						textFormat &= ~swf.TextFormatFlags.NoPrefix;
+					else
+						textFormat |= swf.TextFormatFlags.NoPrefix;
+				}
+			}
 
 			public override sd.Font Font
 			{
@@ -313,6 +326,18 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			if (Widget != null && Widget.Loaded)
 				SetMinimumSize(true);
+		}
+
+		public bool UseMnemonic
+		{
+			get => Control.UseMnemonic;
+			set => Control.UseMnemonic = value;
+		}
+
+		public bool AlwaysShowMnemonic
+		{
+			get => true; // WinForms always shows mnemonics in the label
+			set { /* not supported */ }
 		}
 	}
 }

--- a/src/Eto.WinForms/Forms/Controls/RadioButton.cs
+++ b/src/Eto.WinForms/Forms/Controls/RadioButton.cs
@@ -69,6 +69,18 @@ namespace Eto.WinForms.Forms.Controls
 			set { SetChecked(value); }
 		}
 
+		public bool UseMnemonic
+		{
+			get => Control.UseMnemonic;
+			set => Control.UseMnemonic = value;
+		}
+
+		public bool AlwaysShowMnemonic
+		{
+			get => false;
+			set { /* not supported */ }
+		}
+
 		static readonly Win32.WM[] intrinsicEvents = { Win32.WM.LBUTTONDOWN, Win32.WM.LBUTTONUP, Win32.WM.LBUTTONDBLCLK };
 		public override bool ShouldBubbleEvent(swf.Message msg)
 		{

--- a/src/Eto.WinForms/Platform.cs
+++ b/src/Eto.WinForms/Platform.cs
@@ -19,7 +19,8 @@ namespace Eto.WinForms
 
 		public override PlatformFeatures SupportedFeatures =>
 			PlatformFeatures.DrawableWithTransparentContent
-			| PlatformFeatures.MultiThreadedUI;
+			| PlatformFeatures.MultiThreadedUI
+			| PlatformFeatures.Mnemonics;
 
 		static Platform()
 		{

--- a/src/Eto.WinUI/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.WinUI/Forms/Controls/ButtonHandler.cs
@@ -12,6 +12,8 @@ public class ButtonHandler : WinUIControl<muc.Button, Button, Button.ICallback>,
 		get => _textBlock.Text;
 		set => _textBlock.Text = value;
 	}
+	public bool UseMnemonic { get; set; }
+	public bool AlwaysShowMnemonic { get; set; }
 
 	protected override muc.Button CreateControl() => new muc.Button();
 

--- a/src/Eto.WinUI/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.WinUI/Forms/Controls/CheckBoxHandler.cs
@@ -17,6 +17,8 @@ public class CheckBoxHandler : WinUIControl<muc.CheckBox, CheckBox, CheckBox.ICa
 		get => Control.IsThreeState;
 		set => Control.IsThreeState = value;
 	}
+	public bool UseMnemonic { get; set; }
+	public bool AlwaysShowMnemonic { get; set; }
 
 	protected override muc.CheckBox CreateControl() => new();
 

--- a/src/Eto.WinUI/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.WinUI/Forms/Controls/LabelHandler.cs
@@ -40,6 +40,8 @@ public class LabelHandler : WinUIBorderedControl<muc.TextBlock, Label, Label.ICa
 	}
 
 	public Font Font { get; set; }
+	public bool UseMnemonic { get; set; }
+	public bool AlwaysShowMnemonic { get; set; }
 
 	public override void AttachEvent(string id)
 	{

--- a/src/Eto.Wpf/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ButtonHandler.cs
@@ -1,8 +1,10 @@
+#nullable enable
+
 namespace Eto.Wpf.Forms.Controls
 {
 	public class EtoButton : swc.Button, IEtoWpfControl
 	{
-		public IWpfFrameworkElement Handler { get; set; }
+		public IWpfFrameworkElement? Handler { get; set; }
 
 		protected override sw.Size MeasureOverride(sw.Size constraint)
 		{
@@ -28,13 +30,18 @@ namespace Eto.Wpf.Forms.Controls
 	/// <copyright>(c) 2012-2019 by Curtis Wensley</copyright>
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	public class ButtonHandler<TControl, TWidget, TCallback> : WpfControl<TControl, TWidget, TCallback>, Button.IHandler
-		where TControl: swc.Primitives.ButtonBase
-		where TWidget: Button
-		where TCallback: Button.ICallback
+		where TControl : swc.Primitives.ButtonBase
+		where TWidget : Button
+		where TCallback : Button.ICallback
 	{
-		public swc.Image ImagePart { get; private set; }
+		EtoAccessLabel? _labelPart;
 
-		public swc.Label LabelPart { get; private set; }
+		public swc.Image? ImagePart { get; private set; }
+
+		public EtoAccessLabel LabelPart => _labelPart ??= new EtoAccessLabel
+		{
+			TextAlignment = sw.TextAlignment.Center
+		};
 
 		/// <summary>
 		/// Gets or sets the spacing between the image and the label when both are present
@@ -57,50 +64,98 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected override void Initialize()
 		{
+			Control.HorizontalAlignment = sw.HorizontalAlignment.Stretch;
+			Control.VerticalContentAlignment = sw.VerticalAlignment.Stretch;
 			Control.Click += (sender, e) => Callback.OnClick(Widget, EventArgs.Empty);
-			LabelPart = new swc.Label
-			{
-				IsHitTestVisible = false,
-				VerticalAlignment = sw.VerticalAlignment.Center,
-				HorizontalAlignment = sw.HorizontalAlignment.Center,
-				Padding = new sw.Thickness(0),
-				Visibility = sw.Visibility.Collapsed
-			};
-			swc.Grid.SetColumn(LabelPart, 1);
-			swc.Grid.SetRow(LabelPart, 1);
-			ImagePart = new swc.Image();
-			ImagePart.Visibility = sw.Visibility.Collapsed;
-			var grid = new swc.Grid();
-			grid.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = sw.GridLength.Auto });
-			grid.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = new sw.GridLength(1, sw.GridUnitType.Star) });
-			grid.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = sw.GridLength.Auto });
-			grid.RowDefinitions.Add(new swc.RowDefinition { Height = sw.GridLength.Auto });
-			grid.RowDefinitions.Add(new swc.RowDefinition { Height = new sw.GridLength(1, sw.GridUnitType.Star) });
-			grid.RowDefinitions.Add(new swc.RowDefinition { Height = sw.GridLength.Auto });
-			grid.Children.Add(ImagePart);
-			grid.Children.Add(LabelPart);
+			CreateContent();
 
-			Control.Content = grid;
-
-			sw.Automation.AutomationProperties.SetLabeledBy(Control, LabelPart);
-
-			SetImagePosition();
 			base.Initialize();
 		}
+
+		private void CreateContent()
+		{
+			if (Control.Content is swc.Grid g)
+			{
+				if (_labelPart != null)
+					g.Children.Remove(_labelPart);
+				if (ImagePart != null)
+					g.Children.Remove(ImagePart);
+			}
+			Control.Content = null;
+
+			if (ImagePart == null)
+			{
+				// no image, so just use the label
+				Control.Content = _labelPart;
+				sw.Automation.AutomationProperties.SetLabeledBy(Control, _labelPart);
+				return;
+			}
+
+
+			if (string.IsNullOrEmpty(Text))
+			{
+				// no label, so just use the image
+				sw.Automation.AutomationProperties.SetLabeledBy(Control, null);
+				Control.Content = ImagePart;
+				return;
+			}
+
+			// we have an image and text
+			if (Control.Content is not swc.Grid)
+			{
+				swc.Grid.SetColumn(LabelPart, 1);
+				swc.Grid.SetRow(LabelPart, 1);
+				var grid = new swc.Grid();
+				grid.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = sw.GridLength.Auto });
+				grid.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = new sw.GridLength(1, sw.GridUnitType.Star) });
+				grid.ColumnDefinitions.Add(new swc.ColumnDefinition { Width = sw.GridLength.Auto });
+				grid.RowDefinitions.Add(new swc.RowDefinition { Height = sw.GridLength.Auto });
+				grid.RowDefinitions.Add(new swc.RowDefinition { Height = new sw.GridLength(1, sw.GridUnitType.Star) });
+				grid.RowDefinitions.Add(new swc.RowDefinition { Height = sw.GridLength.Auto });
+				grid.Children.Add(ImagePart);
+				grid.Children.Add(LabelPart);
+
+				Control.Content = grid;
+				sw.Automation.AutomationProperties.SetLabeledBy(Control, LabelPart);
+			}
+			SetImagePosition();
+
+		}
+
 
 		public override bool UseMousePreview => true;
 
 		public override bool UseKeyPreview => true;
 
-		public string Text
+		public string? Text
 		{
-			get { return (LabelPart.Content as string).ToEtoMnemonic(); }
+			get => _labelPart?.Text;
 			set
 			{
-				LabelPart.Content = value.ToPlatformMnemonic();
-				SetImagePosition();
+				if (value == Text)
+					return;
+				var wasEmpty = string.IsNullOrEmpty(Text);
+				var isEmpty = string.IsNullOrEmpty(value);
+
+				if (wasEmpty && !isEmpty)
+				{
+					LabelPart.Text = value;
+					CreateContent();
+				}
+				else if (!wasEmpty && isEmpty)
+				{
+					// don't kill LabelPart, it holds some state
+					LabelPart.Text = null;
+					CreateContent();
+				}
+				else if (!wasEmpty && !isEmpty)
+				{
+					LabelPart.Text = value;
+				}
 			}
 		}
+
+
 		static readonly object Image_Key = new object();
 
 		protected override bool NeedsPixelSizeNotifications => true;
@@ -111,9 +166,12 @@ namespace Eto.Wpf.Forms.Controls
 			SetImage();
 		}
 
-		void SetImage()
+		bool SetImage()
 		{
+			if (ImagePart == null)
+				return false;
 			ImagePart.Source = Image.ToWpf(ParentScale);
+			return true;
 		}
 
 		public Image Image
@@ -123,16 +181,28 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				if (Widget.Properties.TrySet(Image_Key, value))
 				{
-					SetImage();
-					ImagePart.Visibility = value != null ? sw.Visibility.Visible : sw.Visibility.Collapsed;
-					SetImagePosition();
+					if (ImagePart == null && value != null)
+					{
+						ImagePart = new swc.Image { Source = Image.ToWpf(ParentScale) };
+						CreateContent();
+					}
+					else if (ImagePart != null && value == null)
+					{
+						ImagePart = null;
+						CreateContent();
+					}
+					else if (ImagePart != null && value != null)
+					{
+						SetImage();
+					}
 				}
 			}
 		}
 
 		void SetImagePosition()
 		{
-			bool hideLabel = string.IsNullOrEmpty(Text);
+			if (ImagePart == null || LabelPart == null)
+				return;
 			int col, row;
 			sw.Thickness imageSpacing;
 			switch (ImagePosition)
@@ -152,13 +222,13 @@ namespace Eto.Wpf.Forms.Controls
 				case ButtonImagePosition.Above:
 					col = 1; row = 0;
 					Control.HorizontalContentAlignment = sw.HorizontalAlignment.Center;
-					Control.VerticalContentAlignment = hideLabel ? sw.VerticalAlignment.Center : sw.VerticalAlignment.Stretch;
+					Control.VerticalContentAlignment = sw.VerticalAlignment.Stretch;
 					imageSpacing = new sw.Thickness(0, ImageLabelSpacing, 0, 0);
 					break;
 				case ButtonImagePosition.Below:
 					col = 1; row = 2;
 					Control.HorizontalContentAlignment = sw.HorizontalAlignment.Center;
-					Control.VerticalContentAlignment = hideLabel ? sw.VerticalAlignment.Center : sw.VerticalAlignment.Stretch;
+					Control.VerticalContentAlignment = sw.VerticalAlignment.Stretch;
 					imageSpacing = new sw.Thickness(0, 0, 0, ImageLabelSpacing);
 					break;
 				case ButtonImagePosition.Overlay:
@@ -173,8 +243,7 @@ namespace Eto.Wpf.Forms.Controls
 
 			swc.Grid.SetColumn(ImagePart, col);
 			swc.Grid.SetRow(ImagePart, row);
-			LabelPart.Visibility = hideLabel ? sw.Visibility.Collapsed : sw.Visibility.Visible;
-			LabelPart.Margin = ImagePart.Visibility == sw.Visibility.Visible ? imageSpacing : new sw.Thickness(0, 0, 0, 0);
+			LabelPart.Margin = imageSpacing;
 		}
 
 		static readonly object ImagePosition_Key = new object();
@@ -208,10 +277,13 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
-		public override  Color TextColor
+		public override Color TextColor
 		{
-			get { return LabelPart.Foreground.ToEtoColor(); }
-			set { LabelPart.Foreground = value.ToWpfBrush(Control.Foreground); }
+			get => (_labelPart?.Foreground ?? Control.Foreground).ToEtoColor();
+			set
+			{
+				LabelPart.Foreground = value.ToWpfBrush();
+			}
 		}
 
 		static readonly object MinimumSize_Key = new object();
@@ -229,5 +301,24 @@ namespace Eto.Wpf.Forms.Controls
 				}
 			}
 		}
+
+		public bool UseMnemonic
+		{
+			get => _labelPart?.UseMnemonic ?? true;
+			set => LabelPart.UseMnemonic = value;
+		}
+
+		public bool AlwaysShowMnemonic
+		{
+			get => _labelPart?.AlwaysShowMnemonic ?? false;
+			set => LabelPart.AlwaysShowMnemonic = value;
+		}
+
+		public bool EnableMnemonic
+		{
+			get => _labelPart?.EnableMnemonic ?? true;
+			set => LabelPart.EnableMnemonic = value;
+		}
+
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/CheckBoxHandler.cs
@@ -2,14 +2,14 @@ namespace Eto.Wpf.Forms.Controls
 {
 	public class CheckBoxHandler : WpfControl<swc.CheckBox, CheckBox, CheckBox.ICallback>, CheckBox.IHandler
 	{
-		readonly swc.Border border;
+		readonly swc.Border _border;
+		EtoAccessLabel _labelPart;
 
-		public override sw.FrameworkElement ContainerControl
-		{
-			get { return border; }
-		}
+		EtoAccessLabel LabelPart => _labelPart ??= new EtoAccessLabel();
 
-		public CheckBoxHandler ()
+		public override sw.FrameworkElement ContainerControl => _border;
+
+		public CheckBoxHandler()
 		{
 			Control = new swc.CheckBox {
 				IsThreeState = false,
@@ -20,13 +20,13 @@ namespace Eto.Wpf.Forms.Controls
 			Control.Unchecked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 			Control.Indeterminate += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 
-			border = new EtoBorder { Handler = this, Child = Control };
+			_border = new EtoBorder { Handler = this, Child = Control };
 		}
 
 		public override Eto.Drawing.Color BackgroundColor
 		{
-			get { return border.Background.ToEtoColor(); }
-			set { border.Background = value.ToWpfBrush(Control.Background); }
+			get { return _border.Background.ToEtoColor(); }
+			set { _border.Background = value.ToWpfBrush(Control.Background); }
 		}
 
 		public override bool UseMousePreview { get { return true; } }
@@ -41,14 +41,38 @@ namespace Eto.Wpf.Forms.Controls
 
 		public string Text
 		{
-			get { return (Control.Content as string).ToEtoMnemonic(); }
-			set { Control.Content = value.ToPlatformMnemonic(); }
+			get => _labelPart?.Text;
+			set
+			{
+				if (value == Text || (string.IsNullOrEmpty(value) && _labelPart == null))
+					return;
+				LabelPart.Text = value;
+				Control.Content = LabelPart;
+			}
 		}
 
 		public bool ThreeState
 		{
 			get { return Control.IsThreeState; }
 			set { Control.IsThreeState = value; }
+		}
+
+		public bool UseMnemonic
+		{
+			get => _labelPart?.UseMnemonic ?? true;
+			set => LabelPart.UseMnemonic = value;
+		}
+
+		public bool AlwaysShowMnemonic
+		{
+			get => _labelPart?.AlwaysShowMnemonic ?? false;
+			set => LabelPart.AlwaysShowMnemonic = value;
+		}
+
+		public bool EnableMnemonic
+		{
+			get => _labelPart?.EnableMnemonic ?? true;
+			set => LabelPart.EnableMnemonic = value;
 		}
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/EtoAccessLabel.cs
+++ b/src/Eto.Wpf/Forms/Controls/EtoAccessLabel.cs
@@ -1,0 +1,212 @@
+using swd = System.Windows.Documents;
+
+namespace Eto.Wpf.Forms.Controls;
+
+public class EtoAccessLabel : swc.Label
+{
+	string _text;
+	bool _useMnemonic = true;
+	bool _enableMnemonic = true;
+	bool _alwaysShowMnemonic;
+	string _accessKey;
+	sw.TextAlignment _textAlignment;
+	sw.TextDecorationCollection _textDecorations;
+	sw.TextWrapping _textWrapping;
+	public EtoAccessLabel()
+	{
+		Padding = new sw.Thickness(0);
+		HorizontalContentAlignment = sw.HorizontalAlignment.Stretch;
+		VerticalContentAlignment = sw.VerticalAlignment.Center;
+	}
+	
+	public sw.TextAlignment TextAlignment
+	{
+		get => _textAlignment;
+		set
+		{
+			_textAlignment = value;
+			if (Content is swc.TextBlock textBlock)
+			{
+				textBlock.TextAlignment = value;
+			}
+			else if (Content is swc.AccessText accessText)
+			{
+				accessText.TextAlignment = value;
+			}
+		}
+	}
+	
+	public sw.TextDecorationCollection TextDecorations
+	{
+		get => _textDecorations;
+		set
+		{
+			_textDecorations = value;
+			if (Content is swc.TextBlock textBlock)
+			{
+				textBlock.TextDecorations = value;
+			}
+			else if (Content is swc.AccessText accessText)
+			{
+				accessText.TextDecorations = value;
+			}
+		}
+	}
+	
+	protected override void OnAccessKey(swi.AccessKeyEventArgs e)
+	{
+		// move focus to the next control after the label
+		var tRequest = new swi.TraversalRequest(swi.FocusNavigationDirection.Next);
+		MoveFocus(tRequest);
+	}
+	
+	public bool UseMnemonic
+	{
+		get => _useMnemonic;
+		set
+		{
+			if (_useMnemonic == value) return;
+			_useMnemonic = value;
+			CreateContent();
+		}
+	}
+
+	public bool AlwaysShowMnemonic
+	{
+		get => _alwaysShowMnemonic;
+		set
+		{
+			if (_alwaysShowMnemonic == value) return;
+			_alwaysShowMnemonic = value;
+			CreateContent();
+		}
+	}
+
+	public bool EnableMnemonic
+	{
+		get => _enableMnemonic;
+		set
+		{
+			if (_enableMnemonic == value) return;
+			_enableMnemonic = value;
+			CreateContent();
+		}
+	}
+
+	public string Text
+	{
+		get => _text;
+		set
+		{
+			if (_text == value) return;
+			_text = value;
+			CreateContent();
+		}
+	}
+
+	public sw.TextWrapping TextWrapping
+	{
+		get => _textWrapping;
+		set
+		{
+			_textWrapping = value;
+			if (Content is swc.TextBlock textBlock)
+			{
+				textBlock.TextWrapping = value;
+			}
+			else if (Content is swc.AccessText accessText)
+			{
+				accessText.TextWrapping = value;
+			}
+		}
+	}
+
+	static swc.TextBlock UnderlineCharacter(string text, int indexToUnderline)
+	{
+		var textBlock = new swc.TextBlock();
+
+		if (indexToUnderline > 0)
+		{
+			textBlock.Inlines.Add(new swd.Run(text.Substring(0, indexToUnderline)));
+		}
+
+		if (indexToUnderline >= 0 && indexToUnderline < text.Length)
+		{
+			var underline = new swd.Underline(new swd.Run(text[indexToUnderline].ToString()));
+			textBlock.Inlines.Add(underline);
+		}
+
+		if (indexToUnderline + 1 < text.Length)
+		{
+			textBlock.Inlines.Add(new swd.Run(text.Substring(indexToUnderline + 1)));
+		}
+
+		return textBlock;
+	}
+
+	void CreateContent()
+	{
+		if (_accessKey != null)
+		{
+			swi.AccessKeyManager.Unregister(_accessKey, this);
+			_accessKey = null;
+		}
+			
+		if (string.IsNullOrEmpty(_text))
+		{
+			Content = null;
+			return;
+		}
+
+		if (!UseMnemonic)
+		{
+			if (Content is swc.TextBlock tb)
+				tb.Text = _text;
+			else
+				Content = new swc.TextBlock { Text = _text, TextWrapping = _textWrapping, TextAlignment = _textAlignment, TextDecorations = _textDecorations };
+			return;
+		}
+
+		if (AlwaysShowMnemonic || EnableMnemonic)
+		{
+			var mnemonicText = _text.Replace("_", "__");
+			Match match = Conversions.PlatformMnemonic.Match(mnemonicText);
+			if (match.Success)
+			{
+				var sb = new StringBuilder(mnemonicText);
+				sb[match.Index] = '_';
+				char? ch = match.Index < sb.Length - 1 ? sb[match.Index + 1] : null;
+				sb.Replace("&&", "&");
+				if (AlwaysShowMnemonic)
+				{
+					sb.Remove(match.Index, 1);
+					var textBlock = UnderlineCharacter(sb.ToString(), match.Index);
+					textBlock.TextWrapping = _textWrapping;
+					textBlock.TextAlignment = _textAlignment;
+					textBlock.TextDecorations = _textDecorations;
+					Content = textBlock;
+
+					_accessKey = ch.ToString();
+					if (EnableMnemonic)
+						swi.AccessKeyManager.Register(_accessKey, this);
+				}
+				else
+				{
+					if (Content is swc.AccessText accessText)
+						accessText.Text = sb.ToString();
+					else
+						Content = new swc.AccessText { Text = sb.ToString(), TextWrapping = _textWrapping, TextAlignment = _textAlignment, TextDecorations = _textDecorations };
+				}
+				return;
+			}
+		}
+
+		var text = _text.Replace("&&", "&");
+		if (Content is swc.TextBlock tb2)
+			tb2.Text = text;
+		else
+			Content = new swc.TextBlock { Text = text, TextWrapping = _textWrapping, TextAlignment = _textAlignment, TextDecorations = _textDecorations };
+	}
+
+
+}

--- a/src/Eto.Wpf/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/LabelHandler.cs
@@ -1,42 +1,34 @@
 namespace Eto.Wpf.Forms.Controls
 {
-	public class EtoLabel : swc.Label
+	
+	public class EtoLabel : EtoAccessLabel
 	{
-		public LabelHandler Handler { get; set; }
-		protected override void OnAccessKey(swi.AccessKeyEventArgs e)
-		{
-			// move focus to the next control after the label
-			var tRequest = new swi.TraversalRequest(swi.FocusNavigationDirection.Next);
-			MoveFocus(tRequest);
-		}
+		public IWpfFrameworkElement Handler { get; set; }
 
 		protected override sw.Size MeasureOverride(sw.Size constraint)
 		{
-			var size = Handler.MeasureOverride(constraint, base.MeasureOverride);
+			var size = Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
 			size.Width += 1;
 			return size;
 		}
 	}
 
-	public class LabelHandler : WpfControl<swc.Label, Label, Label.ICallback>, Label.IHandler
+	public class LabelHandler : WpfControl<EtoAccessLabel, Label, Label.ICallback>, Label.IHandler
 	{
-		readonly swc.AccessText accessText;
 		double? previousDesiredHeight;
 		string text;
 
 		protected override void SetDecorations(sw.TextDecorationCollection decorations)
 		{
-			accessText.TextDecorations = decorations;
+			Control.TextDecorations = decorations;
 		}
 
 		public LabelHandler()
 		{
-			accessText = new swc.AccessText();
+			// accessText = new swc.AccessText();
 			Control = new EtoLabel
 			{
-				Handler = this,
-				Padding = new sw.Thickness(0),
-				Content = accessText
+				Handler = this
 			};
 			Control.Target = Control;
 			Control.SizeChanged += Control_SizeChanged;
@@ -100,11 +92,10 @@ namespace Eto.Wpf.Forms.Controls
 
 		public TextAlignment TextAlignment
 		{
-			get { return Control.HorizontalContentAlignment.ToEto(); }
+			get { return Control.TextAlignment.ToEto(); }
 			set
 			{
-				Control.HorizontalContentAlignment = value.ToWpf();
-				accessText.TextAlignment = value.ToWpfTextAlignment();
+				Control.TextAlignment = value.ToWpfTextAlignment();
 			}
 		}
 
@@ -116,43 +107,18 @@ namespace Eto.Wpf.Forms.Controls
 
 		public WrapMode Wrap
 		{
-			get
-			{
-				switch (accessText.TextWrapping)
-				{
-					case sw.TextWrapping.NoWrap:
-						return WrapMode.None;
-					case sw.TextWrapping.Wrap:
-						return WrapMode.Character;
-					case sw.TextWrapping.WrapWithOverflow:
-						return WrapMode.Word;
-					default:
-						throw new NotSupportedException();
-				}
-			}
+			get => Control.TextWrapping.ToEto();
 			set
 			{
 				if (value != Wrap)
 				{
-					switch (value)
-					{
-						case WrapMode.Word:
-							accessText.TextWrapping = sw.TextWrapping.WrapWithOverflow;
-							break;
-						case WrapMode.Character:
-							accessText.TextWrapping = sw.TextWrapping.Wrap;
-							break;
-						case WrapMode.None:
-							accessText.TextWrapping = sw.TextWrapping.NoWrap;
-							break;
-						default:
-							throw new NotSupportedException();
-					}
+					Control.TextWrapping = value.ToWpf();
 					SetText();
 					UpdatePreferredSize();
 				}
 			}
 		}
+
 
 		public override void UpdatePreferredSize()
 		{
@@ -162,8 +128,8 @@ namespace Eto.Wpf.Forms.Controls
 
 		public override Color TextColor
 		{
-			get { return accessText.Foreground.ToEtoColor(); }
-			set { accessText.Foreground = value.ToWpfBrush(accessText.Foreground); }
+			get { return Control.Foreground.ToEtoColor(); }
+			set { Control.Foreground = value.ToWpfBrush(Control.Foreground); }
 		}
 
 		public string Text
@@ -176,6 +142,24 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
+		public bool UseMnemonic
+		{
+			get => Control.UseMnemonic;
+			set => Control.UseMnemonic = value;
+		}
+
+		public bool AlwaysShowMnemonic
+		{
+			get => Control.AlwaysShowMnemonic;
+			set => Control.AlwaysShowMnemonic = value;
+		}
+
+		public bool EnableMnemonic
+		{
+			get => Control.EnableMnemonic;
+			set => Control.EnableMnemonic = value;
+		}
+
 		void SetText()
 		{
 			var newText = text;
@@ -186,7 +170,7 @@ namespace Eto.Wpf.Forms.Controls
 				newText = newText.Replace(' ', (char)0xa0); // no break space
 			}
 
-			accessText.Text = newText.ToPlatformMnemonic();
+			Control.Text = newText;
 		}
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
@@ -2,12 +2,12 @@ namespace Eto.Wpf.Forms.Controls
 {
 	public class RadioButtonHandler : WpfControl<swc.RadioButton, RadioButton, RadioButton.ICallback>, RadioButton.IHandler
 	{
-		swc.Border border;
+		swc.Border _border;
+		EtoAccessLabel _labelPart;
 
-		public override sw.FrameworkElement ContainerControl
-		{
-			get { return border; }
-		}
+		EtoAccessLabel LabelPart => _labelPart ??= new EtoAccessLabel();
+
+		public override sw.FrameworkElement ContainerControl => _border;
 
 		public void Create(RadioButton controller)
 		{
@@ -28,7 +28,7 @@ namespace Eto.Wpf.Forms.Controls
 			Control.Checked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 			Control.Unchecked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 
-			border = new EtoBorder { Handler = this, Child = Control };
+			_border = new EtoBorder { Handler = this, Child = Control };
 		}
 
 		void Control_Loaded(object sender, sw.RoutedEventArgs e)
@@ -54,14 +54,38 @@ namespace Eto.Wpf.Forms.Controls
 
 		public string Text
 		{
-			get { return (Control.Content as string).ToEtoMnemonic(); }
-			set { Control.Content = value.ToPlatformMnemonic(); }
+			get => _labelPart?.Text;
+			set
+			{
+				if (value == Text || (string.IsNullOrEmpty(value) && _labelPart == null))
+					return;
+				LabelPart.Text = value;
+				Control.Content = LabelPart;
+			}
 		}
 
 		public override Color BackgroundColor
 		{
-			get { return border.Background.ToEtoColor(); }
-			set { border.Background = value.ToWpfBrush(border.Background); }
+			get { return _border.Background.ToEtoColor(); }
+			set { _border.Background = value.ToWpfBrush(_border.Background); }
+		}
+
+		public bool UseMnemonic
+		{
+			get => _labelPart?.UseMnemonic ?? true;
+			set => LabelPart.UseMnemonic = value;
+		}
+
+		public bool AlwaysShowMnemonic
+		{
+			get => _labelPart?.AlwaysShowMnemonic ?? false;
+			set => LabelPart.AlwaysShowMnemonic = value;
+		}
+
+		public bool EnableMnemonic
+		{
+			get => _labelPart?.EnableMnemonic ?? true;
+			set => LabelPart.EnableMnemonic = value;
 		}
 	}
 }

--- a/src/Eto.Wpf/Platform.cs
+++ b/src/Eto.Wpf/Platform.cs
@@ -21,7 +21,8 @@ namespace Eto.Wpf
 			PlatformFeatures.DrawableWithTransparentContent
 			| PlatformFeatures.CustomCellSupportsControlView
 			| PlatformFeatures.TabIndexWithCustomContainers
-			| PlatformFeatures.MultiThreadedUI;
+			| PlatformFeatures.MultiThreadedUI
+			| PlatformFeatures.Mnemonics;
 
 		static Platform()
 		{

--- a/src/Eto.Wpf/WpfConversions.cs
+++ b/src/Eto.Wpf/WpfConversions.cs
@@ -948,5 +948,59 @@ namespace Eto.Wpf
 			}
 			return null;
 		}
+
+		static swc.TextBlock UnderlineCharacter(string text, int indexToUnderline)
+		{
+			var textBlock = new swc.TextBlock();
+
+			if (indexToUnderline > 0)
+			{
+				textBlock.Inlines.Add(new swd.Run(text.Substring(0, indexToUnderline)));
+			}
+
+			if (indexToUnderline >= 0 && indexToUnderline < text.Length)
+			{
+				var underline = new swd.Underline(new swd.Run(text[indexToUnderline].ToString()));
+				textBlock.Inlines.Add(underline);
+			}
+
+			if (indexToUnderline + 1 < text.Length)
+			{
+				textBlock.Inlines.Add(new swd.Run(text.Substring(indexToUnderline + 1)));
+			}
+
+			return textBlock;
+		}
+		
+		public static sw.TextWrapping ToWpf(this WrapMode value)
+		{
+			switch (value)
+			{
+				case WrapMode.Word:
+					return sw.TextWrapping.WrapWithOverflow;
+				case WrapMode.Character:
+					return sw.TextWrapping.Wrap;
+				case WrapMode.None:
+					return sw.TextWrapping.NoWrap;
+				default:
+					throw new NotSupportedException();
+			}
+		}
+
+
+		public static WrapMode ToEto(this sw.TextWrapping wrapping)
+		{
+			switch (wrapping)
+			{
+				case sw.TextWrapping.NoWrap:
+					return WrapMode.None;
+				case sw.TextWrapping.Wrap:
+					return WrapMode.Character;
+				case sw.TextWrapping.WrapWithOverflow:
+					return WrapMode.Word;
+				default:
+					throw new NotSupportedException();
+			}
+		}
 	}
 }

--- a/src/Eto/Forms/Controls/Button.cs
+++ b/src/Eto/Forms/Controls/Button.cs
@@ -44,7 +44,7 @@ public enum ButtonImagePosition
 /// </code> 
 /// </example>
 [Handler(typeof(Button.IHandler))]
-public class Button : TextControl
+public class Button : TextControl, IMnemonicControl
 {
 	new IHandler Handler { get { return (IHandler)base.Handler; } }
 
@@ -182,6 +182,20 @@ public class Button : TextControl
 			}
 		}
 	}
+	
+	/// <inheritdoc/>
+	public bool UseMnemonic
+	{
+		get => Handler.UseMnemonic;
+		set => Handler.UseMnemonic = value;
+	}
+
+	/// <inheritdoc/>
+	public bool AlwaysShowMnemonic
+	{
+		get => Handler.AlwaysShowMnemonic;
+		set => Handler.AlwaysShowMnemonic = value;
+	}
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="Eto.Forms.Button"/> class.
@@ -256,7 +270,7 @@ public class Button : TextControl
 	/// <summary>
 	/// Handler interface for the <see cref="Button"/> control.
 	/// </summary>
-	public new interface IHandler : TextControl.IHandler
+	public new interface IHandler : TextControl.IHandler, IMnemonicControl
 	{
 		/// <inheritdoc cref="Button.Image"/>
 		Image Image { get; set; }

--- a/src/Eto/Forms/Controls/CheckBox.cs
+++ b/src/Eto/Forms/Controls/CheckBox.cs
@@ -16,7 +16,7 @@ namespace Eto.Forms;
 /// </code>
 /// </example>
 [Handler(typeof(CheckBox.IHandler))]
-public class CheckBox : TextControl
+public class CheckBox : TextControl, IMnemonicControl
 {
 	new IHandler Handler { get { return (IHandler)base.Handler; } }
 
@@ -81,6 +81,21 @@ public class CheckBox : TextControl
 		}
 	}
 
+	/// <inheritdoc/>
+	public bool UseMnemonic
+	{
+		get => Handler.UseMnemonic;
+		set => Handler.UseMnemonic = value;
+	}
+
+	/// <inheritdoc/>
+	public bool AlwaysShowMnemonic
+	{
+		get => Handler.AlwaysShowMnemonic;
+		set => Handler.AlwaysShowMnemonic = value;
+	}
+
+
 	static readonly object callback = new Callback();
 		
 	/// <inheritdoc/>
@@ -114,7 +129,7 @@ public class CheckBox : TextControl
 	/// <summary>
 	/// Handler interface for the <see cref="CheckBox"/> control.
 	/// </summary>
-	public new interface IHandler : TextControl.IHandler
+	public new interface IHandler : TextControl.IHandler, IMnemonicControl
 	{
 		/// <inheritdoc cref="CheckBox.Checked"/>
 		bool? Checked { get; set; }

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -971,8 +971,10 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 		internal set
 		{
 			var old = VisualParent;
-			Properties.Set(VisualParent_Key, value);
-			Handler.SetParent(old, value);
+			if (Properties.TrySet(VisualParent_Key, value))
+			{
+				Handler.SetParent(old, value);
+			}
 		}
 	}
 

--- a/src/Eto/Forms/Controls/IMnemonicControl.cs
+++ b/src/Eto/Forms/Controls/IMnemonicControl.cs
@@ -1,0 +1,38 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Common interface for controls that support mnemonics (e.g. &amp; character in text)
+/// </summary>
+/// <remarks>
+/// Not all platforms support mnemonics, such as macOS.
+/// However, you can still show the mnemonic character in the text by using the &amp; character.
+/// </remarks>
+public interface IMnemonicControl
+{
+	/// <summary>
+	/// Text to display on the control, including mnemonics (e.g. &amp; character to indicate a mnemonic key) when <see cref="UseMnemonic"/> is true.
+	/// </summary>
+	public string Text { get; set; }
+
+	/// <summary>
+	/// Gets or sets whether the control should use mnemonics in the text (e.g. &amp; character to indicate a mnemonic key)
+	/// </summary>
+	/// <remarks>
+	/// This is true by default, and allows the control to process mnemonics in the text with an ampersand character (e.g. "Click &amp;here" will allow the user to press Alt+H to activate the control).
+	/// To show a literal ampersand character, you can use a double ampersand (e.g. "Click &amp;&amp; here").
+	/// Not all platforms support mnemonics, such as macOS, so even if this is set to true, it may not work as expected on those platforms.
+	/// 
+	/// Setting this to false will stop the control from processing mnemonics in the text, and you no longer need to use double ampersands to show an ampersand character.
+	/// </remarks>
+	public bool UseMnemonic { get; set; }
+
+	/// <summary>
+	/// Gets or sets whether the mnemonic character should always be shown, even if the user has not pressed the mnemonic key (e.g. Alt key on Windows)
+	/// </summary>
+	/// <remarks>
+	/// Not all platforms support this, but on those that do, it will always show the mnemonic character in the text.
+	/// On macOS, this will show the mnemonic character in the text, but it will still not be activated by pressing the mnemonic key (e.g. Alt key).
+	/// This is useful if you have other logic hat requires the mnemonic character to be visible, such as for accessibility purposes.
+	/// </remarks>
+	public bool AlwaysShowMnemonic { get; set; }
+}

--- a/src/Eto/Forms/Controls/Label.cs
+++ b/src/Eto/Forms/Controls/Label.cs
@@ -45,7 +45,7 @@ public enum WrapMode
 /// Displays a string of text on the form
 /// </summary>
 [Handler(typeof(Label.IHandler))]
-public class Label : TextControl
+public class Label : TextControl, IMnemonicControl
 {
 	new IHandler Handler { get { return (IHandler)base.Handler; } }
 
@@ -122,10 +122,23 @@ public class Label : TextControl
 		set { Handler.VerticalAlignment = value; }
 	}
 
+	/// <inheritdoc/>
+	public bool UseMnemonic
+	{
+		get => Handler.UseMnemonic;
+		set => Handler.UseMnemonic = value;
+	}
+	/// <inheritdoc/>
+	public bool AlwaysShowMnemonic
+	{
+		get => Handler.AlwaysShowMnemonic;
+		set => Handler.AlwaysShowMnemonic = value;
+	}
+
 	/// <summary>
 	/// Handler interface for the <see cref="Label"/>
 	/// </summary>
-	public new interface IHandler : TextControl.IHandler
+	public new interface IHandler : TextControl.IHandler, IMnemonicControl
 	{
 		/// <summary>
 		/// Gets or sets the horizontal alignment of the text.

--- a/src/Eto/Forms/Controls/RadioButton.cs
+++ b/src/Eto/Forms/Controls/RadioButton.cs
@@ -12,7 +12,7 @@ namespace Eto.Forms;
 /// </remarks>
 /// <seealso cref="RadioButtonList"/>
 [Handler(typeof(RadioButton.IHandler))]
-public class RadioButton : TextControl
+public class RadioButton : TextControl, IMnemonicControl
 {
 	/// <summary>
 	/// Occurs when the <see cref="Checked"/> property is changed.
@@ -103,6 +103,20 @@ public class RadioButton : TextControl
 		set { Handler.Checked = value; }
 	}
 
+	/// <inheritdoc/>
+	public bool UseMnemonic
+	{
+		get => Handler.UseMnemonic;
+		set => Handler.UseMnemonic = value;
+	}
+
+	/// <inheritdoc/>
+	public bool AlwaysShowMnemonic
+	{
+		get => Handler.AlwaysShowMnemonic;
+		set => Handler.AlwaysShowMnemonic = value;
+	}
+
 	/// <summary>
 	/// Callback interface for the <see cref="RadioButton"/>
 	/// </summary>
@@ -155,7 +169,7 @@ public class RadioButton : TextControl
 	/// When using this handler, you must call <see cref="Eto.Widget.Initialize"/> in the constructor.
 	/// </remarks>
 	[AutoInitialize(false)]
-	public new interface IHandler : TextControl.IHandler
+	public new interface IHandler : TextControl.IHandler, IMnemonicControl
 	{
 		/// <summary>
 		/// Used when creating a new instance of the RadioButton to specify the controller

--- a/src/Eto/Platform.cs
+++ b/src/Eto/Platform.cs
@@ -88,13 +88,21 @@ public enum PlatformFeatures
 	/// that do not support this.
 	/// </summary>
 	TabIndexWithCustomContainers = 1 << 2,
-	
+
 	/// <summary>
 	/// Specifies that the Platform supports multi-threaded user interfaces.
 	/// 
 	/// Create
 	/// </summary>
-	MultiThreadedUI = 1 << 3
+	MultiThreadedUI = 1 << 3,
+	/// <summary>
+	/// Specifies that the Platform supports mnemonics in controls, such as the &amp; character in text.
+	/// </summary>
+	/// <remarks>
+	/// Even withoutout support, the platform will parse the &amp; character in text, but it will not
+	/// be activated by pressing the mnemonic key (e.g. Alt key on Windows).
+	/// </remarks>
+	Mnemonics = 1 << 4,
 }
 
 /// <summary>

--- a/src/Shared/Conversions.cs
+++ b/src/Shared/Conversions.cs
@@ -12,12 +12,12 @@
 		/// <summary>
 		/// The regex for mnemonic strings to be converted to Eto
 		/// </summary>
-		static Regex EtoMnemonic => _etoMnemonic ?? (_etoMnemonic = new Regex(@"(?<=([^_](?:[_]{2})*)|^)[_](?![_])", RegexOptions.Compiled));
+		internal static Regex EtoMnemonic => _etoMnemonic ?? (_etoMnemonic = new Regex(@"(?<=([^_](?:[_]{2})*)|^)[_](?![_])", RegexOptions.Compiled));
 
 		/// <summary>
 		/// The regex for mnemonic strings to be converted to a platform
 		/// </summary>
-		static Regex PlatformMnemonic => _platformMnemonic ?? (_platformMnemonic = new Regex(@"(?<=([^&](?:[&]{2})*)|^)[&](?![&])", RegexOptions.Compiled));
+		internal static Regex PlatformMnemonic => _platformMnemonic ?? (_platformMnemonic = new Regex(@"(?<=([^&](?:[&]{2})*)|^)[&](?![&])", RegexOptions.Compiled));
 
 		/// <summary>
 		/// Translates degrees to radians.

--- a/test/Eto.Test/Sections/Behaviors/MnemonicSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/MnemonicSection.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Eto.Test.Sections.Behaviors;
+
+[Section("Behaviors", "Mnemonic")]
+public class MnemonicSection : Panel
+{
+	public MnemonicSection()
+	{
+		var layout = new DynamicLayout { Padding = Padding.Empty, Spacing = new Size(5, 5) };
+
+		layout.AddSpace();
+		layout.BeginCentered();
+
+		layout.AddSeparateRow(CreateUseMnemonicCheckBox());
+		layout.AddSeparateRow(CreateAlwaysShowMnemonicCheckBox());
+
+		layout.EndCentered();
+
+		if (!Platform.SupportedFeatures.HasFlag(PlatformFeatures.Mnemonics))
+		{
+			layout.AddRow(new Panel { Height = 20 });
+			layout.AddRow(new Label { Text = "Mnemonics are not supported on this platform,\nso the shortcuts won't work.", TextAlignment = TextAlignment.Center, TextColor = Colors.Orange });
+			layout.AddRow(new Panel { Height = 20 });
+		}
+
+		layout.AddSpace();
+		layout.BeginCentered();
+
+		layout.AddRow(new Label { Text = "Press Alt+I to press the button below." });
+		layout.AddRow(new Button(OnButtonClicked) { Text = "&I" });
+
+		layout.AddRow(new Label { Text = "Press Alt+J to check the box below." });
+		layout.AddRow(new CheckBox { Text = "&J" });
+
+		layout.AddRow(new Label { Text = "Press Alt+K to select the radio button below." });
+		layout.AddRow(new RadioButton { Text = "&K" });
+
+		layout.AddRow(new Label { Text = "Press Alt+&L to select the text box below." });
+		layout.AddRow(new TextBox { });
+
+		layout.EndCentered();
+		layout.AddSpace();
+
+		Content = layout;
+	}
+
+	private Control CreateAlwaysShowMnemonicCheckBox()
+	{
+		var control = new CheckBox { Text = "AlwaysShowMnemonic" };
+		control.Checked = control.AlwaysShowMnemonic;
+		control.CheckedChanged += (sender, e) =>
+		{
+			foreach (var child in Children.OfType<IMnemonicControl>())
+			{
+				child.AlwaysShowMnemonic = control.Checked == true;
+			}
+		};
+		return control;
+
+	}
+
+	private void OnButtonClicked(object sender, EventArgs e)
+	{
+		Log.Write(sender, "Button was clicked");
+	}
+
+	Control CreateUseMnemonicCheckBox()
+	{
+		var control = new CheckBox { Text = "UseMnemonic" };
+		control.Checked = control.UseMnemonic;
+		control.CheckedChanged += (sender, e) =>
+		{
+			foreach (var child in Children.OfType<IMnemonicControl>())
+			{
+				child.UseMnemonic = control.Checked == true;
+			}
+		};
+		return control;
+	}
+}


### PR DESCRIPTION
Added to Button, CheckBox, Label, and RadioButton.  These also now implement the `IMnemonicControl` interface that contains these properties to make it easier to write common code.

`UseMnemonic`, when true (default), will underline the character following an ampersand.  When false, the Text will be shown literally without parsing any ampersands/mnemonics, and does not require escaping to show ampersands.

`AlwaysShowMnemonic` is a hint to always show the Mnemonic/underlined character.  This only works on Mac and WPF.  Note that on Mac, even though the underlined character is shown, it does not actually do anything as Mnemonics aren't supported on Mac.

To check if a platform supports Mnemonic/shortcuts, you can check if `Platform.SupportedFeatures` has the `PlatformFeatures.Mnemonics` flag.