### PR TITLE
Fix overflow in Size.ToNS() for Int.MaxValue

### DIFF
--- a/src/Eto.Mac/Mac64Extensions.cs
+++ b/src/Eto.Mac/Mac64Extensions.cs
@@ -54,7 +54,7 @@ namespace Eto.Mac
 
 		public static CGSize ToNS(this Size size)
 		{
-			return new CGSize((float)size.Width, (float)size.Height);
+			return new CGSize(size.Width, size.Height);
 		}
 
 		public static Size ToEtoSize(this CGSize size)


### PR DESCRIPTION
The explicit cast to float caused precision loss and negative values in CGSize for large integers like Int.MaxValue. Removing the cast allows implicit conversion to double, preserving exact values.

https://github.com/picoe/Eto/blob/d4197dc1c73a87b2941449fb3828874e9c5764f3/src/Eto.Mac/Mac64Extensions.cs#L157
https://github.com/picoe/Eto/blob/d4197dc1c73a87b2941449fb3828874e9c5764f3/src/Eto.Mac/Forms/Controls/MacLabel.cs#L133