### PR TITLE
Fix assembly versions for releases

### DIFF
--- a/.github/workflows/manual-version-bump.yml
+++ b/.github/workflows/manual-version-bump.yml
@@ -1,0 +1,47 @@
+name: Manual Version Bump and PR
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version number to set'
+        required: true
+        type: string
+
+jobs:
+  set-version-and-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '9.0.x'
+
+      - name: Set version
+        run: |
+          dotnet build build/Build.proj /t:UpdateVersion /p:SetVersion=${{ github.event.inputs.version }}
+
+      - name: Configure git
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+
+      - name: Create branch and commit
+        run: |
+          branch=version-bump/${{ github.event.inputs.version }}
+          git checkout -b "$branch"
+          git add .
+          git commit -m "bump version to ${{ github.event.inputs.version }}"
+          git push origin "$branch"
+
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          title: "bump version to ${{ github.event.inputs.version }}"
+          body: "Automated version bump to ${{ github.event.inputs.version }}."

--- a/build/Build.proj
+++ b/build/Build.proj
@@ -43,7 +43,7 @@
 
     <FileUpdate Files="$(BasePath)build\Common.props"
       WarnOnNoUpdate="true"
-      Pattern='(?&lt;=&lt;Version\s*[^&gt;]+?&gt;)[^&lt;]+(?=&lt;/Version&gt;)'
+      Pattern='(?&lt;=&lt;Version\s*[^&gt;]+?&gt;)[\d\.]+(?=&lt;/Version&gt;)'
       Replacement='$(AssemblyVersion)' />
 
     <PropertyGroup>

--- a/build/Common.props
+++ b/build/Common.props
@@ -23,6 +23,9 @@
 
     <DevVersion>2.11.0</DevVersion>
 
+    <!-- Extract the first two components (Major.Minor) from an assembly version like 2.10.1 to make it 2.10.0.0 -->
+    <Version Condition="$(Version) == '' AND $(BuildBranch.StartsWith('refs/tags/'))">$([System.Version]::Parse($(BuildBranch.Substring(10))).ToString(2)).0.0</Version>
+    
     <Version Condition="$(Version) == ''">2.11.0.0</Version>
 
     <InformationalVersion Condition="$(SetVersion) != ''">$(SetVersion)</InformationalVersion>
@@ -34,7 +37,7 @@
     <InformationalVersion Condition="$(InformationalVersion) == ''">$(DevVersion)-dev</InformationalVersion>
 
     <Company>Picoe Software Solutions</Company>
-    <Copyright>(c) 2010-2021 by Curtis Wensley, 2012-2014 by Vivek Jhaveri and contributors</Copyright>
+    <Copyright>(c) 2010-2025 by Curtis Wensley, 2012-2014 by Vivek Jhaveri and contributors</Copyright>
     
     <PackageVersion>$(InformationalVersion)</PackageVersion>
     <PackageLicenseFile>Eto-LICENSE.txt</PackageLicenseFile>


### PR DESCRIPTION
If the version wasn't set correctly in the branch before the release, the assembly versions of some assemblies would be messed up and have the wrong version.  This ensures releases use the version specified for the assembly version as well as the nuget package version.