### PR TITLE
Enhance NumericMaskedTextStepper

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/NumericStepperHandler.cs
@@ -293,5 +293,19 @@ namespace Eto.GtkSharp.Forms.Controls
 			get => Control.Wrap;
 			set => Control.Wrap = value;
 		}
+		
+		public TextAlignment TextAlignment
+		{
+			get => Control.Alignment < 0.5f ? TextAlignment.Left
+						  : Control.Alignment > 0.5f ? TextAlignment.Right
+						  : TextAlignment.Center;
+			set => Control.Alignment = value switch
+			{
+				TextAlignment.Left => 0,
+				TextAlignment.Center => 0.5f,
+				TextAlignment.Right => 1,
+				_ => throw new NotSupportedException(),
+			};
+		}
 	}
 }

--- a/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextBoxHandler.cs
@@ -456,30 +456,16 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public TextAlignment TextAlignment
 		{
-			get
-			{
-				return Control.Alignment < 0.5f ? TextAlignment.Left
+			get => Control.Alignment < 0.5f ? TextAlignment.Left
 						  : Control.Alignment > 0.5f ? TextAlignment.Right
 						  : TextAlignment.Center;
-			}
-			set
+			set => Control.Alignment = value switch
 			{
-				switch (value)
-				{
-					case TextAlignment.Left:
-						Control.Alignment = 0;
-						break;
-					case TextAlignment.Center:
-						Control.Alignment = 0.5f;
-						break;
-					case TextAlignment.Right:
-						Control.Alignment = 1;
-						break;
-					default:
-						throw new NotSupportedException();
-				}
-
-			}
+				TextAlignment.Left => 0,
+				TextAlignment.Center => 0.5f,
+				TextAlignment.Right => 1,
+				_ => throw new NotSupportedException(),
+			};
 		}
 
 		public override bool ShowBorder

--- a/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
@@ -602,5 +602,11 @@ namespace Eto.Mac.Forms.Controls
 			get => Stepper.ValueWraps;
 			set => Stepper.ValueWraps = value;
 		}
+		
+		public TextAlignment TextAlignment
+		{
+			get => TextField.Alignment.ToEto();
+			set => TextField.Alignment = value.ToNS();
+		}
 	}
 }

--- a/src/Eto.WinForms/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/NumericStepperHandler.cs
@@ -380,5 +380,11 @@ namespace Eto.WinForms.Forms.Controls
 			Control.DecimalPlaces = Math.Max(Math.Min(GetNumberOfDigits(), MaximumDecimalPlaces), DecimalPlaces);
 			Control.UpdateText();
 		}
+
+		public TextAlignment TextAlignment
+		{
+			get => Control.TextAlign.ToEto();
+			set => Control.TextAlign = value.ToSWF();
+		}
 	}
 }

--- a/src/Eto.WinUI/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.WinUI/Forms/Controls/NumericStepperHandler.cs
@@ -50,6 +50,12 @@ public class NumericStepperHandler : WinUIBorderedControl<muc.NumberBox, Numeric
 		get => Control.IsWrapEnabled;
 		set => Control.IsWrapEnabled = value;
 	}
+	public TextAlignment TextAlignment
+	{
+		get => TextBox.TextAlignment.ToEto();
+		set => TextBox.TextAlignment = value.ToWinUI();
+	}
+	
 	public Color TextColor { get; set; }
 	public Font Font { get; set; }
 

--- a/src/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextStepperHandler.cs
@@ -22,6 +22,8 @@ namespace Eto.Wpf.Forms.Controls
 			};
 		}
 
+		protected override sw.Size DefaultSize => new sw.Size(120, double.NaN);
+		
 		public override sw.FrameworkElement TabControl => WatermarkTextBox;
 
 		public override string PlaceholderText

--- a/src/Eto.Wpf/Forms/Controls/WpfListItemHelper.cs
+++ b/src/Eto.Wpf/Forms/Controls/WpfListItemHelper.cs
@@ -102,6 +102,7 @@ namespace Eto.Wpf.Forms.Controls
 			AppendChild(image);
 
 			var text = new WpfTextBindingBlock(textBinding);
+			text.SetValue(sw.FrameworkElement.VerticalAlignmentProperty, sw.VerticalAlignment.Center);
 			text.SetValue(swc.Grid.ColumnProperty, 1);
 			AppendChild(text);
 		}

--- a/src/Eto.Wpf/themes/fluent.xaml
+++ b/src/Eto.Wpf/themes/fluent.xaml
@@ -14,6 +14,10 @@
     <!-- Override border brush for Eto controls to use the Fluent theme color that adapts to dark/light mode -->
     <SolidColorBrush x:Key="EtoBorderBezelBrush" Color="{DynamicResource ControlStrokeColorDefault}" />
 
+    <Style TargetType="efc:EtoSearchTextBox" BasedOn="{StaticResource EtoSearchTextBox}">
+		<Setter Property="Padding" Value="4" />
+	</Style>
+
 </ResourceDictionary>
 
 

--- a/src/Eto.Wpf/themes/fluent/ButtonSpinner.xaml
+++ b/src/Eto.Wpf/themes/fluent/ButtonSpinner.xaml
@@ -71,7 +71,7 @@
         <Setter Property="FocusVisualStyle" Value="{x:Null}" />
         <Setter Property="Margin" Value="2" />
         <Setter Property="Padding" Value="4" />
-        <Setter Property="Height" Value="22" />
+		<Setter Property="MinHeight" Value="20" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type RepeatButton}">
@@ -106,7 +106,7 @@
         <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
-        <Setter Property="Padding" Value="6,4" />
+        <Setter Property="Padding" Value="4,2" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
         <Setter Property="SnapsToDevicePixels" Value="True" />

--- a/src/Eto.Wpf/themes/fluent/WatermarkTextBox.xaml
+++ b/src/Eto.Wpf/themes/fluent/WatermarkTextBox.xaml
@@ -17,7 +17,7 @@
         <Setter Property="Background" Value="{DynamicResource TextControlBackground}" />
         <Setter Property="BorderBrush" Value="{DynamicResource TextControlElevationBorderBrush}" />
         <Setter Property="BorderThickness" Value="{DynamicResource TextControlBorderThemeThickness}" />
-        <Setter Property="Padding" Value="6,4" />
+        <Setter Property="Padding" Value="4,4" />
         <Setter Property="ScrollViewer.PanningMode" Value="VerticalFirst" />
         <Setter Property="Stylus.IsFlicksEnabled" Value="False" />
         <Setter Property="SnapsToDevicePixels" Value="True" />

--- a/src/Eto.Wpf/themes/generic.xaml
+++ b/src/Eto.Wpf/themes/generic.xaml
@@ -75,6 +75,11 @@
 	</Style>
 	<Style TargetType="efc:EtoExpander" BasedOn="{StaticResource {x:Type Expander}}">
 	</Style>
+	
+	<Style TargetType="PasswordBox" BasedOn="{StaticResource {x:Type PasswordBox}}">
+		<Setter Property="Padding" Value="4,2" />
+		<Setter Property="VerticalContentAlignment" Value="Center" />
+	</Style>
 
 
 </ResourceDictionary>

--- a/src/Eto.Wpf/themes/generic/ButtonSpinner.xaml
+++ b/src/Eto.Wpf/themes/generic/ButtonSpinner.xaml
@@ -87,7 +87,7 @@
         <Setter Property="BorderThickness" Value="1" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="VerticalContentAlignment" Value="Stretch" />
-        <Setter Property="Padding" Value="3" />
+        <Setter Property="Padding" Value="2,2" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="{x:Type efc:EtoButtonSpinner}">

