### PR TITLE
Wpf/WinForms: Fix Clipboard.Html

### DIFF
--- a/src/Eto.Wpf/Forms/ClipboardHandler.cs
+++ b/src/Eto.Wpf/Forms/ClipboardHandler.cs
@@ -3,6 +3,12 @@ namespace Eto.Wpf.Forms
 {
 	public class ClipboardHandler : DataObjectHandler<Clipboard, Clipboard.ICallback>, Clipboard.IHandler
 	{
+		const string CfHtmlVersion = "Version:0.9";
+		const string StartHtmlPrefix = "StartHTML:";
+		const string EndHtmlPrefix = "EndHTML:";
+		const string StartFragmentPrefix = "StartFragment:";
+		const string EndFragmentPrefix = "EndFragment:";
+
 		public ClipboardHandler()
 		{
 			Control = new sw.DataObject();
@@ -54,8 +60,18 @@ namespace Eto.Wpf.Forms
 
 		public override string Html
 		{
-			get { return Retry(() => sw.Clipboard.ContainsText(sw.TextDataFormat.Html) ? sw.Clipboard.GetText(sw.TextDataFormat.Html) : null); }
-			set => base.Html = value;
+			get
+			{
+				return Retry(() =>
+				{
+					if (!sw.Clipboard.ContainsText(sw.TextDataFormat.Html))
+						return null;
+
+					var html = sw.Clipboard.GetText(sw.TextDataFormat.Html);
+					return FromClipboardHtmlFormat(html);
+				});
+			}
+			set => base.Html = ToClipboardHtmlFormat(value);
 		}
 
 		public DataObject DataObject
@@ -79,5 +95,116 @@ namespace Eto.Wpf.Forms
 		protected override StringCollection InnerGetFileDropList() => Retry(() => sw.Clipboard.GetFileDropList());
 
 		protected override object InnerGetData(string type) => Retry(() => sw.Clipboard.GetData(type));
+
+		static string FromClipboardHtmlFormat(string html)
+		{
+			if (string.IsNullOrEmpty(html))
+				return html;
+
+			if (!html.StartsWith("Version:", StringComparison.OrdinalIgnoreCase))
+				return html;
+
+			var htmlStart = FindOffset(html, StartHtmlPrefix);
+			var htmlEnd = FindOffset(html, EndHtmlPrefix);
+			if (htmlStart >= 0 && htmlEnd > htmlStart && htmlEnd <= html.Length)
+				return html.Substring(htmlStart, htmlEnd - htmlStart);
+
+			var fragmentStart = FindOffset(html, StartFragmentPrefix);
+			var fragmentEnd = FindOffset(html, EndFragmentPrefix);
+			if (fragmentStart >= 0 && fragmentEnd > fragmentStart && fragmentEnd <= html.Length)
+			{
+				var fragment = html.Substring(fragmentStart, fragmentEnd - fragmentStart);
+				return "<html><body>" + fragment + "</body></html>";
+			}
+
+			return html;
+		}
+
+		static string ToClipboardHtmlFormat(string html)
+		{
+			if (string.IsNullOrEmpty(html))
+				return html;
+
+			if (html.StartsWith("Version:", StringComparison.OrdinalIgnoreCase))
+				return html;
+
+			var fragment = html;
+			if (html.IndexOf("<html", StringComparison.OrdinalIgnoreCase) >= 0)
+			{
+				var startMarkerIndex = html.IndexOf("<!--StartFragment-->", StringComparison.OrdinalIgnoreCase);
+				var endMarkerIndex = html.IndexOf("<!--EndFragment-->", StringComparison.OrdinalIgnoreCase);
+				if (startMarkerIndex >= 0 && endMarkerIndex > startMarkerIndex)
+				{
+					startMarkerIndex += "<!--StartFragment-->".Length;
+					fragment = html.Substring(startMarkerIndex, endMarkerIndex - startMarkerIndex);
+				}
+			}
+			else
+			{
+				html = "<html><body><!--StartFragment-->" + html + "<!--EndFragment--></body></html>";
+			}
+
+			const string startMarker = "<!--StartFragment-->";
+			const string endMarker = "<!--EndFragment-->";
+			var startFragment = html.IndexOf(startMarker, StringComparison.OrdinalIgnoreCase);
+			if (startFragment < 0)
+			{
+				var bodyIndex = html.IndexOf("<body", StringComparison.OrdinalIgnoreCase);
+				if (bodyIndex >= 0)
+				{
+					var bodyEnd = html.IndexOf('>', bodyIndex);
+					if (bodyEnd >= 0)
+					{
+						html = html.Insert(bodyEnd + 1, startMarker).Insert(html.IndexOf("</body>", StringComparison.OrdinalIgnoreCase), endMarker);
+						startFragment = html.IndexOf(startMarker, StringComparison.OrdinalIgnoreCase);
+					}
+				}
+			}
+
+			if (startFragment < 0)
+			{
+				html = "<html><body>" + startMarker + fragment + endMarker + "</body></html>";
+				startFragment = html.IndexOf(startMarker, StringComparison.Ordinal);
+			}
+
+			var endFragment = html.IndexOf(endMarker, StringComparison.OrdinalIgnoreCase);
+			var header =
+				$"{CfHtmlVersion}\r\n" +
+				$"{StartHtmlPrefix}0000000000\r\n" +
+				$"{EndHtmlPrefix}0000000000\r\n" +
+				$"{StartFragmentPrefix}0000000000\r\n" +
+				$"{EndFragmentPrefix}0000000000\r\n";
+
+			var startHtml = header.Length;
+			var endHtml = startHtml + html.Length;
+			var startFragmentOffset = startHtml + startFragment + startMarker.Length;
+			var endFragmentOffset = startHtml + endFragment;
+
+			var fixedHeader =
+				$"{CfHtmlVersion}\r\n" +
+				$"{StartHtmlPrefix}{startHtml:D10}\r\n" +
+				$"{EndHtmlPrefix}{endHtml:D10}\r\n" +
+				$"{StartFragmentPrefix}{startFragmentOffset:D10}\r\n" +
+				$"{EndFragmentPrefix}{endFragmentOffset:D10}\r\n";
+
+			return fixedHeader + html;
+		}
+
+		static int FindOffset(string html, string prefix)
+		{
+			var index = html.IndexOf(prefix, StringComparison.OrdinalIgnoreCase);
+			if (index < 0)
+				return -1;
+
+			index += prefix.Length;
+			var end = index;
+			while (end < html.Length && char.IsDigit(html[end]))
+				end++;
+
+			if (end == index)
+				return -1;
+
+			return int.TryParse(html.Substring(index, end - index), out var offset) ? offset : -1;
+		}
 	}
 }

--- a/test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
@@ -56,8 +56,8 @@ namespace Eto.Test.Sections.Behaviors
 				Items =
 				{
 					new StackLayout
-					{ 
-						Orientation = Orientation.Horizontal, 
+					{
+						Orientation = Orientation.Horizontal,
 						Spacing = 5,
 						Padding = new Padding(10),
 						Items = { copyTextButton, copyHtmlButton, copyImageButton, copyCustomButton, copyObjectButton, pasteTextButton, clearButton }
@@ -66,34 +66,36 @@ namespace Eto.Test.Sections.Behaviors
 				}
 			};
 		}
+		
+		TextArea ReadOnlyTextArea(string text) => new TextArea { Text = text, ReadOnly = true, Border = BorderType.None, BackgroundColor = Colors.Transparent };
 
 		void Update()
 		{
 			using var clipboard = new Clipboard();
-			var panel = new StackLayout { Padding = new Padding(10) };
+			var panel = new StackLayout { Padding = new Padding(10), HorizontalContentAlignment = HorizontalAlignment.Stretch, Spacing = 5 };
 			if (clipboard.Text != null)
 			{
 				panel.Items.Add(new Label { Text = "\nText:", Font = SystemFonts.Bold() });
-				panel.Items.Add(clipboard.Text);
+				panel.Items.Add(ReadOnlyTextArea(clipboard.Text));
 			}
 			if (clipboard.Image != null)
 			{
 				panel.Items.Add(new Label { Text = "\nImage:", Font = SystemFonts.Bold() });
 				panel.Items.Add(new ImageView
-					{
-						Image = clipboard.Image
-					});
+				{
+					Image = clipboard.Image
+				});
 			}
 			if (clipboard.Html != null)
 			{
 				panel.Items.Add(new Label { Text = "\nHtml:", Font = SystemFonts.Bold() });
-				panel.Items.Add(clipboard.Html);
+				panel.Items.Add(ReadOnlyTextArea(clipboard.Html));
 			}
 			var uris = clipboard.Uris;
 			if (uris != null)
 			{
 				panel.Items.Add(new Label { Text = "\nUris:", Font = SystemFonts.Bold() });
-				panel.Items.Add(string.Join(", ", uris.Select(r => r.AbsoluteUri)));
+				panel.Items.Add(ReadOnlyTextArea(string.Join(", ", uris.Select(r => r.AbsoluteUri))));
 			}
 
 			var types = clipboard.Types;
@@ -102,23 +104,47 @@ namespace Eto.Test.Sections.Behaviors
 				foreach (var type in types)
 				{
 					panel.Items.Add(new Label { Text = $"\n{type}:", Font = SystemFonts.Bold() });
-					var data = clipboard.GetData(type);
-					if (data != null)
+					string str = null;
+					byte[] data = null;
+					try
 					{
-						panel.Items.Add($"- Data, Length: {data.Length}");
-						var hexString = BitConverter.ToString(data);
-						panel.Items.Add(hexString.Substring(0, Math.Min(hexString.Length, 1000)));
+						str = clipboard.GetString(type);
+						if (str != null)
+						{
+							panel.Items.Add($"- String, Length: {str.Length}");
+							panel.Items.Add(ReadOnlyTextArea(str));
+						}
 					}
-					var str = clipboard.GetString(type);
-					if (str != null)
+					catch (Exception ex)
 					{
-						panel.Items.Add($"- String, Length: {str.Length}");
-						panel.Items.Add(str);
+						panel.Items.Add($"- Error getting string: {ex.Message}");
 					}
-					var obj = clipboard.GetObject(type);
-					if (obj != null)
+					try
 					{
-						panel.Items.Add($"- Object, Type: {obj.GetType()}: {obj}");
+						data = clipboard.GetData(type);
+						if (data != null)
+						{
+							panel.Items.Add($"- Data, Length: {data.Length}");
+							var hexString = BitConverter.ToString(data);
+							panel.Items.Add(ReadOnlyTextArea(hexString.Substring(0, Math.Min(hexString.Length, 1000))));
+						}
+					}
+					catch (Exception ex)
+					{
+						panel.Items.Add($"- Error getting data: {ex.Message}");
+					}
+					try
+					{
+						var obj = clipboard.GetObject(type);
+						if (obj != null && str == null && data == null)
+						{
+							panel.Items.Add($"- Object, Type: {obj.GetType()}:");
+							panel.Items.Add(ReadOnlyTextArea(obj.ToString()));
+						}
+					}
+					catch (Exception ex)
+					{
+						panel.Items.Add($"- Error getting object: {ex.Message}");
 					}
 				}
 			}

