### PR TITLE
Mac: Don't beep during IME composition when e.Handled = true

### DIFF
--- a/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/DrawableHandler.cs
@@ -242,6 +242,9 @@ namespace Eto.Mac.Forms.Controls
 			isComposing = true;
 			var args = new TextCompositionEventArgs(markedText, true);
 			Callback.OnTextComposition(Widget, args);
+			if (this is IMacViewHandler handler)
+				handler.TextInputCancelled |= args.Handled;
+
 			Invalidate(false);
 		}
 


### PR DESCRIPTION
When handling the TextComposition event and setting e.Handled = true, it should not cause a beep.