### PR TITLE
Add Control.ContextMenu

### DIFF
--- a/src/Eto.Android/Forms/AndroidControl.cs
+++ b/src/Eto.Android/Forms/AndroidControl.cs
@@ -14,9 +14,9 @@ namespace Eto.Android.Forms
 	/// <copyright>(c) 2013 by Curtis Wensley</copyright>
 	/// <license type="BSD-3">See LICENSE for full terms</license>
 	public abstract class AndroidControl<TControl, TWidget, TCallback> : WidgetHandler<TControl, TWidget, TCallback>, Control.IHandler, IAndroidControl
-		where TControl: av.View
-		where TWidget: Control
-		where TCallback: Control.ICallback
+		where TControl : av.View
+		where TWidget : Control
+		where TCallback : Control.ICallback
 	{
 		public abstract av.View ContainerControl { get; }
 
@@ -29,7 +29,7 @@ namespace Eto.Android.Forms
 			switch (id)
 			{
 				case Eto.Forms.Control.MouseDownEvent:
-					if(!attachedTouchEvent)
+					if (!attachedTouchEvent)
 						Control.Touch += Control_Touch;
 					attachedMouseDown = attachedTouchEvent = true;
 					break;
@@ -174,7 +174,7 @@ namespace Eto.Android.Forms
 			{
 				if (!Widget.Loaded)
 					return UserPreferredSize;
-				
+
 				var SizeInDp = new Size(ContainerControl.Width, ContainerControl.Height);
 				return Platform.PxToDp(SizeInDp);
 			}
@@ -219,7 +219,7 @@ namespace Eto.Android.Forms
 		public bool Visible
 		{
 			get { return Control.Visibility == av.ViewStates.Visible; }
-			set 
+			set
 			{
 				var Requested = value ? av.ViewStates.Visible : av.ViewStates.Gone;
 
@@ -307,5 +307,8 @@ namespace Eto.Android.Forms
 		public virtual void UpdateLayout()
 		{
 		}
+		
+		public ContextMenu ContextMenu { get; set; }
+
 	}
 }

--- a/src/Eto.Android/Forms/AndroidPanel.cs
+++ b/src/Eto.Android/Forms/AndroidPanel.cs
@@ -93,17 +93,5 @@ namespace Eto.Android.Forms
 				ContainerControl.SetMinimumHeight(value.Height);
 			}
 		}
-
-		public ContextMenu ContextMenu
-		{
-			get
-			{
-				throw new NotImplementedException();
-			}
-			set
-			{
-				throw new NotImplementedException();
-			}
-		}
 	}
 }

--- a/src/Eto.Android/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Android/Forms/Controls/DrawableHandler.cs
@@ -316,8 +316,6 @@ namespace Eto.Android.Forms.Controls
 				base.Focus();
 		}
 
-		public ContextMenu ContextMenu { get; set; }
-
 		public override av.View ContainerControl => Control;
 
 		public Size ScrollSize

--- a/src/Eto.Android/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Android/Forms/Controls/GridViewHandler.cs
@@ -263,18 +263,6 @@ namespace Eto.Android.Forms.Controls
 			get { return Control; }
 		}
 
-		public ContextMenu ContextMenu
-		{
-			get
-			{
-				throw new NotImplementedException();
-			}
-			set
-			{
-				throw new NotImplementedException();
-			}
-		}
-
 		public void BeginEdit(int row, int column)
 		{
 			throw new NotImplementedException();

--- a/src/Eto.Android/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Android/Forms/Controls/ListBoxHandler.cs
@@ -164,12 +164,6 @@ namespace Eto.Android.Forms.Controls
 			get;
 			set;
 		}
-
-		public ContextMenu ContextMenu
-		{
-			get;
-			set;
-		}
 	}
 
 	public class EtoListBoxItem

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -18,7 +18,6 @@ namespace Eto.GtkSharp.Forms.Controls
 	{
 		ColumnCollection columns;
 		Gtk.TreeViewColumn spacingColumn;
-		ContextMenu contextMenu;
 		readonly Dictionary<int, int> columnMap = new Dictionary<int, int>();
 
 		protected bool SkipSelectedChange { get; set; }
@@ -132,9 +131,6 @@ namespace Eto.GtkSharp.Forms.Controls
 			Control.HeadersVisible = true;
 			ScrolledWindow.Child = Control;
 
-			Control.Events |= Gdk.EventMask.ButtonPressMask;
-			Control.ButtonPressEvent += Connector.HandleButtonPress;
-
 			columns = new ColumnCollection { Handler = this };
 			columns.Register(Widget.Columns);
 			base.Initialize();
@@ -154,6 +150,8 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			Control.QueryTooltip += Control_QueryTooltip;
 			Control.HasTooltip = true;
+
+			HandleEvent(Eto.Forms.Control.MouseDownEvent);			
 		}
 
 		private void Control_QueryTooltip(object o, Gtk.QueryTooltipArgs args)
@@ -193,16 +191,19 @@ namespace Eto.GtkSharp.Forms.Controls
 			public new GridHandler<TWidget, TCallback> Handler { get { return (GridHandler<TWidget, TCallback>)base.Handler; } }
 
 			[GLib.ConnectBefore]
-			public void HandleButtonPress(object o, Gtk.ButtonPressEventArgs args)
+			public override void HandleButtonPressEvent(object sender, Gtk.ButtonPressEventArgs args)
 			{
-				var treeview = o as Gtk.TreeView;
+				base.HandleButtonPressEvent(sender, args);
+
+				if (!Equals(args.RetVal, true))
+					OnTreeButtonPress(sender, args);
 
 				// Gtk default behaviout for multiselect treeview is that
 				// left and right click act the same, which is problematic
 				// when it comes to user selecting multiple items and than
 				// right clicking to find only one item remains selected
 				// or if ctrl is held the current item gets unselected.
-				if (args.Event.Button == 3 && treeview != null)
+				if (!Equals(args.RetVal, true) && args.Event.Button == 3 && sender is Gtk.TreeView treeview)
 				{
 					Gtk.TreeViewDropPosition pos;
 					Gtk.TreePath path;
@@ -221,17 +222,6 @@ namespace Eto.GtkSharp.Forms.Controls
 								args.RetVal = true;
 						}
 					}
-				}
-
-				var handler = Handler;
-				if (handler == null)
-					return;
-					
-				if (handler.contextMenu != null && args.Event.Button == 3 && args.Event.Type == Gdk.EventType.ButtonPress)
-				{
-					var menu = ((ContextMenuHandler)handler.contextMenu.Handler).Control;
-					menu.Popup();
-					menu.ShowAll();
 				}
 			}
 
@@ -271,10 +261,9 @@ namespace Eto.GtkSharp.Forms.Controls
 						selectedRows = selected;
 					}
 				}
-			}
+			}			
 
-			[GLib.ConnectBefore]
-			public virtual void OnTreeButtonPress(object sender, Gtk.ButtonPressEventArgs e)
+			void OnTreeButtonPress(object sender, Gtk.ButtonPressEventArgs e)
 			{
 				if (e.Event.Type == Gdk.EventType.TwoButtonPress || e.Event.Type == Gdk.EventType.ThreeButtonPress)
 					return;
@@ -341,7 +330,7 @@ namespace Eto.GtkSharp.Forms.Controls
 					SetupColumnEvents();
 					break;
 				case Grid.CellClickEvent:
-					Control.ButtonPressEvent += Connector.OnTreeButtonPress;
+					HandleEvent(Eto.Forms.Control.MouseDownEvent);
 					break;
 				case Grid.CellDoubleClickEvent:
 					Control.RowActivated += (sender, e) =>
@@ -514,12 +503,6 @@ namespace Eto.GtkSharp.Forms.Controls
 		public void SetColumnMap(int dataIndex, int column)
 		{
 			columnMap[dataIndex] = column;
-		}
-
-		public ContextMenu ContextMenu
-		{
-			get { return contextMenu; }
-			set { contextMenu = value; }
 		}
 
 		public void EndCellEditing(Gtk.TreePath path, int column)

--- a/src/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
@@ -6,7 +6,6 @@ namespace Eto.GtkSharp.Forms.Controls
 		IIndirectBinding<string> _itemTextBinding;
 		readonly Gtk.ScrolledWindow scroll;
 		GtkEnumerableModel<object> model;
-		ContextMenu contextMenu;
 		CollectionHandler collection;
 		public static Size MaxImageSize = new Size(16, 16);
 
@@ -37,7 +36,6 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			base.Initialize();
 			Size = new Size(80, 80);
-			Control.ButtonPressEvent += Connector.HandleTreeButtonPressEvent;
 			Control.Selection.Changed += Connector.HandleSelectionChanged;
 			Control.RowActivated += Connector.HandleTreeRowActivated;
 		}
@@ -53,19 +51,6 @@ namespace Eto.GtkSharp.Forms.Controls
 		{
 			public new ListBoxHandler Handler { get { return (ListBoxHandler)base.Handler; } }
 
-			[GLib.ConnectBefore]
-			public void HandleTreeButtonPressEvent(object o, Gtk.ButtonPressEventArgs args)
-			{
-				var handler = Handler;
-				if (handler == null)
-					return;
-				if (handler.contextMenu != null && args.Event.Button == 3 && args.Event.Type == Gdk.EventType.ButtonPress)
-				{
-					var menu = (Gtk.Menu)handler.contextMenu.ControlObject;
-					menu.Popup();
-					menu.ShowAll();
-				}
-			}
 
 			public void HandleSelectionChanged(object sender, EventArgs e)
 			{
@@ -107,12 +92,6 @@ namespace Eto.GtkSharp.Forms.Controls
 
 				Control.SetCursor(path, focus_column, false);
 			}
-		}
-
-		public ContextMenu ContextMenu
-		{
-			get { return contextMenu; }
-			set { contextMenu = value; }
 		}
 
 		public GLib.Value GetColumnValue(object item, int column, int row)

--- a/src/Eto.Gtk/Forms/Controls/TreeViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TreeViewHandler.cs
@@ -9,7 +9,6 @@ namespace Eto.GtkSharp.Forms.Controls
 		GtkTreeModel<ITreeItem, ITreeStore> model;
 		CollectionHandler collection;
 		readonly Gtk.TreeView tree;
-		ContextMenu contextMenu;
 		bool cancelExpandCollapseEvents;
 		readonly Gtk.CellRendererText textCell;
 		public static Size MaxImageSize = new Size(16, 16);
@@ -123,14 +122,6 @@ namespace Eto.GtkSharp.Forms.Controls
 			Control = new Gtk.ScrolledWindow();
 			Control.ShadowType = Gtk.ShadowType.In;
 			Control.Add(tree);
-			
-			tree.Events |= Gdk.EventMask.ButtonPressMask;
-		}
-
-		protected override void Initialize()
-		{
-			base.Initialize();
-			tree.ButtonPressEvent += Connector.HandleTreeButtonPressEvent;
 		}
 
 		public override void AttachEvent(string id)
@@ -274,20 +265,6 @@ namespace Eto.GtkSharp.Forms.Controls
 					item.Text = args.NewText;
 				}
 			}
-
-			[GLib.ConnectBefore]
-			public void HandleTreeButtonPressEvent(object o, Gtk.ButtonPressEventArgs args)
-			{
-				var handler = Handler;
-				if (handler == null)
-					return;
-				if (handler.contextMenu != null && args.Event.Button == 3 && args.Event.Type == Gdk.EventType.ButtonPress)
-				{
-					var menu = ((ContextMenuHandler)handler.contextMenu.Handler).Control;
-					menu.Popup();
-					menu.ShowAll();
-				}
-			}
 		}
 
 		public ITreeStore DataStore
