### PR TITLE
Async and cancellable dialogs

### DIFF
--- a/src/Eto.Android/MessageBoxHandler.cs
+++ b/src/Eto.Android/MessageBoxHandler.cs
@@ -10,7 +10,7 @@ using ag = Android.Graphics;
 
 namespace Eto.Android
 {
-	internal class MessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler
+	internal class MessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler, MessageBox.IAsyncHandler
 	{
 		public System.String Text
 		{
@@ -51,10 +51,36 @@ namespace Eto.Android
 			throw new NotSupportedException("Android platform supports only async dialogs. Use ShowAsync()");
 		}
 
-		public void ShowDialogWithCallback(Action<DialogResult> callback, Control parent)
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			var tcs = new TaskCompletionSource<DialogResult>();
+			CancellationTokenRegistration ctr = default;
+
+			var dialog = ShowDialogWithCallback(result => tcs.TrySetResult(result), parent);
+
+			if (cancellationToken.CanBeCanceled)
+			{
+				ctr = cancellationToken.Register(() =>
+				{
+					dialog?.Dismiss();
+					tcs.TrySetCanceled();
+				});
+
+				tcs.Task.ContinueWith(_ => ctr.Dispose(), TaskScheduler.Default);
+			}
+			else if (cancellationToken.IsCancellationRequested)
+			{
+				dialog?.Dismiss();
+				tcs.TrySetCanceled();
+			}
+
+			return tcs.Task;
+		}
+
+		public aa.AlertDialog ShowDialogWithCallback(Action<DialogResult> callback, Control parent)
 		{
 			var Builder = CreateDialog(callback);
-			Builder.Show();
+			return Builder.Show();
 		}
 
 		private aa.AlertDialog.Builder CreateDialog(Action<DialogResult> callback)

--- a/src/Eto.Android/MessageBoxHandler.cs
+++ b/src/Eto.Android/MessageBoxHandler.cs
@@ -51,10 +51,36 @@ namespace Eto.Android
 			throw new NotSupportedException("Android platform supports only async dialogs. Use ShowAsync()");
 		}
 
-		public void ShowDialogWithCallback(Action<DialogResult> callback, Control parent)
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			var tcs = new TaskCompletionSource<DialogResult>();
+			CancellationTokenRegistration ctr = default;
+
+			var dialog = ShowDialogWithCallback(result => tcs.TrySetResult(result), parent);
+
+			if (cancellationToken.CanBeCanceled)
+			{
+				ctr = cancellationToken.Register(() =>
+				{
+					dialog?.Dismiss();
+					tcs.TrySetCanceled();
+				});
+
+				tcs.Task.ContinueWith(_ => ctr.Dispose(), TaskScheduler.Default);
+			}
+			else if (cancellationToken.IsCancellationRequested)
+			{
+				dialog?.Dismiss();
+				tcs.TrySetCanceled();
+			}
+
+			return tcs.Task;
+		}
+
+		public aa.AlertDialog ShowDialogWithCallback(Action<DialogResult> callback, Control parent)
 		{
 			var Builder = CreateDialog(callback);
-			Builder.Show();
+			return Builder.Show();
 		}
 
 		private aa.AlertDialog.Builder CreateDialog(Action<DialogResult> callback)

--- a/src/Eto.Gtk/Forms/AboutDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/AboutDialogHandler.cs
@@ -1,6 +1,6 @@
 ﻿namespace Eto.GtkSharp.Forms
 {
-	public class AboutDialogHandler : WidgetHandler<Gtk.AboutDialog, AboutDialog, AboutDialog.ICallback>, AboutDialog.IHandler
+	public class AboutDialogHandler : WidgetHandler<Gtk.AboutDialog, AboutDialog, AboutDialog.ICallback>, AboutDialog.IHandler, CommonDialog.ICancellableHandler
 	{
 		Image image;
 
@@ -104,5 +104,7 @@
 
 			return DialogResult.Cancel;
 		}
+
+		public void CancelDialog() => Control.Respond((int)Gtk.ResponseType.Cancel);
 	}
 }

--- a/src/Eto.Gtk/Forms/ColorDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/ColorDialogHandler.cs
@@ -1,7 +1,7 @@
 #if GTKCORE
 namespace Eto.GtkSharp.Forms
 {
-	public class ColorDialogHandler : WidgetHandler<Gtk.ColorChooserDialog, ColorDialog, ColorDialog.ICallback>, ColorDialog.IHandler
+	public class ColorDialogHandler : WidgetHandler<Gtk.ColorChooserDialog, ColorDialog, ColorDialog.ICallback>, ColorDialog.IHandler, CommonDialog.ICancellableHandler
 	{
 		public ColorDialogHandler()
 		{
@@ -38,9 +38,11 @@ namespace Eto.GtkSharp.Forms
 
 			if (response == Gtk.ResponseType.Ok)
 				Callback.OnColorChanged(Widget, EventArgs.Empty);
-			
+
 			return response.ToEto();
 		}
+
+		public void CancelDialog() => Control.Respond((int)Gtk.ResponseType.Cancel);
 	}
 }
 #endif

--- a/src/Eto.Gtk/Forms/FontDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/FontDialogHandler.cs
@@ -3,7 +3,7 @@ using Eto.GtkSharp.Drawing;
 
 namespace Eto.GtkSharp.Forms
 {
-	public class FontDialogHandler : WidgetHandler<Gtk.FontChooserDialog, FontDialog, FontDialog.ICallback>, FontDialog.IHandler
+	public class FontDialogHandler : WidgetHandler<Gtk.FontChooserDialog, FontDialog, FontDialog.ICallback>, FontDialog.IHandler, CommonDialog.ICancellableHandler
 	{
 		public FontDialogHandler()
 		{
@@ -54,6 +54,8 @@ namespace Eto.GtkSharp.Forms
 
 			return response.ToEto();
 		}
+
+		public void CancelDialog() => Control.Respond((int)Gtk.ResponseType.Cancel);
 	}
 }
 #endif

--- a/src/Eto.Gtk/Forms/GtkFileDialog.cs
+++ b/src/Eto.Gtk/Forms/GtkFileDialog.cs
@@ -1,6 +1,6 @@
 namespace Eto.GtkSharp.Forms
 {
-	public abstract class GtkFileDialog<TControl, TWidget> : WidgetHandler<TControl, TWidget>, FileDialog.IHandler
+	public abstract class GtkFileDialog<TControl, TWidget> : WidgetHandler<TControl, TWidget>, FileDialog.IHandler, CommonDialog.ICancellableHandler
 #if GTKCORE
 		where TControl: Gtk.FileChooserNative
 #else
@@ -112,6 +112,15 @@ namespace Eto.GtkSharp.Forms
 				System.IO.Directory.SetCurrentDirectory(Control.CurrentFolder);
 			
 			return response;
+		}
+
+		public void CancelDialog()
+		{
+#if GTKCORE
+			Control.Hide();
+#else
+			Control.Respond((int)Gtk.ResponseType.Cancel);
+#endif
 		}
 
 		public void InsertFilter(int index, FileFilter filter)

--- a/src/Eto.Gtk/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/MessageBoxHandler.cs
@@ -1,6 +1,6 @@
 namespace Eto.GtkSharp.Forms
 {
-	public class MessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler
+	public class MessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler, MessageBox.ICancellableHandler
 	{
 		Gtk.MessageDialog control;
 
@@ -16,35 +16,47 @@ namespace Eto.GtkSharp.Forms
 
 		public DialogResult ShowDialog(Control parent)
 		{
+			control = CreateDialog(parent);
+			int ret = control.Run();
+			var result = ToResult((Gtk.ResponseType)ret);
+			CleanupDialog();
+			return result;
+		}
+
+		public void CancelDialog() => control?.Respond((int)Gtk.ResponseType.None);
+
+		Gtk.MessageDialog CreateDialog(Control parent)
+		{
 			Gtk.Window parentWindow = null;
 			if (parent != null && parent.ParentWindow != null)
 				parentWindow = parent.ParentWindow.ControlObject as Gtk.Window;
 
-			control = new Gtk.MessageDialog(parentWindow, Gtk.DialogFlags.Modal, Type.ToGtk(), Buttons.ToGtk(), false, string.Empty);
-			control.Text = Text;
-			control.TypeHint = Gdk.WindowTypeHint.Dialog;
+			var dialog = new Gtk.MessageDialog(parentWindow, Gtk.DialogFlags.Modal, Type.ToGtk(), Buttons.ToGtk(), false, string.Empty)
+			{
+				Text = Text,
+				TypeHint = Gdk.WindowTypeHint.Dialog
+			};
+
 			var caption = Caption ?? ((parent != null && parent.ParentWindow != null) ? parent.ParentWindow.Title : null);
 			if (!string.IsNullOrEmpty(caption))
-				control.Title = caption;
+				dialog.Title = caption;
 			// must add buttons manually for this case
 			if (Buttons == MessageBoxButtons.YesNoCancel)
 			{
-				var bn = (Gtk.Button)control.AddButton(Gtk.Stock.No, (int)Gtk.ResponseType.No);
+				var bn = (Gtk.Button)dialog.AddButton(Gtk.Stock.No, (int)Gtk.ResponseType.No);
 				bn.UseStock = true;
-				var bc = (Gtk.Button)control.AddButton(Gtk.Stock.Cancel, (int)Gtk.ResponseType.Cancel);
+				var bc = (Gtk.Button)dialog.AddButton(Gtk.Stock.Cancel, (int)Gtk.ResponseType.Cancel);
 				bc.UseStock = true;
-				var by = (Gtk.Button)control.AddButton(Gtk.Stock.Yes, (int)Gtk.ResponseType.Yes);
+				var by = (Gtk.Button)dialog.AddButton(Gtk.Stock.Yes, (int)Gtk.ResponseType.Yes);
 				by.UseStock = true;
 			}
-			control.DefaultResponse = DefaultButton.ToGtk(Buttons);
-			int ret = control.Run();
-			control.Hide();
-#if GTKCORE
-			control.Dispose();
-#else
-			control.Destroy();
-#endif
-			var result = ((Gtk.ResponseType)ret).ToEto();
+			dialog.DefaultResponse = DefaultButton.ToGtk(Buttons);
+			return dialog;
+		}
+
+		DialogResult ToResult(Gtk.ResponseType response)
+		{
+			var result = response.ToEto();
 			if (result == DialogResult.None)
 			{
 				switch (Buttons)
@@ -62,6 +74,17 @@ namespace Eto.GtkSharp.Forms
 				}
 			}
 			return result;
+		}
+
+		void CleanupDialog()
+		{
+			control?.Hide();
+#if GTKCORE
+			control?.Dispose();
+#else
+			control?.Destroy();
+#endif
+			control = null;
 		}
 	}
 

--- a/src/Eto.Gtk/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/MessageBoxHandler.cs
@@ -16,35 +16,101 @@ namespace Eto.GtkSharp.Forms
 
 		public DialogResult ShowDialog(Control parent)
 		{
+			control = CreateDialog(parent);
+			int ret = control.Run();
+			var result = ToResult((Gtk.ResponseType)ret);
+			CleanupDialog();
+			return result;
+		}
+
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			var tcs = new TaskCompletionSource<DialogResult>();
+			Application.Instance.AsyncInvoke(() =>
+			{
+				try
+				{
+					control = CreateDialog(parent);
+					CancellationTokenRegistration ctr = default;
+
+					void CancelDialog()
+					{
+						Application.Instance.Invoke(() =>
+						{
+							if (tcs.TrySetCanceled())
+							{
+								control?.Respond((int)Gtk.ResponseType.None);
+							}
+						});
+					}
+
+					if (cancellationToken.CanBeCanceled)
+					{
+						ctr = cancellationToken.Register(CancelDialog);
+						tcs.Task.ContinueWith(_ => ctr.Dispose(), TaskScheduler.Default);
+					}
+					
+					if (cancellationToken.IsCancellationRequested)
+						CancelDialog();
+
+					if (tcs.Task.IsCanceled)
+					{
+						CleanupDialog();
+						return;
+					}
+
+					Gtk.ResponseHandler responseHandler = null;
+					responseHandler = (sender, args) =>
+					{
+						control.Response -= responseHandler;
+						var result = ToResult((Gtk.ResponseType)args.ResponseId);
+						_ = tcs.TrySetResult(result);
+						CleanupDialog();
+					};
+					control.Response += responseHandler;
+					control.ShowAll();
+				}
+				catch (Exception ex)
+				{
+					_ = tcs.TrySetException(ex);
+				}
+			});
+
+			return tcs.Task;
+		}
+
+		Gtk.MessageDialog CreateDialog(Control parent)
+		{
 			Gtk.Window parentWindow = null;
 			if (parent != null && parent.ParentWindow != null)
 				parentWindow = parent.ParentWindow.ControlObject as Gtk.Window;
 
-			control = new Gtk.MessageDialog(parentWindow, Gtk.DialogFlags.Modal, Type.ToGtk(), Buttons.ToGtk(), false, string.Empty);
-			control.Text = Text;
-			control.TypeHint = Gdk.WindowTypeHint.Dialog;
+			var dialog = new Gtk.MessageDialog(parentWindow, Gtk.DialogFlags.Modal, Type.ToGtk(), Buttons.ToGtk(), false, string.Empty)
+			{
+				Text = Text,
+				TypeHint = Gdk.WindowTypeHint.Dialog
+			};
+
 			var caption = Caption ?? ((parent != null && parent.ParentWindow != null) ? parent.ParentWindow.Title : null);
 			if (!string.IsNullOrEmpty(caption))
-				control.Title = caption;
+				dialog.Title = caption;
 			// must add buttons manually for this case
 			if (Buttons == MessageBoxButtons.YesNoCancel)
 			{
-				var bn = (Gtk.Button)control.AddButton(Gtk.Stock.No, (int)Gtk.ResponseType.No);
+				var bn = (Gtk.Button)dialog.AddButton(Gtk.Stock.No, (int)Gtk.ResponseType.No);
 				bn.UseStock = true;
-				var bc = (Gtk.Button)control.AddButton(Gtk.Stock.Cancel, (int)Gtk.ResponseType.Cancel);
+				var bc = (Gtk.Button)dialog.AddButton(Gtk.Stock.Cancel, (int)Gtk.ResponseType.Cancel);
 				bc.UseStock = true;
-				var by = (Gtk.Button)control.AddButton(Gtk.Stock.Yes, (int)Gtk.ResponseType.Yes);
+				var by = (Gtk.Button)dialog.AddButton(Gtk.Stock.Yes, (int)Gtk.ResponseType.Yes);
 				by.UseStock = true;
 			}
-			control.DefaultResponse = DefaultButton.ToGtk(Buttons);
-			int ret = control.Run();
-			control.Hide();
-#if GTKCORE
-			control.Dispose();
-#else
-			control.Destroy();
-#endif
-			var result = ((Gtk.ResponseType)ret).ToEto();
+			dialog.DefaultResponse = DefaultButton.ToGtk(Buttons);
+			return dialog;
+		}
+
+		DialogResult ToResult(Gtk.ResponseType response)
+		{
+			var result = response.ToEto();
 			if (result == DialogResult.None)
 			{
 				switch (Buttons)
@@ -62,6 +128,17 @@ namespace Eto.GtkSharp.Forms
 				}
 			}
 			return result;
+		}
+
+		void CleanupDialog()
+		{
+			control?.Hide();
+#if GTKCORE
+			control?.Dispose();
+#else
+			control?.Destroy();
+#endif
+			control = null;
 		}
 	}
 