--- a/src/Eto.Wpf/themes/generic/SearchTextBox.xaml
+++ b/src/Eto.Wpf/themes/generic/SearchTextBox.xaml
@@ -10,7 +10,8 @@
         <ResourceDictionary Source="WatermarkTextBox.xaml" />
     </ResourceDictionary.MergedDictionaries>
 
-    <Style TargetType="efc:EtoSearchTextBox" BasedOn="{StaticResource WatermarkTextBox}">
+    <Style x:Key="EtoSearchTextBox" TargetType="efc:EtoSearchTextBox" BasedOn="{StaticResource WatermarkTextBox}">
+		<Setter Property="Padding" Value="4,2" />
         <Setter Property="Template">
             <Setter.Value>
                 <ControlTemplate TargetType="efc:EtoSearchTextBox">
@@ -128,6 +129,9 @@
                 </ControlTemplate>
             </Setter.Value>
         </Setter>
+    </Style>
+
+    <Style TargetType="efc:EtoSearchTextBox" BasedOn="{StaticResource EtoSearchTextBox}">
     </Style>
 
 

--- a/src/Eto.Wpf/themes/generic/WatermarkTextBox.xaml
+++ b/src/Eto.Wpf/themes/generic/WatermarkTextBox.xaml
@@ -10,6 +10,7 @@
 
         <ContentControl Content="{Binding}"
                     Foreground="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}"
+					Margin="2,0"
                     Focusable="False" />
     </DataTemplate>
 

--- a/src/Eto/Forms/Controls/CheckBoxList.cs
+++ b/src/Eto/Forms/Controls/CheckBoxList.cs
@@ -26,7 +26,7 @@ public class CheckBoxList : Panel
 	Orientation orientation;
 	ItemDataStore dataStore;
 	readonly List<CheckBox> buttons = new List<CheckBox>();
-	Size spacing = new Size(0, 0);
+	Size spacing = new Size(2, 2);
 	bool settingChecked;
 
 	/// <summary>

--- a/src/Eto/Forms/Controls/MaskedTextStepper.cs
+++ b/src/Eto/Forms/Controls/MaskedTextStepper.cs
@@ -1,82 +1,6 @@
+
 namespace Eto.Forms;
 
-/// <summary>
-/// Masked text box with a variable length numeric mask.
-/// </summary>
-/// <remarks>
-/// This provides a text box that limits the user input to only allow numeric values.
-/// </remarks>
-/// <typeparam name="T">Numeric type such as int, decimal, double, etc.</typeparam>
-public class NumericMaskedTextStepper<T> : MaskedTextStepper<T>
-{
-	/// <summary>
-	/// Gets the numeric provider.
-	/// </summary>
-	/// <value>The masked text provider.</value>
-	public new NumericMaskedTextProvider<T> Provider => (NumericMaskedTextProvider<T>)base.Provider;
-
-	/// <summary>
-	/// Gets or sets a value indicating whether the mask can accept a sign.
-	/// </summary>
-	/// <remarks>
-	/// This defaults to whether the type specified by <typeparamref name="T"/> allows negative values.
-	/// </remarks>
-	/// <value><c>true</c> to allow sign character; otherwise, <c>false</c>.</value>
-	public bool AllowSign
-	{
-		get { return Provider.AllowSign; }
-		set { Provider.AllowSign = value; }
-	}
-
-	/// <summary>
-	/// Gets or sets a value indicating whether the mask can input a decimal.
-	/// </summary>
-	/// <remarks>
-	/// This defaults to whether the type specified by <typeparamref name="T"/> allows decimals, such as when
-	/// it is a decimal, double, or float.
-	/// </remarks>
-	/// <value><c>true</c> to allow decimal; otherwise, <c>false</c>.</value>
-	public bool AllowDecimal
-	{
-		get { return Provider.AllowDecimal; }
-		set { Provider.AllowDecimal = value; }
-	}
-
-	/// <summary>
-	/// Gets or sets the culture for the <see cref="NumericMaskedTextProvider.DecimalCharacter"/> and <see cref="NumericMaskedTextProvider.SignCharacters"/> formatting characters.
-	/// </summary>
-	public CultureInfo Culture
-	{
-		get => Provider.Culture;
-		set
-		{
-			Provider.Culture = value;
-			UpdateText();
-		}
-	}
-
-	/// <summary>
-	/// Initializes a new instance of the <see cref="Forms.NumericMaskedTextStepper{T}"/> class.
-	/// </summary>
-	public NumericMaskedTextStepper()
-		: base(new NumericMaskedTextProvider<T>())
-	{
-	}
-
-	/// <inheritdoc/>
-	protected override void OnKeyDown(KeyEventArgs e)
-	{
-		base.OnKeyDown(e);
-		if (e.KeyData == Keys.Decimal)
-		{
-			var pos = CaretIndex;
-			Provider.Insert(Provider.DecimalCharacter, ref pos);
-			UpdateText();
-			CaretIndex = pos;
-			e.Handled = true;
-		}
-	}
-}
 
 /// <summary>
 /// Masked text box that provides a value converted to/from text