--- a/test/Eto.Test/UnitTests/Forms/ClipboardTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ClipboardTests.cs
@@ -183,7 +183,18 @@ namespace Eto.Test.UnitTests.Forms
 				case DataType.Html:
 					Assert.That(dataObject.ContainsHtml, Is.True);
 					Assert.That(dataObject.Html, Is.Not.Null);
-					Assert.That(dataObject.Html, Is.EqualTo(SampleHtml));
+					if (IsClipboard)
+					{
+						Assert.That(dataObject.Html, Does.Contain(SampleHtml));
+						Assert.That(dataObject.Html, Does.Not.Contain("StartHTML:"));
+						Assert.That(dataObject.Html, Does.Not.Contain("EndHTML:"));
+						Assert.That(dataObject.Html, Does.Not.Contain("StartFragment:"));
+						Assert.That(dataObject.Html, Does.Not.Contain("EndFragment:"));
+					}
+					else
+					{
+						Assert.That(dataObject.Html, Is.EqualTo(SampleHtml));
+					}
 					break;
 				//case DataType.Icon:
 				//Assert.That(dataObject.Image, Is.Not.Null);


### PR DESCRIPTION
This fixes the Clipboard.Html to support the windows-specific CF_HTML format, and return the undecorated HTML with Eto's APIs.