### PR TITLE
Allow more overrides in Eto and Eto.macOS

### DIFF
--- a/src/Eto.Mac/Eto.macOS.csproj
+++ b/src/Eto.Mac/Eto.macOS.csproj
@@ -8,7 +8,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefaultItemExcludes>$(DefaultItemExcludes);build\*</DefaultItemExcludes>
     <NoWarn>$(NoWarn);CA1416;CS8981;NETSDK1202</NoWarn>
-    <SupportedOSPlatformVersion>12.0</SupportedOSPlatformVersion>
+    <SupportedOSPlatformVersion Condition="$(SupportedOSPlatformVersion) == ''">12.0</SupportedOSPlatformVersion>
   </PropertyGroup>
   <ItemGroup>
     <Using Include="AppKit" />

--- a/src/Eto/Eto.csproj
+++ b/src/Eto/Eto.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-  	<TargetFrameworks>netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
+	  <TargetFrameworks Condition="$(TargetFrameworkOverride) == ''">netstandard2.0;net6.0;net8.0;net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(TargetFrameworkOverride) != ''">$(TargetFrameworkOverride)</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <TreatWarningsAsErrors Condition="$(Configuration) == 'Release'">true</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
This allows one to compile e.g. if you want to include it in a project that doesn't yet support .NET 10 SDK.