### PR TITLE
Fix broken WithSize on GTK due to image size caching

### DIFF
--- a/src/Eto/Drawing/Icon.cs
+++ b/src/Eto/Drawing/Icon.cs
@@ -205,7 +205,7 @@ public class Icon : Image
 		float lastScale = 0;
 		foreach (var frame in Frames.OrderBy(r => r.Scale).ThenByDescending(r => r.Size.Width * r.Size.Height))
 		{
-			var ps = Size.Ceiling((SizeF)Size * scale);
+			var ps = Size.Ceiling((SizeF)Handler.Size * scale);
 			var pixelSizeNeeded = ps.Width * ps.Height;
 			var diff = scale - frame.Scale;
 			if (selected == null || (diff < scaleDiff && (diff >= 0 || scaleDiff > 0)))


### PR DESCRIPTION
The WithSize logic was broken on GTK because of the image size cache. During construction of a new icon, the image size could change *after* it had already been accessed and cached, leading to inconsistent or outdated size information.

This commit changes icon construction to fetch the current (non-cached) size directly from the size handler instead of relying on the potentially stale cached value.

The issue can be observed/reproduced using the existing unit test:
  ImageSizeShouldUpdateImageViewSize

https://github.com/picoe/Eto/blob/c426ea7bb32945a4d7db3384e0ed2fef293ae60d/src/Eto.Gtk/Drawing/IconHandler.cs#L179