### PR TITLE
Mac: Don't set RunCommand when MacBuildBundle is not true

### DIFF
--- a/src/Eto.Mac/build/Mac.targets
+++ b/src/Eto.Mac/build/Mac.targets
@@ -56,7 +56,7 @@
   </PropertyGroup>
 
   <!-- dotnet run should launch the .app on macOS -->
-  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(OSX)) AND $(RunCommand) == ''">
+  <PropertyGroup Condition="$([MSBuild]::IsOSPlatform(OSX)) AND $(RunCommand) == '' AND $(MacBuildBundle) == 'True'">
     <RunCommand>$(LauncherFileWithPath)</RunCommand>
     <RunArguments> $(RunArguments)</RunArguments> <!-- space is intentional so it doesn't get overridden -->
   </PropertyGroup>


### PR DESCRIPTION
This would prevent things like `dotnet test` or `dotnet run` work when you set `<MacBuildBundle>` to false.