### PR TITLE
Mac: Fix getting system colors during dark/light mode switch

### DIFF
--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -35,18 +35,44 @@ namespace Eto.Mac
 		{
 			if (color == null)
 				return Colors.Transparent;
-			if (!MacVersion.IsAtLeast(10, 9))
-				return color.ToEto();
 
-			// use the current appearance to get the proper RGB values (it can be different than when the application started).
-			NSAppearance saved = NSAppearance.CurrentAppearance;
-			var appearance = NSApplication.SharedApplication.MainWindow?.EffectiveAppearance;
-			if (appearance != null)
-				NSAppearance.CurrentAppearance = appearance;
+			if (MacVersion.IsAtLeast(11, 0))
+			{
+				// use the effective appearance to get the proper RGB values, 
+				// otherwise it uses NSAppearance.CurrentDrawingAppearance which can be different than the app appearance
+				// when not in a drawing context
+				var effectiveAppearance = NSApplication.SharedApplication.EffectiveAppearance;
+				if (NSAppearance.CurrentDrawingAppearance == effectiveAppearance)
+					return color.ToEto();
+					
+				Color result = Colors.Black;
+				effectiveAppearance.PerformAsCurrentDrawingAppearance(() =>
+				{
+					result = color.ToEto();
+				});
+				return result;
+			}
 
-			var result = color.ToEto();
-			NSAppearance.CurrentAppearance = saved;
-			return result;
+			if (MacVersion.IsAtLeast(10, 14))
+			{
+				// for macOS 10.14/10.15.. should I really be supporting this?  meh.
+				// Save and restore the current appearance around the color conversion
+#pragma warning disable CA1422
+				NSAppearance saved = NSAppearance.CurrentAppearance;
+				var effectiveAppearance = NSApplication.SharedApplication.EffectiveAppearance;
+				if (saved == effectiveAppearance)
+					return color.ToEto();
+					
+				if (effectiveAppearance != null)
+					NSAppearance.CurrentAppearance = effectiveAppearance;
+
+				var result = color.ToEto();
+				NSAppearance.CurrentAppearance = saved;
+#pragma warning restore CA1422
+				return result;
+			}
+			
+			return color.ToEto();
 		}
 
 		[Obsolete("Use ToEto(NSColor) instead")]


### PR DESCRIPTION
The main window doesn't always get its effective appearance updated immediately after the dark/light mode is switched, especially when done automatically or using the display icon in the menu bar.  This ensures it uses the effective appearance of the application instead of whatever window is main, which yields the correct results.