### PR TITLE
Added caching to Image sizes

### DIFF
--- a/src/Eto/Drawing/Image.cs
+++ b/src/Eto/Drawing/Image.cs
@@ -42,7 +42,9 @@ public interface ILockableImage
 [sc.TypeConverter(typeof(ImageConverterInternal))]
 public abstract class Image : Widget
 {
-	new IHandler Handler { get { return (IHandler)base.Handler; } }
+	private Size? _size;
+
+	new IHandler Handler => (IHandler)base.Handler;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="Eto.Drawing.Image"/> class.
@@ -63,10 +65,7 @@ public abstract class Image : Widget
 	/// <summary>
 	/// Gets the size of the image, in pixels
 	/// </summary>
-	public Size Size
-	{
-		get { return Handler.Size; }
-	}
+	public Size Size => _size ??= Handler.Size;
 
 	/// <summary>
 	/// Gets the width of the image, in pixels.
@@ -76,7 +75,7 @@ public abstract class Image : Widget
 	/// </remarks>
 	/// <value>The width of the image, in pixels</value>
 	/// <seealso cref="Size"/>
-	public int Width { get { return Size.Width; } }
+	public int Width => Size.Width;
 
 	/// <summary>
 	/// Gets the height of the image, in pixels.
@@ -86,7 +85,7 @@ public abstract class Image : Widget
 	/// </remarks>
 	/// <value>The height of the image, in pixels</value>
 	/// <seealso cref="Size"/>
-	public int Height { get { return Size.Height; } }
+	public int Height => Size.Height;
 
 	/// <summary>
 	/// Handler interface for the <see cref="Image"/> class


### PR DESCRIPTION
The below code was extremely slow for me, and caching the width/height rectified this issue. I believe any image change requires a new image, so caching them should not break anything.

``` cs
Bitmap texture = new Bitmap(textureWidth, textureHeight, PixelFormat.Format32bppRgba);

  using (BitmapData textureData = texture.Lock())
  {
    int x = 0;
    int y = 0;

    for (int index = 0; index < bitmapList.Count; index++)
    {
      Bitmap bitmap = bitmapList[index];

      if (x >= texture.Width)
      {
        x = 0;
        y += size;
      }

      using (BitmapData bitmapData = bitmap.Lock())
      {
        for (int by = 0; by < Math.Min(texture.Width, size); by++)
        {
          for (int bx = 0; bx < Math.Min(texture.Height, size); bx++)
          {
            Color pixel = bitmapData.GetPixel(bx, by);
            if (pixel.Ab == 0) continue;
            textureData.SetPixel(x + bx, y + by, pixel);
          }
        }
      }

      x += size;
    }
  }
```