### PR TITLE
WinForms: Fix RichTextArea.SetItalic()

### DIFF
--- a/src/Eto.WinForms/Forms/Controls/RichTextAreaHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/RichTextAreaHandler.cs
@@ -99,9 +99,9 @@ namespace Eto.WinForms.Forms.Controls
 		{
 			SetAttribute(range, () => SelectionBold = bold);
 		}
-		public void SetItalic(Range<int> range, bool bold)
+		public void SetItalic(Range<int> range, bool italic)
 		{
-			SetAttribute(range, () => SelectionBold = bold);
+			SetAttribute(range, () => SelectionItalic = italic);
 		}
 		public void SetUnderline(Range<int> range, bool bold)
 		{


### PR DESCRIPTION
Calling `RichTextArea.SetItalic()` on WinForms set the bold state, not the italic state.