@@ -88,13 +12,32 @@ public class NumericMaskedTextStepper<T> : MaskedTextStepper<T>
 /// </remarks>
 public class MaskedTextStepper<T> : MaskedTextStepper
 {
+	T _lastValue;
 	/// <summary>
 	/// Event to handle when the <see cref="Value"/> property changes
 	/// </summary>
-	public event EventHandler<EventArgs> ValueChanged
+	public event EventHandler<EventArgs> ValueChanged;
+
+	/// <inheritdoc/>
+	override protected void OnTextChanged(EventArgs e)
 	{
-		add { TextChanged += value; }
-		remove { TextChanged -= value; }
+		base.OnTextChanged(e);
+
+		var val = Value;
+		if (!EqualityComparer<T>.Default.Equals(val, _lastValue))
+		{
+			OnValueChanged(EventArgs.Empty);
+			_lastValue = val;
+		}
+	}
+
+	/// <summary>
+	/// Raises the <see cref="ValueChanged"/> event.
+	/// </summary>
+	/// <param name="e">Event arguments.</param>
+	protected virtual void OnValueChanged(EventArgs e)
+	{
+		ValueChanged?.Invoke(this, e);
 	}
 
 	/// <summary>
@@ -127,13 +70,15 @@ public class MaskedTextStepper<T> : MaskedTextStepper
 	/// Gets or sets the translated value of the masked text.
 	/// </summary>
 	/// <value>The translated value.</value>
-	public T Value
+	public virtual T Value
 	{
 		get { return Provider != null ? Provider.Value : default(T); }
 		set
 		{
 			if (Provider != null)
 				Provider.Value = value;
+			// if (HasFocus)
+			Provider?.CommitText();
 			UpdateText();
 		}
 	}
@@ -336,8 +281,10 @@ public class MaskedTextStepper : TextStepper
 	{
 		if (provider == null)
 			return;
-		IsUpdatingText++;
 		var hasFocus = HasFocus;
+		if (!hasFocus)
+			provider.CommitText();
+		IsUpdatingText++;
 		if (!hasFocus && ShowPlaceholderWhenEmpty && provider.IsEmpty && !string.IsNullOrEmpty(PlaceholderText))
 			base.Text = null;
 		else if ((hasFocus && ShowPromptMode == ShowPromptMode.OnFocus) || ShowPromptMode == ShowPromptMode.Always)
@@ -375,8 +322,9 @@ public class MaskedTextStepper : TextStepper
 	protected override void OnLostFocus(EventArgs e)
 	{
 		base.OnLostFocus(e);
-		if (ShowPromptMode == ShowPromptMode.OnFocus || ShowPlaceholderWhenEmpty)
-			UpdateText();
+		// if (ShowPromptMode == ShowPromptMode.OnFocus || ShowPlaceholderWhenEmpty)
+		provider?.CommitText();
+		UpdateText();
 	}
 
 	/// <summary>

--- a/src/Eto/Forms/Controls/NumericMaskedTextStepper.cs
+++ b/src/Eto/Forms/Controls/NumericMaskedTextStepper.cs
@@ -1,0 +1,382 @@
+using System.Numerics;
+
+namespace Eto.Forms;
+
+/// <summary>
+/// Masked text box with a variable length numeric mask.
+/// </summary>
+/// <remarks>
+/// This provides a text box that limits the user input to only allow numeric values.
+/// </remarks>
+/// <typeparam name="T">Numeric type such as int, decimal, double, etc.</typeparam>
+public class NumericMaskedTextStepper<T> : MaskedTextStepper<T>
+	where T: struct, IComparable<T>
+#if NET7_0_OR_GREATER
+	, INumber<T>
+#endif
+{
+	T _increment;
+	T _minValue;
+	T _maxValue;
+	bool _wrap;
+	T? _value;
+	Func<object, int, object> _roundFunc;
+
+	/// <summary>
+	/// Gets the numeric provider.
+	/// </summary>
+	/// <value>The masked text provider.</value>
+	public new NumericMaskedTextProvider<T> Provider => (NumericMaskedTextProvider<T>)base.Provider;
+
+	/// <summary>
+	/// Gets or sets a value indicating whether the mask can accept a sign.
+	/// </summary>
+	/// <remarks>
+	/// This defaults to whether the type specified by <typeparamref name="T"/> allows negative values.
+	/// </remarks>
+	/// <value><c>true</c> to allow sign character; otherwise, <c>false</c>.</value>
+	public bool AllowSign
+	{
+		get { return Provider.AllowSign; }
+		set { Provider.AllowSign = value; }
+	}
+
+	/// <summary>
+	/// Gets or sets a value indicating whether the mask can input a decimal.
+	/// </summary>
+	/// <remarks>
+	/// This defaults to whether the type specified by <typeparamref name="T"/> allows decimals, such as when
+	/// it is a decimal, double, or float.
+	/// </remarks>
+	/// <value><c>true</c> to allow decimal; otherwise, <c>false</c>.</value>
+	public bool AllowDecimal
+	{
+		get { return Provider.AllowDecimal; }
+		set { Provider.AllowDecimal = value; }
+	}
+	
+	/// <summary>
+	/// Gets or sets the culture for the <see cref="NumericMaskedTextProvider.DecimalCharacter"/> and <see cref="NumericMaskedTextProvider.SignCharacters"/> formatting characters.
+	/// </summary>
+	public CultureInfo Culture
+	{
+		get => Provider.Culture;
+		set
+		{
+			Provider.Culture = value;
+			UpdateText();
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the number of decimal places to allow.  This will round the value to the specified number of decimal places when set.
+	/// </summary>
+	public int DecimalPlaces
+	{
+		get => Provider.DecimalPlaces;
+		set
+		{
+			if (value == Provider.DecimalPlaces)
+				return;
+			var oldValue = _value;
+			Provider.DecimalPlaces = value;
+			Provider.AllowDecimal = value > 0 || MaximumDecimalPlaces > 0;
+			if (oldValue.HasValue)
+				Provider.Value = oldValue.Value;
+			UpdateText();
+			if (oldValue.HasValue)
+				_value = oldValue.Value;
+		}
+	}
+	
+	/// <summary>
+	/// Gets or sets the maximum number of decimal places allowed.  This will round the value to the specified number of decimal places when set.
+	/// </summary>
+	public int MaximumDecimalPlaces
+	{
+		get => Provider.MaximumDecimalPlaces;
+		set
+		{
+			if (value == Provider.MaximumDecimalPlaces)
+				return;
+			var oldValue = _value;
+			Provider.MaximumDecimalPlaces = value;
+			Provider.AllowDecimal = DecimalPlaces > 0 || value > 0;
+			if (oldValue.HasValue)
+				Provider.Value = oldValue.Value;
+			UpdateText();
+			if (oldValue.HasValue)
+				_value = oldValue.Value;
+		}
+	}
+	
+	/// <summary>
+	/// Gets or sets the format string for the numeric value.
+	/// </summary>
+	public string FormatString
+	{
+		get => Provider.FormatString;
+		set
+		{
+			if (value == Provider.FormatString)
+				return;
+			var oldValue = _value;
+			Provider.FormatString = value;
+			if (oldValue.HasValue)
+				Provider.Value = oldValue.Value;
+			UpdateText();
+			if (oldValue.HasValue)
+				_value = oldValue.Value;
+		}
+	}
+	
+	/// <inheritdoc/>
+	public T MinValue
+	{
+		get => _minValue;
+		set
+		{
+			_minValue = value;
+			AllowSign = value.CompareTo(default(T)) < 0 || _maxValue.CompareTo(default(T)) < 0;
+			if (base.Value.CompareTo(value) < 0)
+				base.Value = value;
+			UpdateValidDirection();
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the maximum value allowed.  This will set the value to the maximum if the current value is greater than the new maximum.
+	/// </summary>
+	public T MaxValue
+	{
+		get => _maxValue;
+		set
+		{
+			_maxValue = value;
+			AllowSign = _minValue.CompareTo(default(T)) < 0 || value.CompareTo(default(T)) < 0;
+			if (base.Value.CompareTo(value) > 0)
+				base.Value = value;
+			UpdateValidDirection();
+		}
+	}
+	
+	/// <summary>
+	/// Gets or sets the increment value for stepping.  This will be added or subtracted from the current value when the stepper buttons are clicked.
+	/// </summary>
+	public T Increment
+	{
+		get => _increment;
+		set
+		{
+			_increment = value;
+			UpdateValidDirection();
+		}
+	}
+	
+	/// <summary>
+	/// Gets or sets whether the value should wrap when incrementing or decrementing past the minimum or maximum values.
+	/// </summary>
+	public bool Wrap
+	{
+		get => _wrap;
+		set
+		{
+			_wrap = value;
+			UpdateValidDirection();
+		}
+	}
+
+	/// <inheritdoc/>
+	public override T Value
+	{
+		get
+		{
+			var val = _value ?? base.Value;
+			
+			if (string.IsNullOrEmpty(FormatString) && MaximumDecimalPlaces > 0 && _roundFunc != null)
+				val = (T)_roundFunc(val, MaximumDecimalPlaces);
+			
+			if (val.CompareTo(_minValue) < 0) return _minValue;
+			if (val.CompareTo(_maxValue) > 0) return _maxValue;
+			return val;
+		}
+		set
+		{
+			if (EqualityComparer<T>.Default.Equals(value, Value))
+				return;
+			var clamped = value;
+			if (clamped.CompareTo(_minValue) < 0) clamped = _minValue;
+			if (clamped.CompareTo(_maxValue) > 0) clamped = _maxValue;
+			base.Value = clamped;
+			_value = value;
+		}
+	}
+
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Forms.NumericMaskedTextStepper{T}"/> class.
+	/// </summary>
+	public NumericMaskedTextStepper()
+		: base(new NumericMaskedTextProvider<T>())
+	{
+		HandleEvent(StepEvent);
+		HandleEvent(KeyDownEvent);
+		HandleEvent(LostFocusEvent);
+		
+		var type = typeof(T);
+		if (TypeDefaults.TryGetValue(type, out var defaults))
+		{
+			_minValue = (T)defaults.min;
+			_maxValue = (T)defaults.max;
+			_increment = (T)defaults.increment;
+			_roundFunc = (Func<object, int, object>)defaults.roundFunc;
+		}
+		else
+		{
+			throw new NotSupportedException($"The type {type} is not supported by {nameof(NumericMaskedTextStepper<T>)}");
+		}
+		Provider.Value = default;
+	}
+
+	Dictionary<Type, (object min, object max, object increment, int maxdecimals, Func<object, int, object> roundFunc)> TypeDefaults = new ()
+	{
+		{ typeof(byte), (byte.MinValue, byte.MaxValue, (byte)1, 0, null) },
+		{ typeof(sbyte), (sbyte.MinValue, sbyte.MaxValue, (sbyte)1, 0, null) },
+		{ typeof(short), (short.MinValue, short.MaxValue, (short)1, 0, null) },
+		{ typeof(ushort), (ushort.MinValue, ushort.MaxValue, (ushort)1, 0, null) },
+		{ typeof(int), (int.MinValue, int.MaxValue, 1, 0, null) },
+		{ typeof(uint), (uint.MinValue, uint.MaxValue, 1u, 0, null) },
+		{ typeof(long), (long.MinValue, long.MaxValue, 1L, 0, null) },
+		{ typeof(ulong), (ulong.MinValue, ulong.MaxValue, 1UL, 0, null) },
+		{ typeof(float), (float.MinValue, float.MaxValue, 1f, 7, (v, i) => Math.Round((float)v, Math.Min(i, 7))) },
+		{ typeof(double), (double.MinValue, double.MaxValue, 1d, 15, (v, i) => Math.Round((double)v, Math.Min(i, 15))) },
+		{ typeof(decimal), (decimal.MinValue, decimal.MaxValue, 1m, 28, (v, i) => Math.Round((decimal)v, Math.Min(i, 28))) }
+	};
+
+	void UpdateValidDirection()
+	{
+		if (ReadOnly)
+		{
+			ValidDirection = StepperValidDirections.None;
+			return;
+		}
+		var dir = StepperValidDirections.None;
+		var val = Value;
+		if (_wrap || val.CompareTo(_maxValue) < 0)
+			dir |= StepperValidDirections.Up;
+		if (_wrap || val.CompareTo(_minValue) > 0)
+			dir |= StepperValidDirections.Down;
+		ValidDirection = dir;
+	}
+
+	/// <inheritdoc/>
+	protected override void OnTextChanged(EventArgs e)
+	{
+		_value = null;
+		base.OnTextChanged(e);
+	}
+
+	/// <inheritdoc/>
+	protected override void OnValueChanged(EventArgs e)
+	{
+		base.OnValueChanged(e);
+		UpdateValidDirection();
+	}
+
+	/// <inheritdoc/>
+	protected override void OnKeyDown(KeyEventArgs e)
+	{
+		base.OnKeyDown(e);
+		if (e.Handled || ReadOnly || !Enabled)
+			return;
+		switch (e.KeyData)
+		{
+			case Keys.Decimal:
+				if (!AllowDecimal)
+					return;
+				var pos = CaretIndex;
+				Provider.Insert(Provider.DecimalCharacter, ref pos);
+				UpdateText();
+				CaretIndex = pos;
+				e.Handled = true;
+				break;
+			case Keys.Enter:
+				UpdateValue();
+				e.Handled = true;
+				break;
+		}
+	}
+
+	/// <inheritdoc/>
+	protected override void OnLostFocus(EventArgs e)
+	{
+		base.OnLostFocus(e);
+		UpdateValue();
+	}
+	
+	void UpdateValue()
+	{
+		if (Provider != null)
+		{
+			var val = Value;
+			Provider.Value = val.CompareTo(_minValue) < 0 ? _minValue : val.CompareTo(_maxValue) > 0 ? _maxValue : val;
+			if (HasFocus)
+				Provider.CommitText();
+		}
+		UpdateText();
+	}
+
+	/// <inheritdoc/>
+	protected override void OnStep(StepperEventArgs e)
+	{
+		base.OnStep(e);
+		if (ReadOnly || !Enabled)
+			return;
+		var val = _value ?? Value;
+		if (e.Direction == StepperDirection.Up)
+			val = Add(val, _increment);
+		else
+			val = Subtract(val, _increment);
+
+		if (_wrap)
+		{
+			if (val.CompareTo(_minValue) < 0)
+				val = _maxValue;
+			else if (val.CompareTo(_maxValue) > 0)
+				val = _minValue;
+		}
+
+		Value = val.CompareTo(_minValue) < 0 ? _minValue : val.CompareTo(_maxValue) > 0 ? _maxValue : val;
+	}
+
+	/// <inheritdoc/>
+	protected override void OnReadOnlyChanged(EventArgs e)
+	{
+		base.OnReadOnlyChanged(e);
+		UpdateValidDirection();
+	}
+
+#if !NET7_0_OR_GREATER
+	MethodInfo _addMethod = typeof(T).GetMethod("op_Addition", new[] { typeof(T), typeof(T) });
+	MethodInfo _subtractMethod = typeof(T).GetMethod("op_Subtraction", new[] { typeof(T), typeof(T) });
+#endif
+
+	private T Add(T val, T increment)
+	{
+#if NET7_0_OR_GREATER
+		return val + increment;
+#else
+		return _addMethod != null ? (T)_addMethod.Invoke(null, new object[] { val, increment }) : throw new InvalidOperationException($"The type {typeof(T)} does not support addition operator.");
+#endif
+		
+	}
+
+	private T Subtract(T val, T increment)
+	{
+#if NET7_0_OR_GREATER
+		return val - increment;
+#else
+		return _subtractMethod != null ? (T)_subtractMethod.Invoke(null, new object[] { val, increment }) : throw new InvalidOperationException($"The type {typeof(T)} does not support subtraction operator.");
+#endif
+	}
+}

--- a/src/Eto/Forms/Controls/NumericStepper.cs
+++ b/src/Eto/Forms/Controls/NumericStepper.cs
@@ -210,7 +210,16 @@ public class NumericStepper : CommonControl
 		get => Handler.Wrap;
 		set => Handler.Wrap = value;
 	}
-
+	
+	/// <summary>
+	/// Gets or sets the text alignment of the numeric value.
+	/// </summary>
+	public TextAlignment TextAlignment
+	{
+		get => Handler.TextAlignment;
+		set => Handler.TextAlignment = value;
+	}
+	
 	/// <summary>
 	/// Gets the binding for the <see cref="Value"/> property.
 	/// </summary>
@@ -377,5 +386,10 @@ public class NumericStepper : CommonControl
 		/// </summary>
 		/// <value><c>true</c> to wrap the value when stepping past its bounds, <c>false</c> to stop</value>
 		bool Wrap { get; set; }
+		
+		/// <summary>
+		/// Gets or sets the text alignment of the numeric value.
+		/// </summary>
+		TextAlignment TextAlignment { get; set; }
 	}
 }

--- a/src/Eto/Forms/Controls/TextBox.cs
+++ b/src/Eto/Forms/Controls/TextBox.cs
@@ -88,8 +88,26 @@ public class TextBox : TextControl
 	public bool ReadOnly
 	{
 		get { return Handler.ReadOnly; }
-		set { Handler.ReadOnly = value; }
+		set
+		{
+			if (Handler.ReadOnly != value)
+			{
+				Handler.ReadOnly = value;
+				OnReadOnlyChanged(EventArgs.Empty);
+			}
+		}
 	}
+
+	/// <summary>
+	/// Event to handle when the <see cref="ReadOnly"/> property changes.
+	/// </summary>
+	public event EventHandler ReadOnlyChanged;
+	
+	/// <summary>
+	/// Raises the <see cref="ReadOnlyChanged"/> event.
+	/// </summary>
+	/// <param name="e">Event arguments</param>
+	protected virtual void OnReadOnlyChanged(EventArgs e) => ReadOnlyChanged?.Invoke(this, e);
 
 	/// <summary>
 	/// Gets or sets the maximum length of the text that can be entered in the control, 0 for no limit.

--- a/src/Eto/Forms/MaskedTextProvider/FixedMaskedTextProvider.cs
+++ b/src/Eto/Forms/MaskedTextProvider/FixedMaskedTextProvider.cs
@@ -302,6 +302,12 @@ public class FixedMaskedTextProvider : IMaskedTextProvider
 		get { return handler.MaskFull; }
 	}
 
+	/// <inheritdoc/>
+	public virtual void CommitText()
+	{
+		handler.CommitText();
+	}
+
 	/// <summary>
 	/// Handler interface for implementations of the <see cref="FixedMaskedTextProvider"/>.
 	/// </summary>

--- a/src/Eto/Forms/MaskedTextProvider/IMaskedTextProvider.cs
+++ b/src/Eto/Forms/MaskedTextProvider/IMaskedTextProvider.cs
@@ -81,6 +81,16 @@ public interface IMaskedTextProvider
 	/// </summary>
 	/// <value><c>true</c> if the mask value is empty; otherwise, <c>false</c>.</value>
 	bool IsEmpty { get; }
+
+	/// <summary>
+	/// Called to update the display text after changes to the mask value.
+	/// </summary>
+	/// <remarks>
+	/// This is called after user changes to the mask value is complete, such as when the control loses focus, or when the user presses enter.
+	/// This allows the mask provider to update the display text after changes are made to the value, 
+	/// while still allowing the user to type in the text without it changing until they are done.
+	/// </remarks>
+	void CommitText();
 }
 
 /// <summary>

--- a/src/Eto/Forms/MaskedTextProvider/NumericMaskedTextProvider.cs
+++ b/src/Eto/Forms/MaskedTextProvider/NumericMaskedTextProvider.cs
@@ -5,8 +5,11 @@ namespace Eto.Forms;
 /// </summary>
 public class NumericMaskedTextProvider<T> : NumericMaskedTextProvider, IMaskedTextProvider<T>
 {
-	Func<string, T> parse;
-	Func<T, string> toString;
+	Func<string, T> _parse;
+	Func<T, string> _toString;
+	string _formatString;
+	int _decimalPlaces;
+	int _maximumDecimalPlaces;
 
 	class Info
 	{
@@ -14,6 +17,7 @@ public class NumericMaskedTextProvider<T> : NumericMaskedTextProvider, IMaskedTe
 		public bool AllowDecimal;
 		public Func<string, object> Parse;
 		public Func<object, string> ToText;
+		public int MaxDecimalPlaces;
 	}
 
 	// do all conversions with invariant culture
@@ -22,9 +26,9 @@ public class NumericMaskedTextProvider<T> : NumericMaskedTextProvider, IMaskedTe
 	// use dictionary instead of reflection for linking
 	static readonly Dictionary<Type, Info> numericTypes = new Dictionary<Type, Info>
 	{
-		{ typeof(decimal), new Info { Parse = s => decimal.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, AllowSign = true, AllowDecimal = true } },
-		{ typeof(double), new Info { Parse = s => double.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, ToText = DoubleToText, AllowSign = true, AllowDecimal = true } },
-		{ typeof(float), new Info { Parse = s => float.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, ToText = FloatToText, AllowSign = true, AllowDecimal = true } },
+		{ typeof(decimal), new Info { Parse = s => decimal.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, AllowSign = true, AllowDecimal = true, MaxDecimalPlaces = 28 } },
+		{ typeof(double), new Info { Parse = s => double.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, ToText = DoubleToText, AllowSign = true, AllowDecimal = true, MaxDecimalPlaces = 17 } },
+		{ typeof(float), new Info { Parse = s => float.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, ToText = FloatToText, AllowSign = true, AllowDecimal = true, MaxDecimalPlaces = 8 } },
 		{ typeof(int), new Info { Parse = s => int.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, AllowSign = true } },
 		{ typeof(uint), new Info { Parse = s => uint.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null } },
 		{ typeof(long), new Info { Parse = s => long.TryParse(s, NumberStyles.Any, Inv, out var d) ? (object)d : null, AllowSign = true } },
@@ -69,16 +73,17 @@ public class NumericMaskedTextProvider<T> : NumericMaskedTextProvider, IMaskedTe
 		{
 			AllowSign = info.AllowSign;
 			AllowDecimal = info.AllowDecimal;
-			parse = text =>
+			MaximumDecimalPlaces = info.MaxDecimalPlaces;
+			_parse = text =>
 			{
 				var val = info.Parse(text);
 				return val == null ? default : (T)val;
 			};
 
 			if (info.ToText != null)
-				toString = val => info.ToText(val);
+				_toString = val => info.ToText(val);
 			else
-				toString = val => Convert.ToString(val, CultureInfo.InvariantCulture);
+				_toString = val => Convert.ToString(val, CultureInfo.InvariantCulture);
 			Validate = text => info.Parse(text?.Replace(DecimalCharacter, '.')) != null;
 		}
 		else
@@ -91,7 +96,7 @@ public class NumericMaskedTextProvider<T> : NumericMaskedTextProvider, IMaskedTe
 			if (tryParseMethod == null || tryParseMethod.ReturnType != typeof(bool))
 				throw new ArgumentException(string.Format("Type of T ({0}) must implement a static bool TryParse(string, out T) method", typeof(T)));
 
-			parse = text =>
+			_parse = text =>
 			{
 				var parameters = new object[] { Text, null };
 				if ((bool)tryParseMethod.Invoke(null, parameters))
@@ -100,7 +105,7 @@ public class NumericMaskedTextProvider<T> : NumericMaskedTextProvider, IMaskedTe
 				}
 				return default;
 			};
-			toString = val => Convert.ToString(val, CultureInfo.InvariantCulture);
+			_toString = val => Convert.ToString(val, CultureInfo.InvariantCulture);
 
 			Validate = text =>
 			{
@@ -116,15 +121,137 @@ public class NumericMaskedTextProvider<T> : NumericMaskedTextProvider, IMaskedTe
 	/// <value>The value of the mask.</value>
 	public T Value
 	{
-		get => parse(Text?.Replace(DecimalCharacter, '.'));
-		set => Text = toString(value)?.Replace('.', DecimalCharacter);
+		get => _parse(Text?.Replace(DecimalCharacter, '.'));
+		set => Text = _toString(value)?.Replace('.', DecimalCharacter);
 	}
+	
+	/// <summary>
+	/// Gets or sets the minimum number of decimal places to include in the output.
+	/// </summary>
+	public int DecimalPlaces
+	{
+		get => _decimalPlaces;
+		set
+		{
+			value = Math.Max(0, value);
+			if (_decimalPlaces == value)
+				return;
+			_decimalPlaces = value;
+			if (_maximumDecimalPlaces < value)
+				_maximumDecimalPlaces = value;
+			_formatString = null; // reset format string since it will override decimal places
+			CommitText();
+		}
+	}
+
+	/// <summary>
+	/// Gets or sets the maximum number of decimal places to include in the output.
+	/// </summary>
+	public int MaximumDecimalPlaces
+	{
+		get => _maximumDecimalPlaces;
+		set
+		{
+			value = Math.Max(0, value);
+			if (_maximumDecimalPlaces == value)
+				return;
+			_maximumDecimalPlaces = value;
+			if (_decimalPlaces > value)
+				_decimalPlaces = value;
+			_formatString = null; // reset format string since it will override decimal places
+			CommitText();
+		}
+	}
+	
+	/// <summary>
+	/// Gets or sets the format string to use for formatting the value. 
+	/// If specified, this will override the <see cref="DecimalPlaces"/> and <see cref="MaximumDecimalPlaces"/> properties.
+	/// </summary>
+	public string FormatString
+	{
+		get => _formatString;
+		set
+		{
+			if (_formatString == value)
+				return;
+			_formatString = value;
+			if (!string.IsNullOrEmpty(value))
+			{
+				_decimalPlaces = 0;
+				_maximumDecimalPlaces = 0;
+			}
+			CommitText();
+		}
+	}
+	
 
 	internal override void SetCulture()
 	{
 		var value = Value;
 		base.SetCulture();
 		Value = value;
+	}
+
+	/// <inheritdoc/>
+	public override void CommitText()
+	{
+		if (TryFormatText(base.Text, out var displayText))
+			SetBuilderText(displayText);
+	}
+
+	void SetBuilderText(string text)
+	{
+		Builder.Clear();
+		if (text != null)
+			Builder.Append(text);
+	}
+
+	bool TryFormatText(string text, out string displayText)
+	{
+		displayText = text ?? string.Empty;
+		if (string.IsNullOrEmpty(text))
+			return true;
+
+		var normalizedInput = text.Replace(DecimalCharacter, '.');
+		if (normalizedInput.Length == 1)
+		{
+			if ((AllowSign && SignCharacters.Contains(normalizedInput[0])) || (AllowDecimal && normalizedInput[0] == '.'))
+				return false;
+		}
+		else if (normalizedInput.Length == 2 && AllowSign && AllowDecimal && SignCharacters.Contains(normalizedInput[0]) && normalizedInput[1] == '.')
+		{
+			return false;
+		}
+
+		// if (Validate != null && !Validate(text))
+		// 	return false;
+
+		var value = _parse(normalizedInput);
+		if (value is IFormattable formattable)
+		{
+			var maximumDecimalPlaces = Math.Max(DecimalPlaces, MaximumDecimalPlaces);
+			var displayFormat = CreateNumberFormat(DecimalPlaces, maximumDecimalPlaces);
+			displayText = formattable.ToString(displayFormat, Inv).Replace('.', DecimalCharacter);
+			return true;
+		}
+
+		displayText = _toString(value)?.Replace('.', DecimalCharacter) ?? string.Empty;
+		return true;
+	}
+
+	string CreateNumberFormat(int decimalPlaces, int maximumDecimalPlaces)
+	{
+		if (!string.IsNullOrEmpty(_formatString))
+			return _formatString;
+		if (maximumDecimalPlaces == int.MaxValue)
+			return "G";
+		if (maximumDecimalPlaces <= 0)
+			return "0";
+		if (decimalPlaces <= 0)
+			return $"0.{new string('#', maximumDecimalPlaces)}";
+		if (maximumDecimalPlaces <= decimalPlaces)
+			return $"0.{new string('0', decimalPlaces)}";
+		return $"0.{new string('0', decimalPlaces)}{new string('#', maximumDecimalPlaces - decimalPlaces)}";
 	}
 }
 

--- a/src/Eto/Forms/MaskedTextProvider/VariableMaskedTextProvider.cs
+++ b/src/Eto/Forms/MaskedTextProvider/VariableMaskedTextProvider.cs
@@ -144,4 +144,9 @@ public abstract class VariableMaskedTextProvider : IMaskedTextProvider
 	{
 		get { return sb.Length == 0; }
 	}
+	
+	/// <inheritdoc/>
+	public virtual void CommitText()
+	{
+	}
 }

--- a/src/Eto/Forms/ThemedControls/ThemedNumericStepperHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedNumericStepperHandler.cs
@@ -5,14 +5,6 @@ namespace Eto.Forms.ThemedControls;
 /// </summary>
 public class ThemedNumericStepperHandler : ThemedControlHandler<NumericMaskedTextStepper<double>, NumericStepper, NumericStepper.ICallback>, NumericStepper.IHandler
 {
-	double _increment = 1;
-	double _minValue = double.MinValue;
-	double _maxValue = double.MaxValue;
-	int _decimalPlaces;
-	int _maximumDecimalPlaces;
-	string _formatString;
-	bool _wrap;
-	double _lastValue;
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="ThemedNumericStepperHandler"/> class.
@@ -20,63 +12,11 @@ public class ThemedNumericStepperHandler : ThemedControlHandler<NumericMaskedTex
 	public ThemedNumericStepperHandler()
 	{
 		Control = new NumericMaskedTextStepper<double>();
-		Control.AllowSign = true;
-		Control.AllowDecimal = true;
-		UpdateFormatString();
+		Control.MaximumDecimalPlaces = 0;
+		Control.ValueChanged += (sender, e) => Callback.OnValueChanged(Widget, EventArgs.Empty);
 	}
 
-	/// <inheritdoc/>
-	protected override void Initialize()
-	{
-		base.Initialize();
-		Control.Step += Control_Step;
-		Control.KeyDown += Control_KeyDown;
-		Control.ValueChanged += Control_ValueChanged;
-	}
 
-	void Control_ValueChanged(object sender, EventArgs e)
-	{
-		var val = Value;
-		if (_lastValue != val)
-		{
-			_lastValue = val;
-			Callback.OnValueChanged(Widget, EventArgs.Empty);
-		}
-		UpdateValidDirection();
-	}
-
-	void Control_Step(object sender, StepperEventArgs e)
-	{
-		var val = Value;
-		if (e.Direction == StepperDirection.Up)
-			val += _increment;
-		else
-			val -= _increment;
-
-		if (_wrap)
-		{
-			if (val < _minValue)
-				val = _maxValue;
-			else if (val > _maxValue)
-				val = _minValue;
-		}
-
-		Value = Math.Max(_minValue, Math.Min(_maxValue, val));
-	}
-
-	void Control_KeyDown(object sender, KeyEventArgs e)
-	{
-		if (e.KeyData == Keys.Up)
-		{
-			Control_Step(sender, new StepperEventArgs(StepperDirection.Up));
-			e.Handled = true;
-		}
-		else if (e.KeyData == Keys.Down)
-		{
-			Control_Step(sender, new StepperEventArgs(StepperDirection.Down));
-			e.Handled = true;
-		}
-	}
 
 	/// <inheritdoc/>
 	public override void AttachEvent(string id)
@@ -99,76 +39,37 @@ public class ThemedNumericStepperHandler : ThemedControlHandler<NumericMaskedTex
 	/// <inheritdoc/>
 	public double Value
 	{
-		get
-		{
-			var val = Control.Value;
-			if (!HasFormatString)
-				val = Math.Round(val, _maximumDecimalPlaces);
-			return Math.Max(_minValue, Math.Min(_maxValue, val));
-		}
-		set
-		{
-			Control.Value = Math.Max(_minValue, Math.Min(_maxValue, value));
-		}
+		get => Control.Value;
+		set => Control.Value = value;
 	}
 
 	/// <inheritdoc/>
 	public double MinValue
 	{
-		get => _minValue;
-		set
-		{
-			_minValue = value;
-			Control.AllowSign = value < 0 || _maxValue < 0;
-			if (Value < value)
-				Value = value;
-			UpdateValidDirection();
-		}
+		get => Control.MinValue;
+		set => Control.MinValue = value;
 	}
 
 	/// <inheritdoc/>
 	public double MaxValue
 	{
-		get => _maxValue;
-		set
-		{
-			_maxValue = value;
-			Control.AllowSign = _minValue < 0 || value < 0;
-			if (Value > value)
-				Value = value;
-			UpdateValidDirection();
-		}
+		get => Control.MaxValue;
+		set => Control.MaxValue = value;
 	}
 
-	void UpdateValidDirection()
-	{
-		var dir = StepperValidDirections.None;
-		var val = Value;
-		if (_wrap || val < _maxValue)
-			dir |= StepperValidDirections.Up;
-		if (_wrap || val > _minValue)
-			dir |= StepperValidDirections.Down;
-		Control.ValidDirection = dir;
-	}
 
 	/// <inheritdoc/>
 	public int DecimalPlaces
 	{
-		get => _decimalPlaces;
-		set
-		{
-			_decimalPlaces = value;
-			if (_maximumDecimalPlaces < value)
-				_maximumDecimalPlaces = value;
-			UpdateFormatString();
-		}
+		get => Control.DecimalPlaces;
+		set => Control.DecimalPlaces = value;
 	}
 
 	/// <inheritdoc/>
 	public double Increment
 	{
-		get => _increment;
-		set => _increment = value;
+		get => Control.Increment;
+		set => Control.Increment = value;
 	}
 
 	/// <inheritdoc/>
@@ -181,27 +82,17 @@ public class ThemedNumericStepperHandler : ThemedControlHandler<NumericMaskedTex
 	/// <inheritdoc/>
 	public int MaximumDecimalPlaces
 	{
-		get => _maximumDecimalPlaces;
-		set
-		{
-			_maximumDecimalPlaces = value;
-			if (_decimalPlaces > value)
-				_decimalPlaces = value;
-			UpdateFormatString();
-		}
+		get => Control.MaximumDecimalPlaces;
+		set => Control.MaximumDecimalPlaces = value;
 	}
 
-	bool HasFormatString => !string.IsNullOrEmpty(_formatString);
+	bool HasFormatString => !string.IsNullOrEmpty(FormatString);
 
 	/// <inheritdoc/>
 	public string FormatString
 	{
-		get => _formatString;
-		set
-		{
-			_formatString = value;
-			UpdateFormatString();
-		}
+		get => Control.FormatString;
+		set => Control.FormatString = value;
 	}
 
 	/// <inheritdoc/>
@@ -214,12 +105,15 @@ public class ThemedNumericStepperHandler : ThemedControlHandler<NumericMaskedTex
 	/// <inheritdoc/>
 	public bool Wrap
 	{
-		get => _wrap;
-		set
-		{
-			_wrap = value;
-			UpdateValidDirection();
-		}
+		get => Control.Wrap;
+		set => Control.Wrap = value;
+	}
+	
+	/// <inheritdoc/>
+	public TextAlignment TextAlignment
+	{
+		get => Control.TextAlignment;
+		set => Control.TextAlignment = value;
 	}
 
 	/// <inheritdoc/>
@@ -229,10 +123,6 @@ public class ThemedNumericStepperHandler : ThemedControlHandler<NumericMaskedTex
 		set => Control.Font = value;
 	}
 
-	void UpdateFormatString()
-	{
-		Control.AllowDecimal = HasFormatString || _maximumDecimalPlaces > 0 || _decimalPlaces > 0;
-	}
 
 	/// <inheritdoc/>
 	protected override Control KeyboardControl => Control;

--- a/src/Shared/FixedMaskedTextProviderHandler.cs
+++ b/src/Shared/FixedMaskedTextProviderHandler.cs
@@ -197,6 +197,10 @@
 		{
 			get { return Provider.MaskFull; }
 		}
+		
+		public virtual void CommitText()
+		{
+		}
 	}
 }
 

