### PR TITLE
[WinForms] CanFocus was apparently never implemented, but CanFocusMe is there. D…

### DIFF
--- a/src/Eto.WinForms/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/DrawableHandler.cs
@@ -36,6 +36,12 @@ namespace Eto.WinForms.Forms.Controls
 				set { canFocus = value; SetStyle(swf.ControlStyles.Selectable, value); }
 			}
 
+			public bool CanFocus
+			{
+				get { return canFocus; }
+				set { canFocus = value; SetStyle(swf.ControlStyles.Selectable, value); }
+			}
+
 			protected override void OnGotFocus(EventArgs e)
 			{
 				base.OnGotFocus(e);


### PR DESCRIPTION
…uplicate CanFocusMe because CanFocusMe is used elsewhere. On WinForms, to have an Eto.Drawable receive focus, instead I had to cast it to the native control and set CanFocus. This hopefully fixes this.

This is my first PR in Eto.Forms. Hopefully I got the architecture correctly.