@@ -300,12 +277,6 @@ namespace Eto.GtkSharp.Forms.Controls
 				collection = new CollectionHandler { Handler = this };
 				collection.Register(value);
 			}
-		}
-
-		public ContextMenu ContextMenu
-		{
-			get { return contextMenu; }
-			set { contextMenu = value; }
 		}
 
 		public ITreeItem SelectedItem

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -1,3 +1,5 @@
+using Eto.GtkSharp.Forms.Menu;
+
 namespace Eto.GtkSharp.Forms
 {
 	public interface IGtkControl
@@ -67,6 +69,7 @@ namespace Eto.GtkSharp.Forms
 		public static readonly object IsMouseCaptured_Key = new object();
 		public static readonly object LastEnteredControls_Key = new object();
 		public static readonly object ShouldTranslatePoints_Key = new object();
+		internal static readonly object ContextMenu_Key = new object();
 		public static uint? DefaultBorderWidth;
 		
 		public static HashSet<IGtkControl> EnteredControls = new HashSet<IGtkControl>();
@@ -79,7 +82,6 @@ namespace Eto.GtkSharp.Forms
 		where TCallback : Control.ICallback
 	{
 		Size asize;
-		bool mouseDownHandled;
 #if GTK2
 		Color? cachedBackgroundColor;
 #endif
@@ -154,7 +156,7 @@ namespace Eto.GtkSharp.Forms
 			ContainerControl.SetSizeRequest(size.Width, size.Height);
 			InvalidateMeasure();
 		}
-		
+
 		internal bool DeferMouseLeave
 		{
 			get => Widget.Properties.Get<bool>(GtkControl.DeferMouseLeave_Key);
@@ -409,14 +411,12 @@ namespace Eto.GtkSharp.Forms
 					EventControl.SizeAllocated += Connector.HandleSizeAllocated;
 					break;
 				case Eto.Forms.Control.MouseDoubleClickEvent:
+					HandleEvent(Eto.Forms.Control.MouseDownEvent);
+					break;
 				case Eto.Forms.Control.MouseDownEvent:
-					if (!mouseDownHandled)
-					{
-						EventControl.AddEvents((int)Gdk.EventMask.ButtonPressMask);
-						EventControl.AddEvents((int)Gdk.EventMask.ButtonReleaseMask);
-						EventControl.ButtonPressEvent += Connector.HandleButtonPressEvent;
-						mouseDownHandled = true;
-					}
+					EventControl.AddEvents((int)Gdk.EventMask.ButtonPressMask);
+					EventControl.AddEvents((int)Gdk.EventMask.ButtonReleaseMask);
+					EventControl.ButtonPressEvent += Connector.HandleButtonPressEvent;
 					break;
 				case Eto.Forms.Control.MouseUpEvent:
 					EventControl.AddEvents((int)Gdk.EventMask.ButtonReleaseMask);
@@ -498,7 +498,7 @@ namespace Eto.GtkSharp.Forms
 			DataObject _dragData;
 			bool _isDrop;
 			bool _mouseEntered;
-			
+
 			protected DragEventArgs DragArgs { get; private set; }
 
 			new GtkControl<TControl, TWidget, TCallback> Handler { get { return (GtkControl<TControl, TWidget, TCallback>)base.Handler; } }
@@ -626,7 +626,7 @@ namespace Eto.GtkSharp.Forms
 				var p = new PointF((float)args.Event.X, (float)args.Event.Y);
 				p = handler.TranslatePoint(args.Event.Window, p);
 				Keys modifiers = args.Event.State.ToEtoKey();
-				
+
 				MouseButtons buttons = args.Event.State.ToEtoMouseButtons();
 
 				handler.Callback.OnMouseMove(handler.Widget, new MouseEventArgs(buttons, modifiers, p));
@@ -651,7 +651,7 @@ namespace Eto.GtkSharp.Forms
 			}
 
 			[GLib.ConnectBefore]
-			public void HandleButtonPressEvent(object sender, Gtk.ButtonPressEventArgs args)
+			public virtual void HandleButtonPressEvent(object sender, Gtk.ButtonPressEventArgs args)
 			{
 				var handler = Handler;
 				if (handler == null)
@@ -678,6 +678,12 @@ namespace Eto.GtkSharp.Forms
 					return;
 				if (mouseArgs.Handled && GtkControl.ShouldCaptureMouse)
 					handler.IsMouseCaptured = true;
+
+				if (!mouseArgs.Handled && buttons == MouseButtons.Alternate && handler.ContextMenu != null)
+				{
+					handler.ContextMenu.Show();
+					mouseArgs.Handled = true;
+				}
 				args.RetVal = mouseArgs.Handled;
 			}
 
@@ -973,7 +979,7 @@ namespace Eto.GtkSharp.Forms
 			}
 #endif
 		}
-		
+
 
 		public virtual bool ShouldTranslatePoints
 		{
@@ -1131,7 +1137,7 @@ namespace Eto.GtkSharp.Forms
 			DragInfo = new DragInfoObject { Data = data, AllowedEffects = allowedEffects };
 
 			DragControl.Data[GtkControl.DropSource_Key] = Widget;
-			
+
 			// set data and ensure it gets cleared out.
 			DragControl.Data[GtkControl.DropSourceData_Key] = data;
 			HandleEvent(Eto.Forms.Control.DragEndEvent);
@@ -1227,7 +1233,7 @@ namespace Eto.GtkSharp.Forms
 		{
 			// ContainerControl.Print
 		}
-		
+
 		public virtual void UpdateLayout()
 		{
 			// is this the best way to force a layout pass?  I can't find anything else..
@@ -1251,7 +1257,7 @@ namespace Eto.GtkSharp.Forms
 		{
 			NativeMethods.gtk_grab_add(EventControl.Handle);
 			var ret = EventControl.HasGrab;
-			
+
 			// var status = Gdk.Display.Default.DefaultSeat.Grab(EventControl.GetWindow(), Gdk.SeatCapabilities.Pointer, false, null, null, null);
 			// var ret = status == Gdk.GrabStatus.Success || status == Gdk.GrabStatus.AlreadyGrabbed;
 			IsMouseCaptured = ret;
@@ -1295,11 +1301,23 @@ namespace Eto.GtkSharp.Forms
 					if (!parent.Widget.RectangleToScreen(new Rectangle(parent.Widget.Size)).Contains(mouseLocation))
 						parent.TriggerMouseLeaveIfNeeded();
 				}
-				
+
 				foreach (var last in lastEntered)
 				{
 					if (last.Widget.RectangleToScreen(new Rectangle(last.Widget.Size)).Contains(mouseLocation))
 						last.TriggerMouseEnterIfNeeded();
+				}
+			}
+		}
+		
+		public ContextMenu ContextMenu
+		{
+			get => Widget.Properties.Get<ContextMenu>(GtkControl.ContextMenu_Key);
+			set
+			{
+				if (Widget.Properties.TrySet(GtkControl.ContextMenu_Key, value))
+				{
+					HandleEvent(Eto.Forms.Control.MouseDownEvent);
 				}
 			}
 		}

--- a/src/Eto.Gtk/Forms/GtkPanel.cs
+++ b/src/Eto.Gtk/Forms/GtkPanel.cs
@@ -2,7 +2,6 @@ namespace Eto.GtkSharp.Forms
 {
 	static class GtkPanel
 	{
-		public static readonly object ContextMenu_Key = new object();
 		public static readonly object MinimumSize_Key = new object();
 	}
 
@@ -63,13 +62,6 @@ namespace Eto.GtkSharp.Forms
 				}
 			}
 			#endif
-		}
-
-
-		public ContextMenu ContextMenu
-		{
-			get => Widget.Properties.Get<ContextMenu>(GtkPanel.ContextMenu_Key);
-			set => Widget.Properties.Set(GtkPanel.ContextMenu_Key, value); // TODO
 		}
 
 		public virtual Size MinimumSize

--- a/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ComboBoxHandler.cs
@@ -81,7 +81,7 @@ namespace Eto.Mac.Forms.Controls
 
 		protected override bool DefaultUseAlignmentFrame => true;
 
-		protected override NSComboBox CreateControl() => new EtoComboBox();
+		protected override NSComboBox CreateControl() => new EtoComboBox { Handler = this };
 
 		protected override void Initialize()
 		{

--- a/src/Eto.Mac/Forms/Controls/DateTimePickerHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DateTimePickerHandler.cs
@@ -1,3 +1,5 @@
+using Eto.Mac.Forms.Menu;
+
 namespace Eto.Mac.Forms.Controls
 {
 	public class DateTimePickerHandler : MacControl<NSDatePicker, DateTimePicker, DateTimePicker.ICallback>, DateTimePicker.IHandler
@@ -108,6 +110,15 @@ namespace Eto.Mac.Forms.Controls
 					handler.curValue = handler.Control.DateValue.ToEto();
 					handler.Callback.OnValueChanged(handler.Widget, EventArgs.Empty);
 					handler.Control.NeedsDisplay = true;
+				}
+			}
+			else if (e.Buttons == MouseButtons.Alternate)
+			{
+				var menu = handler.Widget.ContextMenu;
+				if (menu != null)
+				{
+					menu.Show();
+					e.Handled = true;
 				}
 			}
 		}

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -25,7 +25,6 @@ namespace Eto.Mac.Forms.Controls
 		public static readonly object ScrolledToRow_Key = new object();
 		public static readonly object IsEditing_Key = new object();
 		public static readonly object IsMouseDragging_Key = new object();
-		public static readonly object ContextMenu_Key = new object();
 		public static readonly object IsCancelEdit_Key = new object();
 	}
 
@@ -545,13 +544,12 @@ namespace Eto.Mac.Forms.Controls
 			set { Control.AllowsColumnReordering = value; }
 		}
 
-		public virtual ContextMenu ContextMenu
+		public override ContextMenu ContextMenu
 		{
-			get { return Widget.Properties.Get<ContextMenu>(GridHandler.ContextMenu_Key); }
+			get => base.ContextMenu;
 			set
 			{
-				Widget.Properties.Set(GridHandler.ContextMenu_Key, value);
-				Control.Menu = value.ToNS();
+				base.ContextMenu = value;
 				if (Control.HeaderView != null)
 					Control.HeaderView.Menu = value.ToNS();
 			}

--- a/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ListBoxHandler.cs
@@ -151,8 +151,6 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		public ContextMenu ContextMenu { get; set; }
-
 		protected override NSTableView CreateControl() => new EtoListBoxTableView();
 
 		protected override void Initialize()

--- a/src/Eto.Mac/Forms/Controls/MacControl.cs
+++ b/src/Eto.Mac/Forms/Controls/MacControl.cs
@@ -1,10 +1,11 @@
 using Eto.Mac.Drawing;
+using Eto.Mac.Forms.Menu;
 
 namespace Eto.Mac.Forms.Controls
 {
 	static class MacControl
 	{
-		internal static readonly object Font_Key = new object();
+		public static readonly object Font_Key = new object();
 	}
 
 	public abstract class MacControl<TControl, TWidget, TCallback> : MacView<TControl, TWidget, TCallback>
@@ -20,6 +21,8 @@ namespace Eto.Mac.Forms.Controls
 			set => Control.Enabled = value;
 		}
 
+		public override NSView MenuControl => Control;
+
 		protected bool HasFont => Widget.Properties.ContainsKey(MacControl.Font_Key);
 
 		public virtual Font Font
@@ -32,11 +35,12 @@ namespace Eto.Mac.Forms.Controls
 					Control.Font = value.ToNS() ?? NSFont.SystemFontOfSize(NSFont.SystemFontSize);
 					Control.AttributedStringValue = value.AttributedString(Control.AttributedStringValue);
 					InvalidateMeasure();
-				};
+				}
 			}
 		}
 
 		protected override IColorizeCell ColorizeCell => Control.Cell as IColorizeCell;
