### PR TITLE
Support Location/Size changed events on wrapped native forms on Windows and Mac

### DIFF
--- a/src/Eto.Mac/Forms/NativeFormHandler.cs
+++ b/src/Eto.Mac/Forms/NativeFormHandler.cs
@@ -11,11 +11,16 @@ namespace Eto.Mac.Forms
 		{
 		}
 
+		internal override bool DelayRegisterNotificationCenter => false;
+
 		public override void AttachEvent(string id)
 		{
 			// native window, so attach observers instead of using the delegate so we don't clobber existing functionality
 			switch (id)
 			{
+				case Window.LocationChangedEvent:
+					AddObserver(NSWindow.DidMoveNotification, n => Callback.OnLocationChanged(Widget, EventArgs.Empty));
+					break;
 				case Window.ClosedEvent:
 					AddObserver(NSWindow.WillCloseNotification, n => Callback.OnClosed(Widget, EventArgs.Empty));
 					break;
@@ -39,14 +44,14 @@ namespace Eto.Mac.Forms
 		internal static Window CreateWrapper(NSWindowController windowController, NSWindow nswindow)
 		{
 			var handle = windowController?.Handle ?? nswindow.Handle;
-			
+
 			s_cachedWindows ??= new Dictionary<NativeHandle, WeakReference>();
-			
+
 			if (s_cachedWindows.TryGetValue(handle, out var windowReference) && windowReference.Target is Window window)
 				return window;
-				
+
 			var handler = windowController != null ? new NativeFormHandler(windowController) : new NativeFormHandler(nswindow);
- 			window = new Form(handler);
+			window = new Form(handler);
 			s_cachedWindows[handle] = new WeakReference(window);
 			List<NativeHandle> toRemove = null;
 			foreach (var entry in s_cachedWindows)
@@ -59,7 +64,7 @@ namespace Eto.Mac.Forms
 			}
 			if (toRemove != null)
 			{
-				foreach	(var entry in toRemove)
+				foreach (var entry in toRemove)
 				{
 					s_cachedWindows.Remove(entry);
 				}

--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -6,7 +6,112 @@ namespace Eto.Wpf.Forms
 namespace Eto.WinForms.Forms
 #endif
 {
-	public class HwndFormHandler : WidgetHandler<IntPtr, Form>, Form.IHandler,
+
+	class WindowHookHelper<T>
+	{
+		class HookData
+		{
+			public IntPtr OldHookHandle;
+			public List<WeakReference> Handlers = new();
+		}
+
+		IntPtr _newHookHandle;
+		private readonly Func<T, IntPtr, uint, IntPtr, IntPtr, IntPtr> _callHook;
+
+		private readonly Dictionary<IntPtr, HookData> _hooks = new();
+
+		Win32.WndProcDelegate _wndProc;
+
+		public WindowHookHelper(Func<T, IntPtr, uint, IntPtr, IntPtr, IntPtr> callHook)
+		{
+			_callHook = callHook;
+			_wndProc = WndProc;
+		}
+
+		IntPtr WndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+		{
+			lock (_hooks)
+			{
+				if (_hooks.TryGetValue(hWnd, out var data))
+				{
+					for (int i = 0; i < data.Handlers.Count; i++)
+					{
+						WeakReference weakRef = data.Handlers[i];
+						if (weakRef.Target is T handler)
+						{
+							var ret = _callHook?.Invoke(handler, hWnd, msg, wParam, lParam) ?? IntPtr.Zero;
+							if (ret != IntPtr.Zero)
+								return ret; // if a handler has handled the message, return its result
+						}
+						if (weakRef.Target == null)
+						{
+							data.Handlers.RemoveAt(i);
+							i--;
+						}
+					}
+					if (data.Handlers.Count == 0)
+					{
+						// no handlers left, remove the hook
+						Win32.SetWindowLongPtr(hWnd, Win32.GWL.WNDPROC, data.OldHookHandle);
+						_hooks.Remove(hWnd);
+					}
+					return Win32.CallWindowProc(data.OldHookHandle, hWnd, msg, wParam, lParam);
+				}
+			}
+			return IntPtr.Zero; // no hook found, return zero
+		}
+
+		public void AddHook(IntPtr hwnd, T handler)
+		{
+			lock (_hooks)
+			{
+				if (!_hooks.TryGetValue(hwnd, out var data))
+				{
+					data = new HookData();
+					_hooks[hwnd] = data;
+				}
+				else
+				{
+					if (data.Handlers.Any(w => w.Target is T h && h.Equals(handler)))
+						return; // already added
+				}
+				data.Handlers.Add(new WeakReference(handler));
+				if (data.OldHookHandle == IntPtr.Zero)
+				{
+					_newHookHandle = Marshal.GetFunctionPointerForDelegate(_wndProc);
+					data.OldHookHandle = Win32.SetWindowLongPtr(hwnd, Win32.GWL.WNDPROC, _newHookHandle);
+				}
+			}
+		}
+
+		internal void RemoveHook(IntPtr hwnd, T handler)
+		{
+			lock (_hooks)
+			{
+				if (_hooks.TryGetValue(hwnd, out var data))
+				{
+					for (int i = 0; i < data.Handlers.Count; i++)
+					{
+						WeakReference weakRef = data.Handlers[i];
+						if (weakRef.Target is null || (weakRef.Target is T h && h.Equals(handler)))
+						{
+							data.Handlers.RemoveAt(i);
+							i--;
+						}
+					}
+					if (data.Handlers.Count == 0)
+					{
+						// remove
+						Win32.SetWindowLongPtr(hwnd, Win32.GWL.WNDPROC, data.OldHookHandle);
+						_hooks.Remove(hwnd);
+					}
+				}
+			}
+		}
+	}
+
+
+	public class HwndFormHandler : WidgetHandler<IntPtr, Form, Form.ICallback>, Form.IHandler,
 #if WPF
  IWpfWindow
 #elif WINFORMS
@@ -45,6 +150,28 @@ namespace Eto.WinForms.Forms
     }
 
 #endif
+
+		public static Form Create(IntPtr window)
+		{
+			for (int i = 0; i < g_windows.Count; i++)
+			{
+				WeakReference w = g_windows[i];
+				if (w.Target is HwndFormHandler handler && handler.Control == window)
+				{
+					return handler.Widget;
+				}
+				if (w.Target == null)
+				{
+					g_windows.RemoveAt(i);
+					i--;
+				}
+			}
+			var form = new Form(new HwndFormHandler(window));
+			g_windows.Add(new WeakReference(form.Handler));
+			return form;
+		}
+
+		private static readonly List<WeakReference> g_windows = new();
 
 		public HwndFormHandler(IntPtr hWnd)
 		{
@@ -602,10 +729,93 @@ namespace Eto.WinForms.Forms
 			throw new NotImplementedException();
 		}
 
+		~HwndFormHandler()
+		{
+			Dispose(false);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				_hookHelper?.RemoveHook(Control, this);
+			}
+
+			base.Dispose(disposing);
+		}
+
+		Win32.WndProcDelegate _customWndProcDelegate;
+		static WindowHookHelper<HwndFormHandler> _hookHelper;
+
+		void HookWndProc()
+		{
+			_hookHelper ??= new WindowHookHelper<HwndFormHandler>((handler, hWnd, msg, wParam, lParam) =>
+			{
+				return handler.HandleWndProc(hWnd, msg, wParam, lParam);
+			});
+			_hookHelper.AddHook(Control, this);
+		}
+
+		internal event Win32.WndProcDelegate WndProc
+		{
+			add
+			{
+				if (_customWndProcDelegate == null)
+					HookWndProc();
+				_customWndProcDelegate += value;
+			}
+			remove
+			{
+				_customWndProcDelegate -= value;
+				if (_customWndProcDelegate == null)
+					_hookHelper?.RemoveHook(Control, this);
+			}
+		}
+
+
+		private IntPtr HandleWndProc(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam)
+		{
+			return _customWndProcDelegate?.Invoke(hWnd, msg, wParam, lParam) ?? IntPtr.Zero;
+		}
+
 		public override void AttachEvent(string id)
 		{
 			switch (id)
 			{
+				case Window.LocationChangedEvent:
+					PointF? location = null;
+					// attach window message hook to track location changes
+					WndProc += (hWnd, msg, wParam, lParam) =>
+					{
+						if (msg == (uint)Win32.WM.MOVE || msg == (uint)Win32.WM.SIZE)
+						{
+							var newLocation = Location;
+							if (location == newLocation)
+								return IntPtr.Zero; // no change, do not trigger event
+							location = newLocation;
+							Callback.OnLocationChanged(Widget, EventArgs.Empty);
+						}
+						return IntPtr.Zero;
+					};
+
+					break;
+				case Window.SizeChangedEvent:
+					SizeF? size = null;
+					// attach window message hook to track location changes
+					WndProc += (hWnd, msg, wParam, lParam) =>
+					{
+						if (msg == (uint)Win32.WM.SIZE)
+						{
+							var newSize = Size;
+							if (size == newSize)
+								return IntPtr.Zero; // no change, do not trigger event
+							size = newSize;
+							Callback.OnSizeChanged(Widget, EventArgs.Empty);
+						}
+						return IntPtr.Zero;
+					};
+
+					break;
 				case Window.LogicalPixelSizeChangedEvent:
 					// don't spam the output with warnings for this, many controls use it internally
 					break;

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -84,6 +84,8 @@ namespace Eto
 		public static readonly IntPtr HWND_TOP = new IntPtr(0);
 		public static readonly IntPtr HWND_BOTTOM = new IntPtr(1);
 
+		public delegate IntPtr WndProcDelegate(IntPtr hWnd, uint msg, IntPtr wParam, IntPtr lParam);
+
 		public enum GWL
 		{
 			EXSTYLE = -20,
@@ -197,6 +199,9 @@ namespace Eto
 			USER = 0x400,
 			EM_GETSCROLLPOS = USER + 221,
 			EM_SETSCROLLPOS = USER + 222,
+
+			MOVE = 0x0003,
+			SIZE = 0x0005,
 		}
 
 		public enum VK : long
@@ -341,6 +346,12 @@ namespace Eto
 
 		[DllImport("user32.dll")]
 		public static extern int SetWindowLong(IntPtr hWnd, GWL nIndex, uint dwNewLong);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		public static extern IntPtr SetWindowLongPtr(IntPtr hWnd, GWL nIndex, IntPtr dwNewLong);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		public static extern IntPtr CallWindowProc(IntPtr lpPrevWndFunc, IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);
 
 		[DllImport("user32.dll")]
 		public static extern IntPtr SendMessage(IntPtr hWnd, WM wMsg, IntPtr wParam, IntPtr lParam);

--- a/src/Eto.Wpf/Forms/NativeFormHandler.cs
+++ b/src/Eto.Wpf/Forms/NativeFormHandler.cs
@@ -2,6 +2,27 @@ namespace Eto.Wpf.Forms
 {
 	public class NativeFormHandler : WpfWindow<sw.Window, Form, Form.ICallback>, Form.IHandler
 	{
+		public static Form Create(sw.Window window)
+		{
+			for (int i = 0; i < g_windows.Count; i++)
+			{
+				WeakReference w = g_windows[i];
+				if (w.Target is NativeFormHandler handler && handler.Control == window)
+				{
+					return handler.Widget;
+				}
+				if (w.Target == null)
+				{
+					g_windows.RemoveAt(i);
+					i--;
+				}
+			}
+			var form = new Form(new NativeFormHandler(window));
+			g_windows.Add(new WeakReference(form.Handler));
+			return form;
+		}
+
+		private static readonly List<WeakReference> g_windows = new();
 
 		public NativeFormHandler(sw.Window window)
 		{

--- a/src/Eto.Wpf/WinFormsHelpers.cs
+++ b/src/Eto.Wpf/WinFormsHelpers.cs
@@ -27,7 +27,7 @@ namespace Eto.Wpf
 		{
 			if (windowHandle == IntPtr.Zero)
 				return null;
-			return new Form(new HwndFormHandler(windowHandle));
+			return HwndFormHandler.Create(windowHandle);
 		}
 
 		static readonly object Form_Key = new object();
@@ -41,9 +41,10 @@ namespace Eto.Wpf
 		{
 			if (form == null)
 				return null;
-			var etoForm = new Form(new HwndFormHandler(form.Handle));
+			var etoForm = HwndFormHandler.Create(form.Handle);
 			etoForm.Properties[Form_Key] = form;
 			return etoForm;
 		}
+
 	}
 }

--- a/src/Eto.Wpf/WpfHelpers.cs
+++ b/src/Eto.Wpf/WpfHelpers.cs
@@ -66,8 +66,10 @@ namespace Eto.Forms
 		{
 			if (window == null)
 				return null;
-			return new Form(new NativeFormHandler(window));
+
+			return NativeFormHandler.Create(window);
 		}
+
 
 		/// <summary>
 		/// Wraps a native win32 window in an Eto control so it can be used as a parent when showing dialogs, etc.
@@ -81,7 +83,7 @@ namespace Eto.Forms
 		{
 			if (windowHandle == IntPtr.Zero)
 				return null;
-			return new Form(new HwndFormHandler(windowHandle));
+			return HwndFormHandler.Create(windowHandle);
 		}
 
 		/// <summary>


### PR DESCRIPTION
This also ensures that only a single instance of the wrapped Eto window is created on Windows, like it is for Mac.