### PR TITLE
Fix bracket key mappings in Key.cs

### DIFF
--- a/src/Eto/Forms/Key.cs
+++ b/src/Eto/Forms/Key.cs
@@ -329,8 +329,8 @@
 		  { Keys.Period, "." },
 		  { Keys.Slash, "/" },
 		
-		  { Keys.RightBracket, "[" },
-		  { Keys.LeftBracket, "]" }
+		  { Keys.RightBracket, "]" },
+		  { Keys.LeftBracket, "[" }
 	  };
 
 	  /// <summary>


### PR DESCRIPTION
I noticed that the two were backwards.