+
 
 	}
 }

--- a/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -1,4 +1,5 @@
 using Eto.Mac.Drawing;
+using Eto.Mac.Forms.Menu;
 using Range = Eto.Forms.Range;
 
 namespace Eto.Mac.Forms.Controls
@@ -101,6 +102,8 @@ namespace Eto.Mac.Forms.Controls
 		Range<int> ITextAreaHandler.lastSelection { get; set; }
 		int ITextAreaHandler.SuppressSelectionChanged => suppressSelectionChanged;
 
+		public override NSView MenuControl => Control;
+
 		public override void OnKeyDown(KeyEventArgs e)
 		{
 			if (!AcceptsTab)
@@ -124,6 +127,24 @@ namespace Eto.Mac.Forms.Controls
 				return;
 			}
 			base.OnKeyDown(e);
+		}
+
+		public override ContextMenu ContextMenu
+		{
+			get => base.ContextMenu;
+			set
+			{
+				base.ContextMenu = value;
+				Control.MenuForEvent = OnMenuForEvent;
+			}
+		}
+
+		private NSMenu OnMenuForEvent(NSTextView view, NSMenu menu, NSEvent theEvent, nuint charIndex)
+		{
+			var contextMenu = ContextMenu;
+			if (contextMenu != null)
+				return (contextMenu.Handler as ContextMenuHandler)?.Control;
+			return menu;
 		}
 
 		public NSScrollView Scroll { get; private set; }

--- a/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
@@ -1,4 +1,5 @@
 using Eto.Mac.Forms.Controls;
+using Eto.Mac.Forms.Menu;
 namespace Eto.Mac.Forms.Controls
 {
 	public interface ITextBoxWithMaxLength
@@ -195,6 +196,16 @@ namespace Eto.Mac.Forms.Controls
 				handler.TriggerMouseCallback();
 			}
 		}
+
+		public override NSMenu MenuForEvent(NSEvent theEvent)
+		{
+			var handler = Handler;
+			if (handler == null)
+				return base.MenuForEvent(theEvent);
+			var control = (handler.Widget.ContextMenu?.Handler as ContextMenuHandler)?.Control;
+			return control ?? base.MenuForEvent(theEvent);
+		}
+
 	}
 
 

--- a/src/Eto.Mac/Forms/Controls/TreeViewHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TreeViewHandler.cs
@@ -5,7 +5,6 @@ namespace Eto.Mac.Forms.Controls
 	public class TreeViewHandler : MacControl<NSOutlineView, TreeView, TreeView.ICallback>, TreeView.IHandler
 	{
 		ITreeStore top;
-		ContextMenu contextMenu;
 		readonly Dictionary<ITreeItem, EtoTreeItem> cachedItems = new Dictionary<ITreeItem, EtoTreeItem>();
 		readonly Dictionary<int, EtoTreeItem> topitems = new Dictionary<int, EtoTreeItem>();
 		bool selectionChanging;
@@ -433,16 +432,6 @@ namespace Eto.Mac.Forms.Controls
 						Control.ScrollRowToVisible(row.Value);
 					Control.SelectRow((nint)row.Value, false);
 				}
-			}
-		}
-
-		public ContextMenu ContextMenu
-		{
-			get { return contextMenu; }
-			set
-			{
-				contextMenu = value;
-				Control.Menu = contextMenu == null ? null : ((ContextMenuHandler)contextMenu.Handler).Control;
 			}
 		}
 

--- a/src/Eto.Mac/Forms/MacFieldEditor.cs
+++ b/src/Eto.Mac/Forms/MacFieldEditor.cs
@@ -1,4 +1,5 @@
 using Eto.Mac.Forms.Controls;
+using Eto.Mac.Forms.Menu;
 
 
 namespace Eto.Mac.Forms
@@ -17,7 +18,7 @@ namespace Eto.Mac.Forms
 
 		public IMacControl MacControl => WeakDelegate as IMacControl;
 		public object Handler => MacControl?.WeakHandler?.Target;
-		
+
 		public IMacViewHandler MacViewHandler => Handler as IMacViewHandler;
 
 		WeakReference IMacControl.WeakHandler
@@ -56,7 +57,7 @@ namespace Eto.Mac.Forms
 				baseMethod(theEvent);
 				return;
 			}
-			
+
 			var args = MacConversions.GetMouseEvent(handler, theEvent, false);
 			if (theEvent.ClickCount >= 2)
 				handler.Callback.OnMouseDoubleClick(handler.Widget, args);
@@ -65,7 +66,7 @@ namespace Eto.Mac.Forms
 			{
 				handler.Callback.OnMouseDown(handler.Widget, args);
 			}
-			
+
 			if (!args.Handled)
 			{
 				baseMethod(theEvent);
@@ -96,7 +97,7 @@ namespace Eto.Mac.Forms
 			if (!MouseUpEvent(theEvent))
 				base.MouseUp(theEvent);
 		}
-		
+
 		public override void RightMouseDown(NSEvent theEvent)
 		{
 			MouseDownEvent(theEvent, base.RightMouseDown);
@@ -132,6 +133,19 @@ namespace Eto.Mac.Forms
 
 			return base.ShouldChangeText(affectedCharRange, replacementString);
 		}
+
+		[Export("menuForEvent:")]
+		public NSMenu OnMenuForEvent(NSEvent theEvent)
+		{
+			var handler = MacViewHandler;
+			if (handler != null)
+			{
+				var nativeMenu = (handler.Widget.ContextMenu?.Handler as ContextMenuHandler)?.Control;
+				return nativeMenu;
+			}
+			return null;
+		}
+
 
 		public override bool ResignFirstResponder()
 		{

--- a/src/Eto.Mac/Forms/MacPanel.cs
+++ b/src/Eto.Mac/Forms/MacPanel.cs
@@ -40,11 +40,6 @@ namespace Eto.Mac.Forms
 		}
 	}
 
-	static class MacPanel
-	{
-		public static readonly object ContextMenu_Key = new object();
-	}
-
 	public abstract class MacPanel<TControl, TWidget, TCallback> : MacContainer<TControl, TWidget, TCallback>, Panel.IHandler, IMacPanel
 		where TControl: NSObject
 		where TWidget: Panel
@@ -105,30 +100,6 @@ namespace Eto.Mac.Forms
 #endif
 		}
 
-#if OSX
-
-		public ContextMenu ContextMenu
-		{
-			get => Widget.Properties.Get<ContextMenu>(MacPanel.ContextMenu_Key);
-			set
-			{
-				Widget.Properties.Set(MacPanel.ContextMenu_Key, value);
-				EventControl.Menu = (value?.Handler as ContextMenuHandler)?.Control;
-			}
-		}
-#else
-		public virtual ContextMenu ContextMenu
-		{
-			get
-			{
-				throw new NotImplementedException();
-			}
-			set
-			{
-				throw new NotImplementedException();
-			}
-		}
-#endif
 		protected override SizeF GetNaturalSize(SizeF availableSize)
 		{
 			if (content != null && content.Visible)

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1,4 +1,5 @@
 using Eto.Mac.Forms.Controls;
+using Eto.Mac.Forms.Menu;
 using Eto.Mac.Forms.Printing;
 #if MACOS_NET
 using NSDraggingInfo = AppKit.INSDraggingInfo;
@@ -241,6 +242,7 @@ namespace Eto.Mac.Forms
 		public static readonly IntPtr selInitWithPasteboardWriter_Handle = Selector.GetHandle("initWithPasteboardWriter:");
 		public static readonly IntPtr selClass_Handle = Selector.GetHandle("class");
 		public const string FlagsChangedEvent = "MacView.FlagsChangedEvent";
+		public static readonly object ContextMenu_Key = new object();		
 
 		// before 10.12, we have to call base.Layout() AFTER we do our layout otherwise it doesn't work correctly..
 		// however, that causes (temporary) glitches when resizing especially with Scrollable >= 10.12
@@ -639,6 +641,8 @@ namespace Eto.Mac.Forms
 
 		public virtual NSView FocusControl => EventControl;
 
+		public virtual NSView MenuControl => EventControl;
+
 		public virtual IEnumerable<Control> VisualControls => Enumerable.Empty<Control>();
 
 		internal override bool DelayRegisterNotificationCenter => Widget?.Loaded != true;
@@ -737,7 +741,7 @@ namespace Eto.Mac.Forms
 			get { return Widget.Properties.Get<SizeF?>(MacView.NaturalSizeInfinity_Key); }
 			set { Widget.Properties[MacView.NaturalSizeInfinity_Key] = value; }
 		}
-		
+
 		public virtual void InvalidateMeasure()
 		{
 			NaturalSize = null;
@@ -785,11 +789,11 @@ namespace Eto.Mac.Forms
 			if (preferredSize.Height >= 0)
 				size.Height = preferredSize.Height;
 
-			size =  SizeF.Min(SizeF.Max(size, MinimumSize), MaximumSize);
+			size = SizeF.Min(SizeF.Max(size, MinimumSize), MaximumSize);
 
 			return size;
 		}
-		
+
 		public virtual void UpdateTrackingAreas()
 		{
 			if (!mouseMove)
@@ -950,36 +954,36 @@ namespace Eto.Mac.Forms
 				case NSEventType.LeftMouseDown:
 				case NSEventType.RightMouseDown:
 				case NSEventType.OtherMouseDown:
-				{
-					if (!includeMouseDown)
-						return false;
-					var args = MacConversions.GetMouseEvent(this, evt, false);
-					Callback.OnMouseDown(Widget, args);
-					return args.Handled;
-				}
+					{
+						if (!includeMouseDown)
+							return false;
+						var args = MacConversions.GetMouseEvent(this, evt, false);
+						Callback.OnMouseDown(Widget, args);
+						return args.Handled;
+					}
 				case NSEventType.LeftMouseUp:
 				case NSEventType.RightMouseUp:
 				case NSEventType.OtherMouseUp:
-				{
-					var args = MacConversions.GetMouseEvent(this, evt, false);
-					Callback.OnMouseUp(Widget, args);
-					SuppressMouseTriggerCallback = true;
-					MacView.CapturedControl = null;
-					return args.Handled;
-				}
+					{
+						var args = MacConversions.GetMouseEvent(this, evt, false);
+						Callback.OnMouseUp(Widget, args);
+						SuppressMouseTriggerCallback = true;
+						MacView.CapturedControl = null;
+						return args.Handled;
+					}
 				case NSEventType.LeftMouseDragged:
 				case NSEventType.RightMouseDragged:
 				case NSEventType.OtherMouseDragged:
-				{
-					var args = MacConversions.GetMouseEvent(this, evt, false);
-					Callback.OnMouseMove(Widget, args);
-					return args.Handled;
-				}
+					{
+						var args = MacConversions.GetMouseEvent(this, evt, false);
+						Callback.OnMouseMove(Widget, args);
+						return args.Handled;
+					}
 			}
 			return false;
 		}
 
-		
+
 		public virtual void OnSizeChanged(EventArgs e)
 		{
 		}
