### PR TITLE
Improve RadioButton Click event implementation

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -121,6 +121,7 @@
 			"request": "launch",
 			"preLaunchTask": "build-winforms",
             "program": "${workspaceFolder}/artifacts/test/Eto.Test.WinForms/${config:var.configuration}/net48/Eto.Test.WinForms.exe",
+			"targetArchitecture": "x86_64",
             "args": [],
             "console": "internalConsole",
             "internalConsoleOptions": "openOnSessionStart",

--- a/src/Eto.Android/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Android/Forms/Controls/RadioButtonHandler.cs
@@ -49,6 +49,8 @@ namespace Eto.Android.Forms.Controls
 					item.Checked = (item.ControlObject == sender);
 				}
 			}
+
+			Callback.OnClick(Widget, EventArgs.Empty);
 		}
 	}
 }

--- a/src/Eto.Android/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Android/Forms/Controls/RadioButtonHandler.cs
@@ -32,12 +32,17 @@ namespace Eto.Android.Forms.Controls
 				{
 					controllerInner.group = new List<RadioButton>();
 					controllerInner.group.Add(controller);
-					controllerInner.Control.Click += controllerInner.control_RadioSwitch;
 				}
 
-				controllerInner.group.Add(Widget);
-				Control.Click += controllerInner.control_RadioSwitch;
+				group = controllerInner.group;
+				group.Add(Widget);
 			}
+			else
+			{
+				group = new List<RadioButton> { Widget };
+			}
+
+			Control.Click += control_RadioSwitch;
 		}
 
 		private void control_RadioSwitch(object sender, EventArgs e)
@@ -50,7 +55,8 @@ namespace Eto.Android.Forms.Controls
 				}
 			}
 
-			Callback.OnClick(Widget, EventArgs.Empty);
+			if (ReferenceEquals(sender, Control))
+				Callback.OnClick(Widget, EventArgs.Empty);
 		}
 	}
 }

--- a/src/Eto.Gtk/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/RadioButtonHandler.cs
@@ -62,7 +62,12 @@ namespace Eto.GtkSharp.Forms.Controls
 
 			public void HandleCheckedChanged(object sender, EventArgs e) => Handler?.Callback.OnCheckedChanged(Handler.Widget, EventArgs.Empty);
 
-			public void HandleClick(object sender, EventArgs e) => Handler?.Callback.OnClick(Handler.Widget, EventArgs.Empty);
+			public void HandleClick(object sender, EventArgs e)
+			{
+				// GTK raises Clicked when other grouped radios are unchecked; only fire for the active (user-clicked) one.
+				if (Handler?.Control?.Active == true)
+					Handler.Callback.OnClick(Handler.Widget, EventArgs.Empty);
+			}
 
 			internal void Control_Realized(object sender, EventArgs e) => Handler?.Control_Realized(sender, e);
 		}

--- a/src/Eto.Gtk/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/RadioButtonHandler.cs
@@ -25,7 +25,7 @@ namespace Eto.GtkSharp.Forms.Controls
 			_label.UseUnderline = true;
 			Control.Add(_label);
 			Control.Realized += Connector.Control_Realized;
-
+			Control.Clicked += Connector.HandleClick;
 			Control.Toggled += Connector.HandleCheckedChanged;
 			_box = new Gtk.EventBox();
 			_box.Child = Control;
@@ -61,6 +61,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			public new RadioButtonHandler Handler { get { return (RadioButtonHandler)base.Handler; } }
 
 			public void HandleCheckedChanged(object sender, EventArgs e) => Handler?.Callback.OnCheckedChanged(Handler.Widget, EventArgs.Empty);
+
+			public void HandleClick(object sender, EventArgs e) => Handler?.Callback.OnClick(Handler.Widget, EventArgs.Empty);
 
 			internal void Control_Realized(object sender, EventArgs e) => Handler?.Control_Realized(sender, e);
 		}

--- a/src/Eto.WinForms/Forms/Controls/RadioButton.cs
+++ b/src/Eto.WinForms/Forms/Controls/RadioButton.cs
@@ -32,6 +32,7 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			if (Enabled)
 				SetChecked(true);
+			Callback.OnClick(Widget, EventArgs.Empty);
 		}
 
 		public void Create(RadioButton controller)

