### PR TITLE
Make groupbox padding with empty header symmetric on wpf backend

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/GroupBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GroupBoxHandler.cs
@@ -43,6 +43,8 @@ namespace Eto.Wpf.Forms.Controls
 				headerPadding = header.Padding;
 			var noHeader = string.IsNullOrEmpty(Text);
 			header.Padding = noHeader ? new sw.Thickness(0) : headerPadding.Value;
+			Control.Header = noHeader ? null : Header;
+			Control.Padding = noHeader ? new sw.Thickness(0, 6, 0, 0) : new sw.Thickness(0, 0, 0, 0);
 		}
 
 		public override void SetContainerContent(sw.FrameworkElement content)


### PR DESCRIPTION
The padding in WPF GroupBox controls with empty header was asymmetric due to extra height from the Label header. To achieve symmetry, the header is set to null, and a top padding is added, value extracted from the WPF source code.

https://github.com/dotnet/wpf/blob/092d18b5b2a6f0f1d9963730a4423c95c84652cc/src/Microsoft.DotNet.Wpf/src/Themes/XAML/GroupBox.xaml#L33

Original Screenshot:

<img width="669" height="675" alt="original" src="https://github.com/user-attachments/assets/9dd1a89c-d9dc-446d-bde3-43809be45e26" />

Fixed Screenshoot:
<img width="668" height="668" alt="fixed" src="https://github.com/user-attachments/assets/d653b403-2aff-4ad5-9218-b89e6b93ca8f" />
