### PR TITLE
Mac: Fix scrollbars so they don't show when not needed

### DIFF
--- a/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ScrollableHandler.cs
@@ -212,30 +212,47 @@ namespace Eto.Mac.Forms.Controls
 			else
 			{
 				var preferred = (Content?.GetPreferredSize(SizeF.PositiveInfinity) ?? Size.Empty) + Padding.Size;
-
-				if ((ExpandContentWidth && preferred.Width < clientSize.Width)
-					|| (ExpandContentHeight && preferred.Height < clientSize.Height))
-				{
-					var availableSize = SizeF.PositiveInfinity;
-					if (ExpandContentWidth && preferred.Width < clientSize.Width)
-						availableSize.Width = clientSize.Width;
-					if (ExpandContentHeight && preferred.Height < clientSize.Height)
-						availableSize.Height = clientSize.Height;
-
-					preferred = (Content?.GetPreferredSize(availableSize) ?? Size.Empty) + Padding.Size;
-
-					if (ExpandContentWidth && preferred.Width < clientSize.Width)
-						preferred.Width = clientSize.Width;
-					if (ExpandContentHeight && preferred.Height < clientSize.Height)
-						preferred.Height = clientSize.Height;
-				}					
 				
-				var vbar = preferred.Height > clientSize.Height;
-				var hbar = preferred.Width > clientSize.Width;
-				if (hbar || vbar)
-					clientSize = Control.ContentSizeForFrame(Control.Frame.Size, hbar, vbar).ToEto();
+				for (int i = 0; i < 2; i++)
+				{
+					var proposedSize = preferred;
+					if ((ExpandContentWidth && proposedSize.Width < clientSize.Width)
+							|| (ExpandContentHeight && proposedSize.Height < clientSize.Height))
+					{
+						var availableSize = SizeF.PositiveInfinity;
+						if (ExpandContentWidth && proposedSize.Width < clientSize.Width)
+							availableSize.Width = clientSize.Width - Padding.Horizontal;
+						if (ExpandContentHeight && proposedSize.Height < clientSize.Height)
+							availableSize.Height = clientSize.Height - Padding.Vertical;
 
-				size = SizeF.Max(clientSize, preferred);
+						preferred = (Content?.GetPreferredSize(availableSize) ?? Size.Empty) + Padding.Size;
+					}
+
+					var vbar = preferred.Height > clientSize.Height;
+					var hbar = preferred.Width > clientSize.Width;
+
+					// if we have scrollbars, we need to recalculate the client size again given the scrollbars as they can take space
+					if (hbar || vbar)
+					{
+						clientSize = Control.ContentSizeForFrame(Control.Frame.Size, hbar, vbar).ToEto();
+
+						// if we have overlay scrollbars, we can break out of the loop as they don't take up space
+						if (Control.ScrollerStyle == NSScrollerStyle.Overlay)
+							break;
+					}
+					else
+					{
+						// no scrollbars are needed, so we don't need to recaculate
+						break;
+					}
+				}
+
+				size = preferred;
+				
+				if (ExpandContentWidth && size.Width < clientSize.Width)
+					size.Width = clientSize.Width;
+				if (ExpandContentHeight && size.Height < clientSize.Height)
+					size.Height = clientSize.Height;
 			}
 
 			ContentControl.SetFrameSize(size.ToNS());

--- a/test/Eto.Test.Mac/UnitTests/ScrollableTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/ScrollableTests.cs
@@ -1,12 +1,58 @@
-﻿#if blah
-using Eto.Test.UnitTests;
+﻿using Eto.Test.UnitTests;
 using NUnit.Framework;
 using Eto.Mac.Forms.Controls;
 namespace Eto.Test.Mac.UnitTests
 {
 	[TestFixture]
 	public class ScrollableTests : TestBase
-	{
+	{		
+		[TestCase(300, 100, false, true, true)]
+		[TestCase(100, 300, true, false, true)]
+		[TestCase(300, 300, false, false, true)]
+		[TestCase(100, 100, true, true, true)]
+		
+		[TestCase(300, 100, false, true, false)]
+		[TestCase(100, 300, true, false, false)]
+		[TestCase(300, 300, false, false, false)]
+		[TestCase(100, 100, true, true, false)]
+		
+		[TestCase(200, 200, false, false, false)]
+		[TestCase(200, 100, false, true, false)]
+		[TestCase(100, 200, true, false, false)]
+		public void ScrollableShouldNotHaveScrollBarsWhenContentFits(int width, int height, bool hbar, bool vbar, bool legacy)
+		{
+			ShownAsync(form =>
+			{
+				var scrollable = new Scrollable
+				{
+					Content = new Panel { Size = new Size(200, 200) },
+					Size = new Size(width, height),
+					Border = BorderType.None
+				};
+				var handler = scrollable.Handler as ScrollableHandler;
+				if (legacy)
+					handler.Control.ScrollerStyle = NSScrollerStyle.Legacy;
+				else
+					handler.Control.ScrollerStyle = NSScrollerStyle.Overlay;
+				return scrollable;
+			}, async scrollable =>
+			{
+				await Task.Delay(100); // give time for layout to occur
+				var handler = scrollable.Handler as ScrollableHandler;
+
+				if (hbar)
+					Assert.That(handler.Control.HorizontalScroller.IsHiddenOrHasHiddenAncestor, Is.False, "Scrollable should have horizontal scrollbar when content does not fit");
+				else
+					Assert.That(handler.Control.HorizontalScroller.IsHiddenOrHasHiddenAncestor, Is.True, "Scrollable should not have horizontal scrollbar when content fits");
+					
+				if (vbar)
+					Assert.That(handler.Control.VerticalScroller.IsHiddenOrHasHiddenAncestor, Is.False, "Scrollable should have vertical scrollbar when content does not fit");
+				else
+					Assert.That(handler.Control.VerticalScroller.IsHiddenOrHasHiddenAncestor, Is.True, "Scrollable should not have vertical scrollbar when content fits");
+			});
+
+		}
+		
 		/// <summary>
 		/// When we set a BackgroundColor of a panel, we set WantsLayer and CanDrawSubviewsIntoLayer to true.
 		/// This causes problems with a Scrollable as it makes the content duplicate when scrolling as it was drawn
@@ -48,4 +94,3 @@ namespace Eto.Test.Mac.UnitTests
 		}
 	}
 }
-#endif


### PR DESCRIPTION
This was a regression from #2780 and would cause the scrollbars to show even when not necessary.  This is only apparent when always showing scrollbars in system preferences as it would not take the size of the scrollbars into account.  This was not a problem when using overlay scrollbars.  This fixes both this issue and also keeps the other fixes in place for the `LayoutTests.LabelShouldGetProperSizeWhenContainerSizeIsSetInScrollable` test, ensuring the calculated scroll rectangle is based on the expanded width of the content in the scrollable vs. the desired width.

This also adds some automated tests to ensure this doesn't break again.  The manual tests worked but need manual inspection which made this slip by.