--- a/test/Eto.Test/Sections/Controls/MaskedTextBoxSection.cs
+++ b/test/Eto.Test/Sections/Controls/MaskedTextBoxSection.cs
@@ -20,6 +20,7 @@ namespace Eto.Test.Sections.Controls
 
 			var tb = new NumericMaskedTextBox<double> { Value = rememberValue ? lastValue : 123.456 };
 			tb.ValueChanged += (sender, e) => lastValue = tb.Value;
+			LogValueChanged(tb);
 
 			var l = new Label();
 			l.TextBinding.Bind(Binding.Property(tb, c => c.Value).Convert(r => "Value: " + Convert.ToString(r)));
@@ -35,7 +36,7 @@ namespace Eto.Test.Sections.Controls
 
 			BeginGroup("FixedMaskedTextProvider", padding: 10);
 			AddAutoSized(new MaskedTextBox(new FixedMaskedTextProvider("(999) 000-0000")) { ShowPromptMode = ShowPromptMode.OnFocus, PlaceholderText = "(123) 456-7890" });
-			AddAutoSized(new MaskedTextBox<DateTime>(new FixedMaskedTextProvider<DateTime>("&&/90/0000") { ConvertToValue = DateTime.Parse }));
+			AddAutoSized(LogValueChanged(new MaskedTextBox<DateTime>(new FixedMaskedTextProvider<DateTime>("&&/90/0000") { ConvertToValue = DateTime.Parse })));
 			AddAutoSized(new MaskedTextBox(new FixedMaskedTextProvider(">L0L 0L0")));
 			AddAutoSized(new MaskedTextBox { InsertMode = InsertKeyMode.Toggle });
 			EndGroup();
