### PR TITLE
Fix GTK GroupBox to adhere to user-preferred size

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/GroupBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GroupBoxHandler.cs
@@ -4,7 +4,7 @@ namespace Eto.GtkSharp.Forms.Controls
 	{
 		public GroupBoxHandler ()
 		{
-			Control = new Gtk.Frame ();
+			Control = new EtoFrame { Handler = this };
 		}
 
 		protected override Gtk.Widget FontControl => Control.LabelWidget ?? new Gtk.Label();

--- a/src/Eto.Gtk/Forms/EtoControls.cs
+++ b/src/Eto.Gtk/Forms/EtoControls.cs
@@ -10,11 +10,25 @@ namespace Eto.GtkSharp.Forms
             get => _handler?.Target as IGtkControl;
             set => _handler = new WeakReference(value);
         }
-
-#if GTK3
+        
+#if GTK3        
         protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)
         {
             base.OnGetPreferredWidth(out minimum_width, out natural_width);
+            var h = Handler;
+            if (h != null)
+            {
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Width > 0)
+                    natural_width = userPreferredSize.Width;
+
+                minimum_width = Math.Min(natural_width, minimum_width);
+            }
+        }
+        
+        protected override void OnGetPreferredWidthForHeight(int height, out int minimum_width, out int natural_width)
+        {
+            base.OnGetPreferredWidthForHeight(height, out minimum_width, out natural_width);
             var h = Handler;
             if (h != null)
             {
@@ -40,10 +54,53 @@ namespace Eto.GtkSharp.Forms
             }
         }
 
+		protected override void OnGetPreferredHeightForWidth(int width, out int minimum_height, out int natural_height)
+		{
+			base.OnGetPreferredHeightForWidth(width, out minimum_height, out natural_height);
+            var h = Handler;
+            if (h != null)
+            {
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Height > 0)
+                    natural_height = userPreferredSize.Height;
+
+                minimum_height = Math.Min(natural_height, minimum_height);
+            }
+		}
+        
+        protected override void OnAdjustSizeAllocation(Gtk.Orientation orientation, out int minimum_size, out int natural_size, out int allocated_pos, out int allocated_size)
+        {
+            base.OnAdjustSizeAllocation(orientation, out minimum_size, out natural_size, out allocated_pos, out allocated_size);
+            var h = Handler;
+            if (h != null)
+            {
+                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.UserPreferredSize.Width : h.UserPreferredSize.Height;
+
+                if (preferredSize > 0)
+                    natural_size = preferredSize;
+
+                minimum_size = Math.Min(natural_size, minimum_size);
+            }
+        }
+
+        protected override void OnAdjustSizeRequest(Gtk.Orientation orientation, out int minimum_size, out int natural_size)
+        {
+            base.OnAdjustSizeRequest(orientation, out minimum_size, out natural_size);
+            var h = Handler;
+            if (h != null)
+            {
+                var preferredSize = orientation == Gtk.Orientation.Horizontal ? h.UserPreferredSize.Width : h.UserPreferredSize.Height;
+
+                if (preferredSize > 0)
+                    natural_size = preferredSize;
+
+                minimum_size = Math.Min(natural_size, minimum_size);
+            }
+        }
 #endif
 
     }
-
+    
     public partial class EtoFixed : Gtk.Fixed
     {
         WeakReference _handler;

--- a/src/Eto.Gtk/Forms/EtoControls.cs
+++ b/src/Eto.Gtk/Forms/EtoControls.cs
@@ -2,6 +2,48 @@
 using Eto;
 namespace Eto.GtkSharp.Forms
 {
+    public partial class EtoFrame : Gtk.Frame
+    {
+        WeakReference _handler;
+        public IGtkControl Handler
+        {
+            get => _handler?.Target as IGtkControl;
+            set => _handler = new WeakReference(value);
+        }
+
+#if GTK3
+        protected override void OnGetPreferredWidth(out int minimum_width, out int natural_width)
+        {
+            base.OnGetPreferredWidth(out minimum_width, out natural_width);
+            var h = Handler;
+            if (h != null)
+            {
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Width > 0)
+                    natural_width = userPreferredSize.Width;
+
+                minimum_width = Math.Min(natural_width, minimum_width);
+            }
+        }
+
+        protected override void OnGetPreferredHeight(out int minimum_height, out int natural_height)
+        {
+            base.OnGetPreferredHeight(out minimum_height, out natural_height);
+            var h = Handler;
+            if (h != null)
+            {
+                var userPreferredSize = h.UserPreferredSize;
+                if (userPreferredSize.Height > 0)
+                    natural_height = userPreferredSize.Height;
+
+                minimum_height = Math.Min(natural_height, minimum_height);
+            }
+        }
+
+#endif
+
+    }
+
     public partial class EtoFixed : Gtk.Fixed
     {
         WeakReference _handler;

--- a/src/Eto.Gtk/Forms/EtoControls.tt
+++ b/src/Eto.Gtk/Forms/EtoControls.tt
@@ -9,7 +9,7 @@ using Eto;
 namespace Eto.GtkSharp.Forms
 {
 <#
-var controls = new[] { "Fixed", "EventBox", "Box", "ScrolledWindow" };
+var controls = new[] { "Frame", "Fixed", "EventBox", "Box", "ScrolledWindow" };
 
 foreach (var control in controls)
 {


### PR DESCRIPTION
**Description**  
Fixes a GTK issue where `GroupBox` could expand beyond its explicit size if a child control had a larger preferred width.

**Change**  
- `GroupBoxHandler`: use `EtoFrame { Handler = this }` instead of plain `Gtk.Frame`
- Add minimal `EtoFrame` wrapper applying `UserPreferredSize` in:
  - `OnGetPreferredWidth`
  - `OnGetPreferredHeight`

**Result**  
Explicit GroupBox size is preserved; oversized children no longer force GroupBox width growth.