### PR TITLE
Wpf: Fix calling Focus() on Tree/GridView when it has no selection

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -803,6 +803,13 @@ namespace Eto.Wpf.Forms.Controls
 			SaveColumnFocus();
 			base.Focus();
 			RestoreColumnFocus();
+
+			// ensure we focus the first row if no current cell is set, otherwise using arrow keys after
+			// will not work as expected and actually focus the next/previous control on the form instead of the next/previous row.
+			if (Control.CurrentCell.Item is null && Control.ItemContainerGenerator.ContainerFromIndex(0) is swc.DataGridRow row)
+			{
+				row.MoveFocus(new swi.TraversalRequest(swi.FocusNavigationDirection.Next));
+			}
 		}
 
 		public override void Invalidate(bool invalidateChildren)
@@ -986,7 +993,13 @@ namespace Eto.Wpf.Forms.Controls
 		public bool AllowEmptySelection
 		{
 			get => Widget.Properties.Get<bool>(GridHandler.AllowEmptySelection_Key, true);
-			set => Widget.Properties.Set(GridHandler.AllowEmptySelection_Key, value, true);
+			set
+			{
+				if (Widget.Properties.TrySet(GridHandler.AllowEmptySelection_Key, value, true) && !value)
+				{
+					EnsureSelection();
+				}
+			}
 		}
 		public bool DisableAutoScrollToSelection { get; set; }
 

--- a/test/Eto.Test/Sections/Controls/GridViewSection.cs
+++ b/test/Eto.Test/Sections/Controls/GridViewSection.cs
@@ -182,6 +182,7 @@ namespace Eto.Test.Sections.Controls
 			layout.AddSeparateRow(null,
 						CreateScrollToRow(grid),
 						CreateBeginEditButton(grid),
+						CreateSetFocusButton(grid),
 						null
 					);
 			layout.AddSeparateRow(null,
@@ -203,6 +204,17 @@ namespace Eto.Test.Sections.Controls
 			AddExtraControls(layout);
 			return layout;
 		}
+
+		private Control CreateSetFocusButton(T grid)
+		{
+			var control = new Button { Text = "Set Focus" };
+			control.Click += (sender, e) =>
+			{
+				grid.Focus();
+			};
+			return control;
+		}
+
 
 		protected virtual void AddExtraControls(DynamicLayout layout)
 		{


### PR DESCRIPTION
Using the arrow keys after calling Focus() would traverse to the control before/after the GridView instead of the rows.  This makes calling Focus() the same as pressing Tab to focus the control.