### PR TITLE
Set TabStop too (to participate in Tab navigation) if it is CanFocus for WinForms,…

### DIFF
--- a/src/Eto.WinForms/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/DrawableHandler.cs
@@ -106,15 +106,17 @@ namespace Eto.WinForms.Forms.Controls
 		public bool CanFocus
 		{
 			get { return Control.CanFocusMe; }
-			set {
+			set 
+			{
 				if (value != Control.CanFocusMe)
 				{
+					Control.CanFocusMe = value;
+					
 					if (Control is swf.Control control)
 					{
 						control.TabStop = value;
 					}
 				}
-				Control.CanFocusMe = value;
 			}
 		}
 

--- a/src/Eto.WinForms/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/DrawableHandler.cs
@@ -106,7 +106,16 @@ namespace Eto.WinForms.Forms.Controls
 		public bool CanFocus
 		{
 			get { return Control.CanFocusMe; }
-			set { Control.CanFocusMe = value; }
+			set {
+				if (value != Control.CanFocusMe)
+				{
+					if (Control is swf.Control control)
+					{
+						control.TabStop = value;
+					}
+				}
+				Control.CanFocusMe = value;
+			}
 		}
 
 		public virtual void Update(Rectangle rect)


### PR DESCRIPTION
… consistent with the other platforms: WPF and GTK.

Associated test and bug postmortem:
https://github.com/ris-work/eto-forms-tab-navigation-with-drawables

Thank you.

Fixes #2826