### PR TITLE
Add Drawable text composition APIs for IME support

### DIFF
--- a/src/Eto.Android/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Android/Forms/Controls/DrawableHandler.cs
@@ -286,6 +286,14 @@ namespace Eto.Android.Forms.Controls
 			return new Graphics(new GraphicsHandler(new ag.Canvas()));
 		}
 
+		public void CancelTextComposition()
+		{
+		}
+
+		public void CommitTextComposition()
+		{
+		}
+
 		public Control Content { get; set; }
 
 		public Padding Padding

--- a/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/DrawableHandler.cs
@@ -38,6 +38,21 @@ namespace Eto.GtkSharp.Forms.Controls
 			Create();
 		}
 
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Drawable.TextCompositionEvent:
+				case Drawable.TextInsertionBoundsRequestedEvent:
+					HandleEvent(Eto.Forms.Control.TextInputEvent);
+					HandleEvent(Eto.Forms.Control.GotFocusEvent);
+					HandleEvent(Eto.Forms.Control.LostFocusEvent);
+					return;
+			}
+
+			base.AttachEvent(id);
+		}
+
 		public bool CanFocus
 		{
 			get { return Control.CanFocus; }
@@ -114,6 +129,16 @@ namespace Eto.GtkSharp.Forms.Controls
 		public Graphics CreateGraphics()
 		{
 			return new Graphics(new GraphicsHandler(Control, Control.GetWindow()));
+		}
+
+		public void CancelTextComposition()
+		{
+			Connector.CancelDrawableTextComposition();
+		}
+
+		public void CommitTextComposition()
+		{
+			Connector.CommitDrawableTextComposition();
 		}
 
 		protected override void SetContainerContent(Gtk.Widget content)

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -706,6 +706,89 @@ namespace Eto.GtkSharp.Forms
 
 			Gtk.IMContext context;
 			bool commitHandled;
+			string lastCompositionText;
+			bool? lastCompositionActive;
+
+			bool HandlesDrawableComposition(GtkControl<TControl, TWidget, TCallback> handler)
+			{
+				if (!(handler.Widget is Drawable))
+					return false;
+
+				return handler.IsEventHandled(Drawable.TextCompositionEvent) || handler.IsEventHandled(Drawable.TextInsertionBoundsRequestedEvent);
+			}
+			
+			void UpdateDrawableInputMethodLocation(GtkControl<TControl, TWidget, TCallback> handler)
+			{
+				if (!HandlesDrawableComposition(handler))
+					return;
+
+				var drawable = handler.Widget as Drawable;
+				var callback = handler.Callback as Drawable.ICallback;
+				var window = handler.EventControl?.GetWindow();
+				if (drawable == null || callback == null || window == null)
+					return;
+
+				Context.ClientWindow = window;
+
+				var args = new TextInsertionBoundsEventArgs();
+				callback.OnTextInsertionBoundsRequested(drawable, args);
+				var bounds = args.Bounds ?? new RectangleF(0, 0, 1, Math.Max(1, handler.EventControl.Allocation.Height));
+				if (bounds.Width <= 0)
+					bounds.Width = 1;
+				if (bounds.Height <= 0)
+					bounds.Height = 1;
+
+				Context.CursorLocation = new Gdk.Rectangle(
+					(int)Math.Floor(bounds.X),
+					(int)Math.Floor(bounds.Y),
+					(int)Math.Ceiling(bounds.Width),
+					(int)Math.Ceiling(bounds.Height)
+				);
+			}
+
+			void NotifyDrawableTextComposition(GtkControl<TControl, TWidget, TCallback> handler, string text, bool isActive)
+			{
+				if (!(handler.Widget is Drawable drawable) || !(handler.Callback is Drawable.ICallback callback))
+					return;
+
+				text = text ?? string.Empty;
+				if (lastCompositionActive == isActive && string.Equals(lastCompositionText, text, StringComparison.Ordinal))
+					return;
+
+				lastCompositionText = text;
+				lastCompositionActive = isActive;
+
+				var args = new TextCompositionEventArgs(text, isActive);
+				callback.OnTextComposition(drawable, args);
+				UpdateDrawableInputMethodLocation(handler);
+			}
+
+			public void CancelDrawableTextComposition()
+			{
+				var handler = Handler;
+				if (handler == null || !HandlesDrawableComposition(handler) || context == null)
+					return;
+
+				context.Reset();
+				NotifyDrawableTextComposition(handler, string.Empty, false);
+			}
+
+			public void CommitDrawableTextComposition()
+			{
+				var handler = Handler;
+				if (handler == null || !HandlesDrawableComposition(handler) || context == null)
+					return;
+
+				context.GetPreeditString(out var text, out _, out _);
+				if (!string.IsNullOrEmpty(text))
+				{
+					var tia = new TextInputEventArgs(text);
+					handler.Callback.OnTextInput(handler.Widget, tia);
+				}
+
+				context.Reset();
+				NotifyDrawableTextComposition(handler, string.Empty, false);
+			}
 
 			Gtk.IMContext Context
 			{
@@ -713,7 +796,33 @@ namespace Eto.GtkSharp.Forms
 				{
 					if (context != null)
 						return context;
-					context = new Gtk.IMContextSimple();
+					context = new Gtk.IMMulticontext();
+					context.UsePreedit = true;
+					context.PreeditStart += (o, args) =>
+					{
+						var handler = Handler;
+						if (handler == null || !HandlesDrawableComposition(handler))
+							return;
+
+						UpdateDrawableInputMethodLocation(handler);
+					};
+					context.PreeditChanged += (o, args) =>
+					{
+						var handler = Handler;
+						if (handler == null || !HandlesDrawableComposition(handler))
+							return;
+
+						context.GetPreeditString(out var text, out _, out _);
+						NotifyDrawableTextComposition(handler, text, !string.IsNullOrEmpty(text));
+					};
+					context.PreeditEnd += (o, args) =>
+					{
+						var handler = Handler;
+						if (handler == null || !HandlesDrawableComposition(handler))
+							return;
+
+						NotifyDrawableTextComposition(handler, string.Empty, false);
+					};
 
 					context.Commit += (o, args) =>
 					{
@@ -724,8 +833,16 @@ namespace Eto.GtkSharp.Forms
 						var tia = new TextInputEventArgs(args.Str);
 						handler.Callback.OnTextInput(handler.Widget, tia);
 						commitHandled = tia.Cancel;
+						UpdateDrawableInputMethodLocation(handler);
 						context.Reset();
 					};
+					var currentHandler = Handler;
+					if (currentHandler != null)
+					{
+						UpdateDrawableInputMethodLocation(currentHandler);
+						if (currentHandler.EventControl?.HasFocus == true)
+							context.FocusIn();
+					}
 					return context;
 				}
 			}
@@ -747,6 +864,7 @@ namespace Eto.GtkSharp.Forms
 				if (e == null || !e.Handled)
 				{
 					commitHandled = false;
+					UpdateDrawableInputMethodLocation(handler);
 					if (Context.FilterKeypress(args.Event))
 					{
 						args.RetVal = commitHandled;
@@ -772,6 +890,15 @@ namespace Eto.GtkSharp.Forms
 				var handler = Handler;
 				if (handler == null)
 					return;
+
+				var shouldFocusInputContext = handler.IsEventHandled(Eto.Forms.Control.TextInputEvent)
+					|| HandlesDrawableComposition(handler);
+				if (shouldFocusInputContext)
+				{
+					var inputContext = Context;
+					UpdateDrawableInputMethodLocation(handler);
+					inputContext.FocusIn();
+				}
 				Application.Instance.AsyncInvoke(() => handler.Callback.OnGotFocus(handler.Widget, EventArgs.Empty));
 			}
 
@@ -780,7 +907,17 @@ namespace Eto.GtkSharp.Forms
 				// Handler can be null here after window is closed
 				var handler = Handler;
 				if (handler != null)
+				{
+					if (context != null)
+					{
+						lastCompositionText = null;
+						lastCompositionActive = null;
+						context.FocusOut();
+						if (HandlesDrawableComposition(handler))
+							NotifyDrawableTextComposition(handler, string.Empty, false);
+					}
 					handler.Callback.OnLostFocus(Handler.Widget, EventArgs.Empty);
+				}
 			}
 
 			public void HandleControlRealized(object sender, EventArgs e)

--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -2,10 +2,13 @@ using Eto.Mac.Drawing;
 
 namespace Eto.Mac.Forms.Controls
 {
-	public class DrawableHandler : MacPanel<DrawableHandler.EtoDrawableView, Drawable, Drawable.ICallback>, Drawable.IHandler
+	public class DrawableHandler : MacPanel<DrawableHandler.EtoDrawableView, Drawable, Drawable.ICallback>, Drawable.IHandler, IMacTextInputHandler
 	{
 		Brush backgroundBrush;
 		Color backgroundColor;
+		string markedText = string.Empty;
+		NSRange selectedRange;
+		bool isComposing;
 
 		public bool SupportsCreateGraphics => false;
 
@@ -144,11 +147,123 @@ namespace Eto.Mac.Forms.Controls
 			Control.DisplayRect(rect.ToNS());
 		}
 
+		public void CancelTextComposition()
+		{
+			Control.InputContext?.DiscardMarkedText();
+			EndComposition(raiseEvent: true);
+		}
+
+		public void CommitTextComposition()
+		{
+			if (!isComposing && string.IsNullOrEmpty(markedText))
+				return;
+
+			var text = markedText;
+			EndComposition(raiseEvent: true);
+			Control.InputContext?.DiscardMarkedText();
+
+			if (string.IsNullOrEmpty(text))
+				return;
+
+			var args = new TextInputEventArgs(text);
+			Callback.OnTextInput(Widget, args);
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Drawable.TextCompositionEvent:
+				case Drawable.TextInsertionBoundsRequestedEvent:
+					if (EnsureTextInputImplemented())
+						HandleEvent(Eto.Forms.Control.KeyDownEvent);
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
 		protected override bool OnAcceptsFirstMouse(NSEvent theEvent)
 		{
 			if (CanFocus)
 				return true;
 			return base.OnAcceptsFirstMouse(theEvent);
+		}
+
+		public override void OnKeyDown(KeyEventArgs e)
+		{
+			if (isComposing)
+			{
+				// if we're composing, we need to handle the key events to properly update the composition text
+				// however, we don't want to trigger any other key events (e.g. shortcuts) while composing, so we just return here
+				return;
+			}
+			base.OnKeyDown(e);
+		}
+
+		bool IMacTextInputHandler.HasMarkedText => isComposing;
+
+		NSRange IMacTextInputHandler.MarkedRange => isComposing ? new NSRange(0, markedText.Length) : new NSRange(NSRange.NotFound, 0);
+
+		NSRange IMacTextInputHandler.SelectedRange => selectedRange;
+
+		void IMacTextInputHandler.FinishComposition() => EndComposition(raiseEvent: true);
+
+		void IMacTextInputHandler.SetMarkedText(string text, NSRange selectedRange, NSRange replacementRange)
+		{
+			markedText = text ?? string.Empty;
+			this.selectedRange = selectedRange;
+
+			isComposing = true;
+			var args = new TextCompositionEventArgs(markedText, true);
+			Callback.OnTextComposition(Widget, args);
+			Invalidate(false);
+		}
+
+		void IMacTextInputHandler.UnmarkText()
+		{
+			EndComposition(raiseEvent: true);
+		}
+
+		CGRect IMacTextInputHandler.FirstRectForCharacterRange(NSRange range)
+		{
+			var view = Control;
+			if (view == null)
+				return CGRect.Empty;
+
+			var args = new TextInsertionBoundsEventArgs();
+			Callback.OnTextInsertionBoundsRequested(Widget, args);
+			var localRect = args.Bounds ?? new RectangleF(0, 0, 1, (float)Math.Max(1, view.Bounds.Height));
+			if (localRect.Width <= 0)
+				localRect.Width = 1;
+			if (localRect.Height <= 0)
+				localRect.Height = 1;
+
+			var rect = localRect.ToNS();
+			if (!view.IsFlipped)
+				rect.Y = view.Bounds.Height - rect.Y - rect.Height;
+
+			rect = view.ConvertRectToView(rect, null);
+			return view.Window?.ConvertRectToScreen(rect) ?? CGRect.Empty;
+		}
+
+		void EndComposition(bool raiseEvent)
+		{
+			if (!isComposing && string.IsNullOrEmpty(markedText))
+				return;
+
+			markedText = string.Empty;
+			selectedRange = new NSRange(0, 0);
+			isComposing = false;
+
+			if (raiseEvent)
+			{
+				var args = new TextCompositionEventArgs(string.Empty, false);
+				Callback.OnTextComposition(Widget, args);
+			}
+
+			Invalidate(false);
 		}
 	}
 }

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -485,6 +485,10 @@ namespace Eto.Mac.Forms
 			{
 				handler.TextInputCancelled = false;
 				var text = (string)Messaging.GetNSObject<NSString>(textPtr);
+				if (handler is IMacTextInputHandler textInputHandler)
+				{
+					textInputHandler.FinishComposition();
+				}
 				var args = new TextInputEventArgs(text);
 				handler.Callback.OnTextInput(handler.Widget, args);
 				if (args.Cancel)
@@ -1875,4 +1879,3 @@ namespace Eto.Mac.Forms
 #endif
 	}
 }