@@ -1046,13 +1050,13 @@ namespace Eto.Mac.Forms
 		}
 
 		protected virtual bool DefaultUseNSBoxBackgroundColor => true;
-		
+
 		protected virtual IColorizeCell ColorizeCell => null;
-		
+
 		protected virtual bool UseColorizeCellWithAlphaOnly => false;
 
 		protected void SetBackgroundColor() => SetBackgroundColor(Widget.Properties.Get<Color?>(MacView.BackgroundColorKey));
-		
+
 		protected virtual void SetBackgroundColor(Color? color)
 		{
 			if (color != null)
@@ -1160,7 +1164,7 @@ namespace Eto.Mac.Forms
 				}
 			}
 		}
-		
+
 		public void Print()
 		{
 			MacView.InMouseTrackingLoop = false;
@@ -1238,7 +1242,7 @@ namespace Eto.Mac.Forms
 		{
 			var pt = point.ToNS();
 			var view = ContainerControl;
-			
+
 			// macOS has flipped co-ordinates starting at the bottom left of the main screen,
 			// so we flip to make 0,0 top left
 			var mainFrame = NSScreen.Screens[0].Frame;
@@ -1343,7 +1347,7 @@ namespace Eto.Mac.Forms
 			// trigger Shown multiple times for the same themed control
 			var handler = control.Handler as IMacViewHandler;
 			var isWindow = control is Window;
-			
+
 			// Parent controls get shown event first, then children
 			if (!isWindow)
 				handler?.Callback.OnShown(control, EventArgs.Empty);
@@ -1428,7 +1432,7 @@ namespace Eto.Mac.Forms
 
 			// stop mouse capture, if any
 			MacView.InMouseTrackingLoop = false;
-			
+
 			var session = ContainerControl.BeginDraggingSession(draggingItems, NSApplication.SharedApplication.CurrentEvent, source);
 			handler.Apply(session.DraggingPasteboard);
 
@@ -1466,7 +1470,7 @@ namespace Eto.Mac.Forms
 		}
 
 		public static bool SuppressMouseTriggerCallback { get; set; }
-		
+
 		/// <summary>
 		/// Value to indicate that a mouse tracking loop should be used when a MouseDown is handled by user code.
 		/// Defaults to true.
@@ -1542,7 +1546,7 @@ namespace Eto.Mac.Forms
 			return point;
 		}
 
-		
+
 		/// <summary>
 		/// Provides an event to specify that this control should trigger an initial MouseDown event when clicked on an inactive window
 		/// </summary>
@@ -1596,10 +1600,10 @@ namespace Eto.Mac.Forms
 			// do a mouse tracking loop.  This is needed since the mouse up event gets buried when 
 			// showing context menus, dialogs, etc.
 			MacView.InMouseTrackingLoop = true;
-				
+
 			if (theEvent.ClickCount >= 2)
 				Callback.OnMouseDoubleClick(Widget, args);
-			
+
 			if (!args.Handled)
 			{
 				Callback.OnMouseDown(Widget, args);
@@ -1610,7 +1614,7 @@ namespace Eto.Mac.Forms
 				SuppressMouseEvents++;
 				Messaging.void_objc_msgSendSuper_IntPtr(obj.SuperHandle, sel, theEvent.Handle);
 				SuppressMouseEvents--;
-				
+
 				// some controls use event loops until mouse up, so we need to trigger the mouse up here.
 				if (!SuppressMouseTriggerCallback)
 					TriggerMouseCallback(theEvent, includeMouseDown: false);
@@ -1683,24 +1687,24 @@ namespace Eto.Mac.Forms
 			}
 			return args;
 		}
-		
+
 		bool IMacViewHandler.TextInputCancelled
 		{
 			get => Widget.Properties.Get<bool>(MacView.TextInputCancelled_Key);
 			set => Widget.Properties.Set(MacView.TextInputCancelled_Key, value);
 		}
-		
+
 		public bool TextInputImplemented
 		{
 			get => Widget.Properties.Get<bool>(MacView.TextInputImplemented_Key);
 			private set => Widget.Properties.Set(MacView.TextInputImplemented_Key, value);
 		}
-		
+
 		public virtual void UpdateLayout()
 		{
 			ContainerControl?.Window?.LayoutIfNeeded();
 		}
-		
+
 		public bool AutoAttachNative
 		{
 			get => Widget.Properties.Get<bool>(MacView.AutoAttachNative_Key);
@@ -1736,7 +1740,7 @@ namespace Eto.Mac.Forms
 			// already captured?
 			if (MacView.CapturedControl == this && CaptureLoopEnabled)
 				return true;
-			
+
 			// ensure we release capture of any previous control
 			if (MacView.CapturedControl != this)
 				MacView.CapturedControl?.Widget.ReleaseMouseCapture();
@@ -1773,7 +1777,7 @@ namespace Eto.Mac.Forms
 
 			if (!Widget.RectangleToScreen(new RectangleF(Widget.Size)).Contains(mousePosition))
 				FireMouseLeaveIfNeeded();
-				
+
 			foreach (var parent in parentControls)
 			{
 				if (!parent.Widget.RectangleToScreen(new RectangleF(parent.Widget.Size)).Contains(mousePosition))
@@ -1797,6 +1801,41 @@ namespace Eto.Mac.Forms
 			CaptureLoopEnabled = false;
 			MacView.CapturedControl = null;
 		}
+		
+#if OSX
+
+		public virtual ContextMenu ContextMenu
+		{
+			get
+			{
+
+				var value = Widget.Properties.Get<ContextMenu>(MacView.ContextMenu_Key);
+				if (value == null)
+				{
+					var menu = MenuControl.Menu;
+					if (menu != null)
+					{
+						// create a copy of the menu, this could be shared (and usually is) between multiple controls
+						menu = menu.Copy() as NSMenu;
+						if (menu == null)
+							return null;
+						MenuControl.Menu = menu;
+						value = new ContextMenu(new ContextMenuHandler(menu), ContextMenuHandler.GetMenuItems(menu));
+						Widget.Properties.Set(MacView.ContextMenu_Key, value);
+						return value;
+					}
+				}
+				return value;
+			}
+			set
+			{
+				Widget.Properties.Set(MacView.ContextMenu_Key, value);
+				MenuControl.Menu = (value?.Handler as ContextMenuHandler)?.Control;
+			}
+		}
+#else
+		public virtual ContextMenu ContextMenu { get; set; }
+#endif
 	}
 }
 

--- a/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ButtonMenuItemHandler.cs
@@ -4,6 +4,14 @@ namespace Eto.Mac.Forms.Menu
 {
 	public class ButtonMenuItemHandler : ButtonMenuItemHandler<ButtonMenuItem, ButtonMenuItem.ICallback>
 	{
+		public ButtonMenuItemHandler()
+		{
+		}
+
+		public ButtonMenuItemHandler(NSMenuItem item)
+			: base(item)
+		{
+		}
 	}
 
 	public class ButtonMenuItemHandler<TWidget, TCallback> : MenuHandler<NSMenuItem, TWidget, TCallback>, ButtonMenuItem.IHandler, IMenuActionHandler
@@ -24,18 +32,24 @@ namespace Eto.Mac.Forms.Menu
 				SetImage();
 			}
 		}
+		
+		public ButtonMenuItemHandler()
+		{
+		}
+		
+		public ButtonMenuItemHandler(NSMenuItem item)
+		{
+			Control = item;
+		}
 
 		protected override NSMenuItem CreateControl()
 		{
-			return new NSMenuItem();
-		}
-
-		protected override void Initialize()
-		{
-			Enabled = true;
-			Control.Target = new MenuActionHandler{ Handler = this };
-			Control.Action = MenuActionHandler.selActivate;
-			base.Initialize();
+			return new NSMenuItem
+			{
+				Target = new MenuActionHandler { Handler = this },
+				Action = MenuActionHandler.selActivate,
+				Enabled = true
+			};
 		}
 
 		public override void Activate()

--- a/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
@@ -32,16 +32,49 @@ namespace Eto.Mac.Forms.Menu
 		}
 	}
 
-	public class ContextMenuHandler : WidgetHandler<EtoMenu, ContextMenu, ContextMenu.ICallback>, ContextMenu.IHandler
+	public class ContextMenuHandler : WidgetHandler<NSMenu, ContextMenu, ContextMenu.ICallback>, ContextMenu.IHandler
 	{
-		protected override EtoMenu CreateControl() => new EtoMenu();
+		protected override NSMenu CreateControl() => new EtoMenu();
+		ContextHandler _delegate;
+
+		public ContextMenuHandler()
+		{
+		}
+
+		public ContextMenuHandler(NSMenu control)
+		{
+			Control = control;
+		}
+		
+		internal static IEnumerable<MenuItem> GetMenuItems(NSMenu menu)
+		{
+			for (nint i = 0; i < menu.Count; i++)
+			{
+				var item = menu.ItemAt(i);
+				
+				if (item.HasSubmenu)
+				{
+					yield return new SubMenuItem(new SubMenuItemHandler(item), GetMenuItems(item.Submenu));
+				}
+				else if (item.IsSeparatorItem)
+				{
+					yield return new SeparatorMenuItem(new SeparatorMenuItemHandler(item));
+				}
+				else
+				{
+					yield return new ButtonMenuItem(new ButtonMenuItemHandler(item));
+				}
+			}
+		}
 
 		protected override void Initialize()
 		{
-			Control.WorksWhenModal = true;
+			if (Control is EtoMenu etoMenu)
+				etoMenu.WorksWhenModal = true;
 			Control.AutoEnablesItems = false;
 			Control.ShowsStateColumn = true;
-			Control.Delegate = new ContextHandler() { Handler = this };
+			if (Control.WeakDelegate == null)
+				Control.Delegate = _delegate = new ContextHandler { Handler = this };
 
 			base.Initialize();
 		}

--- a/src/Eto.Mac/Forms/Menu/SeparatorMenuItem.cs
+++ b/src/Eto.Mac/Forms/Menu/SeparatorMenuItem.cs
@@ -6,6 +6,15 @@ namespace Eto.Mac.Forms.Menu
 		{
 			return NSMenuItem.SeparatorItem;
 		}
+		
+		public SeparatorMenuItemHandler()
+		{
+		}
+		
+		public SeparatorMenuItemHandler(NSMenuItem item)
+		{
+			Control = item;
+		}
 
 		protected override bool DisposeControl { get { return false; } }
 

--- a/src/Eto.Mac/Forms/Menu/SubMenuItemHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/SubMenuItemHandler.cs
@@ -31,6 +31,15 @@ namespace Eto.Mac.Forms.Menu
 
 	public class SubMenuItemHandler : ButtonMenuItemHandler<SubMenuItem, SubMenuItem.ICallback>, SubMenuItem.IHandler
 	{
+		public SubMenuItemHandler()
+		{
+		}
+
+		public SubMenuItemHandler(NSMenuItem item)
+		{
+			Control = item;
+		}
+
 		protected override void Initialize()
 		{
 			base.Initialize();

--- a/src/Eto.WinForms/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/TextAreaHandler.cs
@@ -262,21 +262,21 @@ namespace Eto.WinForms.Forms.Controls
 			var pos = Control.GetPositionFromCharIndex(range.End);
 			sd.Point scrollPosition = sd.Point.Empty;
 			Win32.SendMessage(Control.Handle, Win32.WM.EM_GETSCROLLPOS, IntPtr.Zero, ref scrollPosition);
-			
+
 			var si = new Win32.SCROLLINFO();
 			si.cbSize = Marshal.SizeOf(si);
-      		si.fMask = (int)Win32.ScrollInfoMask.SIF_ALL;
+			si.fMask = (int)Win32.ScrollInfoMask.SIF_ALL;
 			Win32.GetScrollInfo(Control.Handle, (int)Win32.SBOrientation.SB_VERT, ref si);
 
 			if (si.nPage > 0)
 				scrollPosition.Y = Math.Min(si.nMax - si.nPage, Math.Max(si.nMin, scrollPosition.Y + pos.Y));
 
 			Win32.GetScrollInfo(Control.Handle, (int)Win32.SBOrientation.SB_HORZ, ref si);
-			
+
 			// only scroll X if not in view already
 			if (si.nPage > 0 && (pos.X < si.nPos || pos.X > si.nPos + si.nPage))
 				scrollPosition.X = Math.Min(si.nMax - si.nPage, Math.Max(si.nMin, scrollPosition.X + pos.X));
-			
+
 			Win32.SendMessage(Control.Handle, Win32.WM.EM_SETSCROLLPOS, IntPtr.Zero, ref scrollPosition);
 		}
 
@@ -296,6 +296,44 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			Win32.SendMessage(Control.Handle, Win32.WM.VSCROLL, (IntPtr)Win32.SB.BOTTOM, IntPtr.Zero);
 			Win32.SendMessage(Control.Handle, Win32.WM.HSCROLL, (IntPtr)GetScrollX(), IntPtr.Zero);
+		}
+
+		protected override swf.ContextMenuStrip GetDefaultContextMenu() => CreateDefaultContextMenu(Control);
+
+		private swf.ContextMenuStrip CreateDefaultContextMenu(swf.TextBoxBase control)
+		{
+			var menu = new swf.ContextMenuStrip();
+
+			var undoItem = new swf.ToolStripMenuItem("Undo", null, (s, e) => control.Undo());
+			var cutItem = new swf.ToolStripMenuItem("Cut", null, (s, e) => control.Cut());
+			var copyItem = new swf.ToolStripMenuItem("Copy", null, (s, e) => control.Copy());
+			var pasteItem = new swf.ToolStripMenuItem("Paste", null, (s, e) => control.Paste());
+			var deleteItem = new swf.ToolStripMenuItem("Delete", null, (s, e) => control.SelectedText = "");
+			var selectAllItem = new swf.ToolStripMenuItem("Select All", null, (s, e) => control.SelectAll());
+
+			menu.Items.AddRange(new swf.ToolStripItem[] {
+				undoItem,
+				new swf.ToolStripSeparator(),
+				cutItem,
+				copyItem,
+				pasteItem,
+				deleteItem,
+				new swf.ToolStripSeparator(),
+				selectAllItem
+			});
+
+			// Dynamically enable/disable items when menu opens
+			menu.Opening += (s, e) =>
+			{
+				undoItem.Enabled = control.CanUndo;
+				cutItem.Enabled = !string.IsNullOrEmpty(control.SelectedText);
+				copyItem.Enabled = !string.IsNullOrEmpty(control.SelectedText);
+				pasteItem.Enabled = swf.Clipboard.ContainsText();
+				deleteItem.Enabled = !string.IsNullOrEmpty(control.SelectedText);
+				selectAllItem.Enabled = control.TextLength > 0 && control.SelectionLength < control.TextLength;
+			};
+
+			return menu;
 		}
 
 	}