--- a/src/Eto.Gtk/Forms/OpenWithDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/OpenWithDialogHandler.cs
@@ -1,14 +1,16 @@
 ﻿#if GTK3
 namespace Eto.GtkSharp.Forms
 {
-	public class OpenWithDialogHandler : WidgetHandler<Gtk.Dialog, OpenWithDialog, OpenWithDialog.ICallback>, OpenWithDialog.IHandler
+	public class OpenWithDialogHandler : WidgetHandler<Gtk.Dialog, OpenWithDialog, OpenWithDialog.ICallback>, OpenWithDialog.IHandler, CommonDialog.ICancellableHandler
 	{
+		Gtk.AppChooserDialog adialog;
+
 		public string FilePath { get; set; }
 
 		public DialogResult ShowDialog(Window parent)
 		{
 			#if GTKCORE
-			var adialog = new Gtk.AppChooserDialog(
+			adialog = new Gtk.AppChooserDialog(
 				parent == null ? null : (parent.ControlObject as Gtk.Window),
 				Gtk.DialogFlags.UseHeaderBar | Gtk.DialogFlags.DestroyWithParent,
 				GLib.FileFactory.NewForPath(FilePath)
@@ -16,19 +18,23 @@ namespace Eto.GtkSharp.Forms
 			#else
 			var handle = parent == null ? IntPtr.Zero : (parent.ControlObject as Gtk.Window).Handle;
 			var adialoghandle = NativeMethods.gtk_app_chooser_dialog_new(handle, 5, NativeMethods.g_file_new_for_path(FilePath));
-			var adialog = new Gtk.AppChooserDialog(adialoghandle);
+			adialog = new Gtk.AppChooserDialog(adialoghandle);
 			#endif
 
-			if (adialog.Run() == (int)Gtk.ResponseType.Ok)
+			var response = (Gtk.ResponseType)adialog.Run();
+			if (response == Gtk.ResponseType.Ok)
 				Process.Start(adialog.AppInfo.Executable, "\"" + FilePath + "\"");
 #if GTKCORE
 			adialog.Dispose();
 #else
 			adialog.Destroy();
 #endif
+			adialog = null;
 
-			return DialogResult.Ok;
+			return response == Gtk.ResponseType.Ok ? DialogResult.Ok : DialogResult.Cancel;
 		}
+
+		public void CancelDialog() => adialog?.Respond((int)Gtk.ResponseType.Cancel);
 	}
 }
 #endif

--- a/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
@@ -1,9 +1,9 @@
 namespace Eto.GtkSharp.Forms
 {
 #if GTKCORE
-	public class SelectFolderDialogHandler : WidgetHandler<Gtk.FileChooserNative, SelectFolderDialog>, SelectFolderDialog.IHandler
+	public class SelectFolderDialogHandler : WidgetHandler<Gtk.FileChooserNative, SelectFolderDialog>, SelectFolderDialog.IHandler, CommonDialog.ICancellableHandler
 #else
-	public class SelectFolderDialogHandler : WidgetHandler<Gtk.FileChooserDialog, SelectFolderDialog>, SelectFolderDialog.IHandler
+	public class SelectFolderDialogHandler : WidgetHandler<Gtk.FileChooserDialog, SelectFolderDialog>, SelectFolderDialog.IHandler, CommonDialog.ICancellableHandler
 #endif
 	{
 		public SelectFolderDialogHandler()
@@ -36,6 +36,15 @@ namespace Eto.GtkSharp.Forms
 			if (response == DialogResult.Ok) System.IO.Directory.SetCurrentDirectory(Control.CurrentFolder);
 
 			return response;
+		}
+
+		public void CancelDialog()
+		{
+#if GTKCORE
+			Control.Hide();
+#else
+			Control.Respond((int)Gtk.ResponseType.Cancel);
+#endif
 		}
 
 		public string Title

--- a/src/Eto.Mac/Forms/MacFileDialog.cs
+++ b/src/Eto.Mac/Forms/MacFileDialog.cs
@@ -30,7 +30,7 @@ namespace Eto.Mac.Forms
 		
 	}
 
-	public abstract class MacFileDialog<TControl, TWidget> : WidgetHandler<TControl, TWidget>, FileDialog.IHandler, IMacFileDialog
+	public abstract class MacFileDialog<TControl, TWidget> : WidgetHandler<TControl, TWidget>, FileDialog.IHandler, CommonDialog.ICancellableHandler, IMacFileDialog
      where TControl: NSSavePanel
      where TWidget: FileDialog
 	{
@@ -151,6 +151,13 @@ namespace Eto.Mac.Forms
 				fileName = null;
 
 			return ret == 1 ? DialogResult.Ok : DialogResult.Cancel;
+		}
+
+		public void CancelDialog()
+		{
+			// Use the panel's own cancel action so it is dismissed cleanly whether shown standalone or as a
+			// sheet attached to a parent window (StopModal alone would leave an attached sheet dangling).
+			Control.Cancel(Control);
 		}
 
 		public void InsertFilter(int index, FileFilter filter)

--- a/src/Eto.Mac/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Mac/Forms/MessageBoxHandler.cs
@@ -1,6 +1,6 @@
 namespace Eto.Mac.Forms
 {
-	public class MessageBoxHandler : MessageBox.IHandler
+	public class MessageBoxHandler : MessageBox.IHandler, MessageBox.ICancellableHandler
 	{
 		public string Text { get; set; }
 
@@ -14,26 +14,15 @@ namespace Eto.Mac.Forms
 
 		public DialogResult ShowDialog(Control parent)
 		{
-			MacView.InMouseTrackingLoop = false;
-			var alert = new NSAlert();
-
-			AddButtons(alert);
-
-			alert.AlertStyle = Convert(Type);
-			alert.MessageText = Caption ?? string.Empty;
-			alert.InformativeText = Text ?? string.Empty;
+			var alert = CreateDialog();
 			var ret = MacModal.Run(alert, parent);
-			switch (Buttons)
-			{
-				default:
-					return DialogResult.Ok;
-				case MessageBoxButtons.OKCancel:
-					return (ret == 1000) ? DialogResult.Ok : DialogResult.Cancel;
-				case MessageBoxButtons.YesNo:
-					return (ret == 1000) ? DialogResult.Yes : DialogResult.No;
-				case MessageBoxButtons.YesNoCancel:
-					return (ret == 1000) ? DialogResult.Yes : (ret == 1001) ? DialogResult.Cancel : DialogResult.No;
-			}
+			return ConvertAlertResult(ret);
+		}
+
+		public void CancelDialog()
+		{
+			// Stops the application-modal session run by MacModal.Run, dismissing the alert as cancelled.
+			NSApplication.SharedApplication.StopModalWithCode((nint)NSModalResponse.Cancel);
 		}
 
 		class CancelView : NSView
@@ -55,6 +44,21 @@ namespace Eto.Mac.Forms
 					return true;
 				}
 				return base.PerformKeyEquivalent(theEvent);
+			}
+		}
+
+		DialogResult ConvertAlertResult(int ret)
+		{
+			switch (Buttons)
+			{
+				default:
+					return DialogResult.Ok;
+				case MessageBoxButtons.OKCancel:
+					return (ret == 1000) ? DialogResult.Ok : DialogResult.Cancel;
+				case MessageBoxButtons.YesNo:
+					return (ret == 1000) ? DialogResult.Yes : DialogResult.No;
+				case MessageBoxButtons.YesNoCancel:
+					return (ret == 1000) ? DialogResult.Yes : (ret == 1001) ? DialogResult.Cancel : DialogResult.No;
 			}
 		}
 
@@ -140,6 +144,20 @@ namespace Eto.Mac.Forms
 		{
 			// set an accessory view to listen for escape key and cmd+.
 			alert.AccessoryView = new CancelView { Code = code };
+		}
+
+		NSAlert CreateDialog()
+		{
+			MacView.InMouseTrackingLoop = false;
+			var alert = new NSAlert();
+
+			AddButtons(alert);
+
+			alert.AlertStyle = Convert(Type);
+			alert.MessageText = Caption ?? string.Empty;
+			alert.InformativeText = Text ?? string.Empty;
+
+			return alert;
 		}
 
 		static NSAlertStyle Convert(MessageBoxType type)

--- a/src/Eto.Mac/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Mac/Forms/MessageBoxHandler.cs
@@ -14,26 +14,51 @@ namespace Eto.Mac.Forms
 
 		public DialogResult ShowDialog(Control parent)
 		{
-			MacView.InMouseTrackingLoop = false;
-			var alert = new NSAlert();
-
-			AddButtons(alert);
-
-			alert.AlertStyle = Convert(Type);
-			alert.MessageText = Caption ?? string.Empty;
-			alert.InformativeText = Text ?? string.Empty;
+			var alert = CreateDialog();
 			var ret = MacModal.Run(alert, parent);
-			switch (Buttons)
+			return ConvertAlertResult(ret);
+		}
+
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			if (cancellationToken.IsCancellationRequested)
+				return Task.FromCanceled<DialogResult>(cancellationToken);
+
+			var tcs = new TaskCompletionSource<DialogResult>();
+			Application.Instance.InvokeAsync(() =>
 			{
-				default:
-					return DialogResult.Ok;
-				case MessageBoxButtons.OKCancel:
-					return (ret == 1000) ? DialogResult.Ok : DialogResult.Cancel;
-				case MessageBoxButtons.YesNo:
-					return (ret == 1000) ? DialogResult.Yes : DialogResult.No;
-				case MessageBoxButtons.YesNoCancel:
-					return (ret == 1000) ? DialogResult.Yes : (ret == 1001) ? DialogResult.Cancel : DialogResult.No;
-			}
+				CancellationTokenRegistration ctr = default;
+				try
+				{
+					var alert = CreateDialog();
+
+					if (cancellationToken.CanBeCanceled)
+					{
+						ctr = cancellationToken.Register(() =>
+						{
+							NSApplication.SharedApplication.BeginInvokeOnMainThread(() =>
+							{
+								if (tcs.TrySetCanceled())
+									NSApplication.SharedApplication.StopModalWithCode((nint)NSModalResponse.Cancel);
+							});
+						});
+					}
+
+					var ret = alert.RunModal();
+					if (!tcs.Task.IsCompleted)
+						tcs.TrySetResult(ConvertAlertResult((int)ret));
+				}
+				catch (Exception ex)
+				{
+					tcs.TrySetException(ex);
+				}
+				finally
+				{
+					ctr.Dispose();
+				}
+			});
+
+			return tcs.Task;
 		}
 
 		class CancelView : NSView
@@ -55,6 +80,21 @@ namespace Eto.Mac.Forms
 					return true;
 				}
 				return base.PerformKeyEquivalent(theEvent);
+			}
+		}
+
+		DialogResult ConvertAlertResult(int ret)
+		{
+			switch (Buttons)
+			{
+				default:
+					return DialogResult.Ok;
+				case MessageBoxButtons.OKCancel:
+					return (ret == 1000) ? DialogResult.Ok : DialogResult.Cancel;
+				case MessageBoxButtons.YesNo:
+					return (ret == 1000) ? DialogResult.Yes : DialogResult.No;
+				case MessageBoxButtons.YesNoCancel:
+					return (ret == 1000) ? DialogResult.Yes : (ret == 1001) ? DialogResult.Cancel : DialogResult.No;
 			}
 		}
 
@@ -140,6 +180,20 @@ namespace Eto.Mac.Forms
 		{
 			// set an accessory view to listen for escape key and cmd+.
 			alert.AccessoryView = new CancelView { Code = code };
+		}
+
+		NSAlert CreateDialog()
+		{
+			MacView.InMouseTrackingLoop = false;
+			var alert = new NSAlert();
+
+			AddButtons(alert);
+
+			alert.AlertStyle = Convert(Type);
+			alert.MessageText = Caption ?? string.Empty;
+			alert.InformativeText = Text ?? string.Empty;
+
+			return alert;
 		}
 
 		static NSAlertStyle Convert(MessageBoxType type)

--- a/src/Eto.Mac/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Mac/Forms/SelectFolderDialogHandler.cs
@@ -1,6 +1,6 @@
 namespace Eto.Mac.Forms
 {
-	public class SelectFolderDialogHandler : WidgetHandler<NSOpenPanel, SelectFolderDialog>, SelectFolderDialog.IHandler
+	public class SelectFolderDialogHandler : WidgetHandler<NSOpenPanel, SelectFolderDialog>, SelectFolderDialog.IHandler, CommonDialog.ICancellableHandler
 	{
 		protected override NSOpenPanel CreateControl()
 		{
@@ -21,6 +21,12 @@ namespace Eto.Mac.Forms
 			MacView.InMouseTrackingLoop = false;
 			var ret = Control.RunModal();
 			return ret == 1 ? DialogResult.Ok : DialogResult.Cancel;
+		}
+
+		public void CancelDialog()
+		{
+			// Use the panel's own cancel action so it is dismissed and ordered out cleanly.
+			Control.Cancel(Control);
 		}
 
 		public string Title

--- a/src/Eto.WinForms/Forms/ColorDialogHandler.cs
+++ b/src/Eto.WinForms/Forms/ColorDialogHandler.cs
@@ -1,8 +1,10 @@
 namespace Eto.WinForms.Forms
 {
-	public class ColorDialogHandler : WidgetHandler<swf.ColorDialog, ColorDialog, ColorDialog.ICallback>, ColorDialog.IHandler
+	public class ColorDialogHandler : WidgetHandler<swf.ColorDialog, ColorDialog, ColorDialog.ICallback>, ColorDialog.IHandler, CommonDialog.ICancellableHandler
 	{
 		static int[] customColors;
+		readonly Win32.CancellableModalDialog _cancellable = new Win32.CancellableModalDialog();
+
 		public ColorDialogHandler()
 		{
 			Control = new swf.ColorDialog
@@ -25,16 +27,14 @@ namespace Eto.WinForms.Forms
 
 		public DialogResult ShowDialog(Window parent)
 		{
-			swf.DialogResult result;
 			if (customColors != null) Control.CustomColors = customColors;
 
 			if (parent?.HasFocus == false)
 				parent.Focus();
 
-			if (parent != null)
-				result = Control.ShowDialog(parent.GetContainerControl());
-			else
-				result = Control.ShowDialog();
+			var result = _cancellable.Show(() => parent != null
+				? Control.ShowDialog(parent.GetContainerControl())
+				: Control.ShowDialog());
 
 			if (result == swf.DialogResult.OK)
 			{
@@ -45,6 +45,10 @@ namespace Eto.WinForms.Forms
 
 			return result.ToEto();
 		}
+
+		// A WH_CBT hook captured the native dialog's window handle when it was shown (see CancellableModalDialog),
+		// so the async ShowDialogAsync can dismiss exactly this dialog when its cancellation token is signalled.
+		public void CancelDialog() => _cancellable.Cancel();
 	}
 }
 

--- a/src/Eto.WinForms/Forms/FontDialogHandler.cs
+++ b/src/Eto.WinForms/Forms/FontDialogHandler.cs
@@ -2,9 +2,10 @@ using Eto.WinForms.Drawing;
 
 namespace Eto.WinForms.Forms
 {
-	public class FontDialogHandler : WidgetHandler<swf.FontDialog, FontDialog, FontDialog.ICallback>, FontDialog.IHandler
+	public class FontDialogHandler : WidgetHandler<swf.FontDialog, FontDialog, FontDialog.ICallback>, FontDialog.IHandler, CommonDialog.ICancellableHandler
 	{
 		Font _font;
+		readonly Win32.CancellableModalDialog _cancellable = new Win32.CancellableModalDialog();
 
 		public FontDialogHandler()
 		{
@@ -56,7 +57,7 @@ namespace Eto.WinForms.Forms
 			if (parent?.HasFocus == false)
 				parent.Focus();
 
-			var result = Control.ShowDialog();
+			var result = _cancellable.Show(() => Control.ShowDialog());
 			if (result == swf.DialogResult.OK)
 			{
 				_font = null;
@@ -65,5 +66,9 @@ namespace Eto.WinForms.Forms
 			}
 			return DialogResult.Cancel;
 		}
+
+		// A WH_CBT hook captured the native dialog's window handle when it was shown (see CancellableModalDialog),
+		// so the async ShowDialogAsync can dismiss exactly this dialog when its cancellation token is signalled.
+		public void CancelDialog() => _cancellable.Cancel();
 	}
 }

--- a/src/Eto.WinForms/Forms/MessageBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/MessageBoxHandler.cs
@@ -1,6 +1,6 @@
 namespace Eto.WinForms.Forms
 {
-	public class MessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler
+	public class MessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler, MessageBox.ICancellableHandler
 	{
 		public string Text { get; set; }
 
@@ -12,6 +12,8 @@ namespace Eto.WinForms.Forms
 
 		public MessageBoxDefaultButton DefaultButton { get; set; }
 
+		readonly Win32.CancellableModalDialog _cancellable = new Win32.CancellableModalDialog();
+
 		public DialogResult ShowDialog(Control parent)
 		{
 			var parentWindow = parent?.ParentWindow;
@@ -20,9 +22,13 @@ namespace Eto.WinForms.Forms
 
 			var caption = Caption ?? parentWindow?.Title;
 			swf.Control c = (parent == null) ? null : (swf.Control)parent.ControlObject;
-			swf.DialogResult result = swf.MessageBox.Show(c, Text, caption, Convert(Buttons), Convert(Type), Convert(DefaultButton, Buttons));
+			swf.DialogResult result = _cancellable.Show(() => swf.MessageBox.Show(c, Text, caption, Convert(Buttons), Convert(Type), Convert(DefaultButton, Buttons)));
 			return result.ToEto();
 		}
+
+		// The native message box runs its modal loop on the UI thread; a WH_CBT hook captured its window handle when
+		// it was shown (see CancellableModalDialog), so we can dismiss exactly that dialog to unblock ShowDialog.
+		public void CancelDialog() => _cancellable.Cancel();
 
 		public static swf.MessageBoxDefaultButton Convert(MessageBoxDefaultButton defaultButton, MessageBoxButtons buttons)
 		{

--- a/src/Eto.WinForms/Forms/MessageBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/MessageBoxHandler.cs
@@ -24,6 +24,108 @@ namespace Eto.WinForms.Forms
 			return result.ToEto();
 		}
 
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			var tcs = new TaskCompletionSource<DialogResult>();
+
+			Application.Instance.InvokeAsync(() =>
+			{
+				CancellationTokenRegistration ctr = default;
+				swf.Form cancelOwner = null;
+				try
+				{
+					var parentWindow = parent?.ParentWindow;
+					if (parentWindow?.HasFocus == false)
+						parentWindow.Focus();
+
+					var caption = Caption ?? parentWindow?.Title;
+					swf.Control ownerControl;
+
+					bool useCancelOwner = cancellationToken.CanBeCanceled || cancellationToken.IsCancellationRequested;
+					if (useCancelOwner)
+					{
+						if (cancellationToken.IsCancellationRequested)
+						{
+							tcs.TrySetCanceled();
+							ctr.Dispose();
+							return;
+						}
+						// Create a hidden owner to own the message box, so we can close it later if cancelled
+						cancelOwner = new swf.Form
+						{
+							Size = sd.Size.Empty,
+						};
+						if (parentWindow?.ControlObject is swf.Form parentForm)
+							cancelOwner.Owner = parentForm;
+
+						ownerControl = cancelOwner;
+
+						ctr = cancellationToken.Register(() =>
+						{
+							if (cancelOwner != null && !cancelOwner.IsDisposed)
+							{
+								cancelOwner.BeginInvoke(new Action(() =>
+								{
+									if (tcs.TrySetCanceled())
+										CloseMessageBox(cancelOwner); // Just disposing of the owner causes a flicker (unlike WPF), so close the message box properly
+								}));
+							}
+							else
+								_ = tcs.TrySetCanceled();
+						});
+					}
+					else
+					{
+						ownerControl = parent == null ? null : (swf.Control)parent.ControlObject;
+					}
+
+					var result = swf.MessageBox.Show(ownerControl, Text, caption, Convert(Buttons), Convert(Type), Convert(DefaultButton, Buttons));
+					tcs.TrySetResult(result.ToEto());
+				}
+				catch (Exception ex)
+				{
+					tcs.TrySetException(ex);
+				}
+				finally
+				{
+					ctr.Dispose();
+					cancelOwner?.Owner?.Focus();
+					cancelOwner?.Dispose();
+				}
+			});
+
+			return tcs.Task;
+		}
+
+		static void CloseMessageBox(swf.Form owner)
+		{
+			if (owner == null || owner.IsDisposed || !owner.IsHandleCreated)
+				return;
+
+			var ownerHandle = owner.Handle;
+			IntPtr messageBoxHandle = IntPtr.Zero;
+			var threadId = Win32.GetCurrentThreadId();
+			Win32.EnumThreadProc callback = (hWnd, lParam) =>
+			{
+				if (hWnd == ownerHandle)
+					return true;
+
+				if (Win32.GetWindow(hWnd, Win32.GW.OWNER) != ownerHandle)
+					return true;
+
+				if (!Win32.IsDialogWindow(hWnd))
+					return true;
+
+				messageBoxHandle = hWnd;
+				return false;
+			};
+
+			Win32.EnumThreadWindows(threadId, callback, IntPtr.Zero);
+
+			if (messageBoxHandle != IntPtr.Zero)
+				Win32.PostMessage(messageBoxHandle, Win32.WM.CLOSE, IntPtr.Zero, IntPtr.Zero);
+		}
+
 		public static swf.MessageBoxDefaultButton Convert(MessageBoxDefaultButton defaultButton, MessageBoxButtons buttons)
 		{
 			switch (defaultButton)

--- a/src/Eto.WinForms/Forms/MessageBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/MessageBoxHandler.cs
@@ -50,6 +50,7 @@ namespace Eto.WinForms.Forms
 							ctr.Dispose();
 							return;
 						}
+						// Create a hidden owner to own the message box, so we can close it later if cancelled
 						cancelOwner = new swf.Form
 						{
 							Size = sd.Size.Empty,
@@ -65,8 +66,8 @@ namespace Eto.WinForms.Forms
 							{
 								cancelOwner.BeginInvoke(new Action(() =>
 								{
-									_ = tcs.TrySetCanceled();
-									cancelOwner.Dispose();
+									if (tcs.TrySetCanceled())
+										CloseMessageBox(cancelOwner); // Just disposing of the owner causes a flicker (unlike WPF), so close the message box properly
 								}));
 							}
 							else
@@ -94,6 +95,35 @@ namespace Eto.WinForms.Forms
 			});
 
 			return tcs.Task;
+		}
+
+		static void CloseMessageBox(swf.Form owner)
+		{
+			if (owner == null || owner.IsDisposed || !owner.IsHandleCreated)
+				return;
+
+			var ownerHandle = owner.Handle;
+			IntPtr messageBoxHandle = IntPtr.Zero;
+			var threadId = Win32.GetCurrentThreadId();
+			Win32.EnumThreadProc callback = (hWnd, lParam) =>
+			{
+				if (hWnd == ownerHandle)
+					return true;
+
+				if (Win32.GetWindow(hWnd, Win32.GW.OWNER) != ownerHandle)
+					return true;
+
+				if (!Win32.IsDialogWindow(hWnd))
+					return true;
+
+				messageBoxHandle = hWnd;
+				return false;
+			};
+
+			Win32.EnumThreadWindows(threadId, callback, IntPtr.Zero);
+
+			if (messageBoxHandle != IntPtr.Zero)
+				Win32.PostMessage(messageBoxHandle, Win32.WM.CLOSE, IntPtr.Zero, IntPtr.Zero);
 		}
 
 		public static swf.MessageBoxDefaultButton Convert(MessageBoxDefaultButton defaultButton, MessageBoxButtons buttons)

--- a/src/Eto.WinForms/Forms/MessageBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/MessageBoxHandler.cs
@@ -52,7 +52,7 @@ namespace Eto.WinForms.Forms
 						}
 						cancelOwner = new swf.Form
 						{
-							Size = Size.Empty,
+							Size = sd.Size.Empty,
 						};
 						if (parentWindow?.ControlObject is swf.Form parentForm)
 							cancelOwner.Owner = parentForm;
@@ -66,7 +66,7 @@ namespace Eto.WinForms.Forms
 								cancelOwner.BeginInvoke(new Action(() =>
 								{
 									_ = tcs.TrySetCanceled();
-									cancelOwner.Close();
+									cancelOwner.Dispose();
 								}));
 							}
 							else
@@ -88,6 +88,7 @@ namespace Eto.WinForms.Forms
 				finally
 				{
 					ctr.Dispose();
+					cancelOwner?.Owner?.Focus();
 					cancelOwner?.Dispose();
 				}
 			});

