### PR TITLE
Update Key.cs to prevent None added into shortcut string

### DIFF
--- a/src/Eto/Forms/Key.cs
+++ b/src/Eto/Forms/Key.cs
@@ -359,7 +359,7 @@
 		  string val;
 		  if (keymap.TryGetValue(mainKey, out val))
 			  AppendSeparator(sb, separator, val);
-		  else
+		  else if (mainKey != Keys.None)
 			  AppendSeparator(sb, separator, mainKey.ToString());
 
 		  return sb.ToString();


### PR DESCRIPTION
Often I find that running code like below

``` cs
Keys key = Keys.Shift;
string shortcut = key.ToShortcutString(" + ");
```

Will give me "Shift + None" when I really just want "Shift".