@@ -48,6 +49,7 @@ namespace Eto.Test.Sections.Controls
 			EndGroup();
 
 			AddSpace();
+			
 		}
 
 		void Set(Action<MaskedTextBox> action)
@@ -56,7 +58,13 @@ namespace Eto.Test.Sections.Controls
 			{
 				action(child);
 			}
-
+		}
+		
+		MaskedTextBox<T> LogValueChanged<T>(MaskedTextBox<T> maskedTextBox)
+		{
+			maskedTextBox.ValueChanged += (sender, e) => Log.Write(sender, $"Value changed: {maskedTextBox.Value}");
+			maskedTextBox.TextChanged += (sender, e) => Log.Write(sender, $"Text changed: {maskedTextBox.Text}");
+			return maskedTextBox;
 		}
 	}
 }

--- a/test/Eto.Test/Sections/Controls/MaskedTextStepperSection.cs
+++ b/test/Eto.Test/Sections/Controls/MaskedTextStepperSection.cs
@@ -20,6 +20,7 @@ namespace Eto.Test.Sections.Controls
 
 			var tb = new NumericMaskedTextStepper<double> { Value = rememberValue ? lastValue : 123.456 };
 			tb.ValueChanged += (sender, e) => lastValue = tb.Value;
+			LogValueChanged(tb);
 
 			var l = new Label();
 			l.TextBinding.Bind(Binding.Property(tb, c => c.Value).Convert(r => "Value: " + Convert.ToString(r)));
