### PR TITLE
Mac: Ensure Grid.IsEditing is false after cancelling edit

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -576,6 +576,8 @@ namespace Eto.GtkSharp.Forms.Controls
 		public void BeginEdit(int row, int column)
 		{
 			var nameColumn = Control.Columns[column];
+			if (nameColumn.Cells.Length == 0)
+				return;
 			var cellRenderer = nameColumn.Cells[0];
 			var path = Control.Model.GetPath(GetIterAtRow(row));
 			Control.Model.IterNChildren();

--- a/src/Eto.Mac/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/CellHandler.cs
@@ -52,6 +52,7 @@ namespace Eto.Mac.Forms.Cells
 		bool isFirstResponder;
 		public event EventHandler<EventArgs> BecameFirstResponder;
 		public event EventHandler<EventArgs> ResignedFirstResponder;
+		public event EventHandler<CancelEventArgs> EditingAborted;
 
 		public override bool BecomeFirstResponder()
 		{
@@ -69,6 +70,22 @@ namespace Eto.Mac.Forms.Cells
 			isFirstResponder = false;
 		}
 
+		public override bool AbortEditing()
+		{
+			var ret = base.AbortEditing();
+			if (ret && EditingAborted != null)
+			{
+				var e = new CancelEventArgs();
+				EditingAborted(this, e);
+				ret = !e.Cancel;
+				if (ret)
+				{
+					isFirstResponder = false;
+				}
+			}
+			return ret;
+		}
+
 		public override bool ResignFirstResponder()
 		{
 			var ret = base.ResignFirstResponder();
@@ -82,7 +99,7 @@ namespace Eto.Mac.Forms.Cells
 	}
 
 	public abstract class CellHandler<TWidget, TCallback> : MacObject<NSObject, TWidget, TCallback>, Cell.IHandler, ICellHandler
-		where TWidget: Cell
+		where TWidget : Cell
 	{
 		WeakReference _columnHandler;
 		public IDataColumnHandler ColumnHandler
@@ -140,7 +157,7 @@ namespace Eto.Mac.Forms.Cells
 		public virtual void SetForegroundColor(NSView view, Color color)
 		{
 		}
-		
+
 		public virtual void ViewRemoved(NSView view)
 		{
 		}

--- a/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Mac/Forms/Cells/TextBoxCellHandler.cs
@@ -129,6 +129,20 @@ namespace Eto.Mac.Forms.Cells
 				};
 
 				var col = Array.IndexOf(tableView.TableColumns(), tableColumn);
+				view.EditingAborted += (sender, e) =>
+				{
+					var colHandler = ColumnHandler;
+					if (colHandler == null)
+						return;
+					var table = colHandler.DataViewHandler?.Table;
+					if (table == null)
+						return;
+					var control = (CellView)sender;
+					var r = (int)control.Tag;
+					var item = getItem(control.Item, r);
+					var ee = MacConversions.CreateCellEventArgs(colHandler.Widget, table, r, col, item);
+					e.Cancel = colHandler.DataViewHandler?.OnCellEditCancelled(ee) ?? false;
+				};
 				view.BecameFirstResponder += (sender, e) =>
 				{
 					var colHandler = ColumnHandler;

--- a/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridColumnHandler.cs
@@ -26,6 +26,8 @@ namespace Eto.Mac.Forms.Controls
 		void OnCellEditing(GridViewCellEventArgs e);
 
 		void OnCellEdited(GridViewCellEventArgs e);
+		
+		bool OnCellEditCancelled(GridViewCellEventArgs e);
 
 		Grid Widget { get; }
 

--- a/src/Eto.Mac/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GridHandler.cs
@@ -794,6 +794,13 @@ namespace Eto.Mac.Forms.Controls
 				AutoSizeColumns(true);
 			}
 		}
+		
+		bool IDataViewHandler.OnCellEditCancelled(GridViewCellEventArgs e)
+		{
+			SetIsEditing(false);
+			return false;
+		}
+		
 
 		Grid IDataViewHandler.Widget => Widget;
 

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
@@ -15,6 +15,57 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		}
 
 		[Test, ManualTest]
+		public void PressingEscapeToCancelShouldEndEditing()
+		{
+			bool? isEditingOnUnload = null;
+			ManualForm("Start editing a cell, then press Escape to cancel editing", form =>
+			{
+				form.Size = new Size(300, 200);
+				
+				var grid = new T();
+				grid.ShowHeader = true;
+				grid.AllowMultipleSelection = true;
+
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell { Binding = Binding.Property((GridTestItem m) => m.Text) }, HeaderText = "TextBoxCell", Editable = true });
+				grid.Columns.Add(new GridColumn
+				{
+					DataCell = new ComboBoxCell
+					{
+						Binding = Binding.Property((GridTestItem m) => (object)m.Text),
+						DataStore = new List<string> { "Item 1", "Item 2", "Item 3" }
+					},
+					HeaderText = "ComboBoxCell",
+					Editable = true
+				});
+
+				var list = new TreeGridItemCollection();
+				list.Add(new GridTestItem { Text = "Item 1" });
+				list.Add(new GridTestItem { Text = "Item 2" });
+				list.Add(new GridTestItem { Text = "Item 3" });
+				SetDataStore(grid, list);
+
+				grid.Shown += (sender, e) =>
+				{
+					grid.BeginEdit(1, 0);
+				};
+
+				grid.CellEdited += (sender, e) =>
+				{
+					Log.Write(sender, $"CellEdited Row: {e.Row}, Column: {e.Column}, IsEditing: {grid.IsEditing}");
+				};
+
+				grid.UnLoad += (sender, e) =>
+				{
+					isEditingOnUnload = grid.IsEditing;
+				};
+
+
+				return grid;
+			});
+			Assert.That(isEditingOnUnload, Is.False, "Grid should not be editing when unloading");
+		}
+
+		[Test, ManualTest]
 		public void BeginEditShoudWorkOnCustomCells()
 		{
 			ManualForm("The custom cell should go in edit mode when clicking the BeginEdit button", form =>
@@ -606,8 +657,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				Assert.That(grid.Columns[0].Width, Is.GreaterThan(50), "First column should be auto-sized to be greater than 50px");
 				Assert.That(grid.Columns[1].Width, Is.GreaterThan(50), "Second column should be auto-sized to be greater than 50px");
 			});
-			
-			
+
+
 		}
 	}
 }


### PR DESCRIPTION
On Mac, if you pressed escape to cancel an edit with a TextBoxCell, Grid.IsEditing would remain true.