--- a/src/Eto.WinForms/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/RadioButtonHandler.cs
@@ -6,10 +6,6 @@ namespace Eto.WinForms.Forms.Controls
 
 		public class EtoRadioButton : swf.RadioButton
 		{
-			public EtoRadioButton()
-			{
-				this.SetStyle(swf.ControlStyles.StandardClick | swf.ControlStyles.StandardDoubleClick, true);
-			}
 		}
 
 		public RadioButtonHandler()

--- a/src/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
@@ -27,6 +27,7 @@ namespace Eto.Wpf.Forms.Controls
 			Control.Loaded += Control_Loaded;
 			Control.Checked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 			Control.Unchecked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
+			Control.Click += (sender, e) => Callback.OnClick(Widget, EventArgs.Empty);
 
 			_border = new EtoBorder { Handler = this, Child = Control };
 		}

--- a/src/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
@@ -27,7 +27,12 @@ namespace Eto.Wpf.Forms.Controls
 			Control.Loaded += Control_Loaded;
 			Control.Checked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 			Control.Unchecked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
-			Control.Click += (sender, e) => Callback.OnClick(Widget, EventArgs.Empty);
+			Control.Click += (sender, e) =>
+			{
+				// Only raise Click for the radio just checked; WPF routes Click when others uncheck.
+				if (Control.IsChecked == true)
+					Callback.OnClick(Widget, EventArgs.Empty);
+			};
 
 			_border = new EtoBorder { Handler = this, Child = Control };
 		}

--- a/src/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/RadioButtonHandler.cs
@@ -27,12 +27,7 @@ namespace Eto.Wpf.Forms.Controls
 			Control.Loaded += Control_Loaded;
 			Control.Checked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
 			Control.Unchecked += (sender, e) => Callback.OnCheckedChanged(Widget, EventArgs.Empty);
-			Control.Click += (sender, e) =>
-			{
-				// Only raise Click for the radio just checked; WPF routes Click when others uncheck.
-				if (Control.IsChecked == true)
-					Callback.OnClick(Widget, EventArgs.Empty);
-			};
+			Control.Click += (sender, e) => Callback.OnClick(Widget, EventArgs.Empty);
 
 			_border = new EtoBorder { Handler = this, Child = Control };
 		}

--- a/src/Eto.iOS/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.iOS/Forms/Controls/RadioButtonHandler.cs
@@ -25,7 +25,11 @@ namespace Eto.iOS.Forms.Controls
 		{
 			base.Initialize();
 			Control.ShowsTouchWhenHighlighted = false;
-			Control.TouchUpInside += (sender, e) => ApplicationHandler.Instance.AsyncInvoke(() => Checked = true);
+			Control.TouchUpInside += (sender, e) => ApplicationHandler.Instance.AsyncInvoke(() =>
+			{
+				Checked = true;
+				Callback.OnClick(Widget, EventArgs.Empty);
+			});
 		}
 
 		public bool Checked

--- a/test/Eto.Test/Sections/Controls/RadioButtonSection.cs
+++ b/test/Eto.Test/Sections/Controls/RadioButtonSection.cs
@@ -80,7 +80,17 @@
 		{
 			control.CheckedChanged += delegate
 			{
-				Log.Write(control, "CheckedChanged, Value: {0}, Checked: {1}", control.Text, control.Checked);
+				Log.Write(control, $"CheckedChanged, Value: {control.Text}, Checked: {control.Checked}");
+			};
+
+			control.Click += delegate
+			{
+				Log.Write(control, $"Click, {control.Text}");
+			};
+			
+			control.MouseDoubleClick += delegate
+			{
+				Log.Write(control, $"MouseDoubleClick, {control.Text}");
 			};
 		}
 	}


### PR DESCRIPTION
RadioButton is documented to have a [Click event](https://pages.picoe.ca/docs/api/html/E_Eto_Forms_RadioButton_Click.htm), but it apparently wasn't wired up on platforms other than macOS.

Expected behavior: triggers once on every click on the radio button, even if it's already checked.

- [x] WinForms: tested, but for unknown reasons the event triggers twice (I could not determine the reason in a reasonable timeframe and gave up on it)
- [x] Wpf: tested, working
- [x] Gtk: tested, working
- [ ] iOS: not tested
- [ ] macOS: not tested (existing handler unchanged)
- [ ] Android: not tested