--- a/src/Eto.WinForms/Forms/MessageBoxHandler.cs
+++ b/src/Eto.WinForms/Forms/MessageBoxHandler.cs
@@ -24,6 +24,77 @@ namespace Eto.WinForms.Forms
 			return result.ToEto();
 		}
 
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			var tcs = new TaskCompletionSource<DialogResult>();
+
+			Application.Instance.InvokeAsync(() =>
+			{
+				CancellationTokenRegistration ctr = default;
+				swf.Form cancelOwner = null;
+				try
+				{
+					var parentWindow = parent?.ParentWindow;
+					if (parentWindow?.HasFocus == false)
+						parentWindow.Focus();
+
+					var caption = Caption ?? parentWindow?.Title;
+					swf.Control ownerControl;
+
+					bool useCancelOwner = cancellationToken.CanBeCanceled || cancellationToken.IsCancellationRequested;
+					if (useCancelOwner)
+					{
+						if (cancellationToken.IsCancellationRequested)
+						{
+							tcs.TrySetCanceled();
+							ctr.Dispose();
+							return;
+						}
+						cancelOwner = new swf.Form
+						{
+							Size = Size.Empty,
+						};
+						if (parentWindow?.ControlObject is swf.Form parentForm)
+							cancelOwner.Owner = parentForm;
+
+						ownerControl = cancelOwner;
+
+						ctr = cancellationToken.Register(() =>
+						{
+							if (cancelOwner != null && !cancelOwner.IsDisposed)
+							{
+								cancelOwner.BeginInvoke(new Action(() =>
+								{
+									_ = tcs.TrySetCanceled();
+									cancelOwner.Close();
+								}));
+							}
+							else
+								_ = tcs.TrySetCanceled();
+						});
+					}
+					else
+					{
+						ownerControl = parent == null ? null : (swf.Control)parent.ControlObject;
+					}
+
+					var result = swf.MessageBox.Show(ownerControl, Text, caption, Convert(Buttons), Convert(Type), Convert(DefaultButton, Buttons));
+					tcs.TrySetResult(result.ToEto());
+				}
+				catch (Exception ex)
+				{
+					tcs.TrySetException(ex);
+				}
+				finally
+				{
+					ctr.Dispose();
+					cancelOwner?.Dispose();
+				}
+			});
+
+			return tcs.Task;
+		}
+
 		public static swf.MessageBoxDefaultButton Convert(MessageBoxDefaultButton defaultButton, MessageBoxButtons buttons)
 		{
 			switch (defaultButton)

--- a/src/Eto.WinForms/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.WinForms/Forms/SelectFolderDialogHandler.cs
@@ -1,23 +1,29 @@
 namespace Eto.WinForms.Forms
 {
-	public class SelectFolderDialogHandler : WidgetHandler<swf.FolderBrowserDialog, SelectFolderDialog>, SelectFolderDialog.IHandler
+	public class SelectFolderDialogHandler : WidgetHandler<swf.FolderBrowserDialog, SelectFolderDialog>, SelectFolderDialog.IHandler, CommonDialog.ICancellableHandler
 	{
+		readonly Win32.CancellableModalDialog _cancellable = new Win32.CancellableModalDialog();
+
 		public SelectFolderDialogHandler ()
 		{
 			Control = new swf.FolderBrowserDialog();
 		}
-	
+
 
 		public DialogResult ShowDialog (Window parent)
 		{
 			if (parent?.HasFocus == false)
 				parent.Focus();
 
-			swf.DialogResult dr;
-			if (parent != null) dr = Control.ShowDialog((swf.IWin32Window)parent.ControlObject);
-			else dr = Control.ShowDialog();
+			var dr = _cancellable.Show(() => parent != null
+				? Control.ShowDialog((swf.IWin32Window)parent.ControlObject)
+				: Control.ShowDialog());
 			return dr.ToEto ();
 		}
+
+		// A WH_CBT hook captured the native dialog's window handle when it was shown (see CancellableModalDialog),
+		// so the async ShowDialogAsync can dismiss exactly this dialog when its cancellation token is signalled.
+		public void CancelDialog() => _cancellable.Cancel();
 
 		public string Title {
 			get {

--- a/src/Eto.WinForms/Forms/WindowsFileDialog.cs
+++ b/src/Eto.WinForms/Forms/WindowsFileDialog.cs
@@ -1,9 +1,15 @@
 namespace Eto.WinForms.Forms
 {
-	public abstract class WindowsFileDialog<TControl, TWidget> : WidgetHandler<TControl, TWidget>, FileDialog.IHandler
+	public abstract class WindowsFileDialog<TControl, TWidget> : WidgetHandler<TControl, TWidget>, FileDialog.IHandler, CommonDialog.ICancellableHandler
 		where TControl : swf.FileDialog
 		where TWidget : FileDialog
 	{
+		readonly Win32.CancellableModalDialog _cancellable = new Win32.CancellableModalDialog();
+
+		// A WH_CBT hook captured the native dialog's window handle when it was shown (see CancellableModalDialog),
+		// allowing the async ShowDialogAsync to dismiss exactly this dialog when its cancellation token is signalled.
+		public void CancelDialog() => _cancellable.Cancel();
+
 		public string FileName
 		{
 			get { return Control.FileName; }
@@ -85,11 +91,9 @@ namespace Eto.WinForms.Forms
 
 			SetFilters();
 
-			swf.DialogResult dr;
-			if (parent != null)
-				dr = Control.ShowDialog((swf.Control)parent.ControlObject);
-			else
-				dr = Control.ShowDialog();
+			var dr = _cancellable.Show(() => parent != null
+				? Control.ShowDialog((swf.Control)parent.ControlObject)
+				: Control.ShowDialog());
 			return dr.ToEto();
 		}
 	}

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -96,6 +96,11 @@ namespace Eto
 			WNDPROC = -4
 		}
 
+		public enum GW : uint
+		{
+			OWNER = 4
+		}
+
 		[Flags]
 		public enum WS : uint
 		{
@@ -151,6 +156,7 @@ namespace Eto
 		public enum WM : uint
 		{
 			SETREDRAW = 0xB,
+			CLOSE = 0x0010,
 
 			GETDLGCODE = 0x0087,
 
@@ -326,6 +332,25 @@ namespace Eto
 		[DllImport("user32.dll")]
 		public static extern IntPtr SetActiveWindow(IntPtr hWnd);
 
+		public delegate bool EnumThreadProc(IntPtr hWnd, IntPtr lParam);
+
+		[DllImport("user32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool EnumThreadWindows(uint dwThreadId, EnumThreadProc lpfn, IntPtr lParam);
+
+		[DllImport("user32.dll")]
+		public static extern IntPtr GetWindow(IntPtr hWnd, GW uCmd);
+
+		[DllImport("user32.dll", CharSet = CharSet.Auto)]
+		public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+		public static bool IsDialogWindow(IntPtr hWnd)
+		{
+			var className = new StringBuilder(256);
+			return GetClassName(hWnd, className, className.Capacity) != 0
+				&& className.ToString() == "#32770";
+		}
+
 		[DllImport("user32.dll")]
 		[return: MarshalAs(UnmanagedType.Bool)]
 		public static extern bool EnableWindow(IntPtr hWnd, [MarshalAs(UnmanagedType.Bool)] bool bEnable);
@@ -376,6 +401,10 @@ namespace Eto
 
 		[DllImport("user32.dll")]
 		public static extern IntPtr SendMessage(IntPtr hWnd, WM wMsg, IntPtr wParam, IntPtr lParam);
+
+		[DllImport("user32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool PostMessage(IntPtr hWnd, WM wMsg, IntPtr wParam, IntPtr lParam);
 
 		[DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
 		public static extern IntPtr SendMessage(IntPtr hWnd, WM msg, IntPtr wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam);
@@ -467,9 +496,14 @@ namespace Eto
 		{
 			KEYBOARD = 2,
 			GETMESSAGE = 3,
+			CBT = 5,
 			KEYBOARD_LL = 13,
 			MOUSE_LL = 14
 		}
+
+		// WH_CBT notification codes (see HCBT_* in winuser.h)
+		public const int HCBT_CREATEWND = 3;
+		public const int HCBT_ACTIVATE = 5;
 
 		[StructLayout(LayoutKind.Sequential)]
 		public struct MSG
@@ -508,6 +542,138 @@ namespace Eto
 		public static extern bool ReleaseCapture();
 
 		public delegate IntPtr HookProc(int code, IntPtr wParam, IntPtr lParam);
+
+		/// <summary>
+		/// Installs a thread-local <c>WH_CBT</c> hook that records the window handle of the next modal dialog shown
+		/// on the current thread. This lets asynchronous dialog cancellation target the exact native dialog window
+		/// unambiguously - even when several dialogs are open - without needing a hidden owner/host window.
+		/// </summary>
+		/// <remarks>
+		/// Create the hook on the UI thread immediately before the blocking native <c>ShowDialog</c> call. The hook
+		/// captures the dialog window when it is first activated and then unhooks itself. <see cref="Cancel"/> posts a
+		/// close request to the captured window, dismissing the dialog as if the user cancelled it. Always
+		/// <see cref="Dispose"/> the hook once the dialog returns. Handlers normally use <see cref="CancellableModalDialog"/>
+		/// rather than driving this directly.
+		/// </remarks>
+		public sealed class ModalDialogHook : IDisposable
+		{
+			readonly HookProc _proc; // keep the delegate rooted for the duration of the unmanaged callback
+			readonly object _sync = new object();
+			IntPtr _hook;
+			IntPtr _dialogHandle;
+			bool _cancelRequested;
+
+			public ModalDialogHook()
+			{
+				_proc = HookCallback;
+				_hook = SetWindowsHookEx((IntPtr)WH.CBT, _proc, IntPtr.Zero, GetCurrentThreadId());
+			}
+
+			/// <summary>
+			/// The captured dialog window, or <see cref="IntPtr.Zero"/> if it has not been shown yet.
+			/// </summary>
+			public IntPtr DialogHandle
+			{
+				get { lock (_sync) return _dialogHandle; }
+			}
+
+			IntPtr HookCallback(int code, IntPtr wParam, IntPtr lParam)
+			{
+				if (code == HCBT_ACTIVATE)
+				{
+					bool cancel = false;
+					lock (_sync)
+					{
+						if (_dialogHandle == IntPtr.Zero)
+						{
+							// wParam is the handle of the window being activated - i.e. the modal dialog.
+							_dialogHandle = wParam;
+							cancel = _cancelRequested;
+						}
+					}
+					// We only need the first activated (modal) window, so stop intercepting once captured.
+					Unhook();
+					if (cancel)
+						PostMessage(wParam, WM.CLOSE, IntPtr.Zero, IntPtr.Zero);
+				}
+				// hhk is ignored by CallNextHookEx, so passing Zero after unhooking is safe.
+				return CallNextHookEx(IntPtr.Zero, code, wParam, lParam);
+			}
+
+			/// <summary>
+			/// Requests the captured dialog to close. If the dialog has not appeared yet it is closed as soon as it is
+			/// shown. Safe to call on the UI thread while the dialog is being displayed.
+			/// </summary>
+			public void Cancel()
+			{
+				IntPtr handle;
+				lock (_sync)
+				{
+					_cancelRequested = true;
+					handle = _dialogHandle;
+				}
+				if (handle != IntPtr.Zero)
+					PostMessage(handle, WM.CLOSE, IntPtr.Zero, IntPtr.Zero);
+			}
+
+			void Unhook()
+			{
+				IntPtr hook;
+				lock (_sync)
+				{
+					hook = _hook;
+					_hook = IntPtr.Zero;
+				}
+				if (hook != IntPtr.Zero)
+					UnhookWindowsHookEx(hook);
+			}
+
+			public void Dispose() => Unhook();
+		}
+
+		/// <summary>
+		/// Reusable helper that handlers embed to implement cancellable modal dialogs via <see cref="ModalDialogHook"/>.
+		/// Wrap the blocking native show in <see cref="Show{T}"/> and forward the handler's <c>CancelDialog</c> to
+		/// <see cref="Cancel"/>.
+		/// </summary>
+		public sealed class CancellableModalDialog
+		{
+			readonly object _sync = new object();
+			ModalDialogHook _hook;
+
+			/// <summary>
+			/// Shows a blocking modal dialog, installing a hook beforehand so it can be cancelled by <see cref="Cancel"/>
+			/// while it is displayed.
+			/// </summary>
+			/// <param name="showDialog">Synchronous, blocking call that displays the native dialog and returns its result.</param>
+			public T Show<T>(Func<T> showDialog)
+			{
+				var hook = new ModalDialogHook();
+				lock (_sync)
+					_hook = hook;
+				try
+				{
+					return showDialog();
+				}
+				finally
+				{
+					lock (_sync)
+						_hook = null;
+					hook.Dispose();
+				}
+			}
+
+			/// <summary>
+			/// Cancels the dialog currently being shown by <see cref="Show{T}"/>, if any.
+			/// </summary>
+			public void Cancel()
+			{
+				ModalDialogHook hook;
+				lock (_sync)
+					hook = _hook;
+				hook?.Cancel();
+			}
+		}
 
 		[StructLayout(LayoutKind.Sequential)]
 		public struct MouseLowLevelHook

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -96,6 +96,11 @@ namespace Eto
 			WNDPROC = -4
 		}
 
+		public enum GW : uint
+		{
+			OWNER = 4
+		}
+
 		[Flags]
 		public enum WS : uint
 		{
@@ -151,6 +156,7 @@ namespace Eto
 		public enum WM : uint
 		{
 			SETREDRAW = 0xB,
+			CLOSE = 0x0010,
 
 			GETDLGCODE = 0x0087,
 
@@ -326,6 +332,25 @@ namespace Eto
 		[DllImport("user32.dll")]
 		public static extern IntPtr SetActiveWindow(IntPtr hWnd);
 
+		public delegate bool EnumThreadProc(IntPtr hWnd, IntPtr lParam);
+
+		[DllImport("user32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool EnumThreadWindows(uint dwThreadId, EnumThreadProc lpfn, IntPtr lParam);
+
+		[DllImport("user32.dll")]
+		public static extern IntPtr GetWindow(IntPtr hWnd, GW uCmd);
+
+		[DllImport("user32.dll", CharSet = CharSet.Auto)]
+		public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+		public static bool IsDialogWindow(IntPtr hWnd)
+		{
+			var className = new StringBuilder(256);
+			return GetClassName(hWnd, className, className.Capacity) != 0
+				&& className.ToString() == "#32770";
+		}
+
 		[DllImport("user32.dll")]
 		[return: MarshalAs(UnmanagedType.Bool)]
 		public static extern bool EnableWindow(IntPtr hWnd, [MarshalAs(UnmanagedType.Bool)] bool bEnable);
@@ -355,6 +380,10 @@ namespace Eto
 
 		[DllImport("user32.dll")]
 		public static extern IntPtr SendMessage(IntPtr hWnd, WM wMsg, IntPtr wParam, IntPtr lParam);
+
+		[DllImport("user32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool PostMessage(IntPtr hWnd, WM wMsg, IntPtr wParam, IntPtr lParam);
 
 		[DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = false)]
 		public static extern IntPtr SendMessage(IntPtr hWnd, WM msg, IntPtr wParam, [MarshalAs(UnmanagedType.LPWStr)] string lParam);

--- a/src/Eto.Wpf/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/MessageBoxHandler.cs
@@ -2,7 +2,7 @@ using WpfMessageBox = System.Windows.MessageBox;
 
 namespace Eto.Wpf.Forms
 {
-	public class MessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler
+	public class MessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler, MessageBox.ICancellableHandler
 	{
 		public string Text { get; set; }
 
@@ -14,6 +14,8 @@ namespace Eto.Wpf.Forms
 
 		public MessageBoxDefaultButton DefaultButton { get; set; }
 
+		readonly Win32.CancellableModalDialog _cancellable = new Win32.CancellableModalDialog();
+
 		public DialogResult ShowDialog(Control parent)
 		{
 			using (var visualStyles = new EnableThemingInScope(ApplicationHandler.EnableVisualStyles))
@@ -24,17 +26,21 @@ namespace Eto.Wpf.Forms
 
 				var element = parent == null ? null : parent.GetContainerControl();
 				var window = element == null ? null : element.GetVisualParent<sw.Window>();
-				sw.MessageBoxResult result;
 				var buttons = Convert(Buttons);
 				var defaultButton = Convert(DefaultButton, Buttons);
 				var icon = Convert(Type);
 				var caption = Caption ?? parentWindow?.Title;
-				if (window != null) result = WpfMessageBox.Show(window, Text, caption, buttons, icon, defaultButton);
-				else result = WpfMessageBox.Show(Text, caption, buttons, icon, defaultButton);
+				var result = _cancellable.Show(() => window != null
+					? WpfMessageBox.Show(window, Text, caption, buttons, icon, defaultButton)
+					: WpfMessageBox.Show(Text, caption, buttons, icon, defaultButton));
 				WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 				return Convert(result);
 			}
 		}
+
+		// WPF's MessageBox is a native Win32 message box running its modal loop on the UI thread; a WH_CBT hook
+		// captured its window handle when shown (see CancellableModalDialog), so we dismiss exactly that dialog.
+		public void CancelDialog() => _cancellable.Cancel();
 
 		public static sw.MessageBoxResult Convert(MessageBoxDefaultButton defaultButton, MessageBoxButtons buttons)
 		{

--- a/src/Eto.Wpf/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/MessageBoxHandler.cs
@@ -63,6 +63,7 @@ namespace Eto.Wpf.Forms
 
 						if (cancellationToken.CanBeCanceled)
 						{
+							// Create a hidden owner to own the message box, so we can close it later if cancelled
 							cancelOwner = new System.Windows.Window()
 							{
 								Width = 0,

--- a/src/Eto.Wpf/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/MessageBoxHandler.cs
@@ -55,7 +55,7 @@ namespace Eto.Wpf.Forms
 					var icon = Convert(Type);
 					var caption = Caption ?? parentWindow?.Title;
 
-					swf.Form cancelOwner = null;
+					System.Windows.Window cancelOwner = null;
 					CancellationTokenRegistration ctr = default;
 					try
 					{
@@ -63,25 +63,28 @@ namespace Eto.Wpf.Forms
 
 						if (cancellationToken.CanBeCanceled)
 						{
-							cancelOwner = new swf.Form
+							cancelOwner = new System.Windows.Window()
 							{
-								Size = sd.Size.Empty,
+								Width = 0,
+								Height = 0,
+								WindowStyle = System.Windows.WindowStyle.None,
+								Visibility = System.Windows.Visibility.Hidden,
+								ShowInTaskbar = false,
+								ShowActivated = false,
+								Owner = window,
 							};
-							if (window != null)
-								cancelOwner.Owner = swf.Control.FromHandle(new System.Windows.Interop.WindowInteropHelper(window).Handle) as swf.Form;
-
-							cancelOwner.Load += (_, _) => cancelOwner.Hide();
 							cancelOwner.Show();
 
 							ctr = cancellationToken.Register(() =>
 							{
-								if (cancelOwner != null && !cancelOwner.IsDisposed)
+								if (cancelOwner != null)
 								{
-									cancelOwner.BeginInvoke(new Action(() =>
+									cancelOwner.Dispatcher.Invoke(() =>
 									{
 										_ = tcs.TrySetCanceled();
+										cancelOwner.Owner?.Focus();
 										cancelOwner.Close();
-									}));
+									});
 								}
 								else
 									_ = tcs.TrySetCanceled();
@@ -89,7 +92,7 @@ namespace Eto.Wpf.Forms
 						}
 
 						if (cancelOwner != null)
-							messageBoxResult = WpfMessageBox.Show(new swf.WindowWrapper(cancelOwner.Handle), Text, caption, buttons, icon, defaultButton);
+							messageBoxResult = WpfMessageBox.Show(cancelOwner, Text, caption, buttons, icon, defaultButton);
 						else if (window != null)
 							messageBoxResult = WpfMessageBox.Show(window, Text, caption, buttons, icon, defaultButton);
 						else
@@ -105,7 +108,8 @@ namespace Eto.Wpf.Forms
 					finally
 					{
 						ctr.Dispose();
-						cancelOwner?.Dispose();
+						cancelOwner?.Owner?.Focus();
+						cancelOwner?.Close();
 					}
 				}
 			});

--- a/src/Eto.Wpf/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/MessageBoxHandler.cs
@@ -37,6 +37,82 @@ namespace Eto.Wpf.Forms
 			}
 		}
 
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			var tcs = new TaskCompletionSource<DialogResult>();
+			Application.Instance.InvokeAsync(() =>
+			{
+				using (var visualStyles = new EnableThemingInScope(ApplicationHandler.EnableVisualStyles))
+				{
+					var parentWindow = parent?.ParentWindow;
+					if (parentWindow?.HasFocus == false)
+						parentWindow.Focus();
+
+					var element = parent == null ? null : parent.GetContainerControl();
+					var window = element == null ? null : element.GetVisualParent<sw.Window>();
+					var buttons = Convert(Buttons);
+					var defaultButton = Convert(DefaultButton, Buttons);
+					var icon = Convert(Type);
+					var caption = Caption ?? parentWindow?.Title;
+
+					swf.Form cancelOwner = null;
+					CancellationTokenRegistration ctr = default;
+					try
+					{
+						sw.MessageBoxResult? messageBoxResult = null;
+
+						if (cancellationToken.CanBeCanceled)
+						{
+							cancelOwner = new swf.Form
+							{
+								Size = sd.Size.Empty,
+							};
+							if (window != null)
+								cancelOwner.Owner = swf.Control.FromHandle(new System.Windows.Interop.WindowInteropHelper(window).Handle) as swf.Form;
+
+							cancelOwner.Load += (_, _) => cancelOwner.Hide();
+							cancelOwner.Show();
+
+							ctr = cancellationToken.Register(() =>
+							{
+								if (cancelOwner != null && !cancelOwner.IsDisposed)
+								{
+									cancelOwner.BeginInvoke(new Action(() =>
+									{
+										_ = tcs.TrySetCanceled();
+										cancelOwner.Close();
+									}));
+								}
+								else
+									_ = tcs.TrySetCanceled();
+							});
+						}
+
+						if (cancelOwner != null)
+							messageBoxResult = WpfMessageBox.Show(new swf.WindowWrapper(cancelOwner.Handle), Text, caption, buttons, icon, defaultButton);
+						else if (window != null)
+							messageBoxResult = WpfMessageBox.Show(window, Text, caption, buttons, icon, defaultButton);
+						else
+							messageBoxResult = WpfMessageBox.Show(Text, caption, buttons, icon, defaultButton);
+
+						WpfFrameworkElementHelper.ShouldCaptureMouse = false;
+						tcs.TrySetResult(Convert(messageBoxResult ?? sw.MessageBoxResult.None));
+					}
+					catch (Exception ex)
+					{
+						tcs.TrySetException(ex);
+					}
+					finally
+					{
+						ctr.Dispose();
+						cancelOwner?.Dispose();
+					}
+				}
+			});
+
+			return tcs.Task;
+		}
+
 		public static sw.MessageBoxResult Convert(MessageBoxDefaultButton defaultButton, MessageBoxButtons buttons)
 		{
 			switch (defaultButton)

--- a/src/Eto.Wpf/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/MessageBoxHandler.cs
@@ -37,6 +37,87 @@ namespace Eto.Wpf.Forms
 			}
 		}
 
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			var tcs = new TaskCompletionSource<DialogResult>();
+			Application.Instance.InvokeAsync(() =>
+			{
+				using (var visualStyles = new EnableThemingInScope(ApplicationHandler.EnableVisualStyles))
+				{
+					var parentWindow = parent?.ParentWindow;
+					if (parentWindow?.HasFocus == false)
+						parentWindow.Focus();
+
+					var element = parent == null ? null : parent.GetContainerControl();
+					var window = element == null ? null : element.GetVisualParent<sw.Window>();
+					var buttons = Convert(Buttons);
+					var defaultButton = Convert(DefaultButton, Buttons);
+					var icon = Convert(Type);
+					var caption = Caption ?? parentWindow?.Title;
+
+					System.Windows.Window cancelOwner = null;
+					CancellationTokenRegistration ctr = default;
+					try
+					{
+						sw.MessageBoxResult? messageBoxResult = null;
+
+						if (cancellationToken.CanBeCanceled)
+						{
+							// Create a hidden owner to own the message box, so we can close it later if cancelled
+							cancelOwner = new System.Windows.Window()
+							{
+								Width = 0,
+								Height = 0,
+								WindowStyle = System.Windows.WindowStyle.None,
+								Visibility = System.Windows.Visibility.Hidden,
+								ShowInTaskbar = false,
+								ShowActivated = false,
+								Owner = window,
+							};
+							cancelOwner.Show();
+
+							ctr = cancellationToken.Register(() =>
+							{
+								if (cancelOwner != null)
+								{
+									cancelOwner.Dispatcher.Invoke(() =>
+									{
+										_ = tcs.TrySetCanceled();
+										cancelOwner.Owner?.Focus();
+										cancelOwner.Close();
+									});
+								}
+								else
+									_ = tcs.TrySetCanceled();
+							});
+						}
+
+						if (cancelOwner != null)
+							messageBoxResult = WpfMessageBox.Show(cancelOwner, Text, caption, buttons, icon, defaultButton);
+						else if (window != null)
+							messageBoxResult = WpfMessageBox.Show(window, Text, caption, buttons, icon, defaultButton);
+						else
+							messageBoxResult = WpfMessageBox.Show(Text, caption, buttons, icon, defaultButton);
+
+						WpfFrameworkElementHelper.ShouldCaptureMouse = false;
+						tcs.TrySetResult(Convert(messageBoxResult ?? sw.MessageBoxResult.None));
+					}
+					catch (Exception ex)
+					{
+						tcs.TrySetException(ex);
+					}
+					finally
+					{
+						ctr.Dispose();
+						cancelOwner?.Owner?.Focus();
+						cancelOwner?.Close();
+					}
+				}
+			});
+
+			return tcs.Task;
+		}
+
 		public static sw.MessageBoxResult Convert(MessageBoxDefaultButton defaultButton, MessageBoxButtons buttons)
 		{
 			switch (defaultButton)

--- a/src/Eto.Wpf/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/SelectFolderDialogHandler.cs
@@ -1,18 +1,24 @@
 namespace Eto.Wpf.Forms
 {
-	public class SelectFolderDialogHandler : WidgetHandler<swf.FolderBrowserDialog, SelectFolderDialog>, SelectFolderDialog.IHandler
+	public class SelectFolderDialogHandler : WidgetHandler<swf.FolderBrowserDialog, SelectFolderDialog>, SelectFolderDialog.IHandler, CommonDialog.ICancellableHandler
 	{
+		readonly Win32.CancellableModalDialog _cancellable = new Win32.CancellableModalDialog();
+
 		public SelectFolderDialogHandler ()
 		{
 			Control = new swf.FolderBrowserDialog ();
 		}
+
+		// A WH_CBT hook captured the native dialog's window handle when it was shown (see CancellableModalDialog),
+		// so the async ShowDialogAsync can dismiss exactly this dialog when its cancellation token is signalled.
+		public void CancelDialog() => _cancellable.Cancel();
 
 		public DialogResult ShowDialog (Window parent)
 		{
 			if (parent?.HasFocus == false)
 				parent.Focus();
 
-			var dr = Control.ShowDialog();
+			var dr = _cancellable.Show(() => Control.ShowDialog());
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 			return dr == swf.DialogResult.OK ? DialogResult.Ok : DialogResult.Cancel;
 		}

--- a/src/Eto.Wpf/Forms/VistaSelectFolderDialogHandler.cs
+++ b/src/Eto.Wpf/Forms/VistaSelectFolderDialogHandler.cs
@@ -6,8 +6,10 @@ namespace Eto.WinForms.Forms
 namespace Eto.Wpf.Forms
 #endif
 {
-	public class VistaSelectFolderDialogHandler : WidgetHandler<cp.CommonOpenFileDialog, SelectFolderDialog>, SelectFolderDialog.IHandler
+	public class VistaSelectFolderDialogHandler : WidgetHandler<cp.CommonOpenFileDialog, SelectFolderDialog>, SelectFolderDialog.IHandler, CommonDialog.ICancellableHandler
 	{
+		readonly Win32.CancellableModalDialog _cancellable = new Win32.CancellableModalDialog();
+
 		public VistaSelectFolderDialogHandler()
 		{
 			Control = new cp.CommonOpenFileDialog
@@ -16,28 +18,29 @@ namespace Eto.Wpf.Forms
 			};
 		}
 
+		// A WH_CBT hook captured the native dialog's window handle when it was shown (see CancellableModalDialog),
+		// so the async ShowDialogAsync can dismiss exactly this dialog when its cancellation token is signalled.
+		public void CancelDialog() => _cancellable.Cancel();
+
 		public DialogResult ShowDialog(Window parent)
 		{
 			if (parent?.HasFocus == false)
 				parent.Focus();
-				
+
 #if WINFORMS
 			// use reflection since adding a parameter requires us to reference PresentationFramework which we don't want in winforms
-			cp.CommonFileDialogResult result;
 			var handle = parent.ToNative()?.Handle;
-			if (handle == null)
+			var result = _cancellable.Show(() =>
 			{
-				result = Control.ShowDialog();
-			}
-			else
-			{
+				if (handle == null)
+					return Control.ShowDialog();
 				var showDialogMethod = Control.GetType().GetMethod("ShowDialog", new[] { typeof(IntPtr) });
-				result = (cp.CommonFileDialogResult)showDialogMethod.Invoke(Control, new object[] { handle.Value });
-			}
+				return (cp.CommonFileDialogResult)showDialogMethod.Invoke(Control, new object[] { handle.Value });
+			});
 #elif WPF
 			// don't use WPF window, parent might be a HwndFormHandler
 			var wpfParent = parent?.NativeHandle;
-			var result = wpfParent != null ? Control.ShowDialog(wpfParent.Value) : Control.ShowDialog();
+			var result = _cancellable.Show(() => wpfParent != null ? Control.ShowDialog(wpfParent.Value) : Control.ShowDialog());
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 #endif
 			switch (result)

--- a/src/Eto.Wpf/Forms/WpfCommonDialog.cs
+++ b/src/Eto.Wpf/Forms/WpfCommonDialog.cs
@@ -2,20 +2,21 @@ using mw = Microsoft.Win32;
 
 namespace Eto.Wpf.Forms
 {
-	public abstract class WpfCommonDialog<TControl, TWidget> : WidgetHandler<TControl, TWidget>, CommonDialog.IHandler
+	public abstract class WpfCommonDialog<TControl, TWidget> : WidgetHandler<TControl, TWidget>, CommonDialog.IHandler, CommonDialog.ICancellableHandler
 		where TControl : mw.CommonDialog
 		where TWidget : CommonDialog
 	{
+		readonly Win32.CancellableModalDialog _cancellable = new Win32.CancellableModalDialog();
+
+		// A WH_CBT hook captured the native dialog's window handle when it was shown (see CancellableModalDialog),
+		// so the async ShowDialogAsync can dismiss exactly this dialog when its cancellation token is signalled.
+		public void CancelDialog() => _cancellable.Cancel();
+
 		public virtual DialogResult ShowDialog (Window parent)
 		{
-			bool? result;
-			if (parent != null) {
-				var owner = parent.ControlObject as sw.Window;
-				result = Control.ShowDialog (owner);
-			}
-			else {
-				result = Control.ShowDialog ();
-			}
+			var result = _cancellable.Show(() => parent != null
+				? Control.ShowDialog(parent.ControlObject as sw.Window)
+				: Control.ShowDialog());
 			WpfFrameworkElementHelper.ShouldCaptureMouse = false;
 			return result != null && result.Value ? DialogResult.Ok : DialogResult.Cancel;
 		}

--- a/src/Eto.iOS/Forms/MessageBoxHandler.cs
+++ b/src/Eto.iOS/Forms/MessageBoxHandler.cs
@@ -1,7 +1,7 @@
 using UIKit;
 namespace Eto.iOS.Forms
 {
-	public class MessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler
+	public class MessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler, MessageBox.IAsyncHandler
 	{
 		public DialogResult ShowDialog (Control parent)
 		{
@@ -9,6 +9,60 @@ namespace Eto.iOS.Forms
 			AddButtons(alert);
 			alert.Show ();
 			return DialogResult.Ok;
+		}
+
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			var tcs = new TaskCompletionSource<DialogResult>();
+			var alert = CreateAlert();
+
+			if (cancellationToken.CanBeCanceled)
+			{
+				cancellationToken.Register(() =>
+				{
+					alert.InvokeOnMainThread(() =>
+					{
+						alert.DismissWithClickedButtonIndex(alert.CancelButtonIndex, false);
+						tcs.TrySetCanceled();
+					});
+				});
+			}
+			else if (cancellationToken.IsCancellationRequested)
+			{
+				tcs.SetCanceled();
+				return tcs.Task;
+			}
+
+			alert.Clicked += (sender, args) => tcs.TrySetResult(ConvertResult(alert, args.ButtonIndex));
+
+			alert.Show();
+			return tcs.Task;
+		}
+
+		DialogResult ConvertResult(UIAlertView alert, nint buttonIndex)
+		{
+			switch (Buttons)
+			{
+				case MessageBoxButtons.OK:
+					return DialogResult.Ok;
+				case MessageBoxButtons.OKCancel:
+					return buttonIndex == alert.CancelButtonIndex ? DialogResult.Cancel : DialogResult.Ok;
+				case MessageBoxButtons.YesNo:
+					return buttonIndex == alert.CancelButtonIndex ? DialogResult.No : DialogResult.Yes;
+				case MessageBoxButtons.YesNoCancel:
+					if (buttonIndex == alert.CancelButtonIndex)
+						return DialogResult.Cancel;
+					return buttonIndex == 0 ? DialogResult.Yes : DialogResult.No;
+				default:
+					return DialogResult.None;
+			}
+		}
+
+		UIAlertView CreateAlert()
+		{
+			var alert = new UIAlertView(Caption ?? string.Empty, Text ?? string.Empty, null, null);
+			AddButtons(alert);
+			return alert;
 		}
 
 		void AddButtons(UIAlertView alert)
@@ -90,4 +144,3 @@ namespace Eto.iOS.Forms
 		public MessageBoxDefaultButton DefaultButton { get; set; }
 	}
 }
-

--- a/src/Eto.iOS/Forms/MessageBoxHandler.cs
+++ b/src/Eto.iOS/Forms/MessageBoxHandler.cs
@@ -11,6 +11,60 @@ namespace Eto.iOS.Forms
 			return DialogResult.Ok;
 		}
 
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			var tcs = new TaskCompletionSource<DialogResult>();
+			var alert = CreateAlert();
+
+			if (cancellationToken.CanBeCanceled)
+			{
+				cancellationToken.Register(() =>
+				{
+					alert.InvokeOnMainThread(() =>
+					{
+						alert.DismissWithClickedButtonIndex(alert.CancelButtonIndex, false);
+						tcs.TrySetCanceled();
+					});
+				});
+			}
+			else if (cancellationToken.IsCancellationRequested)
+			{
+				tcs.SetCanceled();
+				return tcs.Task;
+			}
+
+			alert.Clicked += (sender, args) => tcs.TrySetResult(ConvertResult(alert, args.ButtonIndex));
+
+			alert.Show();
+			return tcs.Task;
+		}
+
+		DialogResult ConvertResult(UIAlertView alert, nint buttonIndex)
+		{
+			switch (Buttons)
+			{
+				case MessageBoxButtons.OK:
+					return DialogResult.Ok;
+				case MessageBoxButtons.OKCancel:
+					return buttonIndex == alert.CancelButtonIndex ? DialogResult.Cancel : DialogResult.Ok;
+				case MessageBoxButtons.YesNo:
+					return buttonIndex == alert.CancelButtonIndex ? DialogResult.No : DialogResult.Yes;
+				case MessageBoxButtons.YesNoCancel:
+					if (buttonIndex == alert.CancelButtonIndex)
+						return DialogResult.Cancel;
+					return buttonIndex == 0 ? DialogResult.Yes : DialogResult.No;
+				default:
+					return DialogResult.None;
+			}
+		}
+
+		UIAlertView CreateAlert()
+		{
+			var alert = new UIAlertView(Caption ?? string.Empty, Text ?? string.Empty, null, null);
+			AddButtons(alert);
+			return alert;
+		}
+
 		void AddButtons(UIAlertView alert)
 		{
 			var OkButton = "OK";
@@ -90,4 +144,3 @@ namespace Eto.iOS.Forms
 		public MessageBoxDefaultButton DefaultButton { get; set; }
 	}
 }
-

--- a/src/Eto/Forms/AsyncModalDialog.cs
+++ b/src/Eto/Forms/AsyncModalDialog.cs
@@ -1,0 +1,90 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Shared orchestration for showing a <em>blocking</em> modal dialog asynchronously with optional cancellation.
+/// </summary>
+/// <remarks>
+/// This drives the pattern used by both <see cref="CommonDialog.ShowDialogAsync(Window, CancellationToken)"/> and
+/// <see cref="MessageBox.ShowAsync(Control, string, string, MessageBoxButtons, MessageBoxType, MessageBoxDefaultButton, CancellationToken)"/>:
+/// the synchronous, blocking <c>showDialog</c> is posted onto the UI thread (where its native modal loop
+/// keeps pumping), and <c>cancelDialog</c> is invoked - while it is showing - to break that loop when the
+/// token is signalled.
+///
+/// This only works on platforms that run a nested modal loop for <c>ShowDialog</c> (i.e. desktop). Event-driven
+/// platforms (e.g. mobile) must provide their own asynchronous display instead.
+/// </remarks>
+static class AsyncModalDialog
+{
+	/// <summary>
+	/// Shows a blocking modal dialog asynchronously.
+	/// </summary>
+	/// <param name="showDialog">Synchronous, blocking call that displays the dialog and returns its result.</param>
+	/// <param name="cancelDialog">
+	/// Interrupts the active <paramref name="showDialog"/>, or <c>null</c> when the dialog cannot be cancelled.
+	/// Callers must ensure a cancellable token is not paired with a <c>null</c> <paramref name="cancelDialog"/>.
+	/// </param>
+	/// <param name="cancellationToken">Token used to cancel the dialog while it is displayed.</param>
+	public static Task<DialogResult> Show(Func<DialogResult> showDialog, Action cancelDialog, CancellationToken cancellationToken)
+	{
+		var tcs = new TaskCompletionSource<DialogResult>();
+		var sync = new object();
+		var cancellationRequested = false;
+		var isShowing = false;
+
+		var registration = default(CancellationTokenRegistration);
+		if (cancelDialog != null && cancellationToken.CanBeCanceled)
+		{
+			registration = cancellationToken.Register(() =>
+			{
+				lock (sync)
+				{
+					cancellationRequested = true;
+					// Only cancel the native dialog if it is currently being shown. If it hasn't been shown yet the
+					// show callback below will observe the flag and never display it.
+					if (isShowing)
+						Application.Instance.AsyncInvoke(cancelDialog);
+				}
+			});
+		}
+
+		Application.Instance.AsyncInvoke(() =>
+		{
+			try
+			{
+				lock (sync)
+				{
+					if (cancellationRequested)
+					{
+						tcs.TrySetCanceled(cancellationToken);
+						return;
+					}
+					isShowing = true;
+				}
+
+				var result = showDialog();
+
+				bool wasCancelled;
+				lock (sync)
+				{
+					isShowing = false;
+					wasCancelled = cancellationRequested;
+				}
+
+				if (wasCancelled)
+					tcs.TrySetCanceled(cancellationToken);
+				else
+					tcs.TrySetResult(result);
+			}
+			catch (Exception ex)
+			{
+				tcs.TrySetException(ex);
+			}
+			finally
+			{
+				registration.Dispose();
+			}
+		});
+
+		return tcs.Task;
+	}
+}

--- a/src/Eto/Forms/CommonDialog.cs
+++ b/src/Eto/Forms/CommonDialog.cs
@@ -76,6 +76,47 @@ public abstract class CommonDialog : Widget
 	}
 
 	/// <summary>
+	/// Shows the dialog asynchronously with the specified parent.
+	/// </summary>
+	public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+	{
+		return ShowDialogAsync(parent != null ? parent.ParentWindow : null, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows the dialog asynchronously with the specified parent window.
+	/// </summary>
+	/// <remarks>
+	/// The dialog is shown using the platform's native modal display, which keeps the UI responsive while the
+	/// returned task is awaited.
+	///
+	/// Passing a <see cref="CancellationToken"/> that <see cref="CancellationToken.CanBeCanceled">can be cancelled</see>
+	/// requires the platform handler to implement <see cref="ICancellableHandler"/>, otherwise a
+	/// <see cref="NotSupportedException"/> is thrown. When no cancellable token is supplied the dialog is shown
+	/// asynchronously on all platforms regardless of cancellation support.
+	/// </remarks>
+	/// <param name="parent">Parent window.</param>
+	/// <param name="cancellationToken">Token used to cancel the dialog while it is displayed.</param>
+	public virtual Task<DialogResult> ShowDialogAsync(Window parent, CancellationToken cancellationToken = default)
+	{
+		Application.Instance.EnsureUIThread();
+
+		if (cancellationToken.IsCancellationRequested)
+			return Task.FromCanceled<DialogResult>(cancellationToken);
+
+		// Only require cancellation support when the caller actually supplies a token that can be cancelled.
+		// A missing/non-cancellable token still shows the dialog asynchronously on every platform.
+		var cancellableHandler = Handler as ICancellableHandler;
+		if (cancellationToken.CanBeCanceled && cancellableHandler == null)
+			throw new NotSupportedException($"{GetType().Name} does not support cancellation of asynchronous display.");
+
+		return AsyncModalDialog.Show(
+			() => Handler.ShowDialog(parent),
+			cancellableHandler != null ? cancellableHandler.CancelDialog : (Action)null,
+			cancellationToken);
+	}
+
+	/// <summary>
 	/// Handler interface for the <see cref="CommonDialog"/>
 	/// </summary>
 	public new interface IHandler : Widget.IHandler
@@ -86,5 +127,21 @@ public abstract class CommonDialog : Widget
 		/// <returns>The dialog result.</returns>
 		/// <param name="parent">Parent window.</param>
 		DialogResult ShowDialog(Window parent);
+	}
+
+	/// <summary>
+	/// Handler interface for common dialogs which support cancelling an active modal display.
+	/// </summary>
+	/// <remarks>
+	/// Handlers implement this to allow <see cref="ShowDialogAsync(Window, CancellationToken)"/> to be cancelled
+	/// via a <see cref="CancellationToken"/> while the dialog is shown. <see cref="CancelDialog"/> is always
+	/// invoked on the UI thread while the dialog is being displayed.
+	/// </remarks>
+	public interface ICancellableHandler : IHandler
+	{
+		/// <summary>
+		/// Cancels the active dialog, dismissing it as if the user cancelled it.
+		/// </summary>
+		void CancelDialog();
 	}
 }

--- a/src/Eto/Forms/Dialog.cs
+++ b/src/Eto/Forms/Dialog.cs
@@ -70,6 +70,15 @@ public class Dialog<T> : Dialog
 	}
 
 	/// <summary>
+	/// Shows the dialog modally asynchronously until it is closed or cancelled.
+	/// </summary>
+	public new async Task<T> ShowModalAsync(CancellationToken cancellationToken)
+	{
+		await base.ShowModalAsync(cancellationToken);
+		return Result;
+	}
+
+	/// <summary>
 	/// Shows the dialog and blocks until the user closes the dialog
 	/// </summary>
 	/// <remarks>
@@ -96,6 +105,15 @@ public class Dialog<T> : Dialog
 	{
 		return base.ShowModalAsync(owner)
 			.ContinueWith(t => Result, TaskContinuationOptions.OnlyOnRanToCompletion);
+	}
+
+	/// <summary>
+	/// Shows the dialog modally asynchronously with the specified owner until it is closed or cancelled.
+	/// </summary>
+	public new async Task<T> ShowModalAsync(Control owner, CancellationToken cancellationToken)
+	{
+		await base.ShowModalAsync(owner, cancellationToken);
+		return Result;
 	}
 
 	/// <summary>
@@ -235,6 +253,15 @@ public class Dialog : Window
 	}
 
 	/// <summary>
+	/// Shows the dialog modally asynchronously with the specified owner until it is closed or cancelled.
+	/// </summary>
+	public Task ShowModalAsync(Control owner, CancellationToken cancellationToken)
+	{
+		Owner = owner != null ? owner.ParentWindow : null;
+		return ShowModalAsync(cancellationToken);
+	}
+
+	/// <summary>
 	/// Shows the dialog modally asynchronously
 	/// </summary>
 	public Task ShowModalAsync()
@@ -248,6 +275,32 @@ public class Dialog : Window
 		}
 
 		return Handler.ShowModalAsync();
+	}
+
+	/// <summary>
+	/// Shows the dialog modally asynchronously until it is closed or cancelled.
+	/// </summary>
+	/// <remarks>
+	/// If the dialog is closed by the user (or programmatically via <see cref="Window.Close()"/>) before the
+	/// token is signalled, the task completes normally and any <see cref="Dialog{T}.Result"/> is preserved.
+	/// The task is only cancelled when the close was triggered by <paramref name="cancellationToken"/>.
+	/// </remarks>
+	/// <param name="cancellationToken">Token used to close the dialog while it is displayed.</param>
+	public async Task ShowModalAsync(CancellationToken cancellationToken)
+	{
+		cancellationToken.ThrowIfCancellationRequested();
+		var showTask = ShowModalAsync();
+		var cancelledByToken = 0;
+		using var registration = cancellationToken.Register(() =>
+		{
+			Interlocked.Exchange(ref cancelledByToken, 1);
+			Application.Instance.AsyncInvoke(Close);
+		});
+		await showTask;
+		// Only surface cancellation when this token actually closed the dialog, otherwise a user-initiated
+		// close (which may carry a Result) would be lost by throwing.
+		if (Volatile.Read(ref cancelledByToken) != 0)
+			cancellationToken.ThrowIfCancellationRequested();
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/MessageBox.cs
+++ b/src/Eto/Forms/MessageBox.cs
@@ -194,6 +194,135 @@ public static class MessageBox
 	}
 
 	/// <summary>
+	/// Shows a message box asynchronously, blocking input to all windows of the application until closed
+	/// </summary>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(string text, MessageBoxType type = MessageBoxType.Information, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync((Control)null, text, null, type, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking input to all windows of the application until closed
+	/// </summary>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="caption">Caption for the title bar or heading of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(string text, string caption, MessageBoxType type = MessageBoxType.Information, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync((Control)null, text, caption, type, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking only the window of the specified <paramref name="parent"/> 
+	/// </summary>
+	/// <param name="parent">Parent control that triggered the message box</param>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(Control parent, string text, MessageBoxType type = MessageBoxType.Information, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync(parent, text, null, type, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking only the window of the specified <paramref name="parent"/> 
+	/// </summary>
+	/// <param name="parent">Parent control that triggered the message box</param>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="caption">Caption for the title bar or heading of the message box</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(Control parent, string text, string caption, MessageBoxType type = MessageBoxType.Information, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync(parent, text, caption, MessageBoxButtons.OK, type, MessageBoxDefaultButton.Default, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking input to all windows of the application until closed
+	/// </summary>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="buttons">Buttons to show on the message box</param>
+	/// <param name="defaultButton">Button to set focus to by default</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(string text, MessageBoxButtons buttons, MessageBoxType type = MessageBoxType.Information, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Default, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync((Control)null, text, buttons, type, defaultButton, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking input to all windows of the application until closed
+	/// </summary>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="buttons">Buttons to show on the message box</param>
+	/// <param name="defaultButton">Button to set focus to by default</param>
+	/// <param name="caption">Caption for the title bar or heading of the message box</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(string text, string caption, MessageBoxButtons buttons, MessageBoxType type = MessageBoxType.Information, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Default, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync((Control)null, text, caption, buttons, type, defaultButton, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking only the window of the specified <paramref name="parent"/> 
+	/// </summary>
+	/// <param name="parent">Parent control that triggered the message box</param>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="buttons">Buttons to show on the message box</param>
+	/// <param name="defaultButton">Button to set focus to by default</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(Control parent, string text, MessageBoxButtons buttons, MessageBoxType type = MessageBoxType.Information, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Default, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync(parent, text, null, buttons, type, defaultButton, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking only the window of the specified <paramref name="parent"/> 
+	/// </summary>
+	/// <param name="parent">Parent control that triggered the message box</param>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="caption">Caption for the title bar or heading of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="buttons">Buttons to show on the message box</param>
+	/// <param name="defaultButton">Button to set focus to by default</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(Control parent, string text, string caption, MessageBoxButtons buttons, MessageBoxType type = MessageBoxType.Information, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Default, CancellationToken cancellationToken = default)
+	{
+		Application.Instance.EnsureUIThread();
+		var mb = Platform.Instance.Create<IHandler>();
+		mb.Text = text;
+		mb.Caption = caption;
+		mb.Type = type;
+		mb.Buttons = buttons;
+		mb.DefaultButton = defaultButton;
+
+		if (cancellationToken.IsCancellationRequested)
+			return Task.FromCanceled<DialogResult>(cancellationToken);
+
+		// Platforms that cannot run a nested modal loop (e.g. mobile) display message boxes in an event-driven
+		// fashion and provide their own asynchronous implementation.
+		if (mb is IAsyncHandler asyncHandler)
+			return asyncHandler.ShowDialogAsync(parent, cancellationToken);
+
+		// Otherwise use the shared blocking-modal orchestration. Cancellation requires the handler to be able to
+		// dismiss an active dialog; if it can't and a cancellable token was supplied, fail fast.
+		var cancellableHandler = mb as ICancellableHandler;
+		if (cancellationToken.CanBeCanceled && cancellableHandler == null)
+			throw new NotSupportedException("This platform does not support cancellation of asynchronous message boxes.");
+
+		return AsyncModalDialog.Show(
+			() => mb.ShowDialog(parent),
+			cancellableHandler != null ? cancellableHandler.CancelDialog : (Action)null,
+			cancellationToken);
+	}
+
+	/// <summary>
 	/// Handler interface for the <see cref="MessageBox"/>
 	/// </summary>
 	public interface IHandler
@@ -224,10 +353,40 @@ public static class MessageBox
 		/// <value>The default button.</value>
 		MessageBoxDefaultButton DefaultButton { get; set; }
 		/// <summary>
-		/// Shows the dialog.
+		/// Shows the dialog, blocking until a result is returned.
 		/// </summary>
 		/// <returns>The dialog result.</returns>
 		/// <param name="parent">Optional parent. If specified, the parent's window should be blocked from input. If null, all windows should be blocked.</param>
 		DialogResult ShowDialog(Control parent);
+	}
+
+	/// <summary>
+	/// Handler interface for message boxes that can dismiss an active blocking modal display, enabling
+	/// cancellation of <see cref="ShowAsync(Control, string, string, MessageBoxButtons, MessageBoxType, MessageBoxDefaultButton, CancellationToken)"/>.
+	/// </summary>
+	/// <remarks>
+	/// Desktop platforms implement this; <see cref="CancelDialog"/> is invoked on the UI thread while the message
+	/// box returned by <see cref="IHandler.ShowDialog(Control)"/> is being shown, and should dismiss it as if cancelled.
+	/// </remarks>
+	public interface ICancellableHandler : IHandler
+	{
+		/// <summary>
+		/// Cancels the active message box, dismissing it as if the user cancelled it.
+		/// </summary>
+		void CancelDialog();
+	}
+
+	/// <summary>
+	/// Handler interface for platforms that display message boxes asynchronously rather than via a blocking modal
+	/// loop (e.g. mobile), providing their own asynchronous implementation.
+	/// </summary>
+	public interface IAsyncHandler : IHandler
+	{
+		/// <summary>
+		/// Shows the message box asynchronously, completing when it closes.
+		/// </summary>
+		/// <param name="parent">Optional parent. If specified, the parent's window should be blocked from input. If null, all windows should be blocked.</param>
+		/// <param name="cancellationToken">Optional cancellation token; handlers should close with a cancel response when requested.</param>
+		Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Eto/Forms/MessageBox.cs
+++ b/src/Eto/Forms/MessageBox.cs
@@ -194,6 +194,118 @@ public static class MessageBox
 	}
 
 	/// <summary>
+	/// Shows a message box asynchronously, blocking input to all windows of the application until closed
+	/// </summary>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(string text, MessageBoxType type = MessageBoxType.Information, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync((Control)null, text, null, type, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking input to all windows of the application until closed
+	/// </summary>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="caption">Caption for the title bar or heading of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(string text, string caption, MessageBoxType type = MessageBoxType.Information, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync((Control)null, text, caption, type, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking only the window of the specified <paramref name="parent"/> 
+	/// </summary>
+	/// <param name="parent">Parent control that triggered the message box</param>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(Control parent, string text, MessageBoxType type = MessageBoxType.Information, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync(parent, text, null, type, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking only the window of the specified <paramref name="parent"/> 
+	/// </summary>
+	/// <param name="parent">Parent control that triggered the message box</param>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="caption">Caption for the title bar or heading of the message box</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(Control parent, string text, string caption, MessageBoxType type = MessageBoxType.Information, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync(parent, text, caption, MessageBoxButtons.OK, type, MessageBoxDefaultButton.Default, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking input to all windows of the application until closed
+	/// </summary>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="buttons">Buttons to show on the message box</param>
+	/// <param name="defaultButton">Button to set focus to by default</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(string text, MessageBoxButtons buttons, MessageBoxType type = MessageBoxType.Information, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Default, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync((Control)null, text, buttons, type, defaultButton, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking input to all windows of the application until closed
+	/// </summary>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="buttons">Buttons to show on the message box</param>
+	/// <param name="defaultButton">Button to set focus to by default</param>
+	/// <param name="caption">Caption for the title bar or heading of the message box</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(string text, string caption, MessageBoxButtons buttons, MessageBoxType type = MessageBoxType.Information, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Default, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync((Control)null, text, caption, buttons, type, defaultButton, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking only the window of the specified <paramref name="parent"/> 
+	/// </summary>
+	/// <param name="parent">Parent control that triggered the message box</param>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="buttons">Buttons to show on the message box</param>
+	/// <param name="defaultButton">Button to set focus to by default</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(Control parent, string text, MessageBoxButtons buttons, MessageBoxType type = MessageBoxType.Information, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Default, CancellationToken cancellationToken = default)
+	{
+		return ShowAsync(parent, text, null, buttons, type, defaultButton, cancellationToken);
+	}
+
+	/// <summary>
+	/// Shows a message box asynchronously, blocking only the window of the specified <paramref name="parent"/> 
+	/// </summary>
+	/// <param name="parent">Parent control that triggered the message box</param>
+	/// <param name="text">Text for the body of the message box</param>
+	/// <param name="caption">Caption for the title bar or heading of the message box</param>
+	/// <param name="type">Type of message box</param>
+	/// <param name="buttons">Buttons to show on the message box</param>
+	/// <param name="defaultButton">Button to set focus to by default</param>
+	/// <param name="cancellationToken">Token used to cancel/close the dialog.</param>
+	public static Task<DialogResult> ShowAsync(Control parent, string text, string caption, MessageBoxButtons buttons, MessageBoxType type = MessageBoxType.Information, MessageBoxDefaultButton defaultButton = MessageBoxDefaultButton.Default, CancellationToken cancellationToken = default)
+	{
+		Application.Instance.EnsureUIThread();
+		var mb = Platform.Instance.Create<IHandler>();
+		mb.Text = text;
+		mb.Caption = caption;
+		mb.Type = type;
+		mb.Buttons = buttons;
+		mb.DefaultButton = defaultButton;
+
+		return mb.ShowDialogAsync(parent, cancellationToken);
+	}
+
+	/// <summary>
 	/// Handler interface for the <see cref="MessageBox"/>
 	/// </summary>
 	public interface IHandler
@@ -229,5 +341,11 @@ public static class MessageBox
 		/// <returns>The dialog result.</returns>
 		/// <param name="parent">Optional parent. If specified, the parent's window should be blocked from input. If null, all windows should be blocked.</param>
 		DialogResult ShowDialog(Control parent);
+		/// <summary>
+		/// Shows the dialog asynchronously, completing when the dialog closes.
+		/// </summary>
+		/// <param name="parent">Optional parent. If specified, the parent's window should be blocked from input. If null, all windows should be blocked.</param>
+		/// <param name="cancellationToken">Optional cancellation token; handlers should close with a cancel response when requested.</param>
+		Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default);
 	}
 }

--- a/src/Eto/Forms/ThemedControls/ThemedAboutHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedAboutHandler.cs
@@ -3,7 +3,7 @@
 /// <summary>
 /// A themed handler for the <see cref="AboutDialog"/> dialog.
 /// </summary>
-public class ThemedAboutDialogHandler : WidgetHandler<Dialog, AboutDialog, AboutDialog.ICallback>, AboutDialog.IHandler
+public class ThemedAboutDialogHandler : WidgetHandler<Dialog, AboutDialog, AboutDialog.ICallback>, AboutDialog.IHandler, CommonDialog.ICancellableHandler
 {
 	string[] designers, developers, documenters;
 	string license;
@@ -242,4 +242,11 @@ public class ThemedAboutDialogHandler : WidgetHandler<Dialog, AboutDialog, About
 
 		return DialogResult.Cancel;
 	}
+
+	/// <summary>
+	/// Closes the about dialog while it is being shown, allowing the asynchronous
+	/// <see cref="CommonDialog.ShowDialogAsync(Window, CancellationToken)"/> to be cancelled. Because the dialog is a
+	/// managed Eto <see cref="Dialog"/>, closing it ends the modal display directly without any native interop.
+	/// </summary>
+	public void CancelDialog() => Control.Close();
 }

--- a/src/Eto/Forms/ThemedControls/ThemedColorDialogHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedColorDialogHandler.cs
@@ -6,10 +6,11 @@ using Eto.Drawing;
 /// A themed handler for the <see cref="ColorDialog"/> control that provides
 /// a color spectrum, hue strip, RGB/Alpha sliders, hex input, and color preview.
 /// </summary>
-public class ThemedColorDialogHandler : WidgetHandler<Widget, ColorDialog, ColorDialog.ICallback>, ColorDialog.IHandler
+public class ThemedColorDialogHandler : WidgetHandler<Widget, ColorDialog, ColorDialog.ICallback>, ColorDialog.IHandler, CommonDialog.ICancellableHandler
 {
 	Color _color = Colors.White;
 	bool _allowAlpha;
+	ThemedColorDialog _activeDialog;
 
 	/// <inheritdoc/>
 	public Color Color
@@ -42,7 +43,16 @@ public class ThemedColorDialogHandler : WidgetHandler<Widget, ColorDialog, Color
 			Callback.OnColorChanged(Widget, EventArgs.Empty);
 		};
 
-		var result = parent != null ? dialog.ShowModal(parent) : dialog.ShowModal();
+		_activeDialog = dialog;
+		DialogResult result;
+		try
+		{
+			result = parent != null ? dialog.ShowModal(parent) : dialog.ShowModal();
+		}
+		finally
+		{
+			_activeDialog = null;
+		}
 
 		if (result == DialogResult.Ok)
 		{
@@ -54,6 +64,13 @@ public class ThemedColorDialogHandler : WidgetHandler<Widget, ColorDialog, Color
 		Callback.OnColorChanged(Widget, EventArgs.Empty);
 		return DialogResult.Cancel;
 	}
+
+	/// <summary>
+	/// Closes the dialog while it is being shown, allowing the asynchronous
+	/// <see cref="CommonDialog.ShowDialogAsync(Window, CancellationToken)"/> to be cancelled. Because the dialog is a
+	/// managed Eto <see cref="Dialog"/>, closing it ends the modal display directly without any native interop.
+	/// </summary>
+	public void CancelDialog() => _activeDialog?.Close();
 
 	class ThemedColorDialog : Dialog<DialogResult>
 	{

--- a/src/Eto/Forms/ThemedControls/ThemedFontDialogHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedFontDialogHandler.cs
@@ -3,9 +3,10 @@ namespace Eto.Forms.ThemedControls;
 /// <summary>
 /// A themed handler for the <see cref="FontDialog"/> control.
 /// </summary>
-public class ThemedFontDialogHandler : WidgetHandler<Widget, FontDialog, FontDialog.ICallback>, FontDialog.IHandler
+public class ThemedFontDialogHandler : WidgetHandler<Widget, FontDialog, FontDialog.ICallback>, FontDialog.IHandler, CommonDialog.ICancellableHandler
 {
 	Font _font;
+	ThemedFontDialog _activeDialog;
 
 	/// <inheritdoc/>
 	public Font Font
@@ -41,7 +42,16 @@ public class ThemedFontDialogHandler : WidgetHandler<Widget, FontDialog, FontDia
 			Callback.OnFontChanged(Widget, EventArgs.Empty);
 		};
 
-		var result = parent != null ? dialog.ShowModal(parent) : dialog.ShowModal();
+		_activeDialog = dialog;
+		DialogResult result;
+		try
+		{
+			result = parent != null ? dialog.ShowModal(parent) : dialog.ShowModal();
+		}
+		finally
+		{
+			_activeDialog = null;
+		}
 
 		if (result == DialogResult.Ok)
 		{
@@ -54,6 +64,13 @@ public class ThemedFontDialogHandler : WidgetHandler<Widget, FontDialog, FontDia
 		Callback.OnFontChanged(Widget, EventArgs.Empty);
 		return DialogResult.Cancel;
 	}
+
+	/// <summary>
+	/// Closes the dialog while it is being shown, allowing the asynchronous
+	/// <see cref="CommonDialog.ShowDialogAsync(Window, CancellationToken)"/> to be cancelled. Because the dialog is a
+	/// managed Eto <see cref="Dialog"/>, closing it ends the modal display directly without any native interop.
+	/// </summary>
+	public void CancelDialog() => _activeDialog?.Close();
 
 	class ThemedFontDialog : Dialog<DialogResult>
 	{

--- a/src/Eto/Forms/ThemedControls/ThemedMessageBoxHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedMessageBoxHandler.cs
@@ -7,7 +7,7 @@ namespace Eto.Forms.ThemedControls
 	/// <summary>
 	/// A themed message box handler to allow more customization and theming
 	/// </summary>
-	public class ThemedMessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler
+	public class ThemedMessageBoxHandler : WidgetHandler<Widget>, MessageBox.IHandler, MessageBox.IAsyncHandler
 	{
 		/// <inheritdoc />
 		public string Text { get; set; }
@@ -23,10 +23,64 @@ namespace Eto.Forms.ThemedControls
 		/// <inheritdoc />
 		public DialogResult ShowDialog(Control parent)
 		{
+			var dlg = CreateDialog(parent);
+
+			dlg.ShowModal(parent);
+
+			return dlg.Result as DialogResult? ?? DialogResult.Cancel;
+		}
+		
+		/// <inheritdoc />
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			var dlg = CreateDialog(parent);
+			var tcs = new TaskCompletionSource<DialogResult>();
+			var registration = default(CancellationTokenRegistration);
+
+			void CancelDialog()
+			{
+				Application.Instance.Invoke(() =>
+				{
+					if (tcs.TrySetCanceled())
+						dlg.Close();
+				});
+			}
+
+			if (cancellationToken.CanBeCanceled)
+				registration = cancellationToken.Register(CancelDialog);
+
+			dlg.Shown += (_, _) => {
+				if (tcs.Task.IsCanceled)
+				{
+					dlg.Close();
+				}
+			};
+
+			if (tcs.Task.IsCompleted)
+			{
+				registration.Dispose();
+				return tcs.Task;
+			}
+
+			dlg.ShowModalAsync(parent).ContinueWith(t =>
+			{
+				registration.Dispose();
+				if (t.IsFaulted)
+					tcs.TrySetException(t.Exception.InnerExceptions);
+				else if (t.IsCanceled)
+					tcs.TrySetCanceled();
+				else
+					tcs.TrySetResult(dlg.Result as DialogResult? ?? DialogResult.None);
+			}, TaskScheduler.FromCurrentSynchronizationContext());
+
+			return tcs.Task;
+		}
+
+		private ThemedMessageBox CreateDialog(Control parent)
+		{
 			var dlg = new ThemedMessageBox();
 			dlg.Title = Caption ?? parent?.ParentWindow?.Title ?? Application.Instance.Localize(Widget, "Error");
 			dlg.Text = Text;
-			// todo: add ability to get icons needed from SystemIcons
 			dlg.Image = GetImage();
 
 			var defaultButton = DefaultButton;
@@ -51,7 +105,6 @@ namespace Eto.Forms.ThemedControls
 				}
 			}
 
-
 			var app = Application.Instance;
 			switch (Buttons)
 			{
@@ -73,9 +126,7 @@ namespace Eto.Forms.ThemedControls
 					break;
 			}
 
-			dlg.ShowModal(parent);
-
-			return dlg.Result as DialogResult? ?? DialogResult.Cancel;
+			return dlg;
 		}
 
 		private Image GetImage()

--- a/src/Eto/Forms/ThemedControls/ThemedMessageBoxHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedMessageBoxHandler.cs
@@ -23,10 +23,64 @@ namespace Eto.Forms.ThemedControls
 		/// <inheritdoc />
 		public DialogResult ShowDialog(Control parent)
 		{
+			var dlg = CreateDialog(parent);
+
+			dlg.ShowModal(parent);
+
+			return dlg.Result as DialogResult? ?? DialogResult.Cancel;
+		}
+		
+		/// <inheritdoc />
+		public Task<DialogResult> ShowDialogAsync(Control parent, CancellationToken cancellationToken = default)
+		{
+			var dlg = CreateDialog(parent);
+			var tcs = new TaskCompletionSource<DialogResult>();
+			var registration = default(CancellationTokenRegistration);
+
+			void CancelDialog()
+			{
+				Application.Instance.Invoke(() =>
+				{
+					if (tcs.TrySetCanceled())
+						dlg.Close();
+				});
+			}
+
+			if (cancellationToken.CanBeCanceled)
+				registration = cancellationToken.Register(CancelDialog);
+
+			dlg.Shown += (_, _) => {
+				if (tcs.Task.IsCanceled)
+				{
+					dlg.Close();
+				}
+			};
+
+			if (tcs.Task.IsCompleted)
+			{
+				registration.Dispose();
+				return tcs.Task;
+			}
+
+			dlg.ShowModalAsync(parent).ContinueWith(t =>
+			{
+				registration.Dispose();
+				if (t.IsFaulted)
+					tcs.TrySetException(t.Exception.InnerExceptions);
+				else if (t.IsCanceled)
+					tcs.TrySetCanceled();
+				else
+					tcs.TrySetResult(dlg.Result as DialogResult? ?? DialogResult.None);
+			}, TaskScheduler.FromCurrentSynchronizationContext());
+
+			return tcs.Task;
+		}
+
+		private ThemedMessageBox CreateDialog(Control parent)
+		{
 			var dlg = new ThemedMessageBox();
 			dlg.Title = Caption ?? parent?.ParentWindow?.Title ?? Application.Instance.Localize(Widget, "Error");
 			dlg.Text = Text;
-			// todo: add ability to get icons needed from SystemIcons
 			dlg.Image = GetImage();
 
 			var defaultButton = DefaultButton;
@@ -51,7 +105,6 @@ namespace Eto.Forms.ThemedControls
 				}
 			}
 
-
 			var app = Application.Instance;
 			switch (Buttons)
 			{
@@ -73,9 +126,7 @@ namespace Eto.Forms.ThemedControls
 					break;
 			}
 
-			dlg.ShowModal(parent);
-
-			return dlg.Result as DialogResult? ?? DialogResult.Cancel;
+			return dlg;
 		}
 
 		private Image GetImage()

--- a/test/Eto.Test/Sections/Dialogs/AboutDialogSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/AboutDialogSection.cs
@@ -6,6 +6,7 @@
 		TextBox entryTitle, entryProgramName, entryVersion, entryCopyright, entryLicense, entryWebsiteURL, entryWebsiteLabel;
 		TextArea entryDescription, entryDevelopers, entryDesigners, entryDocumenters;
 		Button buttonShowDialog;
+		readonly AsyncDialogOptions asyncOptions = new AsyncDialogOptions();
 
 		public AboutDialogSection()
 		{
@@ -75,6 +76,8 @@
 
 			layout4.Add(null, true, true);
 
+			layout4.Add(asyncOptions);
+
 			buttonShowDialog = new Button();
 			buttonShowDialog.Text = "Show Dialog";
 			buttonShowDialog.Click += ButtonShowDialog_Click;
@@ -132,7 +135,10 @@
 			dialog.Developers = entryDevelopers.Text.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
 			dialog.Documenters = entryDocumenters.Text.Split(new string[] { Environment.NewLine }, StringSplitOptions.None);
 
-			dialog.ShowDialog(this);
+			asyncOptions.Run(dialog,
+				() => dialog.ShowDialog(this),
+				token => dialog.ShowDialogAsync(this, token),
+				result => Log.Write(dialog, "Result: {0}", result));
 		}
 	}
 }

--- a/test/Eto.Test/Sections/Dialogs/AsyncDialogOptions.cs
+++ b/test/Eto.Test/Sections/Dialogs/AsyncDialogOptions.cs
@@ -1,0 +1,113 @@
+namespace Eto.Test.Sections.Dialogs
+{
+	/// <summary>
+	/// Reusable "[x] Async   Cancel after [n] s" options row shared by the dialog test sections.
+	///
+	/// Add it to a section's layout and route the section's existing "Show" button through <see cref="Run"/>.
+	/// When <see cref="Async"/> is unchecked the dialog is shown synchronously exactly as before; when checked it
+	/// is shown via the async API and, if the timeout is greater than zero, cancelled after that many seconds.
+	/// </summary>
+	public class AsyncDialogOptions : Panel
+	{
+		/// <summary>Show the dialog using the asynchronous API.</summary>
+		public bool Async { get; set; }
+
+		/// <summary>Seconds before the async dialog is automatically cancelled (0 = no cancellation).</summary>
+		public double CancelAfterSeconds { get; set; } = 3;
+
+		/// <summary>Whether the next async show will use a cancellation token.</summary>
+		public bool UsesCancellation => Async && CancelAfterSeconds > 0;
+
+		public AsyncDialogOptions()
+		{
+			var asyncCheck = new CheckBox { Text = "Async", ToolTip = "Show the dialog with the asynchronous API" };
+			var stepper = new NumericStepper
+			{
+				MinValue = 0,
+				MaxValue = 600,
+				DecimalPlaces = 0,
+				Value = CancelAfterSeconds,
+				Enabled = Async,
+				ToolTip = "Cancel the async dialog after this many seconds (0 = no cancellation)"
+			};
+
+			asyncCheck.CheckedChanged += (sender, e) =>
+			{
+				Async = asyncCheck.Checked ?? false;
+				stepper.Enabled = Async;
+			};
+			stepper.ValueChanged += (sender, e) => CancelAfterSeconds = stepper.Value;
+
+			Content = TableLayout.Horizontal(
+				5,
+				asyncCheck,
+				new Label { Text = "Cancel after (s):", VerticalAlignment = VerticalAlignment.Center },
+				stepper);
+		}
+
+		/// <summary>
+		/// Shows a dialog honoring the current options. The section supplies how to show the dialog synchronously
+		/// and asynchronously (so dialog-specific parameters/parents are preserved), plus how to log the result.
+		/// </summary>
+		/// <param name="logSource">Object used as the source for <see cref="Log"/> output.</param>
+		/// <param name="showSync">Shows the dialog synchronously and returns its result.</param>
+		/// <param name="showAsync">Shows the dialog asynchronously with the supplied cancellation token.</param>
+		/// <param name="onResult">Invoked with the result on completion (not called when cancelled or unsupported).</param>
+		public async void Run(object logSource, Func<DialogResult> showSync, Func<CancellationToken, Task<DialogResult>> showAsync, Action<DialogResult> onResult)
+		{
+			if (!Async)
+			{
+				onResult(showSync());
+				return;
+			}
+
+			using var cts = UsesCancellation ? new CancellationTokenSource(TimeSpan.FromSeconds(CancelAfterSeconds)) : null;
+			if (cts != null)
+				Log.Write(logSource, "Showing async, will cancel in {0}s", CancelAfterSeconds);
+
+			try
+			{
+				onResult(await showAsync(cts?.Token ?? CancellationToken.None));
+			}
+			catch (OperationCanceledException)
+			{
+				Log.Write(logSource, "Async dialog was cancelled");
+			}
+			catch (NotSupportedException ex)
+			{
+				Log.Write(logSource, "Async cancellation not supported: {0}", ex.Message);
+			}
+		}
+
+		/// <summary>
+		/// Shows a modal <see cref="Dialog"/> honoring the current options, using <see cref="Dialog.ShowModalAsync(CancellationToken)"/>
+		/// when async. The dialog is auto-closed (cancelled) after the timeout when one is set.
+		/// </summary>
+		/// <param name="logSource">Object used as the source for <see cref="Log"/> output.</param>
+		/// <param name="showSync">Shows the dialog modally and blocks.</param>
+		/// <param name="showAsync">Shows the dialog modally with the supplied cancellation token.</param>
+		public async void RunModal(object logSource, Action showSync, Func<CancellationToken, Task> showAsync)
+		{
+			if (!Async)
+			{
+				Log.Write(logSource, "Showing dialog (blocking)...");
+				showSync();
+				Log.Write(logSource, "Dialog closed");
+				return;
+			}
+
+			using var cts = UsesCancellation ? new CancellationTokenSource(TimeSpan.FromSeconds(CancelAfterSeconds)) : null;
+			Log.Write(logSource, cts != null ? $"Showing dialog async, will cancel in {CancelAfterSeconds}s..." : "Showing dialog async...");
+
+			try
+			{
+				await showAsync(cts?.Token ?? CancellationToken.None);
+				Log.Write(logSource, "Dialog closed");
+			}
+			catch (OperationCanceledException)
+			{
+				Log.Write(logSource, "Dialog was cancelled");
+			}
+		}
+	}
+}

--- a/test/Eto.Test/Sections/Dialogs/ColorDialogSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/ColorDialogSection.cs
@@ -5,6 +5,8 @@ namespace Eto.Test.Sections.Dialogs
 	{
 		public bool AllowAlpha { get; set; }
 
+		readonly AsyncDialogOptions asyncOptions = new AsyncDialogOptions();
+
 		public ColorDialogSection() : this(true)
 		{
 
@@ -19,6 +21,7 @@ namespace Eto.Test.Sections.Dialogs
 
 			layout.BeginCentered();
 			layout.Add(CreateAllowAlphaCheckBox());
+			layout.Add(asyncOptions);
 			layout.Add(PickColor());
 			layout.Add(PickColorWithStartingColor());
 			if (showCreateDialog)
@@ -62,13 +65,16 @@ namespace Eto.Test.Sections.Dialogs
 					// you need to handle this event for OS X, where the dialog is a floating window
 					Log.Write(dialog, "ColorChanged, Color: {0}", dialog.Color);
 				};
-				var result = dialog.ShowDialog(ParentWindow);
-				if (result == DialogResult.Ok)
-				{
-					Log.Write(dialog, "Result: {0}, Color: {1}", result, dialog.Color);
-				}
-				else
-					Log.Write(dialog, "Result: {0}", result);
+				asyncOptions.Run(dialog,
+					() => dialog.ShowDialog(ParentWindow),
+					token => dialog.ShowDialogAsync(ParentWindow, token),
+					result =>
+					{
+						if (result == DialogResult.Ok)
+							Log.Write(dialog, "Result: {0}, Color: {1}", result, dialog.Color);
+						else
+							Log.Write(dialog, "Result: {0}", result);
+					});
 			};
 			return button;
 		}
@@ -88,13 +94,16 @@ namespace Eto.Test.Sections.Dialogs
 					// need to handle this event for OS X, where the dialog is a floating window
 					Log.Write(dialog, "ColorChanged, Color: {0}", dialog.Color);
 				};
