### PR TITLE
Mac: Fix issue with TextArea.ContextMenu

### DIFF
--- a/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -52,6 +52,18 @@ namespace Eto.Mac.Forms.Controls
 				handler.lastCaretIndex = caretIndex;
 			}
 		}
+
+		public override NSMenu MenuForEvent(NSTextView view, NSMenu menu, NSEvent theEvent, nuint charIndex)
+		{
+			var handler = Handler;
+			if (handler == null)
+				return menu;
+			
+			var contextMenu = handler.Widget.ContextMenu;
+			if (contextMenu != null)
+				return (contextMenu.Handler as ContextMenuHandler)?.Control;
+			return menu;
+		}
 	}
 
 	public class EtoTextView : NSTextView, IMacControl
@@ -127,24 +139,6 @@ namespace Eto.Mac.Forms.Controls
 				return;
 			}
 			base.OnKeyDown(e);
-		}
-
-		public override ContextMenu ContextMenu
-		{
-			get => base.ContextMenu;
-			set
-			{
-				base.ContextMenu = value;
-				Control.MenuForEvent = OnMenuForEvent;
-			}
-		}
-
-		private NSMenu OnMenuForEvent(NSTextView view, NSMenu menu, NSEvent theEvent, nuint charIndex)
-		{
-			var contextMenu = ContextMenu;
-			if (contextMenu != null)
-				return (contextMenu.Handler as ContextMenuHandler)?.Control;
-			return menu;
 		}
 
 		public NSScrollView Scroll { get; private set; }


### PR DESCRIPTION
This would cause a crash in macOS where it would try to override the delegate with the event.  Instead, moved the implementation of MenuForEvent into EtoTextAreaDelegate