--- a/src/Eto.WinForms/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/src/Eto.WinForms/Forms/Menu/ButtonMenuItemHandler.cs
@@ -2,6 +2,15 @@ namespace Eto.WinForms.Forms.Menu
 {
 	public class ButtonMenuItemHandler : ButtonMenuItemHandler<ButtonMenuItem, ButtonMenuItem.ICallback>
 	{
+		public ButtonMenuItemHandler()
+			: base()
+		{
+		}
+		
+		public ButtonMenuItemHandler(swf.ToolStripMenuItem menuItem)
+			: base(menuItem)
+		{
+		}
 	}
 
 	public class ButtonMenuItemHandler<TWidget, TCallback> : MenuItemHandler<swf.ToolStripMenuItem, TWidget, TCallback>, ButtonMenuItem.IHandler
@@ -14,6 +23,13 @@ namespace Eto.WinForms.Forms.Menu
 		public ButtonMenuItemHandler()
 		{
 			Control = new swf.ToolStripMenuItem();
+			Control.Click += (sender, e) => Callback.OnClick(Widget, EventArgs.Empty);
+			Control.DropDownOpening += HandleDropDownOpened;
+		}
+		
+		public ButtonMenuItemHandler(swf.ToolStripMenuItem menuItem)
+		{
+			Control = menuItem;
 			Control.Click += (sender, e) => Callback.OnClick(Widget, EventArgs.Empty);
 			Control.DropDownOpening += HandleDropDownOpened;
 		}

--- a/src/Eto.WinForms/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.WinForms/Forms/Menu/ContextMenuHandler.cs
@@ -1,3 +1,4 @@
+
 namespace Eto.WinForms.Forms.Menu
 {
 	public class ContextMenuHandler : WidgetHandler<swf.ContextMenuStrip, ContextMenu, ContextMenu.ICallback>, ContextMenu.IHandler
@@ -6,6 +7,13 @@ namespace Eto.WinForms.Forms.Menu
 		public ContextMenuHandler()
 		{
 			Control = new swf.ContextMenuStrip();
+			Control.Opening += HandleOpening;
+			Control.KeyDown += HandleKeyDown;
+		}
+
+		public ContextMenuHandler(swf.ContextMenuStrip contextMenuStrip)
+		{
+			Control = contextMenuStrip;
 			Control.Opening += HandleOpening;
 			Control.KeyDown += HandleKeyDown;
 		}
@@ -85,6 +93,22 @@ namespace Eto.WinForms.Forms.Menu
 			{
 				var position = location?.ToSDPoint() ?? swf.Control.MousePosition;
 				Control.Show(position);
+			}
+		}
+
+		internal static IEnumerable<MenuItem> GetMenuItems(swf.ToolStripItemCollection items)
+		{
+			foreach (swf.ToolStripItem item in items)
+			{
+				if (item is swf.ToolStripSeparator sep)
+					yield return new SeparatorMenuItem(new SeparatorMenuItemHandler(sep));
+				else if (item is swf.ToolStripMenuItem menuItem)
+				{
+					if (menuItem.HasDropDownItems)
+						yield return new SubMenuItem(new SubMenuItemHandler(menuItem), GetMenuItems(menuItem.DropDown.Items));
+					else
+						yield return new ButtonMenuItem(new ButtonMenuItemHandler(menuItem));
+				}
 			}
 		}
 	}

--- a/src/Eto.WinForms/Forms/Menu/SeparatorMenuItem.cs
+++ b/src/Eto.WinForms/Forms/Menu/SeparatorMenuItem.cs
@@ -8,6 +8,11 @@ namespace Eto.WinForms.Forms.Menu
 			Control = new swf.ToolStripSeparator();
 		}
 
+		public SeparatorMenuItemHandler(swf.ToolStripSeparator sep)
+		{
+			Control = sep;
+		}
+
 		public string Text
 		{
 			get { return null; }

--- a/src/Eto.WinForms/Forms/Menu/SubMenuItemHandler.cs
+++ b/src/Eto.WinForms/Forms/Menu/SubMenuItemHandler.cs
@@ -10,6 +10,11 @@ namespace Eto.WinForms.Forms.Menu
 			Control.DropDownItems.Add(hiddenItem);
 		}
 
+		public SubMenuItemHandler(swf.ToolStripMenuItem menuItem)
+			: base(menuItem)
+		{
+		}
+
 		public override void AddMenu(int index, MenuItem item)
 		{
 			if (hiddenItem != null)

--- a/src/Eto.WinForms/Forms/WindowsControl.cs
+++ b/src/Eto.WinForms/Forms/WindowsControl.cs
@@ -1,3 +1,4 @@
+using System.Windows.Forms.PropertyGridInternal;
 using Eto.WinForms.Drawing;
 using Eto.WinForms.Forms.Menu;
 namespace Eto.WinForms.Forms
@@ -97,7 +98,7 @@ namespace Eto.WinForms.Forms
 		public static readonly object UseShellDropManager_Key = new object();
 		public static readonly object MouseCaptured_Key = new object();
 		public static readonly object DisableTextChanged_Key = new object();
-
+		internal static readonly object ContextMenu_Key = new object();
 
 		public static bool SkipMouseCapture { get; set; }
 		internal static Control DragSourceControl { get; set; }
@@ -338,16 +339,34 @@ namespace Eto.WinForms.Forms
 			SetScale(XScale, YScale);
 		}
 
-		ContextMenu contextMenu;
+		protected virtual swf.ContextMenuStrip GetDefaultContextMenu() => null;
+
 		public ContextMenu ContextMenu
 		{
-			get { return contextMenu; }
+			get
+			{
+				var contextMenu = Widget.Properties.Get<ContextMenu>(WindowsControl.ContextMenu_Key);
+				if (contextMenu != null)
+					return contextMenu;
+				var defaultMenu = Control.ContextMenuStrip ?? GetDefaultContextMenu();
+				if (defaultMenu != null)
+				{
+					contextMenu = new ContextMenu(new ContextMenuHandler(defaultMenu), ContextMenuHandler.GetMenuItems(defaultMenu.Items));
+					Widget.Properties.Set(WindowsControl.ContextMenu_Key, contextMenu);
+					if (Control.ContextMenuStrip == null)
+						Control.ContextMenuStrip = defaultMenu;
+				}
+				return contextMenu;
+			}
 			set
 			{
-				contextMenu = value;
-				Control.ContextMenuStrip = contextMenu != null ? ((ContextMenuHandler)contextMenu.Handler).Control : null;
+				if (Widget.Properties.TrySet(WindowsControl.ContextMenu_Key, value))
+				{
+					Control.ContextMenuStrip = (value?.Handler as ContextMenuHandler)?.Control;
+				}
 			}
 		}
+
 
 		public override void AttachEvent(string id)
 		{

--- a/src/Eto.WinUI/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.WinUI/Forms/Controls/ListBoxHandler.cs
@@ -32,7 +32,6 @@ public class ListBoxHandler : WinUIControl<muc.ListView, ListBox, ListBox.ICallb
 	}
 	public IIndirectBinding<string> ItemTextBinding { get; set; }
 	public IIndirectBinding<string> ItemKeyBinding { get; set; }
-	public ContextMenu ContextMenu { get; set; }
 	public BorderType Border
 	{
 		get => Control.BorderThickness == new mux.Thickness(0) ? BorderType.None : BorderType.Line;

--- a/src/Eto.WinUI/Forms/Controls/PanelHandler.cs
+++ b/src/Eto.WinUI/Forms/Controls/PanelHandler.cs
@@ -52,7 +52,6 @@ public class PanelHandler : WinUIContainer<EtoDockPanel, Panel, Panel.ICallback>
 		get => Control.GetMinSize().ToEtoSize();
 		set => Control.SetMinSize(value);
 	}
-	public ContextMenu ContextMenu { get; set; }
 	public override mux.FrameworkElement ContainerControl => Control;
 
 	public override Color BackgroundColor

--- a/src/Eto.WinUI/Forms/WinUIBorderedControl.cs
+++ b/src/Eto.WinUI/Forms/WinUIBorderedControl.cs
@@ -20,7 +20,6 @@ public class WinUIBorderedControl<TControl, TWidget, TCallback> : WinUIFramework
 		set => _border.SetMinSize(value);
 
 	}