-				var result = dialog.ShowDialog(ParentWindow);
-				if (result == DialogResult.Ok)
-				{
-					Log.Write(dialog, "Result: {0}, Color: {1}", result, dialog.Color);
-				}
-				else
-					Log.Write(dialog, "Result: {0}", result);
+				asyncOptions.Run(dialog,
+					() => dialog.ShowDialog(ParentWindow),
+					token => dialog.ShowDialogAsync(ParentWindow, token),
+					result =>
+					{
+						if (result == DialogResult.Ok)
+							Log.Write(dialog, "Result: {0}, Color: {1}", result, dialog.Color);
+						else
+							Log.Write(dialog, "Result: {0}", result);
+					});
 			};
 			return button;
 		}

--- a/test/Eto.Test/Sections/Dialogs/DialogSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/DialogSection.cs
@@ -3,7 +3,8 @@ namespace Eto.Test.Sections.Dialogs
 	[Section("Dialogs", typeof(Dialog))]
 	public class DialogSection : Scrollable
 	{
-		public bool UseAsync { get; set; }
+		readonly AsyncDialogOptions asyncOptions = new AsyncDialogOptions();
+
 		public bool AddButtons { get; set; }
 		public bool SetResizable { get; set; }
 		public bool SetMinimizable { get; set; }
@@ -16,7 +17,8 @@ namespace Eto.Test.Sections.Dialogs
 		{
 			var layout = new DynamicLayout { Spacing = new Size(20, 20), DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
 
-			layout.AddSeparateRow(null, UseAsyncCheckBox(), AddButtonsCheckBox(), SetOwnerCheckBox(), null);
+			layout.AddSeparateRow(null, AddButtonsCheckBox(), SetOwnerCheckBox(), null);
+			layout.AddSeparateRow(null, asyncOptions, null);
 			layout.AddSeparateRow(null, ResizableCheckBox(), MinimizableCheckBox(), MaximizableCheckBox(), null);
 			layout.AddSeparateRow(null, "DisplayMode", DisplayModeDropDown(), "WindowState", WindowStateDropDown(), null);
 			layout.BeginVertical();
@@ -33,13 +35,6 @@ namespace Eto.Test.Sections.Dialogs
 		{
 			var control = new CheckBox { Text = "Set owner" };
 			control.CheckedBinding.Bind(this, c => c.SetOwner);
-			return control;
-		}
-
-		Control UseAsyncCheckBox()
-		{
-			var control = new CheckBox { Text = "Use Async" };
-			control.CheckedBinding.Bind(this, c => c.UseAsync);
 			return control;
 		}
 
@@ -177,25 +172,11 @@ namespace Eto.Test.Sections.Dialogs
 			return control;
 		}
 
-		public async void Show(Dialog dialog, Control parent)
+		public void Show(Dialog dialog, Control parent)
 		{
-			if (UseAsync)
-			{
-				Log.Write(null, "Showing dialog async...");
-				var dialogTask = SetOwner ? dialog.ShowModalAsync(parent) : dialog.ShowModalAsync();
-				Log.Write(null, "Waiting for dialog to close...");
-				await dialogTask;
-				Log.Write(null, "Dialog closed");
-			}
-			else
-			{
-				Log.Write(null, "Showing dialog (blocking)...");
-				if (SetOwner)
-					dialog.ShowModal(parent);
-				else
-					dialog.ShowModal();
-				Log.Write(null, "Dialog closed");
-			}
+			asyncOptions.RunModal(dialog,
+				() => { if (SetOwner) dialog.ShowModal(parent); else dialog.ShowModal(); },
+				token => SetOwner ? dialog.ShowModalAsync(parent, token) : dialog.ShowModalAsync(token));
 		}
 	}
 }