-

--- a/src/Eto.Mac/Forms/MacViewTextInput.cs
+++ b/src/Eto.Mac/Forms/MacViewTextInput.cs
@@ -1,30 +1,67 @@
 namespace Eto.Mac.Forms
 {
+	interface IMacTextInputHandler
+	{
+		bool HasMarkedText { get; }
+		NSRange MarkedRange { get; }
+		NSRange SelectedRange { get; }
+		CGRect FirstRectForCharacterRange(NSRange range);
+		void FinishComposition();
+		void SetMarkedText(string text, NSRange selectedRange, NSRange replacementRange);
+		void UnmarkText();
+	}
+
 	static class MacViewTextInput
 	{
 		internal static IntPtr HasMarkedText_Selector = Selector.GetHandle("hasMarkedText");
 		internal static MarshalDelegates.Func_IntPtr_IntPtr_bool HasMarkedText_Delegate = HasMarkedText;
-		static bool HasMarkedText(IntPtr sender, IntPtr sel) => false;
+		static bool HasMarkedText(IntPtr sender, IntPtr sel)
+		{
+			var obj = Runtime.GetNSObject(sender);
+			return MacBase.GetHandler(obj) is IMacTextInputHandler handler && handler.HasMarkedText;
+		}
 
 
 		internal static IntPtr MarkedRange_Selector = Selector.GetHandle("markedRange");
 		internal static MarshalDelegates.Func_IntPtr_IntPtr_NSRange MarkedRange_Delegate = MarkedRange;
-		static NSRange MarkedRange(IntPtr sender, IntPtr sel) => new NSRange(0, 0);
+		static NSRange MarkedRange(IntPtr sender, IntPtr sel)
+		{
+			var obj = Runtime.GetNSObject(sender);
+			return MacBase.GetHandler(obj) is IMacTextInputHandler handler
+				? handler.MarkedRange
+				: new NSRange(NSRange.NotFound, 0);
+		}
 
 		internal static IntPtr SelectedRange_Selector = Selector.GetHandle("selectedRange");
 		internal static MarshalDelegates.Func_IntPtr_IntPtr_NSRange SelectedRange_Delegate = SelectedRange;
-		static NSRange SelectedRange(IntPtr sender, IntPtr sel) => new NSRange(0, 0);
+		static NSRange SelectedRange(IntPtr sender, IntPtr sel)
+		{
+			var obj = Runtime.GetNSObject(sender);
+			return MacBase.GetHandler(obj) is IMacTextInputHandler handler
+				? handler.SelectedRange
+				: new NSRange(0, 0);
+		}
 
 		internal static IntPtr SetMarkedText_Selector = Selector.GetHandle("setMarkedText:selectedRange:replacementRange:");
 		internal static MarshalDelegates.Action_IntPtr_IntPtr_IntPtr_NSRange_NSRange SetMarkedText_Delegate = SetMarkedText;
 		static void SetMarkedText(IntPtr sender, IntPtr sel, IntPtr text, NSRange selectedRange, NSRange replacementRange)
 		{
+			var obj = Runtime.GetNSObject(sender);
+			if (MacBase.GetHandler(obj) is IMacTextInputHandler handler)
+			{
+				handler.SetMarkedText(GetText(text), selectedRange, replacementRange);
+			}
 		}
 
 		internal static IntPtr UnmarkText_Selector = Selector.GetHandle("unmarkText");
 		internal static MarshalDelegates.Action_IntPtr_IntPtr UnmarkText_Delegate = UnmarkText;
 		static void UnmarkText(IntPtr sender, IntPtr sel)
 		{
+			var obj = Runtime.GetNSObject(sender);
+			if (MacBase.GetHandler(obj) is IMacTextInputHandler handler)
+			{
+				handler.UnmarkText();
+			}
 		}
 
 		internal static IntPtr ValidAttributesForMarkedText_Selector = Selector.GetHandle("validAttributesForMarkedText");
@@ -45,6 +82,10 @@ namespace Eto.Mac.Forms
 		static CGRect FirstRectForCharacterRange(IntPtr sender, IntPtr sel, NSRange range, IntPtr actualRange)
 		{
 			var obj = Runtime.GetNSObject(sender);
+			if (MacBase.GetHandler(obj) is IMacTextInputHandler textInputHandler)
+			{
+				return textInputHandler.FirstRectForCharacterRange(range);
+			}
 			if (obj is NSView ctl && MacBase.GetHandler(obj) is IMacViewHandler handler)
 			{
 				var rect = ctl.ConvertRectToView(ctl.Bounds, null);
@@ -64,6 +105,28 @@ namespace Eto.Mac.Forms
 		}
 
 		internal static IntPtr NSTextInputClientProtocol_Handle = ObjCExtensions.GetProtocolHandle("NSTextInputClient");
+
+		static Selector selString = new Selector("string");
+		static string GetText(IntPtr text)
+		{
+			if (text == IntPtr.Zero)
+				return string.Empty;
+
+			var obj = Runtime.GetNSObject(text);
+			if (obj == null)
+				return string.Empty;
+
+			if (obj is NSString str)
+				return str.ToString();
+
+			if (obj.RespondsToSelector(selString))
+			{
+				var stringHandle = Messaging.IntPtr_objc_msgSend(obj.Handle, selString.Handle);
+				return (string)Runtime.GetNSObject<NSString>(stringHandle) ?? string.Empty;
+			}
+
+			return obj.ToString() ?? string.Empty;
+		}
 	}
 
 	partial class MacView<TControl, TWidget, TCallback>

--- a/src/Eto.WinForms/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/DrawableHandler.cs
@@ -103,6 +103,14 @@ namespace Eto.WinForms.Forms.Controls
 			return new Graphics(new GraphicsHandler(Control.CreateGraphics(), true));
 		}
 
+		public virtual void CancelTextComposition()
+		{
+		}
+
+		public virtual void CommitTextComposition()
+		{
+		}
+
 		public bool CanFocus
 		{
 			get { return Control.CanFocusMe; }

--- a/src/Eto.Wpf/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DrawableHandler.cs
@@ -9,6 +9,8 @@ namespace Eto.Wpf.Forms.Controls
 	where TWidget : Drawable
 	where TCallback : Drawable.ICallback
 	{
+		TextStore textStore;
+		bool usesTextStore;
 		bool tiled;
 		sw.FrameworkElement content;
 		Scrollable scrollable;
@@ -159,18 +161,22 @@ namespace Eto.Wpf.Forms.Controls
 			base.OnLoadComplete(e);
 
 			RegisterScrollable();
+			EnsureTextStore();
+			textStore?.Attach();
 		}
 
 		protected override void OnLogicalPixelSizeChanged()
 		{
 			if (Control.IsLoaded)
 				Invalidate(false);
+			NotifyTextStoreLayoutChanged();
 		}
 
 		public override void OnUnLoad(EventArgs e)
 		{
 			base.OnUnLoad(e);
 			UnRegisterScrollable();
+			DisposeTextStore();
 		}
 
 		protected override TControl CreateControl()
@@ -189,6 +195,8 @@ namespace Eto.Wpf.Forms.Controls
 			base.Initialize();
 
 			Control.Loaded += Control_Loaded;
+			Control.GotKeyboardFocus += Control_GotKeyboardFocus;
+			Control.LostKeyboardFocus += Control_LostKeyboardFocus;
 		}
 
 		public void Create() { }
@@ -203,12 +211,102 @@ namespace Eto.Wpf.Forms.Controls
 		void Control_Loaded(object sender, sw.RoutedEventArgs e)
 		{
 			UpdateTiles(true);
+			textStore?.Attach();
 			Control.Loaded -= Control_Loaded; // only perform once
+		}
+
+		void Control_GotKeyboardFocus(object sender, swi.KeyboardFocusChangedEventArgs e)
+		{
+			if (!CanFocus)
+				return;
+
+			EnsureTextStore();
+			textStore?.Attach();
+			textStore?.SetFocused(true);
+		}
+
+		void Control_LostKeyboardFocus(object sender, swi.KeyboardFocusChangedEventArgs e)
+		{
+			textStore?.SetFocused(false);
+		}
+
+		void EnsureTextStore()
+		{
+			if (!usesTextStore || !CanFocus || textStore != null)
+				return;
+
+			textStore = new TextStore(Control, HandleTextStoreCommit, HandleTextStoreComposition, GetInputMethodBounds);
+		}
+
+		void DisposeTextStore()
+		{
+			if (textStore == null)
+				return;
+
+			textStore.Dispose();
+			textStore = null;
+		}
+
+		void NotifyTextStoreLayoutChanged()
+		{
+			textStore?.NotifyLayoutChanged();
+		}
+
+		void HandleTextStoreCommit(string text)
+		{
+			if (string.IsNullOrEmpty(text))
+				return;
+
+			var args = new TextInputEventArgs(text);
+			Callback.OnTextInput(Widget, args);
+		}
+
+		void HandleTextStoreComposition(string text, bool isActive)
+		{
+			var args = new TextCompositionEventArgs(text, isActive);
+			Callback.OnTextComposition(Widget, args);
+			Invalidate(false);
+			NotifyTextStoreLayoutChanged();
+		}
+
+		RectangleF? GetInputMethodBounds()
+		{
+			var args = new TextInsertionBoundsEventArgs();
+			Callback.OnTextInsertionBoundsRequested(Widget, args);
+			return args.Bounds;
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Drawable.TextCompositionEvent:
+				case Drawable.TextInsertionBoundsRequestedEvent:
+					usesTextStore = true;
+					EnsureTextStore();
+					textStore?.Attach();
+					if (Control.IsKeyboardFocusWithin)
+						textStore?.SetFocused(true);
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
 		}
 
 		public virtual Graphics CreateGraphics()
 		{
 			throw new NotSupportedException();
+		}
+
+		public void CancelTextComposition()
+		{
+			textStore?.CancelComposition();
+		}
+
+		public void CommitTextComposition()
+		{
+			textStore?.CommitComposition();
 		}
 
 		void Control_SizeChanged(object sender, sw.SizeChangedEventArgs e)
@@ -218,6 +316,7 @@ namespace Eto.Wpf.Forms.Controls
 			Invalidate(false);
 			content.Width = e.NewSize.Width;
 			content.Height = e.NewSize.Height;
+			NotifyTextStoreLayoutChanged();
 		}
 
 		void SetMaxTiles()
