### PR TITLE
Mac: Adjust MouseDownCanMoveWindow for Drawable

### DIFF
--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -7,9 +7,17 @@ namespace Eto.Mac.Forms.Controls
 		Brush backgroundBrush;
 		Color backgroundColor;
 
+		static readonly object MouseDownCanMoveWindow_Key = new object();
+
 		public bool SupportsCreateGraphics => false;
 
 		public override NSView ContainerControl => Control;
+		
+		public bool? MouseDownCanMoveWindow
+		{
+			get => Widget.Properties.Get<bool?>(MouseDownCanMoveWindow_Key);
+			set => Widget.Properties.Set(MouseDownCanMoveWindow_Key, value);
+		}
 
 		public class EtoDrawableView : MacPanelView
 		{
@@ -37,6 +45,22 @@ namespace Eto.Mac.Forms.Controls
 			// public override bool IsFlipped => true;  // uncomment to test flipped views with GraphicsHandler.
 
 			public bool CanFocus { get; set; }
+
+			public override bool MouseDownCanMoveWindow
+			{
+				get
+				{
+					if (Handler is DrawableHandler drawableHandler)
+					{
+						var canMove = drawableHandler.MouseDownCanMoveWindow;
+						if (canMove.HasValue)
+							return canMove.Value;
+					}
+					if (AcceptsFirstResponder() || AcceptsFirstMouse(NSApplication.SharedApplication.CurrentEvent))
+						return false;
+					return base.MouseDownCanMoveWindow;
+				}
+			}
 
 			public override bool AcceptsFirstResponder() => CanFocus && Drawable?.Enabled == true;
 

--- a/test/Eto.Test/UnitTests/Forms/WindowTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/WindowTests.cs
@@ -567,4 +567,29 @@ public abstract class WindowTests<T> : TestBase
 		popup.Show();
 	}
 	);
+
+	[Test]
+	[ManualTest]
+	public void DrawableWithHandledMouseDownShouldNotMoveWindowWithMovableByWindowBackground() => ManualTest(
+		"Click and drag on the blue area to move the window.\nIt should NOT move.",
+		form =>
+		{
+			form.Owner = Application.Instance.MainForm;
+			form.MovableByWindowBackground = true;
+			form.Padding = 20;
+			form.Size = new Size(400, 300);
+			var drawable = new Drawable
+			{
+				BackgroundColor = Colors.Blue,
+				Size = new Size(400, 300),
+				CanFocus = true
+			};
+
+			drawable.MouseDown += (sender, e) =>
+			{
+				e.Handled = true;
+			};
+
+			return drawable;
+		});
 }


### PR DESCRIPTION
Returns False when Drawable.CanFocus is set, and also added ability to set it on the handler explicitly for styling.