### PR TITLE
Wpf/WinForms: Keyboard.ModifiersChanged event now uses GETMESSAGE hook.

### DIFF
--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -146,7 +146,7 @@ namespace Eto
 			RIGHT = 7
 		}
 
-		public enum WM
+		public enum WM : uint
 		{
 			SETREDRAW = 0xB,
 
@@ -434,17 +434,28 @@ namespace Eto
 		public enum WH
 		{
 			KEYBOARD = 2,
+			GETMESSAGE = 3,
 			KEYBOARD_LL = 13,
 			MOUSE_LL = 14
 		}
 
+		[StructLayout(LayoutKind.Sequential)]
+		public struct MSG
+		{
+			public IntPtr hwnd;       // Handle to the window that receives the message
+			public uint message;      // The message identifier
+			public IntPtr wParam;     // Additional message information (depends on the message)
+			public IntPtr lParam;     // Additional message information (depends on the message)
+			public uint time;         // The time at which the message was posted
+			public POINT pt;          // The cursor position, in screen coordinates, when the message was posted
+		}
 
-		public static IntPtr SetHook(WH hookId, HookProc proc)
+		public static IntPtr SetHook(WH hookId, HookProc proc, uint threadId = 0)
 		{
 			using (Process curProcess = Process.GetCurrentProcess())
 			using (ProcessModule curModule = curProcess.MainModule)
 			{
-				return SetWindowsHookEx((IntPtr)hookId, proc, GetModuleHandle(curModule.ModuleName), 0);
+				return SetWindowsHookEx((IntPtr)hookId, proc, GetModuleHandle(curModule.ModuleName), threadId);
 			}
 		}
 
@@ -455,7 +466,7 @@ namespace Eto
 		public static extern IntPtr GetModuleHandle(string moduleName);
 
 		[DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall)]
-		public static extern IntPtr SetWindowsHookEx(IntPtr hookId, HookProc function, IntPtr instance, int threadId);
+		public static extern IntPtr SetWindowsHookEx(IntPtr hookId, HookProc function, IntPtr instance, uint threadId);
 
 		[DllImport("user32.dll", CharSet = CharSet.Auto, CallingConvention = CallingConvention.StdCall, SetLastError = true)]
 		[return: MarshalAs(UnmanagedType.Bool)]
@@ -528,7 +539,7 @@ namespace Eto
 		}
 
 		[DllImport("kernel32.dll")]
-		static extern uint GetCurrentThreadId();
+		public static extern uint GetCurrentThreadId();
 
 		public static bool GetInfo(out GUITHREADINFO lpgui, uint? threadId = null)
 		{

--- a/src/Eto.Wpf/Forms/KeyboardHandler.cs
+++ b/src/Eto.Wpf/Forms/KeyboardHandler.cs
@@ -19,18 +19,16 @@ namespace Eto.Wpf.Forms
 
 		IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
 		{
-			// only trigger event when the application is active
-			if (nCode == 0 && Application.Instance.IsActive)
+			// Process messages retrieved from the message queue
+			if (nCode >= 0)
 			{
-				if (wParam == (IntPtr)Win32.WM.KEYDOWN || wParam == (IntPtr)Win32.WM.KEYUP
-				|| wParam == (IntPtr)Win32.WM.SYSKEYDOWN || wParam == (IntPtr)Win32.WM.SYSKEYUP)
+				var msg = Marshal.PtrToStructure<Win32.MSG>(lParam);
+
+				if (msg.message == (uint)Win32.WM.KEYDOWN || msg.message == (uint)Win32.WM.KEYUP ||
+					msg.message == (uint)Win32.WM.SYSKEYDOWN || msg.message == (uint)Win32.WM.SYSKEYUP)
 				{
-					var kb = Marshal.PtrToStructure<Win32.KeyboardLowLevelHook>(lParam);
-					// Console.WriteLine($"Callback: {wParam:x}, {lParam}, {kb.VirtualKeyCode:x}, {kb.ScanCode:x}");
-					
-					// this event happens before the state is updated, so we check which key was pressed.
 					var keys = Keys.None;
-					switch (kb.VirtualKeyCode)
+					switch (msg.wParam.ToInt32())
 					{
 						case (int)Win32.VK.RMENU:
 						case (int)Win32.VK.LMENU:
@@ -52,11 +50,14 @@ namespace Eto.Wpf.Forms
 							keys = Keys.Application;
 							break;
 					}
-					if (wParam == (IntPtr)Win32.WM.KEYDOWN || wParam == (IntPtr)Win32.WM.SYSKEYDOWN)
+
+					if (msg.message == (uint)Win32.WM.KEYDOWN || msg.message == (uint)Win32.WM.SYSKEYDOWN)
 						_downKeys = keys;
-					else if (wParam == (IntPtr)Win32.WM.KEYUP || wParam == (IntPtr)Win32.WM.SYSKEYUP)
+					else if (msg.message == (uint)Win32.WM.KEYUP || msg.message == (uint)Win32.WM.SYSKEYUP)
 						_upKeys = keys;
+
 					TriggerChanged();
+
 					_downKeys = null;
 					_upKeys = null;
 				}
@@ -71,7 +72,12 @@ namespace Eto.Wpf.Forms
 				if (_modifiersChanged == null)
 				{
 					_hookProc = new Win32.HookProc(HookCallback);
-					_hookId = Win32.SetHook(Win32.WH.KEYBOARD_LL, _hookProc);
+					_hookId = Win32.SetHook(Win32.WH.GETMESSAGE, _hookProc, Win32.GetCurrentThreadId());
+					if (_hookId == IntPtr.Zero)
+					{
+						int error = Marshal.GetLastWin32Error();
+						Debug.WriteLine($"Failed to set hook. Error: {error}");
+					}
 					_modifiers = Modifiers;
 					_oldLockedKeys.Clear();
 					_oldLockedKeys.AddRange(SupportedLockKeys.Where(IsKeyLocked));


### PR DESCRIPTION
The WH_WH.KEYBOARD_LL hook causes issues when debugging, and can cause keyboard lag in other apps.