### PR TITLE
Mac: Use sRGB color space to fix issues on macOS Tahoe

### DIFF
--- a/build/Common.Build.props
+++ b/build/Common.Build.props
@@ -24,6 +24,7 @@
     <NoWarn>$(NoWarn);NU5105;CS8981;NETSDK1138;SYSLIB0050;SYSLIB0051</NoWarn>
     <LangVersion Condition="$(MSBuildProjectExtension) == '.csproj'">10</LangVersion>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <ValidateXcodeVersion>false</ValidateXcodeVersion>
   </PropertyGroup>
 
   <!-- support t4 templates in projects -->

--- a/src/Eto.Mac/CGConversions.cs
+++ b/src/Eto.Mac/CGConversions.cs
@@ -12,16 +12,9 @@ namespace Eto.iOS
 {
 	public static partial class CGConversions
 	{
-		static CGColorSpace deviceRGB;
+		static CGColorSpace colorSpace;
 
-		static CGColorSpace CreateDeviceRGB()
-		{
-			if (deviceRGB != null)
-				return deviceRGB;
-
-			deviceRGB = CGColorSpace.CreateDeviceRGB();
-			return deviceRGB;
-		}
+		static CGColorSpace CreateColorSpace() => colorSpace ??= CGColorSpace.CreateSrgb();
 
 		public static CGColor ToCG(this NSColor color)
 		{
@@ -34,7 +27,7 @@ namespace Eto.iOS
 				return cgColor;
 
 			// try to convert to RGB colorspace so we can convert it to CGColor
-			var converted = color.UsingColorSpaceFast(NSColorSpace.DeviceRGB);
+			var converted = color.UsingColorSpace(NSColorSpace.SRGBColorSpace);
 			if (converted == null)
 				return new CGColor(0, 0, 0, 1f);
 
@@ -52,7 +45,7 @@ namespace Eto.iOS
 				return nscolor.ToCG();
 			if (color.ControlObject is CGColor cgcolor)
 				return cgcolor;
-			return new CGColor(CreateDeviceRGB(), new nfloat[] { color.R, color.G, color.B, color.A });
+			return new CGColor(CreateColorSpace(), new nfloat[] { color.R, color.G, color.B, color.A });
 		}
 
 		public static Color ToEto(this CGColor color)

--- a/src/Eto.Mac/Drawing/BitmapHandler.cs
+++ b/src/Eto.Mac/Drawing/BitmapHandler.cs
@@ -113,7 +113,8 @@ namespace Eto.Mac.Drawing
 						const int bytesPerPixel = bitsPerPixel / 8;
 						int bytesPerRow = bytesPerPixel * width;
 
-						rep = bmprep = new NSBitmapImageRep(IntPtr.Zero, width, height, bitsPerComponent, 3, false, false, NSColorSpace.DeviceRGB, bytesPerRow, bitsPerPixel);
+						var cgimage = new CGBitmapContext(IntPtr.Zero, width, height, bitsPerComponent, bytesPerRow, CGColorSpace.CreateSrgb(), CGBitmapFlags.NoneSkipLast).ToImage();
+						rep = bmprep = new NSBitmapImageRep(cgimage);
 						Control = new NSImage();
 						Control.AddRepresentation(rep);
 						break;
@@ -126,8 +127,13 @@ namespace Eto.Mac.Drawing
 						const int bitsPerPixel = numComponents * bitsPerComponent;
 						const int bytesPerPixel = bitsPerPixel / 8;
 						int bytesPerRow = bytesPerPixel * width;
-				
-						rep = bmprep = new NSBitmapImageRep(IntPtr.Zero, width, height, bitsPerComponent, numComponents, false, false, NSColorSpace.DeviceRGB, bytesPerRow, bitsPerPixel);
+
+						// no way to create a CGImage with 24bpp AND there's no way to get the sRGB colorspace name,
+						// so create NSBitmapImageRep directly then change colorspace to sRGB.
+						// why oh why apple didn't you make a new version of this API with a colorspace instance vs. name..?
+						using var tmpbmp = new NSBitmapImageRep(IntPtr.Zero, width, height, bitsPerComponent, numComponents, false, false, NSColorSpace.CalibratedRGB, bytesPerRow, bitsPerPixel);
+						rep = bmprep = tmpbmp.ConvertingToColorSpace(NSColorSpace.SRGBColorSpace, NSColorRenderingIntent.Default);
+						
 						Control = new NSImage();
 						Control.AddRepresentation(rep);
 						break;
@@ -140,8 +146,11 @@ namespace Eto.Mac.Drawing
 						const int bitsPerPixel = numComponents * bitsPerComponent;
 						const int bytesPerPixel = bitsPerPixel / 8;
 						int bytesPerRow = bytesPerPixel * width;
+						
+						var cgimage = new CGBitmapContext(IntPtr.Zero, width, height, bitsPerComponent, bytesPerRow, CGColorSpace.CreateSrgb(), CGBitmapFlags.PremultipliedLast).ToImage();
 
-						rep = bmprep = new NSBitmapImageRep(IntPtr.Zero, width, height, bitsPerComponent, numComponents, true, false, NSColorSpace.DeviceRGB, bytesPerRow, bitsPerPixel);
+						// rep = bmprep = new NSBitmapImageRep(IntPtr.Zero, width, height, bitsPerComponent, numComponents, true, false, NSColorSpace.DeviceRGB, bytesPerRow, bitsPerPixel);
+						rep = bmprep = new NSBitmapImageRep(cgimage);
 						Control = new NSImage();
 						Control.AddRepresentation(rep);
 						break;

--- a/src/Eto.Mac/Drawing/LinearGradientBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/LinearGradientBrushHandler.cs
@@ -77,7 +77,7 @@ namespace Eto.iOS.Drawing
 				if (wrap == GradientWrapMode.Pad)
 				{
 					if (Gradient == null)
-						Gradient = new CGGradient(CGColorSpace.CreateDeviceRGB(), new [] { StartColor, EndColor }, new nfloat[] { (nfloat)0f, (nfloat)1f });
+						Gradient = new CGGradient(CGColorSpace.CreateSrgb(), new [] { StartColor, EndColor }, new nfloat[] { (nfloat)0f, (nfloat)1f });
 				}
 				else
 				{
@@ -86,7 +86,7 @@ namespace Eto.iOS.Drawing
 					if (Gradient == null || scale > lastScale)
 					{
 						var stops = GradientHelper.GetGradientStops(StartColor, EndColor, scale, wrap).ToList();
-						Gradient = new CGGradient(CGColorSpace.CreateDeviceRGB(), stops.Select(r => r.Item2).ToArray(), stops.Select(r => (nfloat)r.Item1).ToArray());
+						Gradient = new CGGradient(CGColorSpace.CreateSrgb(), stops.Select(r => r.Item2).ToArray(), stops.Select(r => (nfloat)r.Item1).ToArray());
 						lastScale = scale;
 					}
 				}

--- a/src/Eto.Mac/Drawing/RadialGradientBrushHandler.cs
+++ b/src/Eto.Mac/Drawing/RadialGradientBrushHandler.cs
@@ -79,7 +79,7 @@ namespace Eto.iOS.Drawing
 				{
 					var stops = GradientHelper.GetGradientStops(StartColor.ToCG(), EndColor.ToCG(), scale, wrap).ToList();
 					lastScale = scale;
-					Gradient = new CGGradient(CGColorSpace.CreateDeviceRGB(), stops.Select(r => r.Item2).ToArray(), stops.Select(r => (nfloat)r.Item1).ToArray());
+					Gradient = new CGGradient(CGColorSpace.CreateSrgb(), stops.Select(r => r.Item2).ToArray(), stops.Select(r => (nfloat)r.Item1).ToArray());
 				}
 				else
 				{

--- a/src/Eto.Mac/Eto.macOS.csproj
+++ b/src/Eto.Mac/Eto.macOS.csproj
@@ -7,7 +7,7 @@
     <DefineConstants>$(DefineConstants);OSX;DESKTOP;UNIFIED;MACOS_NET;USE_CFSTRING</DefineConstants>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefaultItemExcludes>$(DefaultItemExcludes);build\*</DefaultItemExcludes>
-    <NoWarn>$(NoWarn);CA1416;CS8981</NoWarn>
+    <NoWarn>$(NoWarn);CA1416;CS8981;NETSDK1202</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="AppKit" />

--- a/src/Eto.Mac/Forms/ColorDialogHandler.cs
+++ b/src/Eto.Mac/Forms/ColorDialogHandler.cs
@@ -152,7 +152,7 @@ namespace Eto.Mac.Forms
 
 		public virtual void OnColorChanged()
 		{
-			_color = Control.Color.UsingColorSpace(NSColorSpace.DeviceRGBColorSpace).ToEto();
+			_color = Control.Color.UsingColorSpace(NSColorSpace.SRGBColorSpace).ToEto();
 			if (_color == _lastColor)
 				return;
 			_lastColor = _color;

--- a/src/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
+++ b/src/Eto.Mac/Forms/Controls/MacImageAndTextCell.cs
@@ -64,8 +64,8 @@ namespace Eto.Mac.Forms.Controls
 		public const int ImagePadding = 2;
 		NSShadow textShadow;
 		NSShadow textHighlightShadow;
-		NSColor groupColor = NSColor.FromCalibratedRgba(0x6F / (float)0xFF, 0x7E / (float)0xFF, 0x8B / (float)0xFF, 1.0F);
-		//light shade: NSColor.FromCalibratedRgba (0x82 / (float)0xFF, 0x90 / (float)0xFF, 0x9D / (float)0xFF, 1.0F);
+		NSColor groupColor = NSColor.FromSrgb(0x6F / (float)0xFF, 0x7E / (float)0xFF, 0x8B / (float)0xFF, 1.0F);
+		//light shade: NSColor.FromSrgb (0x82 / (float)0xFF, 0x90 / (float)0xFF, 0x9D / (float)0xFF, 1.0F);
 		
 
 		public MacImageListItemCell()

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1042,7 +1042,7 @@ namespace Eto.Mac.Forms
 			get { return Widget.Properties.Get<Color?>(MacView.BackgroundColorKey) ?? DefaultBackgroundColor; }
 			set
 			{
-				if (value != BackgroundColor)
+				if (value != Widget.Properties.Get<Color?>(MacView.BackgroundColorKey))
 				{
 					Widget.Properties[MacView.BackgroundColorKey] = value;
 					SetBackgroundColor(value);

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -14,18 +14,7 @@ namespace Eto.Mac
 				return nscolor;
 			if (color.ControlObject is CGColor cgcolor && MacVersion.IsAtLeast(10, 8))
 				return NSColor.FromCGColor(cgcolor);
-			return NSColor.FromDeviceRgba(color.R, color.G, color.B, color.A);
-		}
-
-		public static NSColor ToNSUI(this Color color, bool calibrated)
-		{
-			if (color.ControlObject is NSColor nscolor)
-				return nscolor;
-			if (color.ControlObject is CGColor cgcolor && MacVersion.IsAtLeast(10, 8))
-				return NSColor.FromCGColor(cgcolor);
-			return calibrated
-				? NSColor.FromCalibratedRgba(color.R, color.G, color.B, color.A)
-				: NSColor.FromDeviceRgba(color.R, color.G, color.B, color.A);
+			return NSColor.FromSrgb(color.R, color.G, color.B, color.A);
 		}
 
 		[Obsolete("Use ToEtoWithAppearance(NSColor) instead")]
@@ -57,7 +46,7 @@ namespace Eto.Mac
 			if (color == null)
 				return Colors.Transparent;
 
-			var colorspace = NSColorSpace.DeviceRGBColorSpace;
+			var colorspace = NSColorSpace.SRGBColorSpace;
 
 			var converted = color.UsingColorSpace(colorspace);
 			if (converted == null)

--- a/src/Eto.iOS/Drawing/BitmapHandler.cs
+++ b/src/Eto.iOS/Drawing/BitmapHandler.cs
@@ -73,7 +73,7 @@ namespace Eto.iOS.Drawing
 						Data = NSMutableData.FromLength(bytesPerRow * height);
 
 						provider = new CGDataProvider(Data.MutableBytes, (int)Data.Length, false);
-						cgimage = new CGImage(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, CGColorSpace.CreateDeviceRGB(), CGBitmapFlags.ByteOrder32Little | CGBitmapFlags.PremultipliedFirst, provider, null, true, CGColorRenderingIntent.Default);
+						cgimage = new CGImage(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, CGColorSpace.CreateDeviceRgb(), CGBitmapFlags.ByteOrder32Little | CGBitmapFlags.PremultipliedFirst, provider, null, true, CGColorRenderingIntent.Default);
 						Control = UIImage.FromImage(cgimage, 0f, UIImageOrientation.Up);
 				
 						break;
@@ -89,7 +89,7 @@ namespace Eto.iOS.Drawing
 						//Data = new NSMutableData ((uint)(bytesPerRow * height));
 				
 						provider = new CGDataProvider(Data.MutableBytes, (int)Data.Length, false);
-						cgimage = new CGImage(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, CGColorSpace.CreateDeviceRGB(), CGBitmapFlags.ByteOrder32Little | CGBitmapFlags.NoneSkipFirst, provider, null, true, CGColorRenderingIntent.Default);
+						cgimage = new CGImage(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, CGColorSpace.CreateDeviceRgb(), CGBitmapFlags.ByteOrder32Little | CGBitmapFlags.NoneSkipFirst, provider, null, true, CGColorRenderingIntent.Default);
 						Control = UIImage.FromImage(cgimage, 0f, UIImageOrientation.Up);
 				
 						break;
@@ -104,7 +104,7 @@ namespace Eto.iOS.Drawing
 						Data = new NSMutableData((uint)(bytesPerRow * height));
 				
 						provider = new CGDataProvider(Data.MutableBytes, (int)Data.Length, false);
-						cgimage = new CGImage(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, CGColorSpace.CreateDeviceRGB(), CGBitmapFlags.ByteOrder32Little | CGBitmapFlags.PremultipliedFirst, provider, null, true, CGColorRenderingIntent.Default);
+						cgimage = new CGImage(width, height, bitsPerComponent, bitsPerPixel, bytesPerRow, CGColorSpace.CreateDeviceRgb(), CGBitmapFlags.ByteOrder32Little | CGBitmapFlags.PremultipliedFirst, provider, null, true, CGColorRenderingIntent.Default);
 						Control = UIImage.FromImage(cgimage, 0f, UIImageOrientation.Up);
 						break;
 					}

--- a/src/Eto/Drawing/Color.cs
+++ b/src/Eto/Drawing/Color.cs
@@ -685,7 +685,7 @@ public struct Color : IEquatable<Color>, IComparable<Color>, IControlObjectSourc
 	/// <returns>The 32-bit ARGB value that corresponds to this color</returns>
 	public int ToArgb()
 	{
-		return (int)((uint)(B * byte.MaxValue) | (uint)(G * byte.MaxValue) << 8 | (uint)(R * byte.MaxValue) << 16 | (uint)(A * byte.MaxValue) << 24);
+		return (int)((uint)Bb | (uint)Gb << 8 | (uint)Rb << 16 | (uint)Ab << 24);
 	}
 		
 	/// <summary>
@@ -694,7 +694,7 @@ public struct Color : IEquatable<Color>, IComparable<Color>, IControlObjectSourc
 	/// <returns>A premultiplied ARGB value</returns>
 	public int ToPremultipliedArgb()
 	{
-		return (int)((uint)(B * A * byte.MaxValue) | (uint)(G * A * byte.MaxValue) << 8 | (uint)(R * A * byte.MaxValue) << 16 | (uint)(A * byte.MaxValue) << 24);
+		return (int)((uint)Math.Round(B * A * byte.MaxValue + .5f) | (uint)Math.Round(G * A * byte.MaxValue + .5f) << 8 | (uint)Math.Round(R * A * byte.MaxValue + .5f) << 16 | (uint)Ab << 24);
 	}
 
 	/// <summary>
@@ -704,12 +704,12 @@ public struct Color : IEquatable<Color>, IComparable<Color>, IControlObjectSourc
 	public int ToArgb(ColorStyles style)
 	{
 		if (style.HasFlag(ColorStyles.ExcludeAlpha))
-			return (int)((uint)(B * byte.MaxValue) | (uint)(G * byte.MaxValue) << 8 | (uint)(R * byte.MaxValue) << 16);
+			return (int)((uint)Bb | (uint)Gb << 8 | (uint)Rb << 16);
 
 		if (style.HasFlag(ColorStyles.AlphaLast))
-			return (int)((uint)(A * byte.MaxValue) | (uint)(B * byte.MaxValue) << 8 | (uint)(G * byte.MaxValue) << 16 | (uint)(R * byte.MaxValue) << 24);
+			return (int)((uint)Ab | (uint)Bb << 8 | (uint)Gb << 16 | (uint)Rb << 24);
 		else
-			return (int)((uint)(B * byte.MaxValue) | (uint)(G * byte.MaxValue) << 8 | (uint)(R * byte.MaxValue) << 16 | (uint)(A * byte.MaxValue) << 24);
+			return (int)((uint)Bb | (uint)Gb << 8 | (uint)Rb << 16 | (uint)Ab << 24);
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -1120,7 +1120,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// characteristics of the control and its children, since it must enable layers to do so.
 	/// </remarks>
 	/// <value>The color of the background.</value>
-	public Color BackgroundColor
+	public virtual Color BackgroundColor
 	{
 		get { return Handler.BackgroundColor; }
 		set { Handler.BackgroundColor = value; }

--- a/test/Eto.Test.Mac/Eto.Test.macOS.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.macOS.csproj
@@ -11,7 +11,7 @@
     <PackageSigningKey>3rd Party Mac Developer Installer</PackageSigningKey>
     <MonoBundlingExtraArgs>--nowarn:2006 --nowarn:0176</MonoBundlingExtraArgs>
     <DefineConstants>MACOS_NET</DefineConstants>
-    <SupportedOSPlatformVersion>10.15</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>
     <NoWarn>CA1416;CS8981</NoWarn>
 
     <TrimMode>partial</TrimMode>

--- a/test/Eto.Test.Mac/Info.plist
+++ b/test/Eto.Test.Mac/Info.plist
@@ -11,11 +11,13 @@
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSMinimumSystemVersion</key>
-	<string>10.15</string>
+	<string>12.0</string>
 	<key>NSPrincipalClass</key>
 	<string>NSApplication</string>
 	<key>NSRequiresAquaSystemAppearance</key>
-	<string>False</string>
+	<false/>
+	<key>UIDesignRequiresCompatibility</key>
+	<true/>
 	<key>NSAppTransportSecurity</key>
 	<dict>
 		<key>NSAllowsArbitraryLoads</key>

--- a/test/Eto.Test.Mac/UnitTests/GridViewTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/GridViewTests.cs
@@ -97,7 +97,7 @@ namespace Eto.Test.Mac.UnitTests
 		[TestCase(NSTableViewStyle.Plain, -1, "Some Text", 100, 180)]
 		[TestCase(NSTableViewStyle.Plain, -1, "Some Text", 15, -1)]
 		[TestCase(NSTableViewStyle.Plain, -1, "Some Much Longer Text That Should Still Work", 100, 180)]
-		[TestCase(NSTableViewStyle.Plain, 20, "Some Text", 100)]
+		[TestCase(NSTableViewStyle.Plain, 20, "Some Text", 100, -1)]
 		[TestCase(NSTableViewStyle.Plain, 20, "Some Text", 15, -1)]
 		[TestCase(NSTableViewStyle.Plain, 3, "Some Text", 100, 180)]
 		[TestCase(NSTableViewStyle.Plain, 3, "Some Text", 15, -1)]

--- a/test/Eto.Test/Sections/Drawing/SystemColorSection.cs
+++ b/test/Eto.Test/Sections/Drawing/SystemColorSection.cs
@@ -36,7 +36,19 @@ namespace Eto.Test.Sections.Drawing
 
 		IEnumerable<ControlType> GetControlTypes()
 		{
-			yield return ControlType.Create<Drawable>(c => c.Size = new Size(100, 20));
+			yield return ControlType.Create<Drawable>(c =>
+			{
+				c.Paint += (sender, e) =>
+				{
+					var color = c.BackgroundColor;
+					var g = e.Graphics;
+					var rect = new RectangleF(c.Size);
+					rect.Inset(4);
+					g.FillRectangle(color, rect.X, rect.Y, rect.Width / 2, rect.Height);
+					g.FillRectangle(Color.FromArgb(color.ToArgb()), rect.X + rect.Width / 2, rect.Y, rect.Width / 2, rect.Height);
+				};
+				c.Size = new Size(100, 20);
+			});
 			yield return ControlType.Create<Label>(set: (c,v) => c.Text = v, getTextColor: c => c.TextColor, setTextColor: (c, v) => c.TextColor = v);
 			yield return ControlType.Create<TextBox>(set: (c, v) => c.Text = v, getTextColor: c => c.TextColor, setTextColor: (c, v) => c.TextColor = v);
 			yield return ControlType.Create<TextArea>(set: (c, v) => c.Text = v, getTextColor: c => c.TextColor, setTextColor: (c, v) => c.TextColor = v);

--- a/test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
+++ b/test/Eto.Test/UnitTests/Drawing/BitmapTests.cs
@@ -482,7 +482,7 @@ namespace Eto.Test.UnitTests.Drawing
 			{
 				Assert.That(bmp, Is.Not.Null);
 				Assert.That(savedBitmap, Is.Not.Null);
-				
+
 				Assert.That(bmp.GetPixel(0, 0), Is.EqualTo(topLeft), test + ".1.1");
 				Assert.That(bmp.GetPixel(halfSize, 0), Is.EqualTo(topRight), test + ".1.2");
 				Assert.That(bmp.GetPixel(0, halfSize), Is.EqualTo(bottomLeft), test + ".1.3");
@@ -541,6 +541,43 @@ namespace Eto.Test.UnitTests.Drawing
 
 			GetSavedBitmap();
 			TestPixels(redColor, emptyColor, greenColor, blueColor, "#3");
+		}
+
+		[TestCase(PixelFormat.Format24bppRgb, 24)]
+		[TestCase(PixelFormat.Format32bppRgb, 32)]
+		[TestCase(PixelFormat.Format32bppRgba, 32)]
+		public void BitmapShouldHaveCorrectBits(PixelFormat format, int expectedBits)
+		{
+			Invoke(() =>
+			{
+				var bitmap = new Bitmap(10, 10, format);
+				using var bd = bitmap.Lock();
+				Assert.That(bd.BitsPerPixel, Is.EqualTo(expectedBits));
+			});
+		}
+
+		[TestCase(PixelFormat.Format24bppRgb)]
+		[TestCase(PixelFormat.Format32bppRgb)]
+		public void BitmapShouldNotHaveTransparency(PixelFormat format)
+		{
+			Invoke(() =>
+			{
+				var bitmap = new Bitmap(10, 10, format);
+				using var bd = bitmap.Lock();
+				var color = Color.FromArgb(255, 0, 0, 255); // fully transparent blue
+				bd.SetPixel(0, 0, color);
+				var ms = new MemoryStream();
+				bitmap.Save(ms, ImageFormat.Png);
+				ms.Position = 0;
+				
+				var loadedBitmap = new Bitmap(ms);
+				using var bdLoaded = loadedBitmap.Lock();
+				var gottenColor = bd.GetPixel(0, 0);
+				Assert.That(gottenColor.A, Is.EqualTo(255), "Alpha should be 255");
+				Assert.That(gottenColor.R, Is.EqualTo(0), "Red should be 0");
+				Assert.That(gottenColor.G, Is.EqualTo(0), "Green should be 0");
+				Assert.That(gottenColor.B, Is.EqualTo(255), "Blue should be 255");
+			});
 		}
 	}
 }


### PR DESCRIPTION
- Also fix rounding error in Color.ToArgb()

This fixes some colorspace issues on macOS Tahoe, where colors weren't represented similarly if you draw to a bitmap then to screen, etc.  All colors are now represented (internally) in the generic sRGB colorspace.