### PR TITLE
Make setting TextBox.Text consistent with the TextChanged event and selection

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
@@ -2,6 +2,8 @@ namespace Eto.GtkSharp.Forms.Controls
 {
 	public class TextBoxHandler : TextBoxHandler<Gtk.Entry, TextBox, TextBox.ICallback>
 	{
+		internal static object DisableTextChanged_Key = new object();
+
 		public TextBoxHandler()
 		{
 			Control = new Gtk.Entry();
@@ -84,6 +86,13 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			return new TextBoxConnector();
 		}
+		
+		protected int DisableTextChanged
+		{
+			get => Widget.Properties.Get<int>(TextBoxHandler.DisableTextChanged_Key);
+			set => Widget.Properties.Set(TextBoxHandler.DisableTextChanged_Key, value);
+		}
+		
 
 		protected class TextBoxConnector : GtkControlConnector
 		{
@@ -91,7 +100,13 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleTextChanged(object sender, EventArgs e)
 			{
-				Handler?.Callback.OnTextChanged(Handler.Widget, EventArgs.Empty);
+				var h = Handler;
+				if (h == null)
+					return;
+				if (h.DisableTextChanged > 0)
+					return;
+					
+				h.Callback.OnTextChanged(Handler.Widget, EventArgs.Empty);
 			}
 
 			static Clipboard clipboard;
@@ -243,8 +258,15 @@ namespace Eto.GtkSharp.Forms.Controls
 					Callback.OnTextChanging(Widget, args);
 					if (args.Cancel)
 						return;
+					DisableTextChanged++;
 					Control.Text = newText;
 					lastSelection = null;
+					DisableTextChanged--;
+					if (AutoSelectMode == AutoSelectMode.Never)
+					{
+						Selection = Eto.Forms.Range.FromLength(newText.Length, 0);
+					}
+					Callback.OnTextChanged(Widget, EventArgs.Empty);
 				}
 			}
 		}

--- a/src/Eto.Mac/Forms/Controls/MacText.cs
+++ b/src/Eto.Mac/Forms/Controls/MacText.cs
@@ -71,6 +71,11 @@ namespace Eto.Mac.Forms.Controls
 						Control.AttributedStringValue = Font.AttributedString(newText, oldValue);
 					else
 						Control.AttributedStringValue = oldValue.ToMutable(newText);
+
+					if (AutoSelectMode == AutoSelectMode.Never)
+					{
+						Selection = Eto.Forms.Range.FromLength(newText.Length, 0);
+					}
 					
 					Callback.OnTextChanged(Widget, EventArgs.Empty);
 				}

--- a/src/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/TextBoxHandler.cs
@@ -1,3 +1,4 @@
+
 namespace Eto.WinForms.Forms.Controls
 {
 	[DesignerCategory("Code")]
@@ -76,6 +77,8 @@ namespace Eto.WinForms.Forms.Controls
 				SetPlaceholderText(); // setting border clears this out for some reason
 			}
 		}
+
+		public override Size? GetDefaultSize(Size availableSize) => new Size(100, 23);
 
 		public TextAlignment TextAlignment
 		{
@@ -316,9 +319,14 @@ namespace Eto.WinForms.Forms.Controls
 					Callback.OnTextChanging(Widget, args);
 					if (args.Cancel)
 						return;
+
+					DisableTextChanged++;
 					base.Text = value;
+					DisableTextChanged--;
 					if (AutoSelectMode == AutoSelectMode.Never)
 						Selection = new Range<int>(value.Length, value.Length - 1);
+						
+					Callback.OnTextChanged(Widget, EventArgs.Empty);
 				}
 			}
 		}

--- a/src/Eto.WinForms/Forms/WindowsControl.cs
+++ b/src/Eto.WinForms/Forms/WindowsControl.cs
@@ -96,6 +96,8 @@ namespace Eto.WinForms.Forms
 		public static readonly object Enabled_Key = new object();
 		public static readonly object UseShellDropManager_Key = new object();
 		public static readonly object MouseCaptured_Key = new object();
+		public static readonly object DisableTextChanged_Key = new object();
+
 
 		public static bool SkipMouseCapture { get; set; }
 		internal static Control DragSourceControl { get; set; }
@@ -880,14 +882,20 @@ namespace Eto.WinForms.Forms
 			e.Handled = kpea.Handled;
 		}
 
+		protected int DisableTextChanged
+		{
+			get => Widget.Properties.Get<int>(WindowsControl.DisableTextChanged_Key);
+			set => Widget.Properties.Set(WindowsControl.DisableTextChanged_Key, value);
+		}
+
 		void Control_TextChanged(object sender, EventArgs e)
 		{
-			var widget = Widget as TextControl;
-			if (widget != null)
-			{
-				var callback = (TextControl.ICallback)((ICallbackSource)widget).Callback;
-				callback.OnTextChanged(widget, e);
-			}
+			if (Widget is not TextControl widget || DisableTextChanged > 0)
+				return;
+				
+			var callback = (TextControl.ICallback)((ICallbackSource)widget).Callback;
+			callback.OnTextChanged(widget, e);
+
 		}
 
 		internal virtual bool SetFontTwiceForSomeReason => false;

