### PR TITLE
Centralize Eto.Gtk use of NativeLibrary.SetDllImportResolver

### DIFF
--- a/src/Eto.Gtk/DllImportResolverManager.cs
+++ b/src/Eto.Gtk/DllImportResolverManager.cs
@@ -1,0 +1,52 @@
+#if NET
+namespace Eto.GtkSharp
+{
+	static class DllImportResolverManager
+	{
+		static readonly object gate = new object();
+		static readonly List<DllImportResolver> resolvers = new List<DllImportResolver>();
+
+		static DllImportResolverManager()
+		{
+			NativeLibrary.SetDllImportResolver(typeof(DllImportResolverManager).Assembly, Resolve);
+		}
+
+		public static void Add(DllImportResolver resolver)
+		{
+			if (resolver == null)
+				throw new ArgumentNullException(nameof(resolver));
+
+			lock (gate)
+			{
+				resolvers.Insert(0, resolver); // Insert at beginning so more recent entries get priority over older ones 
+			}
+		}
+
+		public static void Remove(DllImportResolver resolver)
+		{
+			if (resolver == null)
+				throw new ArgumentNullException(nameof(resolver));
+
+			lock (gate)
+			{
+				resolvers.Remove(resolver);
+			}
+		}
+
+		static IntPtr Resolve(string name, Assembly assembly, DllImportSearchPath? path)
+		{
+			lock (gate)
+			{
+				foreach (var resolver in resolvers)
+				{
+					var handle = resolver(name, assembly, path);
+					if (handle != IntPtr.Zero)
+						return handle;
+				}
+			}
+
+			return IntPtr.Zero;
+		}
+	}
+}
+#endif

--- a/src/Eto.Gtk/Forms/LinuxTrayIndicatorHandler.cs
+++ b/src/Eto.Gtk/Forms/LinuxTrayIndicatorHandler.cs
@@ -1,3 +1,4 @@
+using Eto.GtkSharp;
 using Eto.GtkSharp.Drawing;
 using Eto.GtkSharp.Forms.Menu;
 
@@ -51,10 +52,8 @@ namespace Eto.GtkSharp.Forms
 		public LinuxTrayIndicatorHandler()
 		{
 #if NET
-			NativeLibrary.SetDllImportResolver(typeof(LinuxTrayIndicatorHandler).Assembly, (name, assembly, path) =>
+			DllImportResolverManager.Add((name, assembly, path) =>
 			{
-				// Use custom import resolver for libappindicator
-				// Try loading ayatana version first, if that fails, return to default handling
 				if (name == libappindicator) 
 				{
 					IntPtr result = IntPtr.Zero;

--- a/src/Eto.Gtk/NativeMethods.cs
+++ b/src/Eto.Gtk/NativeMethods.cs
@@ -46,7 +46,7 @@ namespace Eto.GtkSharp
 
 			static NMWindows()
 			{
-				NativeLibrary.SetDllImportResolver(typeof(NMWindows).Assembly, (name, assembly, path) =>
+				DllImportResolverManager.Add((name, assembly, path) =>
 				{
 					// Use custom import resolver for libwebkit2gtk
 					// Try loading 4.1 first, if that fails, return to default handling
@@ -293,7 +293,7 @@ namespace Eto.GtkSharp
 
 			static NMLinux()
 			{
-				NativeLibrary.SetDllImportResolver(typeof(NMLinux).Assembly, (name, assembly, path) =>
+				DllImportResolverManager.Add((name, assembly, path) =>
 				{
 					// Use custom import resolver for libwebkit2gtk
 					// Try loading 4.1 first, if that fails, return to default handling
@@ -540,7 +540,7 @@ namespace Eto.GtkSharp
 
 			static NMMac()
 			{
-				NativeLibrary.SetDllImportResolver(typeof(NMMac).Assembly, (name, assembly, path) =>
+				DllImportResolverManager.Add((name, assembly, path) =>
 				{
 					// Use custom import resolver for libwebkit2gtk
 					// Try loading 4.1 first, if that fails, return to default handling

--- a/src/Eto.Gtk/NativeMethods.tt
+++ b/src/Eto.Gtk/NativeMethods.tt
@@ -180,7 +180,7 @@ namespace Eto.GtkSharp
 
 			static <#= pclass[i] #>()
 			{
-				NativeLibrary.SetDllImportResolver(typeof(<#= pclass[i] #>).Assembly, (name, assembly, path) =>
+				DllImportResolverManager.Add((name, assembly, path) =>
 				{
 					// Use custom import resolver for libwebkit2gtk
 					// Try loading 4.1 first, if that fails, return to default handling


### PR DESCRIPTION
Fixes #2884.

Eto.Gtk previously called `NativeLibrary.SetDllImportResolver` in multiple static constructors (`NMLinux`, `NMWindows`, `NMMac`, `LinuxTrayIndicatorHandler`), but an assembly can only register one resolver—any later registration threw, leaving the type unusable.

This change introduces `DllImportResolverManager` to register a single resolver for the assembly and fan out to any number of per-feature delegates. Access to the delegate list is serialized with a lock for thread safety; resolvers themselves must remain load-only (no Add/Remove during resolution) to avoid mutating the collection while it’s being iterated.
