### PR TITLE
Wpf/WinForms: add text alignment to NumericStepper control

### DIFF
--- a/src/Eto.WinForms/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/NumericStepperHandler.cs
@@ -132,7 +132,8 @@ namespace Eto.WinForms.Forms.Controls
 				Handler = this,
 				Maximum = DoubleToDecimal(double.MaxValue),
 				Minimum = DoubleToDecimal(double.MinValue),
-				Width = 80
+				Width = 80,
+				TextAlign = TextAlignment.Left.ToSWF()
 			};
 			Control.ValueChanged += Control_ValueChanged;
 			Control.LostFocus += (sender, e) =>
@@ -145,7 +146,6 @@ namespace Eto.WinForms.Forms.Controls
 				}
 			};
 		}
-		
 		int valueChanging;
 		double? lastValue;
 
@@ -351,7 +351,6 @@ namespace Eto.WinForms.Forms.Controls
 			}
 			valueChanging--;
 		}
-		
 		decimal DoubleToDecimal(double value)
 		{
 			if (double.IsNegativeInfinity(value) || value < (double)decimal.MinValue)
@@ -379,6 +378,12 @@ namespace Eto.WinForms.Forms.Controls
 			Widget.Properties.Remove(ComputedFormatString_Key);
 			Control.DecimalPlaces = Math.Max(Math.Min(GetNumberOfDigits(), MaximumDecimalPlaces), DecimalPlaces);
 			Control.UpdateText();
+		}
+
+		public TextAlignment TextAlignment
+		{
+			get => Control.TextAlign.ToEto();
+			set => Control.TextAlign = value.ToSWF();
 		}
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/NumericStepperHandler.cs
@@ -62,7 +62,8 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				Handler = this,
 				FormatString = "0",
-				Value = 0
+				Value = 0,
+				TextAlignment = Eto.Forms.TextAlignment.Left.ToWpfTextAlignment()
 			};
 			Control.ValueChanged += Control_ValueChanged;
 			Control.Loaded += Control_Loaded;
@@ -128,7 +129,7 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			if (valueChanging > 0)
 				return;
-				
+
 			var val = Value;
 			var newval = GetPreciseValue(val);
 			if (newval != val)
@@ -315,6 +316,15 @@ namespace Eto.Wpf.Forms.Controls
 			}
 			else
 				Control.FormatString = "0";
+		}
+
+		public Eto.Forms.TextAlignment TextAlignment
+		{
+			get { return Control.TextAlignment.ToEto(); }
+			set
+			{
+				Control.TextAlignment = value.ToWpfTextAlignment();
+			}
 		}
 	}
 }

--- a/src/Eto/Forms/Controls/NumericStepper.cs
+++ b/src/Eto/Forms/Controls/NumericStepper.cs
@@ -1,4 +1,4 @@
-﻿namespace Eto.Forms;
+namespace Eto.Forms;
 
 /// <summary>
 /// Control for the user to enter a numeric value (obsolete, use NumericStepper instead)
@@ -212,6 +212,16 @@ public class NumericStepper : CommonControl
 	}
 
 	/// <summary>
+	/// Gets or sets the alignment of the text.
+	/// </summary>
+	/// <value>The text alignment.</value>
+	public TextAlignment TextAlignment
+	{
+		get => Handler.TextAlignment;
+		set => Handler.TextAlignment = value;
+	}
+
+	/// <summary>
 	/// Gets the binding for the <see cref="Value"/> property.
 	/// </summary>
 	/// <value>The value binding.</value>
@@ -371,11 +381,17 @@ public class NumericStepper : CommonControl
 		/// for the thousands separator, decimal separator, and currency symbol.
 		/// </remarks>
 		CultureInfo CultureInfo { get; set; }
-			
+
 		/// <summary>
 		/// A value indicating whether to wrap the value after the user steps past the min or max value
 		/// </summary>
 		/// <value><c>true</c> to wrap the value when stepping past its bounds, <c>false</c> to stop</value>
 		bool Wrap { get; set; }
+
+		/// <summary>
+		/// Gets or sets the alignment of the text.
+		/// </summary>
+		/// <value>The text alignment.</value>
+		TextAlignment TextAlignment { get; set; }
 	}
 }

--- a/test/Eto.Test/Sections/Controls/NumericStepperSection.cs
+++ b/test/Eto.Test/Sections/Controls/NumericStepperSection.cs
@@ -1,4 +1,3 @@
-﻿using Eto.Drawing;
 namespace Eto.Test.Sections.Controls
 {
 	[Section("Controls", typeof(NumericStepper))]
@@ -52,14 +51,18 @@ namespace Eto.Test.Sections.Controls
 
 			var cultureDropDown = new CultureDropDown();
 			cultureDropDown.SelectedValueBinding.Bind(numeric, c => c.CultureInfo);
-			
+
 			var wrap = new CheckBox { Text = "Wrap" };
 			wrap.CheckedBinding.Bind(numeric, n => n.Wrap);
-			
+
 
 			var increment = new NumericStepper { MaximumDecimalPlaces = 15 };
 			increment.ValueBinding.Bind(numeric, n => n.Increment);
-			
+
+			var leftAligned = new NumericStepper { TextAlignment = TextAlignment.Left };
+			var centerAligned = new NumericStepper { TextAlignment = TextAlignment.Center };
+			var rightAligned = new NumericStepper { TextAlignment = TextAlignment.Right };
+
 			var options1 = new StackLayout
 			{
 				Spacing = 5,
@@ -84,6 +87,7 @@ namespace Eto.Test.Sections.Controls
 					"Increment", increment
 				}
 			};
+
 			var options3 = new StackLayout
 			{
 				Spacing = 5,
@@ -96,6 +100,19 @@ namespace Eto.Test.Sections.Controls
 				}
 			};
 
+			var options4 = new StackLayout
+			{
+				Spacing = 5,
+				Orientation = Orientation.Horizontal,
+				VerticalContentAlignment = VerticalAlignment.Center,
+				Items =
+				{
+					"Left Aligned", leftAligned,
+					"Center Aligned", centerAligned,
+					"Right Aligned", rightAligned
+				}
+			};
+
 			Content = new StackLayout
 			{
 				Spacing = 5,
@@ -104,6 +121,7 @@ namespace Eto.Test.Sections.Controls
 					options1,
 					options2,
 					options3,
+					options4,
 					TableLayout.Horizontal(5, "FormatString", formatString, "CultureInfo", cultureDropDown),
 					"Result:", numeric
 				}


### PR DESCRIPTION
Adds text alignment to the NumericStepper control for WPF/WinForms. Also added examples of NumericStepper for each alignment to the Eto.Test App:

<img width="1030" height="784" alt="Screenshot 2025-09-14 171843" src="https://github.com/user-attachments/assets/82f57970-f021-42ba-9489-cb86b1cb9e28" />

Have set the default alignment to `TextAlignment.Left` to keep it consistent with existing behavior.

Have made changes for Gtk but haven't tested.