@@ -35,7 +36,7 @@ namespace Eto.Test.Sections.Controls
 
 			BeginGroup("FixedMaskedTextProvider", padding: 10);
 			AddAutoSized(new MaskedTextStepper(new FixedMaskedTextProvider("(999) 000-0000")) { ShowPromptMode = ShowPromptMode.OnFocus, PlaceholderText = "(123) 456-7890" });
-			AddAutoSized(new MaskedTextStepper<DateTime>(new FixedMaskedTextProvider<DateTime>("&&/90/0000") { ConvertToValue = DateTime.Parse }));
+			AddAutoSized(LogValueChanged(new MaskedTextStepper<DateTime?>(new FixedMaskedTextProvider<DateTime?>("&&/90/0000") { ConvertToValue = s => DateTime.TryParse(s, out var dt) ? dt : (DateTime?)null })));
 			AddAutoSized(new MaskedTextStepper(new FixedMaskedTextProvider(">L0L 0L0")));
 			AddAutoSized(new MaskedTextStepper { InsertMode = InsertKeyMode.Toggle });
 			EndGroup();
@@ -61,8 +62,13 @@ namespace Eto.Test.Sections.Controls
 			{
 				action(child);
 			}
-
 		}
-
+		
+		MaskedTextStepper<T> LogValueChanged<T>(MaskedTextStepper<T> maskedTextBox)
+		{
+			maskedTextBox.ValueChanged += (sender, e) => Log.Write(sender, $"Value changed: {maskedTextBox.Value}");
+			maskedTextBox.TextChanged += (sender, e) => Log.Write(sender, $"Text changed: {maskedTextBox.Text}");
+			return maskedTextBox;
+		}
 	}
 }

