### PR TITLE
Mac: Fix overflow when converting double to int for sizes

### DIFF
--- a/src/Eto.Mac/Mac64Extensions.cs
+++ b/src/Eto.Mac/Mac64Extensions.cs
@@ -34,7 +34,9 @@ namespace Eto.Mac
 
 		public static Point ToEtoPoint(this CGPoint point)
 		{
-			return new Point((int)point.X, (int)point.Y);
+			return new Point(
+				point.X <= int.MinValue ? int.MinValue : point.X >= int.MaxValue ? int.MaxValue : (int)point.X,
+				point.Y <= int.MinValue ? int.MinValue : point.Y >= int.MaxValue ? int.MaxValue : (int)point.Y);
 		}
 
 		public static CGPoint ToNS(this PointF point)
@@ -59,7 +61,7 @@ namespace Eto.Mac
 
 		public static Size ToEtoSize(this CGSize size)
 		{
-			return new Size((int)size.Width, (int)size.Height);
+			return new Size(size.Width >= int.MaxValue ? int.MaxValue : (int)size.Width, size.Height >= int.MaxValue ? int.MaxValue : (int)size.Height);
 		}
 
 		public static CGRect ToNS(this RectangleF rect)
@@ -79,7 +81,12 @@ namespace Eto.Mac
 
 		public static Rectangle ToEtoRectangle(this CGRect rect)
 		{
-			return new Rectangle((int)rect.X, (int)rect.Y, (int)rect.Width, (int)rect.Height);
+			return new Rectangle(
+				rect.X <= int.MinValue ? int.MinValue : rect.X >= int.MaxValue ? int.MaxValue : (int)rect.X,
+				rect.Y <= int.MinValue ? int.MinValue : rect.Y >= int.MaxValue ? int.MaxValue : (int)rect.Y,
+				rect.Width >= int.MaxValue ? int.MaxValue : (int)rect.Width,
+				rect.Height >= int.MaxValue ? int.MaxValue : (int)rect.Height
+			);
 		}
 
 		#if IOS


### PR DESCRIPTION
Especially on Mac Intel machines or running in Rosetta, ToEtoSize() when fed an int.MaxValue would return -int.MaxValue. This caused the preferred size of Labels to be incorrect.

E.g. `(int)new CGSize(int.MaxValue,int.MaxValue).Width = -2147483648`