--- a/test/Eto.Test/Sections/Dialogs/FileDialogSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/FileDialogSection.cs
@@ -11,6 +11,8 @@ namespace Eto.Test.Sections.Dialogs
 
 		public bool MultiSelect { get; set; }
 
+		readonly AsyncDialogOptions asyncOptions = new AsyncDialogOptions();
+
 		public FileDialogSection()
 		{
 			Content = new TableLayout
@@ -23,6 +25,7 @@ namespace Eto.Test.Sections.Dialogs
 					TableLayout.Horizontal(null, new Label { Text = "Directory" }, GetDirectory(), null),
 					TableLayout.Horizontal(null, GetMultiSelect(), null),
 					TableLayout.Horizontal(null, new Label { Text = "Title" }, GetTitle(), null),
+					TableLayout.Horizontal(null, asyncOptions, null),
 					TableLayout.Horizontal(null, OpenFile(), OpenFileWithFilters(), null),
 					TableLayout.Horizontal(null, SaveFile(), SaveFileWithFilters(), null),
 					null
@@ -89,8 +92,10 @@ namespace Eto.Test.Sections.Dialogs
 			{
 				var dialog = new OpenFileDialog();
 				SetAttributes(dialog);
-				var result = dialog.ShowDialog(ParentWindow);
-				Log.Write(dialog, "Result: {0}, FileName: {1}\nFiles: {2}", result, dialog.FileName, string.Join(", ", dialog.Filenames));
+				asyncOptions.Run(dialog,
+					() => dialog.ShowDialog(ParentWindow),
+					token => dialog.ShowDialogAsync(ParentWindow, token),
+					result => Log.Write(dialog, "Result: {0}, FileName: {1}\nFiles: {2}", result, dialog.FileName, string.Join(", ", dialog.Filenames)));
 			};
 			return button;
 		}