--- a/test/Eto.Test/Sections/Controls/NumericStepperSection.cs
+++ b/test/Eto.Test/Sections/Controls/NumericStepperSection.cs
@@ -55,7 +55,9 @@ namespace Eto.Test.Sections.Controls
 			
 			var wrap = new CheckBox { Text = "Wrap" };
 			wrap.CheckedBinding.Bind(numeric, n => n.Wrap);
-			
+
+			var textAlignment = new EnumDropDown<TextAlignment>();
+			textAlignment.SelectedValueBinding.Bind(numeric, n => n.TextAlignment);
 
 			var increment = new NumericStepper { MaximumDecimalPlaces = 15 };
 			increment.ValueBinding.Bind(numeric, n => n.Increment);
@@ -67,9 +69,9 @@ namespace Eto.Test.Sections.Controls
 				VerticalContentAlignment = VerticalAlignment.Center,
 				Items =
 				{
+					"TextAlignment", textAlignment,
 					enabled,
 					readOnly,
-					wrap
 				}
 			};
 			var options2 = new StackLayout
@@ -81,7 +83,8 @@ namespace Eto.Test.Sections.Controls
 				{
 					chkMinValue, minValue,
 					chkMaxValue, maxValue,
-					"Increment", increment
+					"Increment", increment,
+					wrap,
 				}
 			};
 			var options3 = new StackLayout
