### PR TITLE
Unbind commands to handle long lived command instances

### DIFF
--- a/src/Eto/Forms/Controls/Button.cs
+++ b/src/Eto/Forms/Controls/Button.cs
@@ -237,6 +237,14 @@ public class Button : TextControl, IMnemonicControl
 			OnClick(EventArgs.Empty);
 	}
 
+	/// <inheritdoc/>
+	public override void Unbind()
+	{
+		base.Unbind();
+
+		Properties.UnbindCommand(Command_Key);
+	}
+
 	static readonly object callback = new Callback();
 		
 	/// <inheritdoc/>

--- a/src/Eto/Forms/Controls/LinkButton.cs
+++ b/src/Eto/Forms/Controls/LinkButton.cs
@@ -75,6 +75,14 @@ public class LinkButton : TextControl
 		set { Handler.DisabledTextColor = value; }
 	}
 
+	/// <inheritdoc/>
+	public override void Unbind()
+	{
+		base.Unbind();
+
+		Properties.UnbindCommand(Command_Key);
+	}
+
 	static readonly object callback = new Callback();
 	/// <summary>
 	/// Gets an instance of an object used to perform callbacks to the widget from handler implementations

--- a/src/Eto/Forms/Controls/RadioButton.cs
+++ b/src/Eto/Forms/Controls/RadioButton.cs
@@ -117,6 +117,14 @@ public class RadioButton : TextControl, IMnemonicControl
 		set => Handler.AlwaysShowMnemonic = value;
 	}
 
+	/// <inheritdoc/>
+	public override void Unbind()
+	{
+		base.Unbind();
+
+		Properties.UnbindCommand(Command_Key);
+	}
+
 	/// <summary>
 	/// Callback interface for the <see cref="RadioButton"/>
 	/// </summary>

--- a/src/Eto/Forms/Menu/MenuItem.cs
+++ b/src/Eto/Forms/Menu/MenuItem.cs
@@ -265,6 +265,14 @@ public abstract class MenuItem : Menu, ICommandItem
 		OnValidate(EventArgs.Empty);
 	}
 
+	/// <inheritdoc/>
+	public override void Unbind()
+	{
+		base.Unbind();
+
+		Properties.UnbindCommand(Command_Key);
+	}
+
 	/// <summary>
 	/// Callback interface for the <see cref="MenuItem"/>
 	/// </summary>

--- a/src/Eto/Forms/SegmentedButton/SegmentedItem.cs
+++ b/src/Eto/Forms/SegmentedButton/SegmentedItem.cs
@@ -188,6 +188,14 @@ public abstract class SegmentedItem : BindableWidget
 		set { Properties.Set(CommandParameter_Key, value, () => Properties.UpdateCommandCanExecute(Command_Key)); }
 	}
 
+	/// <inheritdoc/>
+	public override void Unbind()
+	{
+		base.Unbind();
+
+		Properties.UnbindCommand(Command_Key);
+	}
+
 	#region Events
 
 	/// <summary>

--- a/src/Eto/Forms/ToolBar/ToolItem.cs
+++ b/src/Eto/Forms/ToolBar/ToolItem.cs
@@ -142,6 +142,14 @@ public abstract class ToolItem : Tool, ICommandItem
 	/// <value>The user-defined tag.</value>
 	public object Tag { get; set; }
 
+	/// <inheritdoc/>
+	public override void Unbind()
+	{
+		base.Unbind();
+
+		Properties.UnbindCommand(Command_Key);
+	}
+
 	/// <summary>
 	/// Handler interface for the <see cref="ToolItem"/>.
 	/// </summary>

--- a/src/Eto/PropertyStore.cs
+++ b/src/Eto/PropertyStore.cs
@@ -437,6 +437,24 @@ public class PropertyStore : Dictionary<object, object>
 	}
 
 	/// <summary>
+	/// Unbinds the command associated with the specified key, removing its registration.
+	/// </summary>
+	/// <remarks>
+	/// If the command associated with the specified key is found, it will be unregistered, allowing for
+	/// cleanup of resources or state related to the command.
+	/// </remarks>
+	/// <param name="key">The key used to identify the command to be unbound. Cannot be null.</param>
+	public void UnbindCommand(object key)
+	{
+		var cmd = Get<CommandWrapper>(key);
+		if (cmd != null)
+		{
+			cmd.Unregister();
+		}
+	}
+
+
+	/// <summary>
 	/// Updates the command's execute status, typically when the CommandParameter changes.
 	/// </summary>
 	/// <param name="key">Key of the command to execute.</param>


### PR DESCRIPTION
If your command instances were long lived, they would be bound to the change events causing a memory leak of the control.

Unbinding happens when disposing of a control, or when calling a control (or parent control's) `Unbind()` method.