### PR TITLE
Fix GTK preferred size calculation

### DIFF
--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -1154,7 +1154,9 @@ namespace Eto.GtkSharp.Forms
 
 		public Window GetNativeParentWindow() => (Control.Toplevel as Gtk.Window).ToEtoWindow();
 
-		public virtual SizeF GetPreferredSize(SizeF availableSize)
+		public virtual SizeF GetPreferredSize(SizeF availableSize) => GetPreferredSizeForControl(availableSize, ContainerControl);
+
+		public virtual SizeF GetPreferredSizeForControl(SizeF availableSize, Gtk.Widget control)
 		{
 			if (!ContainerControl.IsRealized)
 			{
@@ -1177,10 +1179,10 @@ namespace Eto.GtkSharp.Forms
 					width = natural_width = preferred.Width;
 				else
 				{
-					ContainerControl.GetPreferredWidth(out var minimum_width, out natural_width);
+					control.GetPreferredWidth(out var minimum_width, out natural_width);
 					width = Math.Max(minimum_width, Math.Min(size.Width, natural_width));
 				}
-				ContainerControl.GetPreferredHeightForWidth(width, out var minimum_height, out var natural_height);
+				control.GetPreferredHeightForWidth(width, out var minimum_height, out var natural_height);
 				return new SizeF(natural_width, natural_height);
 			}
 			else if (requestMode == Gtk.SizeRequestMode.WidthForHeight && preferred.Width < 0)
@@ -1191,20 +1193,20 @@ namespace Eto.GtkSharp.Forms
 					height = natural_height = preferred.Height;
 				else
 				{
-					ContainerControl.GetPreferredHeight(out var minimum_height, out natural_height);
+					control.GetPreferredHeight(out var minimum_height, out natural_height);
 					height = Math.Max(minimum_height, Math.Min(size.Height, natural_height));
 				}
-				ContainerControl.GetPreferredHeightForWidth(height, out var minimum_width, out var natural_width);
+				control.GetPreferredHeightForWidth(height, out var minimum_width, out var natural_width);
 				return new SizeF(natural_width, natural_height);
 			}
-			ContainerControl.GetPreferredSize(out var minimum, out var natural);
+			control.GetPreferredSize(out var minimum, out var natural);
 			if (preferred.Width >= 0)
 				natural.Width = preferred.Width;
 			if (preferred.Height >= 0)
 				natural.Height = preferred.Height;
 			return new SizeF(natural.Width, natural.Height);
 #else
-			var size = ContainerControl.SizeRequest();
+			var size = control.SizeRequest();
 			return new SizeF(size.Width, size.Height);
 #endif
 		}

--- a/src/Eto.Gtk/Forms/GtkWindow.cs
+++ b/src/Eto.Gtk/Forms/GtkWindow.cs
@@ -932,7 +932,7 @@ namespace Eto.GtkSharp.Forms
 		{
 			Control.GetSize(out var width, out var height);
 			var availableSize = Screen?.WorkingArea.Size ?? SizeF.PositiveInfinity;
-			var preferred = Size.Round(SizeF.Min(base.GetPreferredSize(availableSize), availableSize));
+			var preferred = Size.Round(SizeF.Min(base.GetPreferredSizeForControl(availableSize, Control.Child), availableSize));
 			if (preferred.Width != width || preferred.Height != height)
 			{
 				// signal that we are auto sizing ourselves so don't turn off AutoSize.

--- a/src/Eto.Gtk/Forms/TableLayoutHandler.gtk3.cs
+++ b/src/Eto.Gtk/Forms/TableLayoutHandler.gtk3.cs
@@ -3,6 +3,26 @@ namespace Eto.GtkSharp.Forms
 {
 	public class TableLayoutHandler : GtkContainer<Gtk.Grid, TableLayout, TableLayout.ICallback>, TableLayout.IHandler
 	{
+		public class EtoGrid : Gtk.Grid
+		{
+			protected override void OnGetPreferredHeightForWidth(int width, out int minimum_height, out int natural_height)
+			{
+				if (width == -1)
+				{
+					GetPreferredWidth(out _, out width);
+				}
+				base.OnGetPreferredHeightForWidth(width, out minimum_height, out natural_height);
+			}
+			protected override void OnGetPreferredHeightAndBaselineForWidth(int width, out int minimum_height, out int natural_height, out int minimum_baseline, out int natural_baseline)
+			{
+				if (width == -1)
+				{
+					GetPreferredWidth(out _, out  width);
+				}
+				base.OnGetPreferredHeightAndBaselineForWidth(width, out minimum_height, out natural_height, out minimum_baseline, out natural_baseline);
+			}
+		}
+
 		Gtk.Alignment align;
 		Gtk.EventBox box;
 		bool[] columnScale;
@@ -60,7 +80,7 @@ namespace Eto.GtkSharp.Forms
 			align.Hexpand = false;
 			align.Vexpand = false;
 			box = new EtoEventBox { Child = align, Handler = this };
-			Control = new Gtk.Grid();
+			Control = new EtoGrid();
 			align.Add(Control);
 		}
 

--- a/test/Eto.Test/UnitTests/Forms/Layout/StackLayoutTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Layout/StackLayoutTests.cs
@@ -4,6 +4,36 @@ namespace Eto.Test.UnitTests.Forms.Layout
 	[TestFixture]
 	public class StackLayoutTests : TestBase
 	{
+		[Test, ManualTest]
+		public void WindowShouldShrinkToFitContents()
+		{
+			ManualForm(
+				"WindowShouldShrinkToFitContents",
+				form =>
+				{
+					var stackLayout = new StackLayout();
+					form.AutoSize = true;
+					Application.Instance.InvokeAsync(() =>
+					{
+						stackLayout.Items.Add(
+							new Label
+							{
+								Text = "Neque porro quisquam est qui dolorem ipsum quia dolor sit amet, consectetur, adipisci velit...",
+							}
+						);
+						stackLayout.Items.Add(
+							new Panel
+							{
+								BackgroundColor = Colors.Thistle,
+								Width = 2,
+								Height = 2,
+							}
+						);
+					});
+					return stackLayout;
+				});
+		}
+
 		[Test]
 		public void AddingItemShouldSetChildrenAndParent()
 		{


### PR DESCRIPTION
Calculate preferred width first for unconstrained width-for-height in GTK Grid, as GTK uses minimal width for height unlike Eto's expectation. Use window's direct child for auto-sizing since window preferred size includes client decorations unexpected by gtk_window_resize.

fixes #2855
fixes #2858