-	public ContextMenu ContextMenu { get; set; }
 	public sealed override mux.FrameworkElement ContainerControl => _border;
 
 	public override Color BackgroundColor

--- a/src/Eto.WinUI/Forms/WinUIFrameworkElement.cs
+++ b/src/Eto.WinUI/Forms/WinUIFrameworkElement.cs
@@ -303,6 +303,8 @@ public abstract partial class WinUIFrameworkElement<TControl, TWidget, TCallback
 
 	protected virtual mux.FrameworkElement MouseEventElement => ContainerControl;
 
+	public ContextMenu ContextMenu { get; set; }
+
 	public override void AttachEvent(string id)
 	{
 		switch (id)

--- a/src/Eto.WinUI/Forms/WinUIPanel.cs
+++ b/src/Eto.WinUI/Forms/WinUIPanel.cs
@@ -31,8 +31,6 @@ public abstract class WinUIPanel<TControl, TWidget, TCallback> : WinUIContainer<
 		set => ContainerControl.SetMinSize(value);
 	}
 
-	public ContextMenu ContextMenu { get; set; }
-
 	EtoDockPanel _border;
 
 	public WinUIPanel()

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -120,7 +120,6 @@ namespace Eto.Wpf.Forms.Controls
 		const double DragScrollDelay = 0.1;
 		const double DragScrollFastDelay = 0.01;
 		
-		ContextMenu contextMenu;
 		bool hadFocus;
 		protected bool SkipSelectionChanged { get; set; }
 		protected swc.DataGridColumn CurrentColumn { get; set; }
@@ -390,16 +389,6 @@ namespace Eto.Wpf.Forms.Controls
 			public override void RemoveAllItems()
 			{
 				Handler.Control.Columns.Clear();
-			}
-		}
-
-		public ContextMenu ContextMenu
-		{
-			get { return contextMenu; }
-			set
-			{
-				contextMenu = value;
-				Control.ContextMenu = contextMenu != null ? ((ContextMenuHandler)contextMenu.Handler).Control : null;
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ListBoxHandler.cs
@@ -13,7 +13,6 @@ namespace Eto.Wpf.Forms.Controls
 	public class ListBoxHandler : WpfControl<swc.ListBox, ListBox, ListBox.ICallback>, ListBox.IHandler
 	{
 		IEnumerable<object> store;
-		ContextMenu contextMenu;
 
 		protected override sw.Size DefaultSize => new sw.Size(100, 120);
 
@@ -101,16 +100,6 @@ namespace Eto.Wpf.Forms.Controls
 					var item = store.AsEnumerable().Skip(value).FirstOrDefault();
 					Control.ScrollIntoView(item);
 				}
-			}
-		}
-
-		public ContextMenu ContextMenu
-		{
-			get { return contextMenu; }
-			set
-			{
-				contextMenu = value;
-				Control.ContextMenu = contextMenu != null ? contextMenu.ControlObject as sw.Controls.ContextMenu : null;
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
@@ -1,3 +1,4 @@
+
 namespace Eto.Wpf.Forms.Controls
 {
 	public class EtoTextBox : swc.TextBox, IEtoWpfControl
@@ -112,7 +113,7 @@ namespace Eto.Wpf.Forms.Controls
 			};
 			Wrap = true;
 		}
-		
+
 		protected override void Initialize()
 		{
 			base.Initialize();
@@ -247,7 +248,7 @@ namespace Eto.Wpf.Forms.Controls
 		}
 
 		public TextReplacements SupportedTextReplacements => TextReplacements.None;
-		
+
 		static readonly object Border_Key = new object();
 
 		public virtual BorderType Border
@@ -287,6 +288,22 @@ namespace Eto.Wpf.Forms.Controls
 		}
 
 		public abstract int TextLength { get; }
+
+
+		protected override swc.ContextMenu GetDefaultContextMenu() => CreateDefaultContextMenu();
+		
+		internal static swc.ContextMenu CreateDefaultContextMenu()
+		{
+			var menu = new swc.ContextMenu();
+
+			// Cut / Copy / Paste
+			menu.Items.Add(new swc.MenuItem { Command = swi.ApplicationCommands.Cut });
+			menu.Items.Add(new swc.MenuItem { Command = swi.ApplicationCommands.Copy });
+			menu.Items.Add(new swc.MenuItem { Command = swi.ApplicationCommands.Paste });
+
+			return menu;
+		}
+
 
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -43,7 +43,7 @@ namespace Eto.Wpf.Forms.Controls
 	public abstract class TextBoxHandler<TControl, TWidget, TCallback> : WpfControl<TControl, TWidget, TCallback>, TextBox.IHandler
 		where TControl : swc.Control
 		where TWidget : TextBox
-		where TCallback: TextBox.ICallback
+		where TCallback : TextBox.ICallback
 	{
 		bool initialSelection;
 
@@ -89,7 +89,7 @@ namespace Eto.Wpf.Forms.Controls
 			}
 		}
 
-		public TextBoxHandler ()
+		public TextBoxHandler()
 		{
 		}
 
@@ -129,9 +129,10 @@ namespace Eto.Wpf.Forms.Controls
 
 		static Clipboard clipboard;
 
-		public override void AttachEvent (string id)
+		public override void AttachEvent(string id)
 		{
-			switch (id) {
+			switch (id)
+			{
 				case TextControl.TextChangedEvent:
 					TextBox.TextChanged += TextBox_TextChanged;
 					break;
@@ -261,7 +262,7 @@ namespace Eto.Wpf.Forms.Controls
 					}));
 					break;
 				default:
-					base.AttachEvent (id);
+					base.AttachEvent(id);
 					break;
 			}
 		}
@@ -322,7 +323,7 @@ namespace Eto.Wpf.Forms.Controls
 					endNoGCRegion = false;
 				}
 
-				try 
+				try
 				{
 					DisableTextChanged++;
 					TextBox.Text = newText;
@@ -333,7 +334,7 @@ namespace Eto.Wpf.Forms.Controls
 					if (endNoGCRegion && GCSettings.LatencyMode == GCLatencyMode.NoGCRegion)
 						GC.EndNoGCRegion();
 				}
-				
+
 				if (value != null && AutoSelectMode == AutoSelectMode.Never)
 				{
 					TextBox.BeginChange();
@@ -341,7 +342,7 @@ namespace Eto.Wpf.Forms.Controls
 					TextBox.SelectionLength = 0;
 					TextBox.EndChange();
 				}
-				
+
 				Callback.OnTextChanged(Widget, EventArgs.Empty);
 			}
 		}
@@ -385,7 +386,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		public Range<int> Selection
 		{
-			get => CurrentSelection ??　new Range<int>(TextBox.SelectionStart, TextBox.SelectionStart + TextBox.SelectionLength - 1);
+			get => CurrentSelection ?? new Range<int>(TextBox.SelectionStart, TextBox.SelectionStart + TextBox.SelectionLength - 1);
 			set
 			{
 				CurrentSelection = null;
@@ -419,12 +420,12 @@ namespace Eto.Wpf.Forms.Controls
 			// it does not reflect changes to the selection when it is not focused.
 			if (!TextBox.IsLoaded || HasFocus || string.IsNullOrEmpty(Text))
 				return;
-				
+
 			// got this by poking at various methods
 			var textEditor = TextBox.GetType().GetProperty("TextEditor", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(TextBox);
 			if (textEditor == null)
 				return;
-			
+
 			var selection = textEditor.GetType().GetProperty("Selection", BindingFlags.Instance | BindingFlags.NonPublic)?.GetValue(textEditor);
 			if (selection == null)
 				return;
@@ -455,6 +456,9 @@ namespace Eto.Wpf.Forms.Controls
 			var updateSelectionMethod = caretElement.GetType().GetMethod("UpdateSelection", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.FlattenHierarchy);
 			updateSelectionMethod?.Invoke(caretElement, null);
 		}
+
+		protected override swc.ContextMenu GetDefaultContextMenu() => TextAreaHandler.CreateDefaultContextMenu();
+
 
 	}
 }

--- a/src/Eto.Wpf/Forms/Controls/TreeViewHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TreeViewHandler.cs
@@ -6,7 +6,6 @@ namespace Eto.Wpf.Forms.Controls
 	[Obsolete("Since 2.4. TreeView is deprecated, please use TreeGridView instead.")]
 	public class TreeViewHandler : WpfControl<TreeViewHandler.EtoTreeView, TreeView, TreeView.ICallback>, TreeView.IHandler
 	{
-		ContextMenu contextMenu;
 		ITreeStore topNode;
 		ITreeItem selectedItem;
 		sw.Setter foreground;
@@ -399,19 +398,6 @@ namespace Eto.Wpf.Forms.Controls
 			Control.CurrentItem = selectedItem;
 			selectedItem = null;
 			Control.Loaded -= HandleSelectedItemLoad;
-		}
-
-		public ContextMenu ContextMenu
-		{
-			get { return contextMenu; }
-			set
-			{
-				contextMenu = value;
-				if (contextMenu != null)
-					Control.ContextMenu = ((ContextMenuHandler)contextMenu.Handler).Control;
-				else
-					Control.ContextMenu = null;
-			}
 		}
 
 		public void RefreshData()

--- a/src/Eto.Wpf/Forms/Menu/ButtonMenuItemHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/ButtonMenuItemHandler.cs
@@ -1,3 +1,4 @@
+
 namespace Eto.Wpf.Forms.Menu
 {
 	public class ButtonMenuItemHandler : MenuItemHandler<swc.MenuItem, ButtonMenuItem, ButtonMenuItem.ICallback>, ButtonMenuItem.IHandler
@@ -6,5 +7,11 @@ namespace Eto.Wpf.Forms.Menu
 		{
 			Control = new swc.MenuItem();
 		}
+
+		public ButtonMenuItemHandler(swc.MenuItem mi)
+		{
+			Control = mi;
+		}
+
 	}
 }

--- a/src/Eto.Wpf/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/ContextMenuHandler.cs
@@ -13,6 +13,11 @@ namespace Eto.Wpf.Forms.Menu
 		{
 			Control = new swc.ContextMenu();
 		}
+		
+		public ContextMenuHandler(swc.ContextMenu control)
+		{
+			Control = control;
+		}
 
 		public swi.InputBindingCollection InputBindings
 		{
@@ -124,5 +129,22 @@ namespace Eto.Wpf.Forms.Menu
 			Control.IsOpen = true;
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 		}
+
+		internal static IEnumerable<MenuItem> GetItems(swc.ItemsControl contextMenu)
+		{
+			foreach (var item in contextMenu.Items)
+			{
+				if (item is swc.MenuItem mi)
+				{
+					if (mi.HasItems)
+						yield return new SubMenuItem(new SubMenuItemHandler(mi), GetItems(mi));
+					else
+						yield return new ButtonMenuItem(new ButtonMenuItemHandler(mi));
+				}
+				else if (item is swc.Separator sep)
+					yield return new SeparatorMenuItem(new SeparatorMenuItemHandler(sep));
+			}
+		}
+
 	}
 }

