### PR TITLE
WPF: Fix issue with scrollable controls when used in a AutoSize window

### DIFF
--- a/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
+++ b/src/Eto.Wpf/Forms/Cells/CustomCellHandler.cs
@@ -37,6 +37,7 @@ namespace Eto.Wpf.Forms.Cells
 				var focused = grid?.IsKeyboardFocusWithin != false;
 				CellTextColor = selected && focused 
 					? (cell.GetResourceColor("TextOnAccentFillColorPrimaryBrush", sw.SystemColors.HighlightTextColorKey, sw.SystemColors.HighlightTextBrushKey) ?? Eto.Drawing.SystemColors.HighlightText) 
+					: selected ? (cell.GetResourceColor("TextOnAccentFillColorPrimaryBrush", sw.SystemColors.ControlTextColorKey, sw.SystemColors.ControlTextBrushKey) ?? Eto.Drawing.SystemColors.ControlText)
 					: (cell.GetResourceColor("TextFillColorPrimaryBrush", sw.SystemColors.ControlTextColorKey, sw.SystemColors.ControlTextBrushKey) ?? Eto.Drawing.SystemColors.ControlText);
 			}
 			public void SetRow(sw.FrameworkElement element)

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -23,7 +23,7 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
 		}
-
+		
 		protected override void OnPreviewKeyDown(swi.KeyEventArgs e)
 		{
 			base.OnPreviewKeyDown(e);
@@ -47,7 +47,7 @@ namespace Eto.Wpf.Forms.Controls
 			Loaded += EtoDataGrid_Loaded;
 		}
 
-				private void EtoDataGrid_Loaded(object sender, sw.RoutedEventArgs e)
+		private void EtoDataGrid_Loaded(object sender, sw.RoutedEventArgs e)
 		{
 			var scp = this.FindChild<swc.ScrollContentPresenter>();
 			if (scp != null) scp.RequestBringIntoView += OnRequestBringIntoView;
@@ -127,6 +127,7 @@ namespace Eto.Wpf.Forms.Controls
 		protected override sw.Size DefaultSize => new sw.Size(100, 100);
 		public override bool UseMousePreview => true;
 		public override bool UseKeyPreview => true;
+		protected override bool ContainsScrollViewer => true;
 
 		protected GridHandler()
 		{
@@ -1054,7 +1055,7 @@ namespace Eto.Wpf.Forms.Controls
 			var scrollViewer = ScrollViewer;
 			if (scrollViewer == null)
 				return;
-				
+
 			void ScrollWithIncrement(bool fast, double increment)
 			{
 				var now = DateTime.Now;
@@ -1063,7 +1064,7 @@ namespace Eto.Wpf.Forms.Controls
 					startDragOverTime = now;
 					return;
 				}
-				
+
 				var diff = now - startDragOverTime;
 				if (diff > TimeSpan.FromSeconds(fast ? DragScrollFastDelay : DragScrollDelay))
 				{
@@ -1092,7 +1093,7 @@ namespace Eto.Wpf.Forms.Controls
 				var child = scrollViewer.FindChild<swcp.ScrollBar>("PART_HorizontalScrollBar");
 				height -= child.ActualHeight;
 			}
-			
+
 			if (args.Location.Y > height - DragScrollSize)
 			{
 				ScrollWithIncrement(args.Location.Y > height - DragScrollFastSize, 1);

--- a/src/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
@@ -12,7 +12,7 @@ namespace Eto.Wpf.Forms.Controls
 	}
 
 	public class TextAreaHandler : TextAreaHandler<EtoTextBox, TextArea, TextArea.ICallback>
-	{
+	{		
 		public override string Text
 		{
 			get { return Control.Text; }
@@ -100,6 +100,8 @@ namespace Eto.Wpf.Forms.Controls
 		protected override sw.Size DefaultSize => new sw.Size(100, 60);
 
 		protected override bool PreventUserResize { get { return true; } }
+		
+		protected override bool ContainsScrollViewer => true;		
 
 		public TextAreaHandler()
 		{

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -110,12 +110,24 @@ namespace Eto.Wpf.Forms
 				return hwnd != null ? hwnd.Handle : IntPtr.Zero;
 			}
 		}
+		
+		protected virtual bool ContainsScrollViewer => false;
 
 		public virtual sw.Size MeasureOverride(sw.Size constraint, Func<sw.Size, sw.Size> measure)
 		{
 			// enforce eto-style sizing to wpf controls
 			var size = UserPreferredSize;
 			var control = ContainerControl;
+
+			if (ContainsScrollViewer)
+			{
+				// enclosed scrollable does not size appropriately on Arrange, so we need to 
+				// constrain the size here to prevent it from using the available space incorrectly.
+				if (!double.IsPositiveInfinity(constraint.Width) && size.Width >= 0 && size.Width < constraint.Width)
+					constraint.Width = size.Width;
+				if (!double.IsPositiveInfinity(constraint.Height) && size.Height >= 0 && size.Height < constraint.Height)
+					constraint.Height = size.Height;
+			}
 
 			// Constrain content to the preferred size of this control, if specified.
 			var desired = measure(constraint.IfInfinity(size.InfinityIfNan()));

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
@@ -21,7 +21,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			ManualForm("Start editing a cell, then press Escape to cancel editing", form =>
 			{
 				form.Size = new Size(300, 200);
-				
+
 				var grid = new T();
 				grid.ShowHeader = true;
 				grid.AllowMultipleSelection = true;
@@ -660,5 +660,28 @@ namespace Eto.Test.UnitTests.Forms.Controls
 
 
 		}
+
+		[Test, ManualTest]
+		public void GridInAutosizedWindowShouldShowContentCorrectly() => ManualForm("Grid should show the vertical scrollbar correctly", form =>
+		{
+			form.Resizable = true;
+			form.AutoSize = true;
+
+			var grid = new T();
+			grid.ShowHeader = false;
+			grid.Size = new Size(300, 200);
+
+			grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell { Binding = Binding.Property((GridTestItem m) => m.Text) }, AutoSize = true });
+			grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(0), Expand = true, AutoSize = true });
+
+			var list = new TreeGridItemCollection();
+			for (int i = 0; i < 100; i++)
+			{
+				list.Add(new GridTestItem { Text = $"Item {i}", Values = new[] { $"col {i}.2", $"col {i}.3", $"col {i}.4", $"col {i}.5" } });
+			}
+			SetDataStore(grid, list);
+
+			return grid;
+		});
 	}
 }


### PR DESCRIPTION
When Window.AutoSize is set, the availableSize passed to MeasureOverride is set to the available screen size.  When you have set a specific user preferred size of the control, the scroll viewer would be clipped and be positioned outside of the control.  So, we need to pass the preferred size to the base MeasureOverride() so that the scroll viewer gets set up correctly.