### PR TITLE
Add advanced binding conversion APIs and ManyToSingle helper

### DIFF
--- a/src/Eto/Forms/Binding/BindableExtensions.cs
+++ b/src/Eto/Forms/Binding/BindableExtensions.cs
@@ -39,7 +39,7 @@ public static class BindableExtensions
 	{
 		var binding = new DualBinding<T>(
 			sourceBinding,
-			new BindableBinding<IBindable,T>(bindable, Binding.Property<T>(widgetPropertyName)),
+			new BindableBinding<IBindable, T>(bindable, Binding.Property<T>(widgetPropertyName)),
 			mode
 		);
 		bindable.Bindings.Add(binding);
@@ -77,7 +77,7 @@ public static class BindableExtensions
 	/// <param name="mode">Mode of the binding</param>
 	public static DualBinding<T> Bind<T>(this IBindable bindable, IndirectBinding<T> controlBinding, DirectBinding<T> valueBinding, DualBindingMode mode = DualBindingMode.TwoWay)
 	{
-		var binding = new BindableBinding<IBindable,T>(bindable, controlBinding);
+		var binding = new BindableBinding<IBindable, T>(bindable, controlBinding);
 		return binding.Bind(sourceBinding: valueBinding, mode: mode);
 	}
 
@@ -93,7 +93,7 @@ public static class BindableExtensions
 	/// <param name="defaultContextValue">Default context value to set to the control, if the objectValue or value of the objectBinding is null.</param>
 	public static DualBinding<T> Bind<T>(this IBindable bindable, IndirectBinding<T> controlBinding, object objectValue, IndirectBinding<T> objectBinding, DualBindingMode mode = DualBindingMode.TwoWay, T defaultControlValue = default(T), T defaultContextValue = default(T))
 	{
-		var valueBinding = new ObjectBinding<object,T>(objectValue, objectBinding) {
+		var valueBinding = new ObjectBinding<object, T>(objectValue, objectBinding) {
 			SettingNullValue = defaultContextValue,
 			GettingNullValue = defaultControlValue
 		};
@@ -216,7 +216,7 @@ public static class BindableExtensions
 	/// <param name="binding">Binding to invert.</param>
 	/// <typeparam name="T">The type of the bindable object.</typeparam>
 	public static BindableBinding<T, bool?> Inverse<T>(this BindableBinding<T, bool?> binding)
-		where T: IBindable
+		where T : IBindable
 	{
 		return binding.Convert(c => !c, c => !c);
 	}
@@ -228,7 +228,7 @@ public static class BindableExtensions
 	/// <param name="binding">Binding to invert.</param>
 	/// <typeparam name="T">The type of the bindable object.</typeparam>
 	public static BindableBinding<T, bool> Inverse<T>(this BindableBinding<T, bool> binding)
-		where T: IBindable
+		where T : IBindable
 	{
 		return binding.Convert(c => !c, c => !c);
 	}
@@ -262,8 +262,8 @@ public static class BindableExtensions
 	/// <typeparam name="T">The type of the bindable object.</typeparam>
 	/// <typeparam name="TValue">The value type to convert from nullable to non-nullable.</typeparam>
 	public static BindableBinding<T, TValue> DefaultIfNull<T, TValue>(this BindableBinding<T, TValue?> binding, TValue? defaultValue = null)
-		where T: IBindable
-		where TValue: struct
+		where T : IBindable
+		where TValue : struct
 	{
 		return binding.Convert(c => c ?? defaultValue ?? default(TValue), c => c);
 	}
@@ -281,5 +281,47 @@ public static class BindableExtensions
 		where TValue : class
 	{
 		return binding.Convert(c => c ?? defaultValue, c => c);
+	}
+
+	/// <summary>
+	/// Converts a binding of an enumerable of items to a single value by using the provided <paramref name="getValue"/> function to get the value from each item, and if there are multiple items with different values, returns the specified <paramref name="mixedValue"/>.
+	/// When setting the value, it will use the provided <paramref name="setValue"/> function to set the value for each item in the enumerable.
+	/// </summary>
+	/// <typeparam name="T">The type of the items in the enumerable.</typeparam>
+	/// <typeparam name="TValue">The type of the value to extract from each item.</typeparam>
+	/// <param name="binding">The binding of the enumerable of items.</param>
+	/// <param name="getValue">A function to get the value from each item.</param>
+	/// <param name="setValue">A function to set the value for each item.</param>
+	/// <param name="mixedValue">The default value to return if there are multiple different values.</param>
+	/// <returns>A binding that represents a single value extracted from the enumerable.</returns>
+	public static IndirectBinding<TValue> ManyToSingle<T, TValue>(this IndirectBinding<IEnumerable<T>> binding, Func<T, TValue> getValue, Action<T, TValue> setValue = null, TValue mixedValue = default)
+	{
+		return binding.Convert(c =>
+		{
+			TValue result = default;
+			bool first = true;
+			foreach (var item in c)
+			{
+				var value = getValue(item);
+				if (first)
+				{
+					result = value;
+					first = false;
+				}
+				else if (Comparer<TValue>.Default.Compare(result, value) != 0)
+				{
+					result = mixedValue;
+					break;
+				}
+			}
+			return result;
+		},
+		(c, v) =>
+		{
+			foreach (var item in c)
+			{
+				setValue(item, v);
+			}
+		});
 	}
 }

--- a/src/Eto/Forms/Binding/BindingChangedEventArgs.cs
+++ b/src/Eto/Forms/Binding/BindingChangedEventArgs.cs
@@ -13,6 +13,12 @@ public class BindingChangedEventArgs : EventArgs
 	public object Value => InternalValue;
 
 	internal virtual object InternalValue { get; set; }
+	
+	/// <summary>
+	/// Gets or sets the update mode for this change event
+	/// This is used to determine if the change is being set to the source or target of the binding
+	/// </summary>
+	public BindingUpdateMode? UpdateMode { get; internal set; }
 
 	/// <summary>
 	/// Initializes a new instance of the BindingChangedEventArgs with the specified value
@@ -20,7 +26,18 @@ public class BindingChangedEventArgs : EventArgs
 	/// <param name="value">value that the binding was set to</param>
 	public BindingChangedEventArgs(object value)
 	{
-		this.InternalValue = value;
+		InternalValue = value;
+	}
+	
+	/// <summary>
+	/// Initializes a new instance of the BindingChangedEventArgs with the specified value and update mode
+	/// </summary>
+	/// <param name="value">value that the binding was set to</param>
+	/// <param name="updateMode">update mode for this change event</param>
+	public BindingChangedEventArgs(object value, BindingUpdateMode? updateMode)
+	{
+		InternalValue = value;
+		UpdateMode = updateMode;
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/Binding/BindingChangingEventArgs.cs
+++ b/src/Eto/Forms/Binding/BindingChangingEventArgs.cs
@@ -21,6 +21,12 @@ public class BindingChangingEventArgs : CancelEventArgs
 	}
 
 	internal virtual object InternalValue { get; set; }
+	
+	/// <summary>
+	/// Gets or sets the update mode for this change event
+	/// This is used to determine if the change is being set to the source or target of the binding
+	/// </summary>
+	public BindingUpdateMode? UpdateMode { get; internal set; }
 
 	/// <summary>
 	/// Initializes a new instance of the BindingChangingEventArgs with the specifid value
@@ -28,7 +34,18 @@ public class BindingChangingEventArgs : CancelEventArgs
 	/// <param name="value"></param>
 	public BindingChangingEventArgs(object value)
 	{
-		this.Value = value;
+		Value = value;
+	}
+	
+	/// <summary>
+	/// Initializes a new instance of the BindingChangingEventArgs with the specified value and update mode
+	/// </summary>
+	/// <param name="value">value that the binding is being set to</param>
+	/// <param name="updateMode">update mode for this change event</param>
+	public BindingChangingEventArgs(object value, BindingUpdateMode? updateMode)
+	{
+		Value = value;
+		UpdateMode = updateMode;
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/Binding/DirectBinding.cs
+++ b/src/Eto/Forms/Binding/DirectBinding.cs
@@ -84,6 +84,49 @@ public abstract class DirectBinding<T> : Binding
 	}
 
 	/// <summary>
+	/// Converts this binding's value to another value using delegates.
+	/// </summary>
+	/// <remarks>
+	/// This differs from <see cref="Convert{TValue}(Func{T, TValue}, Func{TValue, T})"/> in that it allows the 
+	/// set value delegate to have access to the original parent value, which can be useful when needing to call
+	/// a method of the parent binding instead of converting the value directly, or performing other logic.
+	/// </remarks>
+	/// <typeparam name="TValue">The type of the value for the new binding.</typeparam>
+	/// <param name="getValue">Delegate to get the value from the original binding's type.</param>
+	/// <param name="setValue">Delegate to set the value to the original binding's type.</param>
+	/// <returns>A new binding with the specified <typeparamref name="TValue"/> type.</returns>
+	public DirectBinding<TValue> Convert<TValue>(Func<T, TValue> getValue, Action<T, TValue> setValue)
+	{
+		return new DelegateBinding<TValue>(
+			() => getValue != null ? getValue(DataValue) : default(TValue),
+			r => setValue?.Invoke(DataValue, r),
+			addChangeEvent: ev => DataValueChanged += ev,
+			removeChangeEvent: ev => DataValueChanged -= ev
+		);
+	}
+	
+	/// <summary>
+	/// Converts this binding's value to another value using an <see cref="IValueConverter"/>.
+	/// </summary>
+	/// <typeparam name="TValue">The type of the value for the new binding.</typeparam>
+	/// <param name="converter">The value converter to use.</param>
+	/// <param name="conveterParameter">An optional parameter to pass to the converter.</param>
+	/// <param name="culture">An optional culture to use for the conversion.</param>
+	/// <returns>A new binding with the specified <typeparamref name="TValue"/> type.</returns>
+	/// <exception cref="ArgumentNullException"></exception>
+	public DirectBinding<TValue> Convert<TValue>(IValueConverter converter, object conveterParameter = null, CultureInfo culture = null)
+	{
+		if (converter == null)
+			throw new ArgumentNullException(nameof(converter));
+		return new DelegateBinding<TValue>(
+			() => (TValue)converter.Convert(DataValue, typeof(TValue), conveterParameter, culture),
+			r => DataValue = (T)converter.ConvertBack(r, typeof(T), conveterParameter, culture),
+			addChangeEvent: ev => DataValueChanged += ev,
+			removeChangeEvent: ev => DataValueChanged -= ev
+		);
+	}
+
+	/// <summary>
 	/// Casts this binding value to another (compatible) type.
 	/// </summary>
 	/// <typeparam name="TValue">The type to cast the values of this binding to.</typeparam>

--- a/src/Eto/Forms/Binding/DualBinding.cs
+++ b/src/Eto/Forms/Binding/DualBinding.cs
@@ -166,12 +166,12 @@ public class DualBinding<T> : Binding
 		{
 			channeling = true;
 			var value = Destination.DataValue;
-			var args = new BindingChangingEventArgs(value);
+			var args = new BindingChangingEventArgs(value, BindingUpdateMode.Source);
 			OnChanging(args);
 			if (!args.Cancel)
 			{
 				Source.DataValue = value;
-				OnChanged(new BindingChangedEventArgs(value));
+				OnChanged(new BindingChangedEventArgs(value, BindingUpdateMode.Source));
 			}
 			channeling = false;
 		}
@@ -186,12 +186,12 @@ public class DualBinding<T> : Binding
 		{
 			channeling = true;
 			var value = Source.DataValue;
-			var args = new BindingChangingEventArgs(value);
+			var args = new BindingChangingEventArgs(value, BindingUpdateMode.Destination);
 			OnChanging(args);
 			if (!args.Cancel)
 			{
 				Destination.DataValue = value;
-				OnChanged(new BindingChangedEventArgs(value));
+				OnChanged(new BindingChangedEventArgs(value, BindingUpdateMode.Destination));
 			}
 			channeling = false;
 		}

--- a/src/Eto/Forms/Binding/IndirectBinding.cs
+++ b/src/Eto/Forms/Binding/IndirectBinding.cs
@@ -148,6 +148,28 @@ public abstract class IndirectBinding<T> : Binding, IIndirectBinding<T>
 	}
 
 	/// <summary>
+	/// Converts this binding's value to another value using delegates.
+	/// </summary>
+	/// <remarks>
+	/// This differs from <see cref="Convert{TValue}(Func{T, TValue}, Func{TValue, T})"/> in that it allows the 
+	/// set value delegate to have access to the original parent value, which can be useful when needing to call
+	/// a method of the parent binding instead of converting the value directly, or performing other logic.
+	/// </remarks>
+	/// <typeparam name="TValue">The type to convert to.</typeparam>
+	/// <param name="getValue">Delegate to get the value from the original binding's type.</param>
+	/// <param name="setValue">Delegate to set the value to the original binding's type.</param>
+	/// <returns>A new binding that will be converted using the specified delegates.</returns>
+	public IndirectBinding<TValue> Convert<TValue>(Func<T, TValue> getValue, Action<T, TValue> setValue)
+	{
+		return new DelegateBinding<object, TValue>(
+			m => getValue != null ? getValue(GetValue(m)) : default(TValue),
+			(m, val) => { if (setValue != null) setValue(GetValue(m), val); },
+			addChangeEvent: AddValueChangedHandler,
+			removeChangeEvent: RemoveValueChangedHandler
+		);
+	}
+
+	/// <summary>
 	/// Converts the binding using the specified <paramref name="converter"/> object.
 	/// </summary>
 	/// <returns>A new binding that will be converted using the specified IValueConverter.</returns>

--- a/test/Eto.Test/UnitTests/Forms/Bindings/DirectBindingConversionTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Bindings/DirectBindingConversionTests.cs
@@ -1,0 +1,85 @@
+using System.Globalization;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Bindings;
+
+class TrackingConverter : IValueConverter
+{
+	public object LastConvertValue { get; private set; }
+	public Type LastConvertTargetType { get; private set; }
+	public object LastConvertParameter { get; private set; }
+	public CultureInfo LastConvertCulture { get; private set; }
+	public object LastConvertBackValue { get; private set; }
+	public Type LastConvertBackTargetType { get; private set; }
+	public object LastConvertBackParameter { get; private set; }
+	public CultureInfo LastConvertBackCulture { get; private set; }
+
+	public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+	{
+		LastConvertValue = value;
+		LastConvertTargetType = targetType;
+		LastConvertParameter = parameter;
+		LastConvertCulture = culture;
+
+		var delta = System.Convert.ToInt32(parameter, CultureInfo.InvariantCulture);
+		var converted = System.Convert.ToInt32(value, CultureInfo.InvariantCulture) + delta;
+
+		if (targetType == typeof(string))
+			return converted.ToString(culture);
+		if (targetType == typeof(double))
+			return (double)converted;
+
+		return converted;
+	}
+
+	public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+	{
+		LastConvertBackValue = value;
+		LastConvertBackTargetType = targetType;
+		LastConvertBackParameter = parameter;
+		LastConvertBackCulture = culture;
+
+		var delta = System.Convert.ToInt32(parameter, CultureInfo.InvariantCulture);
+		var converted = System.Convert.ToInt32(value, CultureInfo.InvariantCulture) - delta;
+
+		if (targetType == typeof(string))
+			return converted.ToString(culture);
+		if (targetType == typeof(double))
+			return (double)converted;
+
+		return converted;
+	}
+}
+
+[TestFixture]
+public class DirectBindingConversionTests
+{
+	[Test]
+	public void ConvertWithConverterShouldRoundTrip()
+	{
+		var item = new BindObject { IntProperty = 7 };
+		var converter = new TrackingConverter();
+		var culture = CultureInfo.GetCultureInfo("fr-FR");
+		var binding = Binding.Property(item, r => r.IntProperty).Convert<string>(converter, conveterParameter: 3, culture: culture);
+
+		Assert.That(binding.DataValue, Is.EqualTo("10"));
+		Assert.That(converter.LastConvertTargetType, Is.EqualTo(typeof(string)));
+		Assert.That(converter.LastConvertParameter, Is.EqualTo(3));
+		Assert.That(converter.LastConvertCulture, Is.EqualTo(culture));
+
+		binding.DataValue = "11";
+		Assert.That(item.IntProperty, Is.EqualTo(8));
+		Assert.That(converter.LastConvertBackTargetType, Is.EqualTo(typeof(int)));
+		Assert.That(converter.LastConvertBackParameter, Is.EqualTo(3));
+		Assert.That(converter.LastConvertBackCulture, Is.EqualTo(culture));
+	}
+
+	[Test]
+	public void ConvertWithNullConverterShouldThrow()
+	{
+		var item = new BindObject { IntProperty = 7 };
+		var binding = Binding.Property(item, r => r.IntProperty);
+
+		Assert.Throws<ArgumentNullException>(() => binding.Convert<string>((IValueConverter)null));
+	}
+}

--- a/test/Eto.Test/UnitTests/Forms/Bindings/IndirectBindingConversionTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Bindings/IndirectBindingConversionTests.cs
@@ -1,0 +1,39 @@
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Bindings;
+
+[TestFixture]
+public class IndirectBindingConversionTests
+{
+	[Test]
+	public void ConvertWithGenericConverterShouldUseInvariantCultureByDefault()
+	{
+		var item = new BindObject { IntProperty = 7 };
+		var converter = new TrackingConverter();
+		var binding = Binding.Property((BindObject r) => r.IntProperty).Convert<string>(converter, conveterParameter: 4);
+
+		Assert.That(binding.GetValue(item), Is.EqualTo("11"));
+		Assert.That(converter.LastConvertTargetType, Is.EqualTo(typeof(string)));
+		Assert.That(converter.LastConvertCulture, Is.EqualTo(CultureInfo.InvariantCulture));
+
+		binding.SetValue(item, "15");
+		Assert.That(item.IntProperty, Is.EqualTo(11));
+		Assert.That(converter.LastConvertBackTargetType, Is.EqualTo(typeof(int)));
+		Assert.That(converter.LastConvertBackCulture, Is.EqualTo(CultureInfo.InvariantCulture));
+	}
+
+	[Test]
+	public void ConvertWithExplicitPropertyTypeShouldUseConverterType()
+	{
+		var item = new BindObject { IntProperty = 7 };
+		var converter = new TrackingConverter();
+		var binding = Binding.Property((BindObject r) => r.IntProperty).Convert(converter, typeof(double), conveterParameter: 2);
+
+		Assert.That(binding.GetValue(item), Is.EqualTo(9d));
+		Assert.That(converter.LastConvertTargetType, Is.EqualTo(typeof(double)));
+
+		binding.SetValue(item, 13d);
+		Assert.That(item.IntProperty, Is.EqualTo(11));
+		Assert.That(converter.LastConvertBackTargetType, Is.EqualTo(typeof(int)));
+	}
+}

--- a/test/Eto.Test/UnitTests/Forms/Bindings/ManyToSingleBindingTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Bindings/ManyToSingleBindingTests.cs
@@ -1,0 +1,63 @@
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Bindings;
+
+[TestFixture]
+public class ManyToSingleBindingTests
+{
+	class ManyItem
+	{
+		public int Value { get; set; }
+	}
+
+	class ManyContainer
+	{
+		public IEnumerable<ManyItem> Items { get; set; }
+	}
+
+	[Test]
+	public void ManyToSingleShouldReturnSingleOrMixedValue()
+	{
+		var binding = Binding.Property((ManyContainer c) => c.Items).ManyToSingle(i => i.Value, mixedValue: -1);
+
+		var sameValues = new ManyContainer
+		{
+			Items = new[]
+			{
+				new ManyItem { Value = 2 },
+				new ManyItem { Value = 2 }
+			}
+		};
+
+		var mixedValues = new ManyContainer
+		{
+			Items = new[]
+			{
+				new ManyItem { Value = 2 },
+				new ManyItem { Value = 3 }
+			}
+		};
+
+		Assert.That(binding.GetValue(sameValues), Is.EqualTo(2));
+		Assert.That(binding.GetValue(mixedValues), Is.EqualTo(-1));
+	}
+
+	[Test]
+	public void ManyToSingleShouldSetValueForEachItem()
+	{
+		var binding = Binding.Property((ManyContainer c) => c.Items).ManyToSingle(
+			getValue: i => i.Value,
+			setValue: (i, v) => i.Value = v
+		);
+
+		var item1 = new ManyItem { Value = 1 };
+		var item2 = new ManyItem { Value = 2 };
+		var data = new ManyContainer { Items = new[] { item1, item2 } };
+
+		binding.SetValue(data, 9);
+
+		Assert.That(item1.Value, Is.EqualTo(9));
+		Assert.That(item2.Value, Is.EqualTo(9));
+		Assert.That(binding.GetValue(data), Is.EqualTo(9));
+	}
+}


### PR DESCRIPTION
- Add DirectBinding.Convert overloads for parent-aware setter delegates and IValueConverter
- Add IndirectBinding.Convert overload with parent-aware setter delegates
- Add BindableExtensions.ManyToSingle to project many values into one mixed/single value binding
- Add UpdateMode to BindingChanged/BindingChanging args and set it in DualBinding sync paths
- Add unit tests for direct/indirect conversion behavior and ManyToSingle semantics