@@ -114,8 +119,10 @@ namespace Eto.Test.Sections.Dialogs
 				};
 				SetAttributes(dialog);
 
-				var result = dialog.ShowDialog(ParentWindow);
-				Log.Write(dialog, "Result: {0}, CurrentFilter: {1}, FileName: {2}\nFiles: {3}", result, dialog.CurrentFilter, dialog.FileName, string.Join(", ", dialog.Filenames));
+				asyncOptions.Run(dialog,
+					() => dialog.ShowDialog(ParentWindow),
+					token => dialog.ShowDialogAsync(ParentWindow, token),
+					result => Log.Write(dialog, "Result: {0}, CurrentFilter: {1}, FileName: {2}\nFiles: {3}", result, dialog.CurrentFilter, dialog.FileName, string.Join(", ", dialog.Filenames)));
 			};
 			return button;
 		}
@@ -140,9 +147,14 @@ namespace Eto.Test.Sections.Dialogs
 				};
 				SetAttributes(dialog);
 
-				var result = dialog.ShowDialog(ParentWindow);
-				Log.Write(dialog, "Result: {0}, CurrentFilter: {1}, FileName: {2}", result, dialog.CurrentFilter, dialog.FileName);
-				dialog.Dispose();
+				asyncOptions.Run(dialog,
+					() => dialog.ShowDialog(ParentWindow),
+					token => dialog.ShowDialogAsync(ParentWindow, token),
+					result =>
+					{
+						Log.Write(dialog, "Result: {0}, CurrentFilter: {1}, FileName: {2}", result, dialog.CurrentFilter, dialog.FileName);
+						dialog.Dispose();
+					});
 			};
 			return button;
 		}
