### PR TITLE
Automate release a little more and categorize release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,21 @@
+changelog:
+  categories:
+    - title: 🚀 Features
+      labels:
+        - feature
+        - enhancement
+
+    - title: 🐛 Bug Fixes
+      labels:
+        - bug
+        - fix
+
+    - title: 🧰 Maintenance
+      labels:
+        - chore
+        - refactor
+        - docs
+
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
   pull_request:
     branches: [ develop ]
   release:
-    types: [ published ]
+    types: [ published, prereleased ]
 
 env:
   DotNetVersion: "8.0.115"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,5 +24,5 @@ jobs:
         name: ${{ github.event.milestone.title }}
         body_path: milestone_description.md
         generate_release_notes: true
-        draft: true
+        prerelease: true
 


### PR DESCRIPTION
This will attempt to chain the release creation with creating the build.

Before it was : Close Milestone > Change release to pre-release > wait for build > verify build > release

Hopefully it can be: Close Milestone > wait for build > verify build > release