### PR TITLE
Fix(macOS): Prevent nested app bundle on publish

### DIFF
--- a/src/Eto.Mac/build/BundleDotNetCore.targets
+++ b/src/Eto.Mac/build/BundleDotNetCore.targets
@@ -243,7 +243,7 @@
 
   <Target Name="MacCopyPublishFiles" DependsOnTargets="MacInitializeBundle">
     <ItemGroup>
-      <LauncherFiles Include="$(PublishDir)\**\*" Exclude="$(LauncherPath)**\*" />
+      <LauncherFiles Include="$(PublishDir)\**\*" Exclude="$(OutputAppPath)**\*" />
       <LauncherFiles Remove="$(PublishDir)\**\*.pdb" Condition="$(MacIncludeSymbols) != 'True'" />
     </ItemGroup>
 


### PR DESCRIPTION
When publishing a .NET Core application on macOS, the `MacCopyPublishFiles` target would incorrectly copy the generated .app bundle into itself. This resulted in a nested directory structure (e.g., `MyCoolApp.app/Contents/MacOS/MyCoolApp.app`).

This was caused by excluding `$(LauncherPath)` which only excludes the executable, not the entire app bundle directory.

The fix changes the exclusion to `$(OutputAppPath)`, which correctly points to the root of the `.app` bundle, preventing it from being copied into its own `Contents/MacOS` directory.