@@ -154,9 +166,14 @@ namespace Eto.Test.Sections.Dialogs
 			{
 				var dialog = new SaveFileDialog();
 				SetAttributes(dialog);
-				var result = dialog.ShowDialog(ParentWindow);
-				Log.Write(dialog, "Result: {0}, FileName: {1}", result, dialog.FileName);
-				dialog.Dispose();
+				asyncOptions.Run(dialog,
+					() => dialog.ShowDialog(ParentWindow),
+					token => dialog.ShowDialogAsync(ParentWindow, token),
+					result =>
+					{
+						Log.Write(dialog, "Result: {0}, FileName: {1}", result, dialog.FileName);
+						dialog.Dispose();
+					});
 			};
 			return button;
 		}

--- a/test/Eto.Test/Sections/Dialogs/FontDialogSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/FontDialogSection.cs
@@ -13,6 +13,8 @@ namespace Eto.Test.Sections.Dialogs
 		bool updating;
 		Drawable metricsPreview;
 
+		readonly AsyncDialogOptions asyncOptions = new AsyncDialogOptions();
+
 		public FontDialogSection()
 		{
 			var layout = new DynamicLayout { DefaultSpacing = new Size(5, 5), Padding = new Padding(10) };
@@ -31,6 +33,7 @@ namespace Eto.Test.Sections.Dialogs
 			layout.AddSpace();
 			layout.EndHorizontal();
 			layout.EndVertical();
+			layout.AddSeparateRow(null, asyncOptions, null);
 			layout.AddSeparateRow(null, new Label { Text = "Set Font Family", VerticalAlignment = VerticalAlignment.Center }, PickFontFamily(), null);
 
 			layout.AddSeparateRow(null, FontList(), FontStyles(), FontSizes(), null);
@@ -229,8 +232,10 @@ namespace Eto.Test.Sections.Dialogs
 					UpdatePreview(dialog.Font);
 					Log.Write(dialog, "FontChanged, Font: {0}", dialog.Font);
 				};
-				var result = dialog.ShowDialog(ParentWindow);
-				Log.Write(dialog, "Result: {0}", result);
+				asyncOptions.Run(dialog,
+					() => dialog.ShowDialog(ParentWindow),
+					token => dialog.ShowDialogAsync(ParentWindow, token),
+					result => Log.Write(dialog, "Result: {0}", result));
 			};
 			return button;
 		}
@@ -250,9 +255,11 @@ namespace Eto.Test.Sections.Dialogs
 					UpdatePreview(dialog.Font);
 					Log.Write(dialog, "FontChanged, Font: {0}", dialog.Font);
 				};
-				var result = dialog.ShowDialog(ParentWindow);
-				// do not get the font here, it may return immediately with a result of DialogResult.None on certain platforms
-				Log.Write(dialog, "Result: {0}", result);
+				// do not get the font in the result handler, it may return immediately with a result of DialogResult.None on certain platforms
+				asyncOptions.Run(dialog,
+					() => dialog.ShowDialog(ParentWindow),
+					token => dialog.ShowDialogAsync(ParentWindow, token),
+					result => Log.Write(dialog, "Result: {0}", result));
 			};
 			return button;
 		}

--- a/test/Eto.Test/Sections/Dialogs/MessageBoxSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/MessageBoxSection.cs
@@ -15,6 +15,8 @@ namespace Eto.Test.Sections.Dialogs
 
 		public bool AttachToParent { get; set; }
 