--- a/src/Eto.Wpf/Forms/Menu/SeparatorMenuItemHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/SeparatorMenuItemHandler.cs
@@ -2,9 +2,14 @@ namespace Eto.Wpf.Forms.Menu
 {
 	public class SeparatorMenuItemHandler : WidgetHandler<swc.Separator, SeparatorMenuItem>, SeparatorMenuItem.IHandler
 	{
-		public SeparatorMenuItemHandler ()
+		public SeparatorMenuItemHandler()
 		{
-			Control = new swc.Separator ();
+			Control = new swc.Separator();
+		}
+
+		public SeparatorMenuItemHandler(swc.Separator control)
+		{
+			Control = control ?? new swc.Separator();
 		}
 
 		public string Text

--- a/src/Eto.Wpf/Forms/Menu/SubMenuItemHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/SubMenuItemHandler.cs
@@ -12,6 +12,11 @@ namespace Eto.Wpf.Forms.Menu
 			Control.Items.Add(hiddenItem);
 		}
 
+		public SubMenuItemHandler(swc.MenuItem mi)
+		{
+			Control = mi;
+		}
+
 		public override void AttachEvent(string id)
 		{
 			switch (id)

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -1,3 +1,4 @@
+using Eto.Wpf.Forms.Menu;
 using System.Windows.Interop;
 using static System.Windows.WpfDataObjectExtensions;
 
@@ -85,6 +86,7 @@ namespace Eto.Wpf.Forms
 		internal static IWpfFrameworkElement LastDragTarget;
 		
 		internal static readonly object LoadActionList_Key = new object();
+		internal static readonly object ContextMenu_Key = new object();
 	}
 
 	public abstract partial class WpfFrameworkElement<TControl, TWidget, TCallback> : WidgetHandler<TControl, TWidget, TCallback>, Control.IHandler, IWpfFrameworkElement
@@ -184,6 +186,7 @@ namespace Eto.Wpf.Forms
 		}
 
 		public virtual sw.FrameworkElement ContainerControl => Control;
+		public virtual sw.FrameworkElement MenuControl => Control;
 
 		public virtual Size Size
 		{
@@ -1160,6 +1163,35 @@ namespace Eto.Wpf.Forms
 		}
 
 		public bool IsMouseCaptured => ContainerControl.IsMouseCaptured;
+		
+		protected virtual swc.ContextMenu GetDefaultContextMenu() => null;
+
+		public ContextMenu ContextMenu
+		{
+			get
+			{
+				var contextMenu = Widget.Properties.Get<ContextMenu>(WpfFrameworkElement.ContextMenu_Key);
+				if (contextMenu != null)
+					return contextMenu;
+				var defaultMenu = MenuControl.ContextMenu ?? GetDefaultContextMenu();
+				if (defaultMenu != null)
+				{
+					contextMenu = new ContextMenu(new ContextMenuHandler(defaultMenu), ContextMenuHandler.GetItems(defaultMenu));
+					Widget.Properties.Set(WpfFrameworkElement.ContextMenu_Key, contextMenu);
+					if (MenuControl.ContextMenu == null)
+						MenuControl.ContextMenu = defaultMenu;
+				}
+				return contextMenu;
+			}
+			set
+			{
+				if (Widget.Properties.TrySet(WpfFrameworkElement.ContextMenu_Key, value))
+				{
+					MenuControl.ContextMenu = (value?.Handler as ContextMenuHandler)?.Control;
+				}
+			}
+		}
+
 		public bool CaptureMouse()
 		{
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;

--- a/src/Eto.Wpf/Forms/WpfPanel.cs
+++ b/src/Eto.Wpf/Forms/WpfPanel.cs
@@ -57,17 +57,6 @@ namespace Eto.Wpf.Forms
 			}
 		}
 
-		ContextMenu contextMenu;
-		public ContextMenu ContextMenu
-		{
-			get { return contextMenu; }
-			set
-			{
-				contextMenu = value;
-				Control.ContextMenu = contextMenu != null ? ((ContextMenuHandler)contextMenu.Handler).Control : null;
-			}
-		}
-
 		protected WpfPanel()
 		{
 		}

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -1421,6 +1421,24 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 		}
 	}
 
+	/// <summary>
+	/// Gets or sets the context menu that appears when the user right-clicks on the control.
+	/// </summary>
+	/// <remarks>
+	/// On some platforms and controls, such as macOS, the context menu can have additional items added by the system.
+	/// 
+	/// Also the menu may appear when pressing different keys, such as a control-click on macOS, or when
+	/// pressing the menu key on Windows keyboards.
+	/// 
+	/// There is also some other semantic differences of using this vs. showing a context menu manually, such as on Windows, 
+	/// right clicking on a TextBox or TextArea will keep the selection visible, whereas this would not be the case if you showed
+	/// the context menu manually.
+	/// </remarks>
+	public ContextMenu ContextMenu
+	{
+		get { return Handler.ContextMenu; }
+		set { Handler.ContextMenu = value; }
+	}
 
 	/// <summary>
 	/// Handles the disposal of this control
@@ -1739,7 +1757,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// </summary>
 	/// <copyright>(c) 2014 by Curtis Wensley</copyright>
 	/// <license type="BSD-3">See LICENSE for full terms</license>