@@ -387,6 +486,7 @@ namespace Eto.Wpf.Forms.Controls
 				Invalidate(false);
 			}
 			UpdateTiles();
+			NotifyTextStoreLayoutChanged();
 		}
 
 		public override void Invalidate(bool invalidateChildren)

--- a/src/Eto.Wpf/Forms/Controls/TextStore.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextStore.cs
@@ -1,0 +1,733 @@
+using System;
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Windows;
+using System.Windows.Interop;
+using Eto.Drawing;
+
+namespace Eto.Wpf.Forms.Controls
+{
+	[ComVisible(true)]
+	[ClassInterface(ClassInterfaceType.None)]
+	internal sealed class TextStore :
+			Win32.ITextStoreACP,
+			Win32.ITfContextOwnerCompositionSink,
+			Win32.ITfMouseTrackerACP,
+			Win32.ITfTextEditSink,
+			Win32.ITfThreadFocusSink,
+			Win32.ITfTransitoryExtensionSink,
+			IDisposable
+	{
+		readonly FrameworkElement control;
+		readonly Action<string> commitText;
+		readonly Action<string, bool> updateComposition;
+		readonly Func<RectangleF?> getInputMethodRectangle;
+
+		Win32.ITfThreadMgr threadMgr;
+		Win32.ITfDocumentMgr documentMgr;
+		Win32.ITfContext context;
+		Win32.ITfSource threadMgrSource;
+		Win32.ITfSource contextSource;
+		Win32.ITextStoreACPSink acpSink;
+		IntPtr acpSinkPointer;
+		int sinkMask;
+		int clientId;
+		int editCookie;
+		int currentLockType;
+		int threadFocusCookie = Win32.TF_INVALID_COOKIE;
+		int textEditCookie = Win32.TF_INVALID_COOKIE;
+		int transitoryCookie = Win32.TF_INVALID_COOKIE;
+		int nextMouseCookie = 1;
+		bool activated;
+		bool attached;
+		bool disposed;
+		bool focused;
+		int selectionStart;
+		int selectionEnd;
+		int compositionDepth;
+		int compositionStart;
+		int compositionEnd;
+		string text = string.Empty;
+		string compositionText = string.Empty;
+		bool? lastCompositionIsActive;
+		string pendingCommit;
+
+		public TextStore(FrameworkElement control, Action<string> commitText, Action<string, bool> updateComposition, Func<RectangleF?> getInputMethodRectangle)
+		{
+			this.control = control ?? throw new ArgumentNullException(nameof(control));
+			this.commitText = commitText;
+			this.updateComposition = updateComposition;
+			this.getInputMethodRectangle = getInputMethodRectangle;
+		}
+
+		public bool IsAttached => attached;
+
+		IntPtr Hwnd => (PresentationSource.FromVisual(control) as HwndSource)?.Handle ?? IntPtr.Zero;
+
+		public void Attach()
+		{
+			if (disposed || attached || !control.IsLoaded)
+				return;
+
+			int hr = Win32.TF_GetThreadMgr(out threadMgr);
+			if (hr != Win32.S_OK || threadMgr == null)
+			{
+				hr = Win32.TF_CreateThreadMgr(out threadMgr);
+				if (hr != Win32.S_OK || threadMgr == null)
+					return;
+			}
+
+			hr = threadMgr.Activate(out clientId);
+			if (hr != Win32.S_OK)
+				return;
+
+			activated = true;
+
+			hr = threadMgr.CreateDocumentMgr(out documentMgr);
+			if (hr != Win32.S_OK || documentMgr == null)
+				return;
+
+			hr = documentMgr.CreateContext(clientId, 0, this, out context, out editCookie);
+			if (hr != Win32.S_OK || context == null)
+				return;
+
+			hr = documentMgr.Push(context);
+			if (hr != Win32.S_OK)
+				return;
+
+			threadMgrSource = threadMgr as Win32.ITfSource;
+			if (threadMgrSource != null)
+			{
+				var iid = Win32.IID_ITfThreadFocusSink;
+				threadMgrSource.AdviseSink(ref iid, this, out threadFocusCookie);
+			}
+
+			contextSource = context as Win32.ITfSource;
+			if (contextSource != null)
+			{
+				var textEditIid = Win32.IID_ITfTextEditSink;
+				contextSource.AdviseSink(ref textEditIid, this, out textEditCookie);
+
+				var transitoryIid = Win32.IID_ITfTransitoryExtensionSink;
+				contextSource.AdviseSink(ref transitoryIid, this, out transitoryCookie);
+			}
+
+			attached = true;
+			SetFocused(focused);
+		}
+
+		public void SetFocused(bool value)
+		{
+			focused = value;
+
+			if (!attached || disposed || threadMgr == null || documentMgr == null)
+				return;
+
+			var hwnd = Hwnd;
+			if (hwnd == IntPtr.Zero)
+				return;
+
+			if (value)
+			{
+				threadMgr.AssociateFocus(hwnd, documentMgr, out _);
+				threadMgr.SetFocus(documentMgr);
+				NotifyLayoutChanged();
+			}
+			else
+			{
+				ClearComposition();
+				threadMgr.AssociateFocus(hwnd, null, out _);
+			}
+		}
+
+		public void NotifyLayoutChanged()
+		{
+			if (!attached || acpSink == null || (sinkMask & Win32.TS_AS_LAYOUT_CHANGE) == 0)
+				return;
+
+			acpSink.OnLayoutChange(Win32.TsLayoutCode.TS_LC_CHANGE, 0);
+		}
+
+		public void CancelComposition()
+		{
+			if (disposed)
+				return;
+
+			pendingCommit = null;
+			compositionDepth = 0;
+			ClearComposition();
+
+			if (!focused || !attached || threadMgr == null || documentMgr == null)
+				return;
+
+			var hwnd = Hwnd;
+			if (hwnd == IntPtr.Zero)
+				return;
+
+			threadMgr.AssociateFocus(hwnd, null, out _);
+			threadMgr.AssociateFocus(hwnd, documentMgr, out _);
+			threadMgr.SetFocus(documentMgr);
+			NotifyLayoutChanged();
+		}
+
+		public void CommitComposition()
+		{
+			if (disposed)
+				return;
+
+			var committed = !string.IsNullOrEmpty(pendingCommit) ? pendingCommit : compositionText;
+			pendingCommit = null;
+			compositionDepth = 0;
+			ClearComposition();
+
+			if (!string.IsNullOrEmpty(committed))
+				commitText?.Invoke(committed);
+
+			NotifyLayoutChanged();
+		}
+
+		public void Dispose()
+		{
+			if (disposed)
+				return;
+
+			disposed = true;
+
+			try
+			{
+				SetFocused(false);
+			}
+			catch
+			{
+			}
+
+			if (contextSource != null)
+			{
+				if (textEditCookie != Win32.TF_INVALID_COOKIE)
+					contextSource.UnadviseSink(textEditCookie);
+				if (transitoryCookie != Win32.TF_INVALID_COOKIE)
+					contextSource.UnadviseSink(transitoryCookie);
+			}
+
+			if (threadMgrSource != null && threadFocusCookie != Win32.TF_INVALID_COOKIE)
+				threadMgrSource.UnadviseSink(threadFocusCookie);
+
+			if (activated && threadMgr != null)
+				threadMgr.Deactivate();
+
+			if (acpSinkPointer != IntPtr.Zero)
+			{
+				Marshal.Release(acpSinkPointer);
+				acpSinkPointer = IntPtr.Zero;
+			}
+
+			acpSink = null;
+			contextSource = null;
+			threadMgrSource = null;
+			context = null;
+			documentMgr = null;
+			threadMgr = null;
+			attached = false;
+		}
+
+		static int Clamp(int value, int min, int max)
+		{
+			if (value < min)
+				return min;
+			if (value > max)
+				return max;
+			return value;
+		}
+
+		void SetCompositionText(string value, int start, int end)
+		{
+			value ??= string.Empty;
+			var isActive = compositionDepth > 0;
+			var changed = compositionText != value || compositionStart != start || compositionEnd != end || lastCompositionIsActive != isActive;
+			compositionText = value;
+			compositionStart = start;
+			compositionEnd = end;
+			if (changed)
+			{
+				lastCompositionIsActive = isActive;
+				updateComposition?.Invoke(compositionText, isActive);
+			}
+		}
+
+		void UpdateCompositionTextFromRange()
+		{
+			var start = Clamp(compositionStart, 0, text.Length);
+			var end = Clamp(compositionEnd, start, text.Length);
+			SetCompositionText(text.Substring(start, end - start), start, end);
+		}
+
+		void UpdateCompositionRangeForChange(int start, int end, int newLength)
+		{
+			var oldLength = end - start;
+			var delta = newLength - oldLength;
+
+			if (compositionEnd < compositionStart)
+				compositionEnd = compositionStart;
+
+			if (compositionStart == compositionEnd)
+			{
+				compositionStart = start;
+				compositionEnd = start + newLength;
+				return;
+			}
+
+			if (end < compositionStart)
+			{
+				compositionStart += delta;
+				compositionEnd += delta;
+				return;
+			}
+
+			if (start > compositionEnd)
+				return;
+
+			compositionStart = Math.Min(compositionStart, start);
+			compositionEnd = Math.Max(compositionEnd, end) + delta;
+			if (compositionEnd < compositionStart)
+				compositionEnd = compositionStart;
+		}
+
+		bool TryGetRangeText(Win32.ITfRange range, int editCookie, out string value)
+		{
+			value = null;
+			if (range == null)
+				return false;
+
+			var buffer = new char[Math.Max(64, text.Length + 32)];
+			var hr = range.GetText(editCookie, 0, buffer, buffer.Length, out var count);
+			if (hr != Win32.S_OK && hr != Win32.S_FALSE)
+				return false;
+
+			value = count > 0 ? new string(buffer, 0, count) : string.Empty;
+			return true;
+		}
+
+		bool TryGetRangeExtent(Win32.ITfRange range, out int start, out int end)
+		{
+			start = 0;
+			end = 0;
+
+			if (!(range is Win32.ITfRangeACP rangeAcp))
+				return false;
+
+			var hr = rangeAcp.GetExtent(out start, out var count);
+			if (hr != Win32.S_OK)
+				return false;
+
+			end = start + Math.Max(0, count);
+			return true;
+		}
+
+		void ClearComposition()
+		{
+			var hadComposition = compositionText.Length > 0 || compositionStart != selectionEnd || compositionEnd != selectionEnd;
+			compositionText = string.Empty;
+			compositionStart = selectionEnd;
+			compositionEnd = selectionEnd;
+			pendingCommit = null;
+			if (hadComposition || lastCompositionIsActive != false)
+			{
+				lastCompositionIsActive = false;
+				updateComposition?.Invoke(string.Empty, false);
+			}
+		}
+
+		void ReplaceText(int start, int end, string replacement, out Win32.TS_TEXTCHANGE change)
+		{
+			start = Clamp(start, 0, text.Length);
+			end = Clamp(end, start, text.Length);
+			replacement = replacement ?? string.Empty;
+
+			text = text.Remove(start, end - start).Insert(start, replacement);
+			selectionStart = selectionEnd = start + replacement.Length;
+
+			change = new Win32.TS_TEXTCHANGE
+			{
+				acpStart = start,
+				acpOldEnd = end,
+				acpNewEnd = start + replacement.Length
+			};
+
+			if (acpSink != null)
+			{
+				if ((sinkMask & Win32.TS_AS_TEXT_CHANGE) != 0)
+					acpSink.OnTextChange(0, ref change);
+				if ((sinkMask & Win32.TS_AS_SEL_CHANGE) != 0)
+					acpSink.OnSelectionChange();
+			}
+
+			if (replacement.Length == 0)
+			{
+				if (compositionDepth > 0)
+				{
+					UpdateCompositionRangeForChange(start, end, 0);
+					UpdateCompositionTextFromRange();
+				}
+				return;
+			}
+
+			if (compositionDepth > 0)
+			{
+				UpdateCompositionRangeForChange(start, end, replacement.Length);
+				UpdateCompositionTextFromRange();
+				return;
+			}
+
+			commitText?.Invoke(replacement);
+		}
+
+		bool TryGetControlScreenRect(out Win32.RECT rect)
+		{
+			rect = default;
+
+			if (!control.IsLoaded || control.ActualWidth <= 0 || control.ActualHeight <= 0)
+				return false;
+
+			var inputRect = getInputMethodRectangle?.Invoke();
+			var localRect = inputRect ?? new RectangleF(0, 0, 1, Math.Max(1, (float)control.ActualHeight));
+			if (localRect.Width <= 0)
+				localRect.Width = 1;
+			if (localRect.Height <= 0)
+				localRect.Height = 1;
+
+			var topLeft = control.PointToScreen(new System.Windows.Point(localRect.X, localRect.Y));
+			rect.left = (int)Math.Round(topLeft.X);
+			rect.top = (int)Math.Round(topLeft.Y);
+			rect.right = rect.left + (int)Math.Ceiling(localRect.Width);
+			rect.bottom = rect.top + (int)Math.Ceiling(localRect.Height);
+			return true;
+		}
+
+		public int AdviseSink(ref Guid riid, IntPtr punk, int mask)
+		{
+			if (riid != Win32.IID_ITextStoreACPSink)
+				return Win32.E_INVALIDARG;
+			if (punk == IntPtr.Zero)
+				return Win32.E_INVALIDARG;
+			if (acpSinkPointer != IntPtr.Zero && acpSinkPointer != punk)
+				return Win32.CONNECT_E_ADVISELIMIT;
+
+			if (acpSinkPointer == IntPtr.Zero)
+			{
+				acpSinkPointer = punk;
+				Marshal.AddRef(acpSinkPointer);
+				acpSink = (Win32.ITextStoreACPSink)Marshal.GetObjectForIUnknown(acpSinkPointer);
+			}
+
+			sinkMask = mask;
+			return Win32.S_OK;
+		}
+
+		public int UnadviseSink(IntPtr punk)
+		{
+			if (acpSinkPointer == IntPtr.Zero)
+				return Win32.CONNECT_E_NOCONNECTION;
+			if (punk != IntPtr.Zero && punk != acpSinkPointer)
+				return Win32.CONNECT_E_NOCONNECTION;
+
+			Marshal.Release(acpSinkPointer);
+			acpSinkPointer = IntPtr.Zero;
+			acpSink = null;
+			sinkMask = 0;
+			return Win32.S_OK;
+		}
+
+		public int RequestLock(int lockFlags, out int sessionResult)
+		{
+			sessionResult = Win32.S_OK;
+
+			if (acpSink == null)
+				return Win32.E_FAIL;
+
+			if (currentLockType != 0)
+			{
+				sessionResult = Win32.TS_E_SYNCHRONOUS;
+				return Win32.TS_S_ASYNC;
+			}
+
+			currentLockType = lockFlags;
+			try
+			{
+				return acpSink.OnLockGranted(lockFlags);
+			}
+			finally
+			{
+				currentLockType = 0;
+			}
+		}
+
+		public int GetStatus(out Win32.TS_STATUS status)
+		{
+			status = new Win32.TS_STATUS
+			{
+				dwDynamicFlags = Win32.TS_SD_UIINTEGRATIONENABLE,
+				dwStaticFlags = Win32.TS_SS_TRANSITORY | Win32.TS_SS_NOHIDDENTEXT
+			};
+			return Win32.S_OK;
+		}
+
+		public int QueryInsert(int acpTestStart, int acpTestEnd, int cch, out int acpResultStart, out int acpResultEnd)
+		{
+			acpResultStart = Clamp(acpTestStart, 0, text.Length);
+			acpResultEnd = acpResultStart + Math.Max(0, cch);
+			return Win32.S_OK;
+		}
+
+		public int GetSelection(int index, int count, Win32.TS_SELECTION_ACP[] selection, out int fetchedCount)
+		{
+			fetchedCount = 0;
+			if (selection == null || selection.Length == 0 || count <= 0)
+				return Win32.E_INVALIDARG;
+			if (index != 0 && index != Win32.TF_DEFAULT_SELECTION)
+				return Win32.TS_E_NOSELECTION;
+
+			selection[0] = new Win32.TS_SELECTION_ACP
+			{
+				acpStart = selectionStart,
+				acpEnd = selectionEnd,
+				style_ase = Win32.TsActiveSelEnd.TS_AE_END,
+				style_fInterimChar = false
+			};
+			fetchedCount = 1;
+			return Win32.S_OK;
+		}
+
+		public int SetSelection(int count, Win32.TS_SELECTION_ACP[] selection)
+		{
+			if (selection == null || selection.Length == 0 || count <= 0)
+				return Win32.E_INVALIDARG;
+
+			selectionStart = Clamp(selection[0].acpStart, 0, text.Length);
+			selectionEnd = Clamp(selection[0].acpEnd, 0, text.Length);
+
+			if (acpSink != null && (sinkMask & Win32.TS_AS_SEL_CHANGE) != 0)
+				acpSink.OnSelectionChange();
+
+			if (compositionDepth > 0)
+			{
+				UpdateCompositionTextFromRange();
+			}
+
+			return Win32.S_OK;
+		}
+
+		public int GetText(int acpStart, int acpEnd, char[] plainText, int plainTextLength, out int plainTextReturned, Win32.TS_RUNINFO[] runInfo, int runInfoLength, out int runInfoReturned, out int nextAcp)
+		{
+			plainTextReturned = 0;
+			runInfoReturned = 0;
+
+			var start = Clamp(acpStart, 0, text.Length);
+			var end = acpEnd < 0 ? text.Length : Clamp(acpEnd, start, text.Length);
+			var range = text.Substring(start, end - start);
+
+			if (plainText != null && plainTextLength > 0)
+			{
+				plainTextReturned = Math.Min(range.Length, plainTextLength);
+				range.CopyTo(0, plainText, 0, plainTextReturned);
+			}
+
+			if (runInfo != null && runInfo.Length > 0)
+			{
+				runInfo[0] = new Win32.TS_RUNINFO
+				{
+					uCount = range.Length,
+					type = Win32.TsRunType.TS_RT_PLAIN
+				};
+				runInfoReturned = 1;
+			}
+
+			nextAcp = end;
+			return Win32.S_OK;
+		}
+
+		public int SetText(int flags, int acpStart, int acpEnd, char[] replacementText, int length, out Win32.TS_TEXTCHANGE change)
+		{
+			var replacement = replacementText == null || length <= 0 ? string.Empty : new string(replacementText, 0, Math.Min(length, replacementText.Length));
+			ReplaceText(acpStart, acpEnd, replacement, out change);
+			return Win32.S_OK;
+		}
+
+		public int GetFormattedText(int acpStart, int acpEnd, out System.Runtime.InteropServices.ComTypes.IDataObject dataObject)
+		{
+			dataObject = null;
+			return Win32.E_NOTIMPL;
+		}
+
+		public int GetEmbedded(int acpPos, ref Guid service, ref Guid riid, out IntPtr unk)
+		{
+			unk = IntPtr.Zero;
+			return Win32.TS_E_NOOBJECT;
+		}
+
+		public int QueryInsertEmbedded(IntPtr guidService, IntPtr formatEtc, out bool insertable)
+		{
+			insertable = false;
+			return Win32.S_OK;
+		}
+
+		public int InsertEmbedded(int flags, int acpStart, int acpEnd, System.Runtime.InteropServices.ComTypes.IDataObject dataObject, out Win32.TS_TEXTCHANGE change)
+		{
+			change = default;
+			return Win32.E_NOTIMPL;
+		}
+
+		public int InsertTextAtSelection(int flags, char[] replacementText, int length, out int acpStart, out int acpEnd, out Win32.TS_TEXTCHANGE change)
+		{
+			acpStart = selectionStart;
+			acpEnd = selectionEnd;
+			var replacement = replacementText == null || length <= 0 ? string.Empty : new string(replacementText, 0, Math.Min(length, replacementText.Length));
+			ReplaceText(selectionStart, selectionEnd, replacement, out change);
+			return Win32.S_OK;
+		}
+
+		public int InsertEmbeddedAtSelection(int flags, System.Runtime.InteropServices.ComTypes.IDataObject dataObject, out int acpStart, out int acpEnd, out Win32.TS_TEXTCHANGE change)
+		{
+			acpStart = selectionStart;
+			acpEnd = selectionEnd;
+			change = default;
+			return Win32.E_NOTIMPL;
+		}
+
+		public int RequestSupportedAttrs(int flags, int filterAttrCount, IntPtr filterAttrs) => Win32.S_OK;
+
+		public int RequestAttrsAtPosition(int acpPos, int filterAttrCount, IntPtr filterAttrs, int flags) => Win32.S_OK;
+
+		public int RequestAttrsTransitioningAtPosition(int acpPos, int filterAttrCount, IntPtr filterAttrs, int flags) => Win32.S_OK;
+
+		public int FindNextAttrTransition(int acpStart, int acpHalt, int filterAttrCount, IntPtr filterAttrs, int flags, out int acpNext, out bool found, out int foundOffset)
+		{
+			acpNext = Clamp(acpHalt, 0, text.Length);
+			found = false;
+			foundOffset = 0;
+			return Win32.S_OK;
+		}
+
+		public int RetrieveRequestedAttrs(int count, IntPtr attrValues, out int fetchedCount)
+		{
+			fetchedCount = 0;
+			return Win32.S_OK;
+		}
+
+		public int GetEndACP(out int acp)
+		{
+			acp = text.Length;
+			return Win32.S_OK;
+		}
+
+		public int GetActiveView(out int viewCookie)
+		{
+			viewCookie = 0;
+			return Win32.S_OK;
+		}
+
+		public int GetACPFromPoint(int viewCookie, ref Win32.POINT point, int flags, out int acp)
+		{
+			acp = compositionDepth > 0 ? compositionEnd : selectionEnd;
+			return Win32.S_OK;
+		}
+
+		public int GetTextExt(int viewCookie, int acpStart, int acpEnd, out Win32.RECT rect, out bool clipped)
+		{
+			clipped = false;
+			if (!TryGetControlScreenRect(out rect))
+				return Win32.TS_E_NOLAYOUT;
+			return Win32.S_OK;
+		}
+
+		public int GetScreenExt(int viewCookie, out Win32.RECT rect)
+		{
+			if (!TryGetControlScreenRect(out rect))
+				return Win32.TS_E_NOLAYOUT;
+			return Win32.S_OK;
+		}
+
+		public int GetWnd(int viewCookie, out IntPtr hwnd)
+		{
+			hwnd = Hwnd;
+			return hwnd != IntPtr.Zero ? Win32.S_OK : Win32.TS_E_NOLAYOUT;
+		}
+
+		public int OnSetThreadFocus()
+		{
+			NotifyLayoutChanged();
+			return Win32.S_OK;
+		}
+
+		public int OnKillThreadFocus() => Win32.S_OK;
+
+		public int OnStartComposition(Win32.ITfCompositionView composition, out bool ok)
+		{
+			compositionDepth++;
+			SetCompositionText(compositionText, selectionStart, selectionEnd);
+			ok = true;
+			return Win32.S_OK;
+		}
+
+		public int OnUpdateComposition(Win32.ITfCompositionView composition, Win32.ITfRange rangeNew)
+		{
+			NotifyLayoutChanged();
+			return Win32.S_OK;
+		}
+
+		public int OnEndComposition(Win32.ITfCompositionView composition)
+		{
+			if (compositionDepth > 0)
+				compositionDepth--;
+
+			if (compositionDepth == 0 && string.IsNullOrEmpty(pendingCommit) && !string.IsNullOrEmpty(compositionText))
+			{
+				pendingCommit = compositionText;
+			}
+
+			if (compositionDepth == 0 && !string.IsNullOrEmpty(pendingCommit))
+			{
+				var committed = pendingCommit;
+				ClearComposition();
+				commitText?.Invoke(committed);
+			}
+			else if (compositionDepth == 0)
+			{
+				ClearComposition();
+			}
+
+			return Win32.S_OK;
+		}
+
+		public int OnEndEdit(Win32.ITfContext context, int readOnlyEditCookie, Win32.ITfEditRecord editRecord) => Win32.S_OK;
+
+		public int OnTransitoryExtensionUpdated(Win32.ITfContext context, int readOnlyEditCookie, Win32.ITfRange resultRange, Win32.ITfRange compositionRange, out bool deleteResultRange)
+		{
+			deleteResultRange = false;
+			pendingCommit = null;
+
+			if (resultRange != null && TryGetRangeText(resultRange, readOnlyEditCookie, out var resultText))
+				pendingCommit = resultText;
+
+			if (compositionRange != null)
+			{
+				if (TryGetRangeText(compositionRange, readOnlyEditCookie, out var value))
+				{
+					if (TryGetRangeExtent(compositionRange, out var start, out var end))
+						SetCompositionText(value, start, end);
+					else
+						SetCompositionText(value, compositionStart, compositionStart + value.Length);
+				}
+			}
+
+			return Win32.S_OK;
+		}
+
+		public int AdviseMouseSink(Win32.ITfRangeACP range, Win32.ITfMouseSink sink, out int cookie)
+		{
+			cookie = nextMouseCookie++;
+			return Win32.S_OK;
+		}
+
+		public int UnadviseMouseSink(int cookie) => Win32.S_OK;
+	}
+}