--- a/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -306,8 +306,6 @@ namespace Eto.Wpf.Forms.Controls
 				if (args.Cancel)
 					return;
 
-				var needsTextChanged = TextBox.Text == newText;
-
 				// Improve performance when setting text often
 				// See https://github.com/dotnet/wpf/issues/5887#issuecomment-1604577981
 				var endNoGCRegion = EnableNoGCRegion
@@ -326,7 +324,9 @@ namespace Eto.Wpf.Forms.Controls
 
 				try 
 				{
-					TextBox.Text = newText; 
+					DisableTextChanged++;
+					TextBox.Text = newText;
+					DisableTextChanged--;
 				}
 				finally
 				{
@@ -334,7 +334,7 @@ namespace Eto.Wpf.Forms.Controls
 						GC.EndNoGCRegion();
 				}
 				
-				if (value != null && AutoSelectMode == AutoSelectMode.Never && !HasFocus)
+				if (value != null && AutoSelectMode == AutoSelectMode.Never)
 				{
 					TextBox.BeginChange();
 					TextBox.SelectionStart = value.Length;
@@ -342,10 +342,7 @@ namespace Eto.Wpf.Forms.Controls
 					TextBox.EndChange();
 				}
 				
-				if (needsTextChanged)
-				{
-					Callback.OnTextChanged(Widget, EventArgs.Empty);
-				}
+				Callback.OnTextChanged(Widget, EventArgs.Empty);
 			}
 		}
 

--- a/test/Eto.Test/UnitTests/Forms/Controls/TextBoxTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/TextBoxTests.cs
@@ -4,7 +4,7 @@ using Range = Eto.Forms.Range;
 namespace Eto.Test.UnitTests.Forms.Controls
 {
 	public abstract class TextBoxBase<T> : TestBase
-		where T: TextBox, new()
+		where T : TextBox, new()
 	{
 		[Test, ManualTest]
 		public void SettingTextShouldClearUndoBuffer()
@@ -21,7 +21,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 					textBox.Text = "Thanks, now try to undo";
 					textBox.Focus();
 				};
-				
+
 				return new TableLayout
 				{
 					Spacing = new Size(5, 5),
@@ -33,7 +33,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				};
 			});
 		}
-		
+
 		[Test, ManualTest]
 		public void CaretIndexShouldStartInInitialPosition()
 		{
@@ -220,10 +220,10 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			Assert.That(args.Text, Is.EqualTo(text), "#2.4");
 			Assert.That(args.Range, Is.EqualTo(Range.FromLength(rangeStart, rangeLength)), "#2.5");
 		}
-		
+
 		[Test, ManualTest]
 		public void ManyUpdatesShouldNotCauseHangs()
-		{	
+		{
 			TimeSpan maxElapsed = TimeSpan.MinValue;
 			ManualForm(
 			"There should not be any pausing",
@@ -268,6 +268,43 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				return layout;
 			});
 			Assert.That(maxElapsed, Is.LessThan(TimeSpan.FromSeconds(1)), "There were long pauses in the UI");
+		}
+		
+		[TestCase(false)]
+		[TestCase(true)]
+		public void TextChangedShouldFireAfterSelectionWasChangedForNeverAutoSelectMode(bool withFocus)
+		{
+			bool textChangedFired = false;
+			Range<int>? selection = null;
+			string newText = null;
+			Shown(form =>
+			{
+				var textBox = new T();
+				textBox.AutoSelectMode = AutoSelectMode.Never;
+				textBox.Text = "Hello";
+				textBox.Selection = new Range<int>(1, 3);
+				textBox.TextChanged += (sender, e) =>
+				{
+					textChangedFired = true;
+					selection = textBox.Selection;
+					newText = textBox.Text;
+				};
+				
+				return textBox;
+			}, textBox =>
+			{
+				if (withFocus)
+					textBox.Focus();
+
+				Assert.That(textChangedFired, Is.False, "#1");
+				var setText = "Something else";
+				textBox.Text = setText;
+				Assert.That(textChangedFired, Is.True, "#2");
+				Assert.That(selection, Is.EqualTo(Range.FromLength(setText.Length, 0)), "#3");
+				Assert.That(newText, Is.EqualTo(setText), "#4");
+				Assert.That(textBox.Text, Is.EqualTo(setText), "#5");
+				Assert.That(textBox.Selection, Is.EqualTo(Range.FromLength(setText.Length, 0)), "#6");
+			});
 		}
 	}
 


### PR DESCRIPTION
This ensures that the selection is set during the TextChanged event after setting the Text explicitly, especially when using AutoSelectMode.Never.