-	public new interface IHandler : Widget.IHandler
+	public new interface IHandler : Widget.IHandler, IContextMenuHost
 	{
 		/// <summary>
 		/// Gets or sets the color for the background of the control

--- a/src/Eto/Forms/Controls/GridView.cs
+++ b/src/Eto/Forms/Controls/GridView.cs
@@ -444,10 +444,10 @@ public class GridView : Grid, ISelectableControl<object>
 	/// Gets or sets the context menu when right clicking or pressing the menu button on the control.
 	/// </summary>
 	/// <value>The context menu.</value>
-	public ContextMenu ContextMenu
+	public new ContextMenu ContextMenu
 	{
-		get { return Handler.ContextMenu; }
-		set { Handler.ContextMenu = value; }
+		get { return base.ContextMenu; }
+		set { base.ContextMenu = value; }
 	}
 
 	/// <summary>
@@ -500,7 +500,7 @@ public class GridView : Grid, ISelectableControl<object>
 	/// <summary>
 	/// Handler interface for the <see cref="GridView"/>.
 	/// </summary>
-	public new interface IHandler : Grid.IHandler, IContextMenuHost
+	public new interface IHandler : Grid.IHandler
 	{
 		/// <summary>
 		/// Gets or sets the data store for the items to show in the grid.

--- a/src/Eto/Forms/Controls/ListBox.cs
+++ b/src/Eto/Forms/Controls/ListBox.cs
@@ -86,10 +86,10 @@ public class ListBox : ListControl
 	/// Gets or sets the context menu for the control.
 	/// </summary>
 	/// <value>The context menu.</value>
-	public ContextMenu ContextMenu
+	public new ContextMenu ContextMenu
 	{
-		get { return Handler.ContextMenu; }
-		set { Handler.ContextMenu = value; }
+		get { return base.ContextMenu; }
+		set { base.ContextMenu = value; }
 	}
 	
 	/// <summary>

--- a/src/Eto/Forms/Controls/Panel.cs
+++ b/src/Eto/Forms/Controls/Panel.cs
@@ -72,10 +72,10 @@ public class Panel : Container
 	/// user taps and holds their finger down on the control.
 	/// </remarks>
 	/// <value>The context menu.</value>
-	public ContextMenu ContextMenu
+	public new ContextMenu ContextMenu
 	{
-		get { return Handler.ContextMenu; }
-		set { Handler.ContextMenu = value; }
+		get { return base.ContextMenu; }
+		set { base.ContextMenu = value; }
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/src/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -468,6 +468,14 @@ public class ThemedControlHandler<TControl, TWidget, TCallback> : WidgetHandler<
 
 	/// <inheritdoc />
 	public bool IsMouseCaptured => Control.IsMouseCaptured;
+
+	/// <inheritdoc />
+	public ContextMenu ContextMenu
+	{
+		get => Control.ContextMenu;
+		set => Control.ContextMenu = value;
+	}
+
 	/// <inheritdoc />
 	public bool CaptureMouse() => Control.CaptureMouse();
 	/// <inheritdoc />

--- a/src/Eto/Forms/Controls/TreeGridView.cs
+++ b/src/Eto/Forms/Controls/TreeGridView.cs
@@ -566,10 +566,10 @@ public class TreeGridView : Grid
 	/// Gets or sets the context menu when right clicking or pressing the menu key on an item.
 	/// </summary>
 	/// <value>The context menu.</value>
-	public ContextMenu ContextMenu
+	public new ContextMenu ContextMenu
 	{
-		get { return Handler.ContextMenu; }
-		set { Handler.ContextMenu = value; }
+		get { return base.ContextMenu; }
+		set { base.ContextMenu = value; }
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/Controls/TreeView.cs
+++ b/src/Eto/Forms/Controls/TreeView.cs
@@ -400,10 +400,10 @@ public class TreeView : Control
 	/// Gets or sets the context menu to show when the user right clicks or presses the menu key
 	/// </summary>
 	/// <value>The context menu to show, or null to have no menu</value>
-	public ContextMenu ContextMenu
+	public new ContextMenu ContextMenu
 	{
-		get { return Handler.ContextMenu; }
-		set { Handler.ContextMenu = value; }
+		get { return base.ContextMenu; }
+		set { base.ContextMenu = value; }
 	}
 
 	#region Callback

--- a/src/Eto/Forms/Menu/ButtonMenuItem.cs
+++ b/src/Eto/Forms/Menu/ButtonMenuItem.cs
@@ -17,7 +17,7 @@ public class ButtonMenuItem : MenuItem, ISubmenu, IBindableWidgetContainer
 	/// Gets the collection of menu items.
 	/// </summary>
 	/// <value>The items.</value>
-	public MenuItemCollection Items => items ?? (items = new MenuItemCollection(Handler, this));
+	public MenuItemCollection Items => items ??= new MenuItemCollection(Handler, this);
 
 	/// <summary>
 	/// Gets a value indicating whether this sub menu should trim its child menu items when loaded onto a form
@@ -30,6 +30,17 @@ public class ButtonMenuItem : MenuItem, ISubmenu, IBindableWidgetContainer
 	/// </summary>
 	public ButtonMenuItem()
 	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Eto.Forms.ButtonMenuItem"/> class with the specified handler.
+	/// </summary>
+	/// <param name="handler">The handler for the button menu item.</param>
+	/// <param name="items">Initial items in the menu</param>
+	public ButtonMenuItem(IHandler handler, IEnumerable<MenuItem> items = null)
+		: base(handler)
+	{
+		this.items = new MenuItemCollection(Handler, this, items);
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/Menu/ContextMenu.cs
+++ b/src/Eto/Forms/Menu/ContextMenu.cs
@@ -23,15 +23,15 @@ public interface IContextMenuHost
 [Handler(typeof(ContextMenu.IHandler))]
 public class ContextMenu : Menu, ISubmenu
 {
-	MenuItemCollection items;
+	MenuItemCollection _items;
 
-	new IHandler Handler { get { return (IHandler)base.Handler; } }
+	new IHandler Handler => (IHandler)base.Handler;
 
 	/// <summary>
 	/// Gets the menu items in the context menu
 	/// </summary>
 	/// <value>The items.</value>
-	public MenuItemCollection Items { get { return items ?? (items = new MenuItemCollection(Handler, this)); } }
+	public MenuItemCollection Items => _items ??= new MenuItemCollection(Handler, this);
 
 	/// <summary>
 	/// Gets a value indicating whether this sub menu should trim its child menu items when loaded onto a form
@@ -54,6 +54,22 @@ public class ContextMenu : Menu, ISubmenu
 	{
 		Trim = true;
 		Closed += HandleClosed;
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Eto.Forms.ContextMenu"/> class with a specified handler.
+	/// </summary>
+	/// <param name="handler">The handler for the context menu.</param>
+	/// <param name="items">Items to populate the menu</param>
+	public ContextMenu(IHandler handler, IEnumerable<MenuItem> items = null)
+		: base(handler)
+	{
+		Trim = true;
+		Closed += HandleClosed;
+		if (items != null)
+		{
+			_items = new MenuItemCollection(Handler, this, items);
+		}
 	}
 
 	void HandleClosed(object sender, EventArgs e)

--- a/src/Eto/Forms/Menu/Menu.cs
+++ b/src/Eto/Forms/Menu/Menu.cs
@@ -8,6 +8,22 @@ namespace Eto.Forms;
 public abstract class Menu : BindableWidget
 {
 	/// <summary>
+	/// Initializes a new instance of the <see cref="Eto.Forms.Menu"/> class.
+	/// </summary>
+	public Menu()
+	{
+	}
+	
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Eto.Forms.Menu"/> class with a specified handler.
+	/// </summary>
+	/// <param name="handler">The handler for the menu.</param>
+	public Menu(IHandler handler)
+		: base(handler)
+	{
+	}
+	
+	/// <summary>
 	/// Called before the menu is assigned to a control/window
 	/// </summary>
 	/// <param name="e">Event arguments</param>

--- a/src/Eto/Forms/Menu/MenuItem.cs
+++ b/src/Eto/Forms/Menu/MenuItem.cs
@@ -146,6 +146,15 @@ public abstract class MenuItem : Menu, ICommandItem
 	}
 
 	/// <summary>
+	/// Initializes a new instance of the <see cref="Eto.Forms.MenuItem"/> class with the specified handler.
+	/// </summary>
+	/// <param name="handler">The handler for the menu item.</param>
+	protected MenuItem(IHandler handler)
+		: base(handler)
+	{
+	}
+
+	/// <summary>
 	/// Initializes a new instance of the <see cref="Eto.Forms.MenuItem"/> class with the specified command.
 	/// </summary>
 	/// <remarks>

--- a/src/Eto/Forms/Menu/MenuItemCollection.cs
+++ b/src/Eto/Forms/Menu/MenuItemCollection.cs
@@ -10,10 +10,15 @@ public class MenuItemCollection : Collection<MenuItem>, IList
 	internal readonly Menu.ISubmenuHandler parent;
 	internal readonly Menu parentItem;
 
-	internal MenuItemCollection(Menu.ISubmenuHandler parent, Menu parentItem)
+	internal MenuItemCollection(Menu.ISubmenuHandler parent, Menu parentItem, IEnumerable<MenuItem> items = null)
 	{
 		this.parent = parent;
 		this.parentItem = parentItem;
+		if (items != null)
+		{
+			foreach (var item in items)
+				base.InsertItem(Count, item);
+		}
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/Menu/SeparatorMenuItem.cs
+++ b/src/Eto/Forms/Menu/SeparatorMenuItem.cs
@@ -14,4 +14,20 @@ public class SeparatorMenuItem : MenuItem
 	public new interface IHandler : MenuItem.IHandler
 	{
 	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Eto.Forms.SeparatorMenuItem"/> class.
+	/// </summary>
+	public SeparatorMenuItem()
+	{
+	}
+	
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Eto.Forms.SeparatorMenuItem"/> class with the specified handler.
+	/// </summary>
+	/// <param name="handler">The handler for the separator menu item.</param>
+	public SeparatorMenuItem(IHandler handler)
+		: base(handler)
+	{
+	}
 }

--- a/src/Eto/Forms/Menu/SubMenuItem.cs
+++ b/src/Eto/Forms/Menu/SubMenuItem.cs
@@ -97,6 +97,16 @@ public class SubMenuItem : ButtonMenuItem, ISubmenu, IBindableWidgetContainer
 	public SubMenuItem()
 	{
 	}
+	
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Eto.Forms.SubMenuItem"/> class with the specified handler.
+	/// </summary>
+	/// <param name="handler">The handler for the submenu item.</param>
+	/// <param name="items">Initial items in the submenu</param>
+	public SubMenuItem(IHandler handler, IEnumerable<MenuItem> items = null)
+		: base(handler, items)
+	{
+	}
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="Eto.Forms.SubMenuItem"/> class with the specified <paramref name="items" />.

--- a/src/Eto/Forms/ThemedControls/ThemedDocumentPageHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedDocumentPageHandler.cs
@@ -52,10 +52,10 @@ public class ThemedDocumentPageHandler : ThemedContainerHandler<Panel, DocumentP
 	/// Gets or sets the context menu.
 	/// </summary>
 	/// <value>The context menu.</value>
-	public ContextMenu ContextMenu
+	public new ContextMenu ContextMenu
 	{
-		get { return Control.ContextMenu; }
-		set { Control.ContextMenu = value; }
+		get { return base.ContextMenu; }
+		set { base.ContextMenu = value; }
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/ThemedControls/ThemedExpanderHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedExpanderHandler.cs
@@ -133,10 +133,10 @@ public class ThemedExpanderHandler : ThemedContainerHandler<StackLayout, Expande
 	/// <summary>
 	/// Gets or sets the context menu of the expander.
 	/// </summary>
-	public ContextMenu ContextMenu
+	public new ContextMenu ContextMenu
 	{
-		get { return Control.ContextMenu; }
-		set { Control.ContextMenu = value; }
+		get { return base.ContextMenu; }
+		set { base.ContextMenu = value; }
 	}
 
 	/// <summary>

--- a/test/Eto.Test/Handlers/TabPageHandler.cs
+++ b/test/Eto.Test/Handlers/TabPageHandler.cs
@@ -25,12 +25,6 @@
 			set { Tab.Text = value; }
 		}
 
-		public ContextMenu ContextMenu
-		{
-			get { return Control.ContextMenu; }
-			set { Control.ContextMenu = value; } // TODO
-		}
-
 		public Image Image
 		{
 			get { return Tab.Image; }

--- a/test/Eto.Test/Sections/Behaviors/ControlContextMenuSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ControlContextMenuSection.cs
@@ -1,0 +1,44 @@
+namespace Eto.Test.Sections.Behaviors
+{
+	[Section("Behaviors", "Control ContextMenu")]
+	public class ControlContextMenuSection : AllControlsBase
+	{
+		
+		public ControlContextMenuSection()
+		{
+			ContextMenu = CreateContextMenu(this);
+		}
+		protected override void LogEvents(Control control)
+		{
+			base.LogEvents(control);
+
+			control.ContextMenu = CreateContextMenu(control);
+		}
+
+		private ContextMenu CreateContextMenu(Control control)
+		{
+			var menu = new ContextMenu();
+			var item1 = new ButtonMenuItem { Text = "I&tem 1" };
+			item1.Click += (sender, e) => Log.Write(control, "Clicked Item 1");
+			menu.Items.Add(item1);
+			var item2 = new ButtonMenuItem { Text = "Item &2" };
+			item2.Click += (sender, e) => Log.Write(control, "Clicked Item 2");
+			menu.Items.Add(item2);
+			var subMenu = new SubMenuItem { Text = "Sub Menu" };
+			var subItem1 = new ButtonMenuItem { Text = "Sub Item &1" };
+			subItem1.Click += (sender, e) => Log.Write(control, "Clicked Sub Item 1");
+			subMenu.Items.Add(subItem1);
+			var subItem2 = new ButtonMenuItem { Text = "Sub Item &2" };
+			subItem2.Click += (sender, e) => Log.Write(control, "Clicked Sub Item 2");
+			subMenu.Items.Add(subItem2);
+			menu.Items.Add(subMenu);
+			
+			menu.Opening += (sender, e) => Log.Write(control, "ContextMenu Opening");
+			menu.Closing += (sender, e) => Log.Write(control, "ContextMenu Closing");
+			menu.Closed += (sender, e) => Log.Write(control, "ContextMenu Closed");
+			
+			return menu;
+		}
+	}
+}
+

--- a/test/Eto.Test/Sections/Controls/TextAreaSection.cs
+++ b/test/Eto.Test/Sections/Controls/TextAreaSection.cs
@@ -13,6 +13,12 @@ namespace Eto.Test.Sections.Controls
 			var text = new TextArea { Text = LoremGenerator.GenerateLines(3, 100) };
 			LogEvents(text);
 
+			if (text.ContextMenu != null)
+			{
+				text.ContextMenu.Items.Insert(0, new ButtonMenuItem(TestItemClick) { Text = "Test" });
+				text.ContextMenu.Items.Insert(1, new SeparatorMenuItem());
+			}
+
 			return new TableLayout
 			{
 				Padding = new Padding(10),
@@ -26,6 +32,11 @@ namespace Eto.Test.Sections.Controls
 					text
 				}
 			};
+		}
+
+		private void TestItemClick(object sender, EventArgs e)
+		{
+			Log.Write(sender, "Test item clicked");
 		}
 
 		public static Control TextAreaOptions(TextArea text)
@@ -83,7 +94,7 @@ namespace Eto.Test.Sections.Controls
 					SetBorderType(text),
 					null
 				}
-				};
+			};
 		}
 
 		private static Control SetBorderType(TextArea text)
@@ -103,7 +114,7 @@ namespace Eto.Test.Sections.Controls
 		private static Control ScrollToDropDown(TextArea text)
 		{
 			var button = new SegmentedButton { SelectionMode = SegmentedSelectionMode.None };
-			
+
 			void ScrollToRange(object sender, EventArgs e)
 			{
 				var dlg = new Dialog<bool> { Title = "Select Range" };
@@ -121,7 +132,7 @@ namespace Eto.Test.Sections.Controls
 
 				dlg.PositiveButtons.Add(done);
 				dlg.DefaultButton = done;
-				
+
 				if (dlg.ShowModal())
 				{
 					text.ScrollTo(new Range<int>((int)start.Value, (int)end.Value));
@@ -184,7 +195,8 @@ namespace Eto.Test.Sections.Controls
 		static Control TextReplacementsDropDown(TextArea text)
 		{
 			var control = new Button { Text = "TextReplacements" };
-			control.Click += (sender, e) => {
+			control.Click += (sender, e) =>
+			{
 				var replacements = text.TextReplacements;
 				var supported = text.SupportedTextReplacements;
 				var contextMenu = new ContextMenu();
@@ -200,7 +212,8 @@ namespace Eto.Test.Sections.Controls
 					if (!supported.HasFlag(val))
 						continue;
 					var checkItem = new CheckMenuItem { Text = val.ToString(), Checked = replacements.HasFlag(val) };
-					checkItem.CheckedChanged += (sender2, e2) => {
+					checkItem.CheckedChanged += (sender2, e2) =>
+					{
 						var rep = text.TextReplacements;
 						if (checkItem.Checked)
 							rep |= val;

--- a/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ApplicationTests.cs
@@ -121,8 +121,10 @@ public class ApplicationTests : TestBase
 				tcs.SetException(e);
 			}
 		});
+#pragma warning disable CA1416
 		if (EtoEnvironment.Platform.IsWindows)
 			thread.SetApartmentState(ApartmentState.STA);
+#pragma warning restore CA1416
 		thread.Start();
 		return tcs.Task;
 	}	


### PR DESCRIPTION
This adds the ability to set a custom ContextMenu for a control, which has different semantics than creating/showing the context menu manually on a right click. E.g. showing with the menu key (Windows), or control+click (macOS), and keeping the selection of a TextBox/TextArea while the menu is shown (Windows).

Previously, this was only implemented for Panel-derived controls, GridView, ListBox, etc.