--- a/src/Eto.Wpf/Win32.tsf.cs
+++ b/src/Eto.Wpf/Win32.tsf.cs
@@ -1,0 +1,393 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace Eto
+{
+	partial class Win32
+	{
+		internal const int S_OK = 0x00000000;
+		internal const int S_FALSE = 0x00000001;
+		internal const int E_FAIL = unchecked((int)0x80004005);
+		internal const int E_INVALIDARG = unchecked((int)0x80070057);
+		internal const int E_NOTIMPL = unchecked((int)0x80004001);
+		internal const int CONNECT_E_ADVISELIMIT = unchecked((int)0x80040200);
+		internal const int CONNECT_E_NOCONNECTION = unchecked((int)0x80040204);
+
+		internal const int TS_E_INVALIDPOS = unchecked((int)0x80040200);
+		internal const int TS_E_NOLOCK = unchecked((int)0x80040201);
+		internal const int TS_E_NOOBJECT = unchecked((int)0x80040202);
+		internal const int TS_E_NOSELECTION = unchecked((int)0x80040205);
+		internal const int TS_E_NOLAYOUT = unchecked((int)0x80040206);
+		internal const int TS_E_INVALIDPOINT = unchecked((int)0x80040207);
+		internal const int TS_E_SYNCHRONOUS = unchecked((int)0x80040208);
+		internal const int TS_E_READONLY = unchecked((int)0x80040209);
+		internal const int TS_S_ASYNC = 0x00040300;
+
+		internal const int TS_AS_TEXT_CHANGE = 0x01;
+		internal const int TS_AS_SEL_CHANGE = 0x02;
+		internal const int TS_AS_LAYOUT_CHANGE = 0x04;
+		internal const int TS_AS_ATTR_CHANGE = 0x08;
+		internal const int TS_AS_STATUS_CHANGE = 0x10;
+
+		internal const int TS_LF_SYNC = 0x01;
+		internal const int TS_LF_READ = 0x02;
+		internal const int TS_LF_READWRITE = 0x06;
+
+		internal const int TS_SD_READONLY = 0x001;
+		internal const int TS_SD_LOADING = 0x002;
+		internal const int TS_SD_UIINTEGRATIONENABLE = 0x020;
+
+		internal const int TS_SS_TRANSITORY = 0x004;
+		internal const int TS_SS_NOHIDDENTEXT = 0x008;
+
+		internal const int TF_INVALID_COOKIE = -1;
+		internal const int TF_DEFAULT_SELECTION = unchecked((int)0xFFFFFFFF);
+
+		internal static readonly Guid IID_ITextStoreACP = new Guid("28888FE3-C2A0-483A-A3EA-8CB1CE51FF3D");
+		internal static readonly Guid IID_ITextStoreACPSink = new Guid("22D44C94-A419-4542-A272-AE26093ECECF");
+		internal static readonly Guid IID_ITfThreadFocusSink = new Guid("C0F1DB0C-3A20-405C-A303-96B6010A885F");
+		internal static readonly Guid IID_ITfContextOwnerCompositionSink = new Guid("5F20AA40-B57A-4F34-96AB-3576F377CC79");
+		internal static readonly Guid IID_ITfTextEditSink = new Guid("8127D409-CCD3-4683-967A-B43D5B482BF7");
+		internal static readonly Guid IID_ITfTransitoryExtensionSink = new Guid("A615096F-1C57-4813-8A15-55EE6E5A839C");
+		internal static readonly Guid IID_ITfMouseTrackerACP = new Guid("3BDD78E2-C16E-47FD-B883-CE6FACC1A208");
+
+		[DllImport("msctf.dll")]
+		internal static extern int TF_CreateThreadMgr(out ITfThreadMgr threadMgr);
+
+		[DllImport("msctf.dll")]
+		internal static extern int TF_GetThreadMgr(out ITfThreadMgr threadMgr);
+
+		[StructLayout(LayoutKind.Sequential)]
+		internal struct TS_STATUS
+		{
+			public int dwDynamicFlags;
+			public int dwStaticFlags;
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		internal struct TS_TEXTCHANGE
+		{
+			public int acpStart;
+			public int acpOldEnd;
+			public int acpNewEnd;
+		}
+
+		internal enum TsActiveSelEnd
+		{
+			TS_AE_NONE = 0,
+			TS_AE_START = 1,
+			TS_AE_END = 2
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		internal struct TS_SELECTION_ACP
+		{
+			public int acpStart;
+			public int acpEnd;
+			public TsActiveSelEnd style_ase;
+
+			[MarshalAs(UnmanagedType.Bool)]
+			public bool style_fInterimChar;
+		}
+
+		internal enum TsRunType
+		{
+			TS_RT_PLAIN = 0,
+			TS_RT_HIDDEN = 1,
+			TS_RT_OPAQUE = 2
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		internal struct TS_RUNINFO
+		{
+			public int uCount;
+			public TsRunType type;
+		}
+
+		internal enum TsLayoutCode
+		{
+			TS_LC_CREATE = 0,
+			TS_LC_CHANGE = 1,
+			TS_LC_DESTROY = 2
+		}
+
+		[ComImport]
+		[Guid("AA80E7FD-2021-11D2-93E0-0060B067B86E")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfContext
+		{
+		}
+
+		[ComImport]
+		[Guid("2433BF8E-0F9B-435C-BA2C-180611978C30")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfContextView
+		{
+		}
+
+		[ComImport]
+		[Guid("4EA48A35-60AE-446F-8FD6-E6A8D82459F7")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfSource
+		{
+			[PreserveSig]
+			int AdviseSink(ref Guid riid, [MarshalAs(UnmanagedType.Interface)] object punk, out int cookie);
+
+			[PreserveSig]
+			int UnadviseSink(int cookie);
+		}
+
+		[ComImport]
+		[Guid("AA80E7F4-2021-11D2-93E0-0060B067B86E")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfDocumentMgr
+		{
+			[PreserveSig]
+			int CreateContext(int clientId, int flags, [MarshalAs(UnmanagedType.Interface)] object textStore, out ITfContext context, out int editCookie);
+
+			[PreserveSig]
+			int Push([MarshalAs(UnmanagedType.Interface)] ITfContext context);
+		}
+
+		[ComImport]
+		[Guid("AA80E801-2021-11D2-93E0-0060B067B86E")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfThreadMgr
+		{
+			[PreserveSig]
+			int Activate(out int clientId);
+
+			[PreserveSig]
+			int Deactivate();
+
+			[PreserveSig]
+			int CreateDocumentMgr(out ITfDocumentMgr documentMgr);
+
+			[PreserveSig]
+			int EnumDocumentMgrs(out IntPtr enumDocumentMgrs);
+
+			[PreserveSig]
+			int GetFocus(out ITfDocumentMgr documentMgr);
+
+			[PreserveSig]
+			int SetFocus([MarshalAs(UnmanagedType.Interface)] ITfDocumentMgr documentMgr);
+
+			[PreserveSig]
+			int AssociateFocus(IntPtr hwnd, [MarshalAs(UnmanagedType.Interface)] ITfDocumentMgr documentMgr, out ITfDocumentMgr previousDocumentMgr);
+
+			[PreserveSig]
+			int IsThreadFocus([MarshalAs(UnmanagedType.Bool)] out bool threadFocus);
+		}
+
+		[ComImport]
+		[Guid("22D44C94-A419-4542-A272-AE26093ECECF")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITextStoreACPSink
+		{
+			[PreserveSig]
+			int OnTextChange(int flags, ref TS_TEXTCHANGE change);
+
+			[PreserveSig]
+			int OnSelectionChange();
+
+			[PreserveSig]
+			int OnLayoutChange(TsLayoutCode layoutCode, int viewCookie);
+
+			[PreserveSig]
+			int OnStatusChange(int flags);
+
+			[PreserveSig]
+			int OnAttrsChange(int acpStart, int acpEnd, int attrCount, IntPtr attrs);
+
+			[PreserveSig]
+			int OnLockGranted(int lockFlags);
+
+			[PreserveSig]
+			int OnStartEditTransaction();
+
+			[PreserveSig]
+			int OnEndEditTransaction();
+		}
+
+		[ComImport]
+		[Guid("28888FE3-C2A0-483A-A3EA-8CB1CE51FF3D")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITextStoreACP
+		{
+			[PreserveSig]
+			int AdviseSink(ref Guid riid, IntPtr punk, int mask);
+
+			[PreserveSig]
+			int UnadviseSink(IntPtr punk);
+
+			[PreserveSig]
+			int RequestLock(int lockFlags, out int sessionResult);
+
+			[PreserveSig]
+			int GetStatus(out TS_STATUS status);
+
+			[PreserveSig]
+			int QueryInsert(int acpTestStart, int acpTestEnd, int cch, out int acpResultStart, out int acpResultEnd);
+
+			[PreserveSig]
+			int GetSelection(int index, int count, [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 1)] TS_SELECTION_ACP[] selection, out int fetchedCount);
+
+			[PreserveSig]
+			int SetSelection(int count, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 0)] TS_SELECTION_ACP[] selection);
+
+			[PreserveSig]
+			int GetText(int acpStart, int acpEnd, [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] char[] text, int textLength, out int textLengthReturned, [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 7)] TS_RUNINFO[] runInfo, int runInfoLength, out int runInfoReturned, out int nextAcp);
+
+			[PreserveSig]
+			int SetText(int flags, int acpStart, int acpEnd, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 4)] char[] text, int length, out TS_TEXTCHANGE change);
+
+			[PreserveSig]
+			int GetFormattedText(int acpStart, int acpEnd, out System.Runtime.InteropServices.ComTypes.IDataObject dataObject);
+
+			[PreserveSig]
+			int GetEmbedded(int acpPos, ref Guid service, ref Guid riid, out IntPtr unk);
+
+			[PreserveSig]
+			int QueryInsertEmbedded(IntPtr guidService, IntPtr formatEtc, [MarshalAs(UnmanagedType.Bool)] out bool insertable);
+
+			[PreserveSig]
+			int InsertEmbedded(int flags, int acpStart, int acpEnd, System.Runtime.InteropServices.ComTypes.IDataObject dataObject, out TS_TEXTCHANGE change);
+
+			[PreserveSig]
+			int InsertTextAtSelection(int flags, [In, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 2)] char[] text, int length, out int acpStart, out int acpEnd, out TS_TEXTCHANGE change);
+
+			[PreserveSig]
+			int InsertEmbeddedAtSelection(int flags, System.Runtime.InteropServices.ComTypes.IDataObject dataObject, out int acpStart, out int acpEnd, out TS_TEXTCHANGE change);
+
+			[PreserveSig]
+			int RequestSupportedAttrs(int flags, int filterAttrCount, IntPtr filterAttrs);
+
+			[PreserveSig]
+			int RequestAttrsAtPosition(int acpPos, int filterAttrCount, IntPtr filterAttrs, int flags);
+
+			[PreserveSig]
+			int RequestAttrsTransitioningAtPosition(int acpPos, int filterAttrCount, IntPtr filterAttrs, int flags);
+
+			[PreserveSig]
+			int FindNextAttrTransition(int acpStart, int acpHalt, int filterAttrCount, IntPtr filterAttrs, int flags, out int acpNext, [MarshalAs(UnmanagedType.Bool)] out bool found, out int foundOffset);
+
+			[PreserveSig]
+			int RetrieveRequestedAttrs(int count, IntPtr attrValues, out int fetchedCount);
+
+			[PreserveSig]
+			int GetEndACP(out int acp);
+
+			[PreserveSig]
+			int GetActiveView(out int viewCookie);
+
+			[PreserveSig]
+			int GetACPFromPoint(int viewCookie, ref POINT point, int flags, out int acp);
+
+			[PreserveSig]
+			int GetTextExt(int viewCookie, int acpStart, int acpEnd, out RECT rect, [MarshalAs(UnmanagedType.Bool)] out bool clipped);
+
+			[PreserveSig]
+			int GetScreenExt(int viewCookie, out RECT rect);
+
+			[PreserveSig]
+			int GetWnd(int viewCookie, out IntPtr hwnd);
+		}
+
+		[ComImport]
+		[Guid("C0F1DB0C-3A20-405C-A303-96B6010A885F")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfThreadFocusSink
+		{
+			[PreserveSig]
+			int OnSetThreadFocus();
+
+			[PreserveSig]
+			int OnKillThreadFocus();
+		}
+
+		[ComImport]
+		[Guid("5F20AA40-B57A-4F34-96AB-3576F377CC79")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfContextOwnerCompositionSink
+		{
+			[PreserveSig]
+			int OnStartComposition([MarshalAs(UnmanagedType.Interface)] ITfCompositionView composition, [MarshalAs(UnmanagedType.Bool)] out bool ok);
+
+			[PreserveSig]
+			int OnUpdateComposition([MarshalAs(UnmanagedType.Interface)] ITfCompositionView composition, [MarshalAs(UnmanagedType.Interface)] ITfRange rangeNew);
+
+			[PreserveSig]
+			int OnEndComposition([MarshalAs(UnmanagedType.Interface)] ITfCompositionView composition);
+		}
+
+		[ComImport]
+		[Guid("8127D409-CCD3-4683-967A-B43D5B482BF7")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfTextEditSink
+		{
+			[PreserveSig]
+			int OnEndEdit([MarshalAs(UnmanagedType.Interface)] ITfContext context, int readOnlyEditCookie, [MarshalAs(UnmanagedType.Interface)] ITfEditRecord editRecord);
+		}
+
+		[ComImport]
+		[Guid("A615096F-1C57-4813-8A15-55EE6E5A839C")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfTransitoryExtensionSink
+		{
+			[PreserveSig]
+			int OnTransitoryExtensionUpdated([MarshalAs(UnmanagedType.Interface)] ITfContext context, int readOnlyEditCookie, [MarshalAs(UnmanagedType.Interface)] ITfRange resultRange, [MarshalAs(UnmanagedType.Interface)] ITfRange compositionRange, [MarshalAs(UnmanagedType.Bool)] out bool deleteResultRange);
+		}
+
+		[ComImport]
+		[Guid("3BDD78E2-C16E-47FD-B883-CE6FACC1A208")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfMouseTrackerACP
+		{
+			[PreserveSig]
+			int AdviseMouseSink([MarshalAs(UnmanagedType.Interface)] ITfRangeACP range, [MarshalAs(UnmanagedType.Interface)] ITfMouseSink sink, out int cookie);
+
+			[PreserveSig]
+			int UnadviseMouseSink(int cookie);
+		}
+
+		[ComImport]
+		[Guid("A1ADAAA2-3A24-449D-AC96-5183E7F5C217")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfMouseSink
+		{
+		}
+
+		[ComImport]
+		[Guid("42D4D099-7C1A-4A89-B836-6C6F22160DF0")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfEditRecord
+		{
+		}
+
+		[ComImport]
+		[Guid("D7540241-F9A1-4364-BEFC-DBCD2C4395B7")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfCompositionView
+		{
+		}
+
+		[ComImport]
+		[Guid("AA80E7FF-2021-11D2-93E0-0060B067B86E")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfRange
+		{
+			[PreserveSig]
+			int GetText(int editCookie, int flags, [Out, MarshalAs(UnmanagedType.LPArray, SizeParamIndex = 3)] char[] text, int textLength, out int textLengthReturned);
+		}
+
+		[ComImport]
+		[Guid("057A6296-029B-4154-B79A-0D461D4EA94C")]
+		[InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+		internal interface ITfRangeACP
+			: ITfRange
+		{
+			[PreserveSig]
+			int GetExtent(out int anchor, out int count);
+		}
+	}
+}

--- a/src/Eto.iOS/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.iOS/Forms/Controls/DrawableHandler.cs
@@ -128,5 +128,13 @@ namespace Eto.iOS.Forms.Controls
 				}
 			}
 		}
+
+		public void CancelTextComposition()
+		{
+		}
+
+		public void CommitTextComposition()
+		{
+		}
 	}
 }

--- a/src/Eto/Forms/Controls/Drawable.cs
+++ b/src/Eto/Forms/Controls/Drawable.cs
@@ -43,12 +43,64 @@ public class PaintEventArgs : EventArgs
 [Handler(typeof(Drawable.IHandler))]
 public class Drawable : Panel
 {
-	new IHandler Handler { get { return (IHandler)base.Handler; } }
+	new IHandler Handler => (IHandler)base.Handler;
+
+	static Drawable()
+	{
+		EventLookup.Register<Drawable>(d => d.OnTextComposition(null), TextCompositionEvent);
+		EventLookup.Register<Drawable>(d => d.OnTextInsertionBoundsRequested(null), TextInsertionBoundsRequestedEvent);
+	}
 
 	/// <summary>
 	/// Event to handle custom painting on the control
 	/// </summary>
 	public event EventHandler<PaintEventArgs> Paint;
+
+
+	/// <summary>
+	/// Event identifier for handlers when attaching the <see cref="TextComposition"/> event.
+	/// </summary>
+	public const string TextCompositionEvent = "Drawable.TextComposition";
+
+	/// <summary>
+	/// Event identifier for handlers when attaching the <see cref="TextInsertionBoundsRequested"/> event.
+	/// </summary>
+	public const string TextInsertionBoundsRequestedEvent = "Drawable.TextInsertionBoundsRequested";
+
+	/// <summary>
+	/// Event raised when live text composition changes, such as inline composition preview text.
+	/// </summary>
+	/// <remarks>
+	/// This event is raised when composing text with an input method editor (IME).  
+	/// The event will be raised whenever the composition text changes, or when the composition becomes active or inactive.
+	/// 
+	/// The composition text is typically shown inline at the caret position, and is used to show the current 
+	/// composition state of the IME, such as when entering complex characters in East Asian languages.
+	/// The <see cref="TextInsertionBoundsRequested"/> event is used to specify where the composition text interface
+	/// should be displayed.
+	/// 
+	/// The composition text is not committed text, and should not be treated as such.  The completed text will 
+	/// be provided in the <see cref="Control.TextInput"/> event when the composition is committed.
+	/// </remarks>
+	public event EventHandler<TextCompositionEventArgs> TextComposition
+	{
+		add => Properties.AddHandlerEvent(TextCompositionEvent, value);
+		remove => Properties.RemoveEvent(TextCompositionEvent, value);
+	}
+
+	/// <summary>
+	/// Event raised when the platform needs the current text insertion bounds for text UI placement.
+	/// </summary>
+	/// <remarks>
+	/// Handle this event to provide the current caret or insertion rectangle in drawable client coordinates.
+	/// Platforms can query this whenever they need to position text-related UI such as composition, candidate,
+	/// or emoji panels.
+	/// </remarks>
+	public event EventHandler<TextInsertionBoundsEventArgs> TextInsertionBoundsRequested
+	{
+		add => Properties.AddHandlerEvent(TextInsertionBoundsRequestedEvent, value);
+		remove => Properties.RemoveEvent(TextInsertionBoundsRequestedEvent, value);
+	}
 
 	/// <summary>
 	/// Initializes a new instance of the <see cref="Eto.Forms.Drawable"/> class.
@@ -94,6 +146,24 @@ public class Drawable : Panel
 	{
 		if (Paint != null)
 			Paint(this, e);
+	}
+
+	/// <summary>
+	/// Raises the <see cref="TextComposition"/> event.
+	/// </summary>
+	/// <param name="e">Composition event arguments.</param>
+	protected virtual void OnTextComposition(TextCompositionEventArgs e)
+	{
+		Properties.TriggerEvent(TextCompositionEvent, this, e);
+	}
+
+	/// <summary>
+	/// Raises the <see cref="TextInsertionBoundsRequested"/> event.
+	/// </summary>
+	/// <param name="e">Text insertion bounds event arguments.</param>
+	protected virtual void OnTextInsertionBoundsRequested(TextInsertionBoundsEventArgs e)
+	{
+		Properties.TriggerEvent(TextInsertionBoundsRequestedEvent, this, e);
 	}
 
 	/// <summary>
@@ -145,6 +215,30 @@ public class Drawable : Panel
 		Handler.Update(region);
 	}
 
+	/// <summary>
+	/// Cancels any active text composition associated with this drawable.
+	/// </summary>
+	/// <remarks>
+	/// This can be used when the insertion point changes while an input method editor (IME) composition
+	/// is active, such as when clicking to move the caret.
+	/// </remarks>
+	public void CancelTextComposition()
+	{
+		Handler.CancelTextComposition();
+	}
+
+	/// <summary>
+	/// Commits any active text composition associated with this drawable.
+	/// </summary>
+	/// <remarks>
+	/// This finalizes the current input method editor (IME) composition and raises the resulting text
+	/// through the normal <see cref="Control.TextInput"/> flow.
+	/// </remarks>
+	public void CommitTextComposition()
+	{
+		Handler.CommitTextComposition();
+	}
+
 	static readonly object callback = new Callback();
 	/// <summary>
 	/// Gets an instance of an object used to perform callbacks to the widget from handler implementations
@@ -161,6 +255,16 @@ public class Drawable : Panel
 		/// Raises the paint event.
 		/// </summary>
 		void OnPaint(Drawable widget, PaintEventArgs e);
+
+		/// <summary>
+		/// Raises the live text composition event.
+		/// </summary>
+		void OnTextComposition(Drawable widget, TextCompositionEventArgs e);
+
+		/// <summary>
+		/// Raises the text insertion bounds requested event.
+		/// </summary>
+		void OnTextInsertionBoundsRequested(Drawable widget, TextInsertionBoundsEventArgs e);
 	}
 
 	/// <summary>
@@ -175,6 +279,24 @@ public class Drawable : Panel
 		{
 			using (widget.Platform.Context)
 				widget.OnPaint(e);
+		}
+
+		/// <summary>
+		/// Raises the live text composition event.
+		/// </summary>
+		public void OnTextComposition(Drawable widget, TextCompositionEventArgs e)
+		{
+			using (widget.Platform.Context)
+				widget.OnTextComposition(e);
+		}
+
+		/// <summary>
+		/// Raises the text insertion bounds requested event.
+		/// </summary>
+		public void OnTextInsertionBoundsRequested(Drawable widget, TextInsertionBoundsEventArgs e)
+		{
+			using (widget.Platform.Context)
+				widget.OnTextInsertionBoundsRequested(e);
 		}
 	}
 
@@ -242,6 +364,17 @@ public class Drawable : Panel
 		/// </remarks>
 		/// <returns>A new graphics context that can be used to draw directly onto the control</returns>
 		Graphics CreateGraphics();
+
+		/// <summary>
+		/// Cancels any active text composition associated with this drawable.
+		/// </summary>
+		void CancelTextComposition();
+
+		/// <summary>
+		/// Commits any active text composition associated with this drawable.
+		/// </summary>
+		void CommitTextComposition();
+
 	}
 
 	#endregion

--- a/src/Eto/Forms/Controls/TextCompositionEventArgs.cs
+++ b/src/Eto/Forms/Controls/TextCompositionEventArgs.cs
@@ -1,0 +1,28 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Event arguments for live text composition updates such as inline composition preview text.
+/// </summary>
+public class TextCompositionEventArgs : HandledEventArgs
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TextCompositionEventArgs"/> class.
+	/// </summary>
+	/// <param name="text">Current composition text.</param>
+	/// <param name="isActive">Indicates whether composition is active.</param>
+	public TextCompositionEventArgs(string text, bool isActive)
+	{
+		Text = text ?? string.Empty;
+		IsActive = isActive;
+	}
+
+	/// <summary>
+	/// Gets the current composition text.
+	/// </summary>
+	public string Text { get; }
+
+	/// <summary>
+	/// Gets a value indicating whether the composition is currently active.
+	/// </summary>
+	public bool IsActive { get; }
+}

--- a/src/Eto/Forms/Controls/TextInsertionBoundsEventArgs.cs
+++ b/src/Eto/Forms/Controls/TextInsertionBoundsEventArgs.cs
@@ -1,0 +1,21 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Event arguments used to provide the current text insertion bounds for a drawable.
+/// </summary>
+public class TextInsertionBoundsEventArgs : EventArgs
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="TextInsertionBoundsEventArgs"/> class.
+	/// </summary>
+	/// <param name="bounds">Text insertion bounds in drawable client coordinates.</param>
+	public TextInsertionBoundsEventArgs(RectangleF? bounds = null)
+	{
+		Bounds = bounds;
+	}
+
+	/// <summary>
+	/// Gets or sets the current text insertion bounds in drawable client coordinates.
+	/// </summary>
+	public RectangleF? Bounds { get; set; }
+}

--- a/test/Eto.Test/Sections/Controls/DrawableSection.cs
+++ b/test/Eto.Test/Sections/Controls/DrawableSection.cs
@@ -49,6 +49,11 @@ namespace Eto.Test.Sections.Controls
 						)
 					)),
 