+		readonly AsyncDialogOptions asyncOptions = new AsyncDialogOptions();
+
 		public MessageBoxSection()
 		{
 			MessageBoxText = "Some message";
@@ -48,6 +50,7 @@ namespace Eto.Test.Sections.Dialogs
 
 			layout.EndVertical();
 
+			layout.AddSeparateRow(null, asyncOptions, null);
 			layout.AddSeparateRow(null, ShowDialogButton(), null);
 			layout.Add(null);
 
@@ -108,15 +111,16 @@ namespace Eto.Test.Sections.Dialogs
 			control.Click += (sender, e) =>
 			{
 				var caption = string.IsNullOrEmpty(MessageBoxCaption) ? null : MessageBoxCaption;
-				DialogResult result;
-				if (AttachToParent)
-					result = MessageBox.Show(this, text: MessageBoxText, caption: caption, type: MessageBoxType, buttons: MessageBoxButtons, defaultButton: MessageBoxDefaultButton);
-				else
-					result = MessageBox.Show(text: MessageBoxText, caption: caption, type: MessageBoxType, buttons: MessageBoxButtons, defaultButton: MessageBoxDefaultButton);
-				Log.Write(this, "MessageBox Result: {0}", result);
+				asyncOptions.Run(this,
+					() => AttachToParent
+						? MessageBox.Show(this, text: MessageBoxText, caption: caption, type: MessageBoxType, buttons: MessageBoxButtons, defaultButton: MessageBoxDefaultButton)
+						: MessageBox.Show(text: MessageBoxText, caption: caption, type: MessageBoxType, buttons: MessageBoxButtons, defaultButton: MessageBoxDefaultButton),
+					token => AttachToParent
+						? MessageBox.ShowAsync(this, text: MessageBoxText, caption: caption, type: MessageBoxType, buttons: MessageBoxButtons, defaultButton: MessageBoxDefaultButton, cancellationToken: token)
+						: MessageBox.ShowAsync(text: MessageBoxText, caption: caption, type: MessageBoxType, buttons: MessageBoxButtons, defaultButton: MessageBoxDefaultButton, cancellationToken: token),
+					result => Log.Write(this, "MessageBox Result: {0}", result));
 			};
 			return control;
 		}
 	}
 }
-

--- a/test/Eto.Test/Sections/Dialogs/MessageBoxSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/MessageBoxSection.cs
@@ -48,7 +48,7 @@ namespace Eto.Test.Sections.Dialogs
 
 			layout.EndVertical();
 
-			layout.AddSeparateRow(null, ShowDialogButton(), null);
+			layout.AddSeparateRow(null, ShowDialogButton(), ShowAsyncDialogButton(), null);
 			layout.Add(null);
 
 			Content = layout;
@@ -117,6 +117,32 @@ namespace Eto.Test.Sections.Dialogs
 			};
 			return control;
 		}
+
+		Control ShowAsyncDialogButton()
+		{
+			var control = new Button { Text = "Show Dialog Async" };
+			control.Click += async (sender, e) =>
+			{
+				var caption = string.IsNullOrEmpty(MessageBoxCaption) ? null : MessageBoxCaption;
+				using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(3));
+				Task<DialogResult> task;
+				if (AttachToParent)
+					task = MessageBox.ShowAsync(this, text: MessageBoxText, caption: caption, type: MessageBoxType, buttons: MessageBoxButtons, defaultButton: MessageBoxDefaultButton, cancellationToken: cts.Token);
+				else
+					task = MessageBox.ShowAsync(text: MessageBoxText, caption: caption, type: MessageBoxType, buttons: MessageBoxButtons, defaultButton: MessageBoxDefaultButton, cancellationToken: cts.Token);
+
+				Log.Write(this, "Async MessageBox created, will cancel in 3 seconds");
+				try
+				{
+					var result = await task;
+					Log.Write(this, "Async MessageBox Result: {0}", result);
+				}
+				catch (OperationCanceledException)
+				{
+					Log.Write(this, "Async MessageBox was cancelled");
+				}
+			};
+			return control;
+		}
 	}
 }
-

--- a/test/Eto.Test/Sections/Dialogs/OpenWithDialogSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/OpenWithDialogSection.cs
@@ -3,34 +3,29 @@
 	[Section("Dialogs", typeof(OpenWithDialog))]
 	public class OpenWithDialogSection : Panel
     {
+		readonly AsyncDialogOptions asyncOptions = new AsyncDialogOptions();
+
         public OpenWithDialogSection()
         {
-			var layout = new DynamicLayout();
-			layout.DefaultPadding = new Padding(10);
-			layout.DefaultSpacing = new Size(4, 4);
-			layout.BeginVertical();
+			var layout = new DynamicLayout { Spacing = new Size(20, 20), DefaultSpacing = new Size(5, 5), Padding = 10 };
 
-			layout.BeginHorizontal();
-			layout.Add(new Label { Text = "File to open: ", VerticalAlignment = VerticalAlignment.Center });
-			var filepicker1 = new FilePicker { FileAction = FileAction.OpenFile };
-			layout.Add(filepicker1, true, false);
-			layout.EndHorizontal();
+			var filepicker1 = new FilePicker { FileAction = FileAction.OpenFile, Width = 300 };
+			var button1 = new Button { Text = "Show Dialog" };
 
-			layout.BeginHorizontal();
+			layout.AddSeparateRow(null, new Label { Text = "File to open:", VerticalAlignment = VerticalAlignment.Center }, filepicker1, null);
+			layout.AddSeparateRow(null, asyncOptions, null);
+			layout.AddSeparateRow(null, button1, null);
+
 			layout.Add(null);
-			var button1 = new Button();
-			button1.Text = "Show Dialog";
-			layout.Add(button1, true, false);
-			layout.EndHorizontal();
 
-			layout.Add(null, false, true);
-
-			layout.EndVertical();
 			Content = layout;
 
 			button1.Click += delegate {
 				var dialog = new OpenWithDialog(filepicker1.FilePath);
-				dialog.ShowDialog(this);
+				asyncOptions.Run(dialog,
+					() => dialog.ShowDialog(this),
+					token => dialog.ShowDialogAsync(this, token),
+					result => Log.Write(dialog, "Result: {0}", result));
 			};
         }
     }

--- a/test/Eto.Test/Sections/Dialogs/SelectFolderSection.cs
+++ b/test/Eto.Test/Sections/Dialogs/SelectFolderSection.cs
@@ -11,12 +11,15 @@ namespace Eto.Test.Sections.Dialogs
 
 		string InitialFolder { get; set; } = EtoEnvironment.GetFolderPath(EtoSpecialFolder.Documents);
 
+		readonly AsyncDialogOptions asyncOptions = new AsyncDialogOptions();
+
 		public SelectFolderSection()
 		{
 			var layout = new DynamicLayout { Spacing = new Size(20, 20), DefaultSpacing = new Size(5, 5), Padding = 10 };
 
 			layout.AddSeparateRow(null, "Title:", TitleTextBox(), null);
 			layout.AddSeparateRow(null, SetParentCheckBox(), SetInitialFolderCheckBox(), null);
+			layout.AddSeparateRow(null, asyncOptions, null);
 			layout.AddSeparateRow(null, SelectFolder(), null);
 
 			layout.Add(null);
@@ -59,14 +62,18 @@ namespace Eto.Test.Sections.Dialogs
 
 				if (SetInitialFolder)
 					dialog.Directory = InitialFolder;
-				
-				var result = SetDialogParent ? dialog.ShowDialog(ParentWindow) : dialog.ShowDialog(null);
-				if (result == DialogResult.Ok)
-				{
-					Log.Write(dialog, "Result: {0}, Folder: {1}", result, dialog.Directory);
-				}
-				else
-					Log.Write(dialog, "Result: {0}", result);
+
+				var parent = SetDialogParent ? ParentWindow : null;
+				asyncOptions.Run(dialog,
+					() => dialog.ShowDialog(parent),
+					token => dialog.ShowDialogAsync(parent, token),
+					result =>
+					{
+						if (result == DialogResult.Ok)
+							Log.Write(dialog, "Result: {0}, Folder: {1}", result, dialog.Directory);
+						else
+							Log.Write(dialog, "Result: {0}", result);
+					});
 			};
 			return button;
 		}

--- a/test/Eto.Test/UnitTests/Forms/CommonDialogAsyncTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/CommonDialogAsyncTests.cs
@@ -1,0 +1,118 @@
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms
+{
+	/// <summary>
+	/// A <see cref="CommonDialog"/> whose handler deliberately does not implement
+	/// <see cref="CommonDialog.ICancellableHandler"/>, used to exercise the "cancellation not supported" path of
+	/// <see cref="CommonDialog.ShowDialogAsync(Window, CancellationToken)"/> independently of platform capabilities.
+	/// </summary>
+	[Handler(typeof(IHandler))]
+	public class UncancellableDialog : CommonDialog
+	{
+		public new interface IHandler : CommonDialog.IHandler { }
+	}
+
+	public class UncancellableDialogHandler : WidgetHandler<UncancellableDialog>, UncancellableDialog.IHandler
+	{
+		// Intentionally not ICancellableHandler. Returns immediately without showing UI so it is safe in unit tests.
+		public DialogResult ShowDialog(Window parent) => DialogResult.Cancel;
+	}
+
+	/// <summary>
+	/// Tests for the asynchronous <see cref="CommonDialog.ShowDialogAsync(Window, CancellationToken)"/> contract.
+	///
+	/// The deterministic tests (token already cancelled, unsupported + cancellable token) never display a dialog,
+	/// so they are safe to run unattended. The cancel-while-shown tests do display a native dialog that is
+	/// automatically cancelled, so they self-dismiss without user interaction.
+	/// </summary>
+	[TestFixture]
+	public class CommonDialogAsyncTests : TestBase
+	{
+		static CommonDialogAsyncTests()
+		{
+			Platform.Instance.Add<UncancellableDialog.IHandler>(() => new UncancellableDialogHandler());
+		}
+
+		static CommonDialog CreateCancellable() => new OpenFileDialog();
+
+		// Desktop common dialogs now support cancellation, so the "not supported" path is exercised with a dialog
+		// whose handler explicitly opts out of ICancellableHandler.
+		static CommonDialog CreateNonCancellable() => new UncancellableDialog();
+
+		[Test, InvokeOnUI]
+		public void AlreadyCancelledTokenShouldNotShowDialog()
+		{
+			// Regardless of whether the dialog supports cancellation, an already-cancelled token must short-circuit
+			// before the dialog is ever displayed.
+			foreach (var dialog in new[] { CreateCancellable(), CreateNonCancellable() })
+			{
+				var cts = new CancellationTokenSource();
+				cts.Cancel();
+				var task = dialog.ShowDialogAsync(null, cts.Token);
+				Assert.That(task.IsCanceled, Is.True, $"{dialog.GetType().Name} should return a cancelled task without showing");
+			}
+		}
+
+		[Test, InvokeOnUI]
+		public void CancellableTokenOnUnsupportedDialogShouldThrow()
+		{
+			// A token that can be cancelled requires cancellation support; if the handler can't honor it we must
+			// fail fast rather than silently ignore the token.
+			var dialog = CreateNonCancellable();
+			using var cts = new CancellationTokenSource();
+			Assert.Throws<NotSupportedException>(() => dialog.ShowDialogAsync(null, cts.Token));
+		}
+
+		[Test, InvokeOnUI]
+		public void NonCancellableTokenOnUnsupportedDialogShouldNotThrow()
+		{
+			// A missing/non-cancellable token must never throw NotSupportedException, even when the handler has no
+			// cancellation support - the dialog is simply shown asynchronously. The show is scheduled on the UI
+			// queue; disposing immediately prevents it from ever being presented in this synchronous test.
+			var dialog = CreateNonCancellable();
+			Task<DialogResult> task = null;
+			Assert.DoesNotThrow(() => task = dialog.ShowDialogAsync(null, CancellationToken.None));
+			dialog.Dispose();
+			// observe the task so a faulted show (against the disposed handler) doesn't surface as unobserved
+			task?.ContinueWith(t => { _ = t.Exception; }, TaskScheduler.Default);
+		}
+
+		[Test]
+		public void FileDialogShouldCancelWhileShownWhenSupported()
+		{
+			Async(10000, async () =>
+			{
+				var dialog = CreateCancellable();
+				using var cts = new CancellationTokenSource();
+
+				Task<DialogResult> task;
+				try
+				{
+					task = dialog.ShowDialogAsync(null, cts.Token);
+				}
+				catch (NotSupportedException)
+				{
+					// Platform cannot cancel this dialog type; throwing satisfies the contract.
+					return;
+				}
+
+				// give the native dialog a moment to appear, then cancel it
+				await Task.Delay(600);
+				cts.Cancel();
+
+				OperationCanceledException caught = null;
+				try
+				{
+					await task;
+				}
+				catch (OperationCanceledException ex)
+				{
+					caught = ex;
+				}
+
+				Assert.That(caught, Is.Not.Null, "A supported dialog should be cancelled by its token while shown");
+			});
+		}
+	}
+}

--- a/test/Eto.Test/UnitTests/Forms/DialogTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/DialogTests.cs
@@ -213,6 +213,77 @@ namespace Eto.Test.UnitTests.Forms
 		}
 
 		[Test]
+		public void ShowModalAsyncWithAlreadyCancelledTokenShouldNotShow()
+		{
+			Async(async () =>
+			{
+				var dlg = new Dialog { Content = "Should never be shown", Size = new Size(200, 200) };
+				var cts = new CancellationTokenSource();
+				cts.Cancel();
+
+				OperationCanceledException caught = null;
+				try
+				{
+					await dlg.ShowModalAsync(cts.Token);
+				}
+				catch (OperationCanceledException ex)
+				{
+					caught = ex;
+				}
+
+				Assert.That(caught, Is.Not.Null, "Should throw OperationCanceledException for an already-cancelled token");
+				Assert.That(dlg.Loaded, Is.False, "Dialog should never have been shown");
+			});
+		}
+
+		[Test]
+		public void ShowModalAsyncShouldCancelWhenTokenSignalled()
+		{
+			Async(10000, async () =>
+			{
+				var dlg = new Dialog<bool> { Content = "Should auto-cancel", Size = new Size(200, 200) };
+				using var cts = new CancellationTokenSource();
+
+				var task = dlg.ShowModalAsync(cts.Token);
+				// let the dialog get shown, then cancel from outside
+				await Task.Delay(250);
+				cts.Cancel();
+
+				OperationCanceledException caught = null;
+				try
+				{
+					await task;
+				}
+				catch (OperationCanceledException ex)
+				{
+					caught = ex;
+				}
+
+				Assert.That(caught, Is.Not.Null, "Dialog should throw OperationCanceledException when cancelled");
+				Assert.That(dlg.Loaded, Is.False, "Dialog should be closed after cancellation");
+			});
+		}
+
+		[Test]
+		public void ShowModalAsyncShouldPreserveResultWhenClosedBeforeCancellation()
+		{
+			Async(10000, async () =>
+			{
+				var dlg = new Dialog<bool> { Content = "Closes with a result", Size = new Size(200, 200) };
+				using var cts = new CancellationTokenSource();
+
+				var task = dlg.ShowModalAsync(cts.Token);
+				await Task.Delay(250);
+				// user-style close that carries a result, before the token is ever signalled
+				dlg.Close(true);
+
+				var result = await task;
+
+				Assert.That(result, Is.True, "Result should be preserved when the dialog is closed before cancellation");
+			});
+		}
+
+		[Test]
 		public void DisposingBeforeShowingAsyncShouldNotCrash()
 		{
 			Invoke(() =>


### PR DESCRIPTION
Addresses #838 — adds an asynchronous, cancellable way to show message boxes, common dialogs, and modal dialogs across platforms.

This started as just needing async/cancellable `MessageBox.Show` on GTK, but grew into a fairly complete implementation covering message boxes, the common dialogs (color/font/file/folder), and custom `Dialog`s.

## API

- `MessageBox.ShowAsync(...)` — async overloads mirroring `MessageBox.Show`, each taking an optional  `CancellationToken`.
- `CommonDialog.ShowDialogAsync(parent, CancellationToken)` — covers `OpenFileDialog`, `SaveFileDialog`, `ColorDialog`, `FontDialog`, `SelectFolderDialog`, `AboutDialog`, etc.
- `Dialog.ShowModalAsync(CancellationToken)` / `Dialog<T>.ShowModalAsync(CancellationToken)`.

Semantics:
- With **no token** (or a non-cancellable one), the dialog is simply shown asynchronously on every platform — the native modal loop keeps the UI responsive while the returned task is awaited.
- With a **cancellable token**, the platform handler must support cancellation; if it can't, a `NotSupportedException` is thrown.
- An already-cancelled token short-circuits and never shows the dialog.
- A user-initiated close (which may carry a `Dialog<T>.Result`) completes the task normally; the task only faults with `OperationCanceledException` when the **token** closed it.

Shared orchestration lives in `AsyncModalDialog`: it posts the blocking `ShowDialog` onto the UI thread (where the native modal loop pumps) and invokes the handler's cancel callback — while it's showing — to break that loop when the token is signalled.

## Windows: WH_CBT hook

The original draft of this PR used a hidden dummy owner form because there was no reliable way to identify the native dialog to dismiss it. That's replaced with a cleaner approach:

Just before the blocking `ShowDialog` call, a thread-local **`WH_CBT`** hook is installed (`Win32.ModalDialogHook`). It captures the dialog's window handle on first `HCBT_ACTIVATE`, then unhooks itself. Cancellation posts `WM_CLOSE` to that exact handle — so the right dialog is dismissed unambiguously even when several are open, with no host/owner window and no flicker. Handlers compose this via the small `Win32.CancellableModalDialog` helper.

This covers, on both **WinForms** and **WPF**: `MessageBox`, `ColorDialog`, `FontDialog`,  `OpenFileDialog`/`SaveFileDialog`, and `SelectFolderDialog`.

Managed/themed dialogs that aren't native windows (`ThemedAboutDialogHandler`, and on WPF after the Xceed removal, `ThemedColorDialogHandler` / `ThemedFontDialogHandler`) are made cancellable by simply closing the underlying Eto `Dialog` — no native interop needed.

## Platform status

- **GTK** — manually tested, works as expected.
- **WinForms / WPF** — manually tested, works as expected.
- **Mac / iOS / Android** — preliminary and largely untested; `ShowDialogAsync` on these should be considered a starting point, not finished.

## Not supported

- `OpenWithDialog` on Windows remains a fire-and-forget shell launch (`rundll32 OpenAs_RunDLL`), so it doesn't support cancellation. (`SHOpenWithDialog` was evaluated but on Windows 11 it's a UWP picker that can't distinguish select from cancel, although it does block until the dialog closes.) The async API surfaces this as `NotSupportedException`, which the test harness catches and logs.