@@ -95,6 +98,18 @@ namespace Eto.Test.Sections.Controls
 					"MaximumDecimalPlaces", maxDecimalPlaces
 				}
 			};
+			
+			var options4 = new StackLayout
+			{
+				Spacing = 5,
+				Orientation = Orientation.Horizontal,
+				VerticalContentAlignment = VerticalAlignment.Center,
+				Items =
+				{
+					"FormatString", formatString,
+					"CultureInfo", cultureDropDown
+				}
+			};
 
 			Content = new StackLayout
 			{
@@ -104,7 +119,7 @@ namespace Eto.Test.Sections.Controls
 					options1,
 					options2,
 					options3,
-					TableLayout.Horizontal(5, "FormatString", formatString, "CultureInfo", cultureDropDown),
+					options4,
 					"Result:", numeric
 				}
 			};

--- a/test/Eto.Test/UnitTests/Forms/MaskedTextProvider/NumericMaskedTextProviderTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/MaskedTextProvider/NumericMaskedTextProviderTests.cs
@@ -1,0 +1,128 @@
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.MaskedTextProvider
+{
+	[TestFixture]
+	public class NumericMaskedTextProviderTests
+	{
+		[Test]
+		public void TextShouldShowAtLeastDecimalPlaces()
+		{
+			var provider = new NumericMaskedTextProvider<double>
+			{
+				DecimalPlaces = 2,
+				MaximumDecimalPlaces = 4,
+				Value = 123
+			};
+			provider.CommitText();
+
+			Assert.That(provider.Text, Is.EqualTo("123.00"));
+			Assert.That(provider.DisplayText, Is.EqualTo("123.00"));
+		}
+
+		[Test]
+		public void TextShouldShowUpToMaximumDecimalPlaces()
+		{
+			var provider = new NumericMaskedTextProvider<double>
+			{
+				DecimalPlaces = 2,
+				MaximumDecimalPlaces = 4,
+				Value = 123.456789
+			};
+			provider.CommitText();
+
+			Assert.That(provider.Text, Is.EqualTo("123.4568"));
+			Assert.That(provider.DisplayText, Is.EqualTo("123.4568"));
+		}
+
+		[Test]
+		public void TextShouldRetainSignificantDecimalsUpToMaximum()
+		{
+			var provider = new NumericMaskedTextProvider<double>
+			{
+				DecimalPlaces = 2,
+				MaximumDecimalPlaces = 4,
+				Value = 123.4
+			};
+			provider.CommitText();
+
+			Assert.That(provider.Text, Is.EqualTo("123.40"));
+
+			provider.Value = 123.456;
+			provider.CommitText();
+
+			Assert.That(provider.Text, Is.EqualTo("123.456"));
+		}
+
+		[Test]
+		public void DecimalPlacePropertiesShouldStayInRange()
+		{
+			var provider = new NumericMaskedTextProvider<double>();
+
+			provider.DecimalPlaces = 3;
+			Assert.That(provider.DecimalPlaces, Is.EqualTo(3));
+			Assert.That(provider.MaximumDecimalPlaces, Is.EqualTo(3));
+
+			provider.MaximumDecimalPlaces = 1;
+			Assert.That(provider.DecimalPlaces, Is.EqualTo(1));
+			Assert.That(provider.MaximumDecimalPlaces, Is.EqualTo(1));
+		}
+
+		[Test]
+		public void IncompleteInputShouldRemainEditable()
+		{
+			var provider = new NumericMaskedTextProvider<double>
+			{
+				DecimalPlaces = 2,
+				MaximumDecimalPlaces = 4
+			};
+
+			provider.Text = "-";
+			Assert.That(provider.Text, Is.EqualTo("-"));
+
+			provider.Text = "12.";
+			Assert.That(provider.Text, Is.EqualTo("12."));
+		}
+
+		[Test]
+		public void InsertShouldUseDisplayedDecimalDigitsForCaretPositions()
+		{
+			var provider = new NumericMaskedTextProvider<double>
+			{
+				DecimalPlaces = 3,
+				MaximumDecimalPlaces = 4,
+				Value = 1
+			};
+
+			var position = provider.Text.Length;
+			var inserted = provider.Insert('2', ref position);
+			provider.CommitText();
+
+			Assert.That(inserted, Is.True);
+			Assert.That(provider.Text, Is.EqualTo("1.0002"));
+			Assert.That(position, Is.EqualTo(provider.Text.Length));
+		}
+
+		[Test]
+		public void DeleteShouldPreserveEditableDecimalsUntilFormatted()
+		{
+			var provider = new NumericMaskedTextProvider<double>
+			{
+				DecimalPlaces = 4,
+				MaximumDecimalPlaces = 5,
+				Value = 1.00002
+			};
+			provider.CommitText();
+
+			var position = provider.Text.Length;
+			var deleted = provider.Delete(ref position, 1, false);
+
+			Assert.That(deleted, Is.True);
+			Assert.That(provider.Text, Is.EqualTo("1.0000"));
+
+			provider.CommitText();
+
+			Assert.That(provider.Text, Is.EqualTo("1.0000"));
+		}
+	}
+}


### PR DESCRIPTION
- Fixes up NumericStepper regressions on WPF (which now uses ThemedNumericStepperHandler) due to removal of XWT.
- Added NumericStepper.TextAlignment. Fixes #2822.
- Add ability for IMaskedTextProvider to update text after editing vs. during editing to allow more flexibility for free form input for variable providers
- Add TextBox.ReadOnlyChanged and OnReadOnlyChanged
- Add MinValue/MaxValue/Increment/Wrap/FormatString/MaximumDecimalPlaces/DecimalPlaces to NumericMaskedTextStepper<T>
- Add DecimalPlaces/MaximumDecimalPlaces/FormatString to NumericMaskedTextProvider