### PR TITLE
Prevents Invalidate for non-visible and disposed items

### DIFF
--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -768,6 +768,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// </remarks>
 	public void Invalidate()
 	{
+		if (IsDisposed || !Visible) return;
 		Handler.Invalidate(true);
 	}
 
@@ -780,6 +781,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// <param name="invalidateChildren"><c>True</c> to invalidate all children, <c>false</c> to only invalidate the container</param>
 	public void Invalidate(bool invalidateChildren)
 	{
+		if (IsDisposed || !Visible) return;
 		Handler.Invalidate(invalidateChildren);
 	}
 
@@ -792,6 +794,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// <param name="rect">Rectangle to repaint</param>
 	public void Invalidate(Rectangle rect)
 	{
+		if (IsDisposed || !Visible) return;
 		Handler.Invalidate(rect, true);
 	}
 
@@ -805,6 +808,7 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 	/// <param name="invalidateChildren"><c>True</c> to invalidate all children, <c>false</c> to only invalidate the container</param>
 	public void Invalidate(Rectangle rect, bool invalidateChildren)
 	{
+		if (IsDisposed || !Visible) return;
 		Handler.Invalidate(rect, invalidateChildren);
 	}
 


### PR DESCRIPTION
This fixes a crash for me and I know Invalidate is never useful for Disposed or invisible items, so explicitly preventing this seems smart to me.