+					new TableLayout(
+						"IME Input",
+						InputMethodDrawable()
+					),
+
 					(Platform.SupportedFeatures & PlatformFeatures.DrawableWithTransparentContent) == 0 ?
 					new TableRow(
 						"(Transparent content on drawable not supported on this platform)"
@@ -277,6 +282,121 @@ namespace Eto.Test.Sections.Controls
 			return control;
 		}
 
+		Control InputMethodDrawable()
+		{
+			const int padding = 12;
+			var text = string.Empty;
+			var compositionText = string.Empty;
+			var compositionActive = false;
+			var drawable = new Drawable
+			{
+				CanFocus = true,
+				Size = new Size(420, 60),
+				BackgroundColor = Colors.White
+			};
+			var font = SystemFonts.Default();
+
+			RectangleF getCaretRect(float pointsToPixels = 1f, bool forInputMethod = false)
+			{
+				var displayText = text;
+				if (!forInputMethod || Platform.IsGtk)
+					displayText += compositionText;
+					
+				var size = font.MeasureString(displayText);
+				return new RectangleF(
+					padding + size.Width,
+					padding,
+					2,
+					font.LineHeight * pointsToPixels
+				);
+			}
+
+			void updateCaret()
+			{
+				drawable.Invalidate();
+			}
+
+			drawable.Paint += (sender, pe) =>
+			{
+				var size = font.MeasureString(text);
+				size.Height = font.LineHeight * pe.Graphics.PixelsPerPoint;
+				pe.Graphics.Clear(Colors.White);
+				pe.Graphics.DrawRectangle(Colors.DarkGray, 0, 0, drawable.Width - 1, drawable.Height - 1);
+				pe.Graphics.DrawText(font, Colors.Black, padding, padding, text);
+				if (compositionActive && !string.IsNullOrEmpty(compositionText))
+				{
+					var compositionX = padding + size.Width;
+					pe.Graphics.DrawText(font, Colors.DarkSlateBlue, compositionX, padding, compositionText);
+					var compositionWidth = Math.Max(1, font.MeasureString(compositionText).Width);
+					var underlineY = padding + size.Height;
+					pe.Graphics.DrawLine(Colors.DarkSlateBlue, compositionX, underlineY, compositionX + compositionWidth, underlineY);
+				}
+				if (drawable.HasFocus)
+				{
+					var caret = getCaretRect(pe.Graphics.PixelsPerPoint);
+					pe.Graphics.FillRectangle(Colors.DarkBlue, caret);
+				}
+			};
+			drawable.GotFocus += (sender, e) => drawable.Invalidate();
+			drawable.LostFocus += (sender, e) => drawable.Invalidate();
+			drawable.MouseDown += (sender, e) =>
+			{
+				if (e.Buttons == MouseButtons.Primary)
+					drawable.CommitTextComposition();
+				else
+					drawable.CancelTextComposition();
+				drawable.Focus();
+				e.Handled = true;
+			};
+			drawable.TextInput += (sender, e) =>
+			{
+				if (!string.IsNullOrEmpty(e.Text))
+				{
+					text += e.Text;
+					compositionText = string.Empty;
+					compositionActive = false;
+					Log.Write(sender, $"TextInput: '{e.Text}'");
+					updateCaret();
+				}
+				e.Cancel = true;
+			};
+			drawable.TextComposition += (sender, e) =>
+			{
+				compositionText = e.Text ?? string.Empty;
+				compositionActive = e.IsActive && !string.IsNullOrEmpty(compositionText);
+				Log.Write(sender, $"TextComposition: '{compositionText}', Active={e.IsActive}");
+				updateCaret();
+				e.Handled = true;
+			};
+			drawable.TextInsertionBoundsRequested += (sender, e) => e.Bounds = getCaretRect(forInputMethod: true);
+			drawable.KeyDown += (sender, e) =>
+			{
+				if (e.KeyData == Keys.Backspace)
+				{
+					if (text.Length > 0)
+					{
+						text = text.Substring(0, text.Length - 1);
+						updateCaret();
+					}
+					e.Handled = true;
+				}
+				Log.Write(sender, $"KeyDown: {e.KeyData}");
+			};
+
+			updateCaret();
+
+			return new StackLayout
+			{
+				HorizontalContentAlignment = HorizontalAlignment.Stretch,
+				Spacing = 6,
+				Items =
+				{
+					"Click inside the drawable and type with an IME. The candidate/composition UI should follow the caret.",
+					drawable
+				}
+			};
+		}
+
 		void LogEvents(Drawable control, string name)
 		{
 			control.Paint += delegate(object sender, PaintEventArgs pe)
@@ -286,4 +406,3 @@ namespace Eto.Test.Sections.Controls
 		}
 	}
 }
-


### PR DESCRIPTION
While the TextBox, TextArea, and other text input controls intrinsically support IME, this allows you to create a custom drawn control using a Drawable that also fully supports IME input and events.

This adds the ability to properly respond to IME text composition events from a Drawable using the following new APIs:

- `Drawable.TextComposition` : Respond to IME events during text composition
- `Drawable.TextInsertionBoundsRequested` : To return an appropriate position for the cursor/insertion point for the OS to display the IME UI.
- `Drawable.CancelTextComposition()` : Cancel a text composition if in progress
- `Drawable.CommitTextComposition()` : Commits a composition in progress

