### PR TITLE
Add Gestures support for Magnification/Pan/Rotate/Scroll

### DIFF
--- a/src/Eto.Android/Forms/AndroidControl.cs
+++ b/src/Eto.Android/Forms/AndroidControl.cs
@@ -307,6 +307,10 @@ namespace Eto.Android.Forms
 		public virtual void UpdateLayout()
 		{
 		}
+
+		public virtual void AddGesture(Gesture item) { }
+		public virtual void ClearGestures() { }
+		public virtual void RemoveGesture(Gesture item) { }
 		
 		public ContextMenu ContextMenu { get; set; }
 

--- a/src/Eto.Gtk/Forms/Controls/GestureHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GestureHandler.cs
@@ -1,0 +1,246 @@
+#if GTKCORE
+namespace Eto.GtkSharp.Forms.Controls
+{
+	interface IGtkGestureHandler : Gesture.IHandler
+	{
+		void AttachTo(Gtk.Widget widget);
+		void Detach();
+	}
+
+	public abstract class GestureHandler<TControl, TWidget> : WidgetHandler<TControl, TWidget>, IGtkGestureHandler
+		where TControl : Gtk.Gesture
+		where TWidget : Gesture
+	{
+		bool _enabled = true;
+
+		protected new Gesture.ICallback Callback => (Gesture.ICallback)((ICallbackSource)Widget).Callback;
+
+		public bool Enabled
+		{
+			get => _enabled;
+			set
+			{
+				_enabled = value;
+				if (Control != null)
+					Control.PropagationPhase = value ? Gtk.PropagationPhase.Bubble : Gtk.PropagationPhase.None;
+			}
+		}
+
+		public void AttachTo(Gtk.Widget widget)
+		{
+			Detach();
+			Control = CreateGesture(widget);
+			Control.PropagationPhase = _enabled ? Gtk.PropagationPhase.Bubble : Gtk.PropagationPhase.None;
+		}
+
+		public void Detach()
+		{
+			if (Control != null)
+			{
+				Control.Dispose();
+				Control = null;
+			}
+		}
+
+		protected abstract TControl CreateGesture(Gtk.Widget widget);
+	}
+
+	public class MagnificationGestureHandler : GestureHandler<Gtk.GestureZoom, MagnificationGesture>, MagnificationGesture.IHandler
+	{
+		double _previousScale = 1.0;
+		float _magnification;
+
+		public float Magnification => _magnification;
+
+		protected override Gtk.GestureZoom CreateGesture(Gtk.Widget widget)
+		{
+			var gesture = new Gtk.GestureZoom(widget);
+			gesture.Begin += (sender, e) => _previousScale = gesture.ScaleDelta;
+			gesture.ScaleChanged += (sender, e) =>
+			{
+				var current = gesture.ScaleDelta;
+				_magnification = _previousScale > 0 ? (float)(current / _previousScale - 1.0) : 0f;
+				_previousScale = current;
+				Callback.OnActivated(Widget, EventArgs.Empty);
+			};
+			return gesture;
+		}
+	}
+
+	public class RotationGestureHandler : GestureHandler<Gtk.GestureRotate, RotationGesture>, RotationGesture.IHandler
+	{
+		double _previousAngle;
+		float _rotation;
+
+		public float Rotation => _rotation;
+
+		protected override Gtk.GestureRotate CreateGesture(Gtk.Widget widget)
+		{
+			var gesture = new Gtk.GestureRotate(widget);
+			gesture.Begin += (sender, e) => _previousAngle = gesture.AngleDelta;
+			gesture.AngleChanged += (sender, e) =>
+			{
+				// AngleDelta is the cumulative rotation in radians since the gesture began.
+				// Gtk measures counter-clockwise; expose degrees clockwise to match other platforms.
+				var current = gesture.AngleDelta;
+				_rotation = (float)(-(current - _previousAngle) * 180.0 / Math.PI);
+				_previousAngle = current;
+				if (_rotation == 0f)
+					return;
+				Callback.OnActivated(Widget, EventArgs.Empty);
+			};
+			return gesture;
+		}
+	}
+
+	public class PanGestureHandler : GestureHandler<Gtk.GestureDrag, PanGesture>, PanGesture.IHandler
+	{
+		PointF _translation;
+		PointF _velocity;
+		double _previousX;
+		double _previousY;
+		DateTime _previousTime;
+		MouseButtons _mouseButtons = MouseButtons.Primary;
+
+		public PointF Translation => _translation;
+		public PointF Velocity => _velocity;
+		public MouseButtons Buttons
+		{
+			get => _mouseButtons;
+			set
+			{
+				if (value == MouseButtons.None)
+					throw new ArgumentException($"{nameof(Buttons)} cannot be {nameof(MouseButtons.None)}.", nameof(value));
+				_mouseButtons = value;
+				if (Control != null)
+					Control.Button = ToGtkButton(value);
+			}
+		}
+
+		protected override Gtk.GestureDrag CreateGesture(Gtk.Widget widget)
+		{
+			var gesture = new Gtk.GestureDrag(widget);
+			gesture.Button = ToGtkButton(_mouseButtons);
+			gesture.DragBegin += (sender, e) =>
+			{
+				_previousX = 0;
+				_previousY = 0;
+				_previousTime = DateTime.UtcNow;
+			};
+			gesture.DragUpdate += (sender, e) =>
+			{
+				if (!IsMouseButtonMatched())
+					return;
+
+				gesture.GetOffset(out var x, out var y);
+				var now = DateTime.UtcNow;
+				var dx = x - _previousX;
+				var dy = y - _previousY;
+				var dt = (now - _previousTime).TotalSeconds;
+				_translation = new PointF((float)dx, (float)dy);
+				_velocity = dt > 0 ? new PointF((float)(dx / dt), (float)(dy / dt)) : PointF.Empty;
+				_previousX = x;
+				_previousY = y;
+				_previousTime = now;
+				Callback.OnActivated(Widget, EventArgs.Empty);
+			};
+			return gesture;
+		}
+
+		bool IsMouseButtonMatched()
+		{
+			return (Mouse.Buttons & _mouseButtons) == _mouseButtons;
+		}
+
+		static uint ToGtkButton(MouseButtons buttons)
+		{
+			switch (buttons)
+			{
+				case MouseButtons.Primary:
+					return 1;
+				case MouseButtons.Middle:
+					return 2;
+				case MouseButtons.Alternate:
+					return 3;
+				default:
+					return 0;
+			}
+		}
+	}
+
+	public class ScrollGestureHandler : WidgetHandler<object, ScrollGesture>, ScrollGesture.IHandler, IGtkGestureHandler
+	{
+		Gtk.Widget _widget;
+		bool _enabled = true;
+		DateTime _previousTime;
+		SizeF _delta;
+		PointF _velocity;
+
+		protected new Gesture.ICallback Callback => (Gesture.ICallback)((ICallbackSource)Widget).Callback;
+
+		public bool Enabled
+		{
+			get => _enabled;
+			set => _enabled = value;
+		}
+
+		public SizeF Delta => _delta;
+		public PointF Velocity => _velocity;
+
+		public void AttachTo(Gtk.Widget widget)
+		{
+			Detach();
+			_widget = widget;
+			_widget.AddEvents((int)Gdk.EventMask.ScrollMask);
+			_widget.ScrollEvent += HandleScrollEvent;
+		}
+
+		public void Detach()
+		{
+			if (_widget == null)
+				return;
+			_widget.ScrollEvent -= HandleScrollEvent;
+			_widget = null;
+		}
+
+		void HandleScrollEvent(object o, Gtk.ScrollEventArgs args)
+		{
+			if (!Enabled)
+				return;
+
+			var delta = GetDelta(args);
+			if (delta.IsZero)
+				return;
+
+			var now = DateTime.UtcNow;
+			var dt = _previousTime == default ? 0 : (now - _previousTime).TotalSeconds;
+			_previousTime = now;
+
+			_delta = delta;
+			_velocity = dt > 0 ? new PointF((float)(delta.Width / dt), (float)(delta.Height / dt)) : PointF.Empty;
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+
+		SizeF GetDelta(Gtk.ScrollEventArgs args)
+		{
+			var scrollAmount = Widget.WheelScrollAmount;
+
+			switch (args.Event.Direction)
+			{
+				case Gdk.ScrollDirection.Down:
+					return new SizeF(0f, -scrollAmount);
+				case Gdk.ScrollDirection.Left:
+					return new SizeF(scrollAmount, 0f);
+				case Gdk.ScrollDirection.Right:
+					return new SizeF(-scrollAmount, 0f);
+				case Gdk.ScrollDirection.Up:
+					return new SizeF(0f, scrollAmount);
+				case Gdk.ScrollDirection.Smooth:
+					return new SizeF((float)args.Event.DeltaX * scrollAmount, (float)args.Event.DeltaY * scrollAmount);
+				default:
+					return SizeF.Empty;
+			}
+		}
+	}
+}
+#endif

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -1471,5 +1471,40 @@ namespace Eto.GtkSharp.Forms
 				}
 			}
 		}
+
+#if GTKCORE
+		public virtual void AddGesture(Gesture item)
+		{
+			if (item == null)
+				throw new ArgumentNullException(nameof(item));
+
+			var handler = ((IHandlerSource)item).Handler as Eto.GtkSharp.Forms.Controls.IGtkGestureHandler;
+			if (handler == null)
+				throw new NotSupportedException($"Gesture '{item.GetType().FullName}' is not supported on GTK");
+
+			handler.AttachTo(EventControl);
+		}
+
+		public virtual void ClearGestures()
+		{
+			foreach (var gesture in Widget.Gestures)
+			{
+				if (((IHandlerSource)gesture).Handler is Eto.GtkSharp.Forms.Controls.IGtkGestureHandler handler)
+					handler.Detach();
+			}
+		}
+
+		public virtual void RemoveGesture(Gesture item)
+		{
+			if (item == null)
+				return;
+			if (((IHandlerSource)item).Handler is Eto.GtkSharp.Forms.Controls.IGtkGestureHandler handler)
+				handler.Detach();
+		}
+#else
+		public virtual void AddGesture(Gesture item) { }
+		public virtual void ClearGestures() { }
+		public virtual void RemoveGesture(Gesture item) { }
+#endif
 	}
 }

--- a/src/Eto.Gtk/Platform.cs
+++ b/src/Eto.Gtk/Platform.cs
@@ -111,6 +111,12 @@ namespace Eto.GtkSharp
 			p.Add<RadialGradientBrush.IHandler>(() => new RadialGradientBrushHandler());
 			p.Add<SystemColors.IHandler>(() => new SystemColorsHandler());
 			p.Add<FormattedText.IHandler>(() => new FormattedTextHandler());
+#if GTKCORE
+			p.Add<MagnificationGesture.IHandler>(() => new MagnificationGestureHandler());
+			p.Add<RotationGesture.IHandler>(() => new RotationGestureHandler());
+			p.Add<PanGesture.IHandler>(() => new PanGestureHandler());
+			p.Add<ScrollGesture.IHandler>(() => new ScrollGestureHandler());
+#endif
 
 			// Forms.Cells
 			p.Add<CheckBoxCell.IHandler>(() => new CheckBoxCellHandler());

--- a/src/Eto.Mac/Forms/Controls/GestureHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GestureHandler.cs
@@ -1,0 +1,264 @@
+using System.Runtime.CompilerServices;
+
+namespace Eto.Mac.Forms.Controls
+{
+	interface IMacGestureHandler : Gesture.IHandler
+	{
+		Gesture Gesture { get; }
+		NSGestureRecognizer Recognizer { get; }
+	}
+
+	interface IMacGestureActivationHandler
+	{
+		void OnActivated(NSGestureRecognizer recognizer);
+	}
+
+	interface IMacScrollWheelGestureHandler
+	{
+		Gesture Gesture { get; }
+		bool OnScrollWheel(NSEvent theEvent);
+	}
+
+	class GestureRecognizerTarget : NSObject
+	{
+		WeakReference handler;
+
+		public static readonly Selector ActivatedSelector = new Selector("activated:");
+
+		public GestureRecognizerTarget(IMacGestureActivationHandler handler)
+		{
+			this.handler = new WeakReference(handler);
+		}
+
+		[Export("activated:")]
+		public void Activated(NSGestureRecognizer recognizer)
+		{
+			(handler.Target as IMacGestureActivationHandler)?.OnActivated(recognizer);
+		}
+	}
+
+	class EtoGestureRecognizerDelegate : NSGestureRecognizerDelegate
+	{
+		public static readonly EtoGestureRecognizerDelegate Instance = new EtoGestureRecognizerDelegate();
+		readonly ConditionalWeakTable<NSGestureRecognizer, IMacGestureHandler> handlers = new ConditionalWeakTable<NSGestureRecognizer, IMacGestureHandler>();
+
+		public void Register(NSGestureRecognizer recognizer, IMacGestureHandler handler)
+		{
+			handlers.Remove(recognizer);
+			handlers.Add(recognizer, handler);
+		}
+
+		public override bool ShouldRecognizeSimultaneously(NSGestureRecognizer gestureRecognizer, NSGestureRecognizer otherGestureRecognizer)
+		{
+			return gestureRecognizer != null
+				&& otherGestureRecognizer != null
+				&& handlers.TryGetValue(gestureRecognizer, out var gestureHandler)
+				&& handlers.TryGetValue(otherGestureRecognizer, out var otherGestureHandler)
+				&& gestureHandler.Gesture.CanRecognizeSimultaneouslyWith(otherGestureHandler.Gesture);
+		}
+	}
+
+	public abstract class GestureHandler<TControl, TWidget> : WidgetHandler<TControl, TWidget>, IMacGestureHandler, IMacGestureActivationHandler
+		where TControl : NSGestureRecognizer
+		where TWidget : Gesture
+	{
+		GestureRecognizerTarget target;
+
+		protected new Gesture.ICallback Callback => (Gesture.ICallback)((ICallbackSource)Widget).Callback;
+
+		protected NSObject Target => target ??= new GestureRecognizerTarget(this);
+
+		public bool Enabled
+		{
+			get => Control.Enabled;
+			set => Control.Enabled = value;
+		}
+
+		protected override void Initialize()
+		{
+			base.Initialize();
+			Control.Target = Target;
+			Control.Action = GestureRecognizerTarget.ActivatedSelector;
+			Control.Delegate = EtoGestureRecognizerDelegate.Instance;
+			EtoGestureRecognizerDelegate.Instance.Register(Control, this);
+		}
+
+		Gesture IMacGestureHandler.Gesture => Widget;
+
+		NSGestureRecognizer IMacGestureHandler.Recognizer => Control;
+
+		protected virtual void OnActivated(NSGestureRecognizer recognizer)
+		{
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+
+		void IMacGestureActivationHandler.OnActivated(NSGestureRecognizer recognizer) => OnActivated(recognizer);
+	}
+
+	public class MagnificationGestureHandler : GestureHandler<NSMagnificationGestureRecognizer, MagnificationGesture>, MagnificationGesture.IHandler
+	{
+		public float Magnification => (float)Control.Magnification;
+
+		protected override NSMagnificationGestureRecognizer CreateControl()
+		{
+			return new NSMagnificationGestureRecognizer();
+		}
+
+		protected override void OnActivated(NSGestureRecognizer recognizer)
+		{
+			base.OnActivated(recognizer);
+			if (Control.State == NSGestureRecognizerState.Changed)
+			{
+				Control.Magnification = 0; // reset magnification so we get the delta each time
+			}
+			
+		}
+	}
+
+	public class RotationGestureHandler : GestureHandler<NSRotationGestureRecognizer, RotationGesture>, RotationGesture.IHandler
+	{
+		// NSRotationGestureRecognizer reports radians counter-clockwise; expose degrees clockwise.
+		public float Rotation => (float)(-Control.Rotation * 180.0 / Math.PI);
+
+		protected override NSRotationGestureRecognizer CreateControl()
+		{
+			return new NSRotationGestureRecognizer();
+		}
+
+		protected override void OnActivated(NSGestureRecognizer recognizer)
+		{
+			base.OnActivated(recognizer);
+			if (Control.State == NSGestureRecognizerState.Changed)
+				Control.Rotation = 0; // reset so we get the delta each time
+		}
+	}
+
+	public class PanGestureHandler : GestureHandler<NSPanGestureRecognizer, PanGesture>, PanGesture.IHandler
+	{
+		MouseButtons _mouseButtons = MouseButtons.Primary;
+
+		NSView View => Control.View;
+
+		public PointF Translation => ToEtoVector(Control.TranslationInView(View), View);
+
+		public PointF Velocity => ToEtoVector(Control.VelocityInView(View), View);
+		public MouseButtons Buttons
+		{
+			get => _mouseButtons;
+			set
+			{
+				if (value == MouseButtons.None)
+					throw new ArgumentException($"{nameof(Buttons)} cannot be {nameof(MouseButtons.None)}.", nameof(value));
+				_mouseButtons = value;
+				ApplyButtonMask();
+			}
+		}
+
+		protected override NSPanGestureRecognizer CreateControl()
+		{
+			return new NSPanGestureRecognizer();
+		}
+
+		protected override void Initialize()
+		{
+			base.Initialize();
+			ApplyButtonMask();
+		}
+
+		protected override void OnActivated(NSGestureRecognizer recognizer)
+		{
+			if (!IsMouseButtonMatched())
+			{
+				Control.SetTranslation(CGPoint.Empty, View);
+				return;
+			}
+
+			base.OnActivated(recognizer);
+			if (Control.State == NSGestureRecognizerState.Changed)
+				Control.SetTranslation(CGPoint.Empty, View);
+		}
+
+		bool IsMouseButtonMatched()
+		{
+			return (Mouse.Buttons & _mouseButtons) == _mouseButtons;
+		}
+
+		void ApplyButtonMask()
+		{
+			Control.ButtonMask = ToButtonMask(_mouseButtons);
+		}
+
+		static nuint ToButtonMask(MouseButtons buttons)
+		{
+			nuint mask = 0;
+			if ((buttons & MouseButtons.Primary) != 0)
+				mask |= 1;
+			if ((buttons & MouseButtons.Alternate) != 0)
+				mask |= 2;
+			if ((buttons & MouseButtons.Middle) != 0)
+				mask |= 4;
+			return mask;
+		}
+
+		static PointF ToEtoVector(CGPoint vector, NSView view)
+		{
+			var result = vector.ToEto();
+			if (view?.IsFlipped == false)
+				result.Y = -result.Y;
+			return result;
+		}
+	}
+
+	public class ScrollGestureHandler : WidgetHandler<object, ScrollGesture>, ScrollGesture.IHandler, IMacScrollWheelGestureHandler
+	{
+		bool enabled = true;
+		SizeF delta;
+		PointF velocity;
+		double lastScrollTimestamp;
+
+		protected new Gesture.ICallback Callback => (Gesture.ICallback)((ICallbackSource)Widget).Callback;
+
+		public bool Enabled
+		{
+			get => enabled;
+			set => enabled = value;
+		}
+
+		public SizeF Delta => delta;
+
+		public PointF Velocity => velocity;
+
+		Gesture IMacScrollWheelGestureHandler.Gesture => Widget;
+
+		public bool OnScrollWheel(NSEvent theEvent)
+		{
+			if (!Enabled)
+				return false;
+
+			delta = theEvent.HasPreciseScrollingDeltas
+				? new SizeF((float)theEvent.ScrollingDeltaX, (float)theEvent.ScrollingDeltaY)
+				: new SizeF((float)theEvent.DeltaX * ScrollGesture.DefaultWheelScrollAmount / Widget.WheelScrollAmount, (float)theEvent.DeltaY * ScrollGesture.DefaultWheelScrollAmount / Widget.WheelScrollAmount);
+
+			var timestamp = theEvent.Timestamp;
+			var phase = theEvent.Phase;
+			if (phase == NSEventPhase.Began || lastScrollTimestamp <= 0 || timestamp <= lastScrollTimestamp)
+				velocity = PointF.Empty;
+			else
+			{
+				var elapsed = timestamp - lastScrollTimestamp;
+				velocity = new PointF((float)(delta.Width / elapsed), (float)(delta.Height / elapsed));
+			}
+			lastScrollTimestamp = timestamp;
+
+			if (!delta.IsZero)
+				Callback.OnActivated(Widget, EventArgs.Empty);
+
+			if (phase == NSEventPhase.Ended || phase == NSEventPhase.Cancelled)
+			{
+				lastScrollTimestamp = 0;
+				velocity = PointF.Empty;
+			}
+			return true;
+		}
+	}
+}

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -329,6 +329,7 @@ namespace Eto.Mac.Forms
 			{
 				if (handler.Widget?.IsDisposed != false) return;
 				var theEvent = Messaging.GetNSObject<NSEvent>(e);
+				TriggerScrollWheelGestures(handler, theEvent);
 				var args = MacConversions.GetMouseEvent(handler, theEvent, true);
 				if (!args.Delta.IsZero)
 				{
@@ -341,6 +342,20 @@ namespace Eto.Mac.Forms
 			}
 			else
 				Messaging.void_objc_msgSendSuper_IntPtr(obj.SuperHandle, sel, e);
+		}
+
+		static void TriggerScrollWheelGestures(IMacViewHandler handler, NSEvent theEvent)
+		{
+			var gestures = handler.Widget.Gestures
+				.Select(gesture => ((IHandlerSource)gesture).Handler as IMacScrollWheelGestureHandler)
+				.Where(gesture => gesture != null)
+				.ToArray();
+			var firstGesture = gestures.FirstOrDefault();
+			foreach (var gesture in gestures)
+			{
+				if (gesture == firstGesture || firstGesture.Gesture.CanRecognizeSimultaneouslyWith(gesture.Gesture))
+					gesture.OnScrollWheel(theEvent);
+			}
 		}
 
 		static int _interpretingKeyEvents;
@@ -650,6 +665,13 @@ namespace Eto.Mac.Forms
 		NSTrackingArea tracking;
 		NSTrackingAreaOptions mouseOptions;
 		MouseDelegate mouseDelegate;
+		List<GestureRecognizerReference> gestureRecognizers;
+
+		class GestureRecognizerReference
+		{
+			public Gesture Gesture { get; set; }
+			public NSGestureRecognizer Recognizer { get; set; }
+		}
 
 		public override IntPtr NativeHandle { get { return Control.Handle; } }
 
@@ -1010,7 +1032,6 @@ namespace Eto.Mac.Forms
 			}
 			return false;
 		}
-
 
 		public virtual void OnSizeChanged(EventArgs e)
 		{
@@ -1841,6 +1862,40 @@ namespace Eto.Mac.Forms
 		{
 			CaptureLoopEnabled = false;
 			MacView.CapturedControl = null;
+		}
+
+		public void AddGesture(Gesture item)
+		{
+			if (item == null)
+				throw new ArgumentNullException(nameof(item));
+
+			var itemHandler = ((IHandlerSource)item).Handler;
+			var handler = itemHandler as IMacGestureHandler;
+			var scrollWheelHandler = itemHandler as IMacScrollWheelGestureHandler;
+			if (handler == null && scrollWheelHandler == null)
+				throw new NotSupportedException($"Gesture '{item.GetType().FullName}' is not supported on Mac");
+
+			if (handler != null)
+				EventControl.AddGestureRecognizer(handler.Recognizer);
+			if (scrollWheelHandler != null)
+				AddMethod(MacView.selScrollWheel, MacView.TriggerMouseWheel_Delegate, "v@:@");
+		}
+
+		public void ClearGestures()
+		{
+			foreach (var gesture in Widget.Gestures)
+			{
+				if (((IHandlerSource)gesture).Handler is IMacGestureHandler handler)
+					EventControl.RemoveGestureRecognizer(handler.Recognizer);
+			}
+		}
+
+		public void RemoveGesture(Gesture item)
+		{
+			if (item == null)
+				return;
+			if (((IHandlerSource)item).Handler is IMacGestureHandler handler)
+				EventControl.RemoveGestureRecognizer(handler.Recognizer);
 		}
 		
 #if OSX

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -134,6 +134,10 @@ namespace Eto.Mac
 			p.Add<Color.IHandler>(() => new ColorHandler());
 			p.Add<SystemColors.IHandler>(() => new SystemColorsHandler());
 			p.Add<FormattedText.IHandler>(() => new FormattedTextHandler());
+			p.Add<MagnificationGesture.IHandler>(() => new MagnificationGestureHandler());
+			p.Add<RotationGesture.IHandler>(() => new RotationGestureHandler());
+			p.Add<PanGesture.IHandler>(() => new PanGestureHandler());
+			p.Add<ScrollGesture.IHandler>(() => new ScrollGestureHandler());
 
 			// Forms.Cells
 			p.Add<CheckBoxCell.IHandler>(() => new CheckBoxCellHandler());

--- a/src/Eto.WinForms/BubbleEventFilter.cs
+++ b/src/Eto.WinForms/BubbleEventFilter.cs
@@ -133,7 +133,8 @@ namespace Eto.WinForms
 				return false;
 
 			var modifiers = swf.Control.ModifierKeys.ToEto();
-			var delta = new SizeF(0, Win32.GetWheelDeltaWParam(be.Message.WParam) / WinConversions.WheelDelta);
+			var wheelDelta = Win32.GetWheelDeltaWParam(be.Message.WParam) / WinConversions.WheelDelta;
+			var delta = be.Message.Msg == (int)Win32.WM.MOUSEHWHEEL ? new SizeF(-wheelDelta, 0) : new SizeF(0, wheelDelta);
 			var buttons = Win32.GetMouseButtonWParam(be.Message.WParam).ToEto();
 			if (modifyButtons != null)
 				buttons = modifyButtons(buttons);

--- a/src/Eto.WinForms/Forms/ApplicationHandler.cs
+++ b/src/Eto.WinForms/Forms/ApplicationHandler.cs
@@ -143,7 +143,7 @@ namespace Eto.WinForms.Forms
 			if (BubbleMouseEvents)
 			{
 				var bubble = new BubbleEventFilter();
-				bubble.AddBubbleMouseEvent((c, cb, e) => cb.OnMouseWheel(c, e), null, Win32.WM.MOUSEWHEEL);
+				bubble.AddBubbleMouseEvents((c, cb, e) => cb.OnMouseWheel(c, e), null, Win32.WM.MOUSEWHEEL, Win32.WM.MOUSEHWHEEL);
 				bubble.AddBubbleMouseEvent((c, cb, e) => cb.OnMouseMove(c, e), null, Win32.WM.MOUSEMOVE);
 				bubble.AddBubbleMouseEvents((c, cb, e) => 
 				{

--- a/src/Eto.WinForms/Forms/Controls/GestureHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GestureHandler.cs
@@ -1,0 +1,518 @@
+namespace Eto.WinForms.Forms.Controls
+{
+	interface IWinFormsGestureHandler : Gesture.IHandler
+	{
+		Gesture Gesture { get; }
+		bool CanProcessGesture(ref Win32.GESTUREINFO info);
+		bool CanProcessWheel(SizeF delta);
+		void ProcessGesture(ref Win32.GESTUREINFO info, float scale);
+		void ProcessWheel(SizeF delta);
+		void Reset();
+		void AttachTo(swf.Control control);
+		void Detach();
+	}
+
+	class WinFormsGestureCoordinator : swf.NativeWindow, IDisposable
+	{
+		readonly swf.Control _control;
+		readonly List<IWinFormsGestureHandler> _handlers = new List<IWinFormsGestureHandler>();
+		bool _configured;
+
+		public WinFormsGestureCoordinator(swf.Control control)
+		{
+			_control = control;
+			if (_control.IsHandleCreated)
+				OnHandleCreated(_control, EventArgs.Empty);
+			_control.HandleCreated += OnHandleCreated;
+			_control.HandleDestroyed += OnHandleDestroyed;
+		}
+
+		public int Count => _handlers.Count;
+
+		public void Register(IWinFormsGestureHandler handler)
+		{
+			_handlers.Add(handler);
+			handler.AttachTo(_control);
+			ConfigureGestures();
+		}
+
+		public void Unregister(IWinFormsGestureHandler handler)
+		{
+			if (_handlers.Remove(handler))
+				handler.Detach();
+		}
+
+		void OnHandleCreated(object sender, EventArgs e)
+		{
+			if (Handle == IntPtr.Zero)
+				AssignHandle(_control.Handle);
+			ConfigureGestures();
+		}
+
+		void OnHandleDestroyed(object sender, EventArgs e)
+		{
+			_configured = false;
+			ReleaseHandle();
+			foreach (var handler in _handlers)
+				handler.Reset();
+		}
+
+		void ConfigureGestures()
+		{
+			if (_configured || !_control.IsHandleCreated)
+				return;
+			var configs = new[]
+			{
+				new Win32.GESTURECONFIG { dwID = 0, dwWant = Win32.GC_ALLGESTURES, dwBlock = 0 }
+			};
+			if (Win32.SetGestureConfig(_control.Handle, 0, configs.Length, configs, Marshal.SizeOf(typeof(Win32.GESTURECONFIG))))
+				_configured = true;
+		}
+
+		protected override void WndProc(ref swf.Message m)
+		{
+			if (m.Msg == (int)Win32.WM.GESTURE && _handlers.Count > 0)
+			{
+				var info = new Win32.GESTUREINFO { cbSize = Marshal.SizeOf(typeof(Win32.GESTUREINFO)) };
+				if (Win32.GetGestureInfo(m.LParam, ref info))
+				{
+					var scale = GetScaleFactor();
+					if (info.dwID == Win32.GID_END)
+					{
+						for (int i = 0; i < _handlers.Count; i++)
+							_handlers[i].ProcessGesture(ref info, scale);
+					}
+					else
+					{
+						ProcessRecognizingHandlers(handler => handler.CanProcessGesture(ref info), handler => handler.ProcessGesture(ref info, scale));
+					}
+				}
+			}
+			else if ((m.Msg == (int)Win32.WM.MOUSEWHEEL || m.Msg == (int)Win32.WM.MOUSEHWHEEL) && _handlers.Count > 0)
+			{
+				var wheelDelta = Win32.GetWheelDeltaWParam(m.WParam) / WinConversions.WheelDelta;
+				var delta = m.Msg == (int)Win32.WM.MOUSEHWHEEL ? new SizeF(-wheelDelta, 0) : new SizeF(0, wheelDelta);
+				ProcessRecognizingHandlers(handler => handler.CanProcessWheel(delta), handler => handler.ProcessWheel(delta));
+			}
+			base.WndProc(ref m);
+		}
+
+		void ProcessRecognizingHandlers(Func<IWinFormsGestureHandler, bool> canProcess, Action<IWinFormsGestureHandler> process)
+		{
+			var firstHandler = _handlers.FirstOrDefault(canProcess);
+			if (firstHandler == null)
+				return;
+
+			for (int i = 0; i < _handlers.Count; i++)
+			{
+				var handler = _handlers[i];
+				if (!canProcess(handler))
+					continue;
+				if (handler == firstHandler || firstHandler.Gesture.CanRecognizeSimultaneouslyWith(handler.Gesture))
+					process(handler);
+			}
+		}
+
+		float GetScaleFactor()
+		{
+			if (Win32.PerMonitorDpiSupported && _control.IsHandleCreated)
+			{
+				var dpi = Win32.GetDpiForWindow(_control.Handle);
+				if (dpi > 0)
+					return dpi / 96f;
+			}
+			return Win32.SystemDpi;
+		}
+
+		public void Dispose()
+		{
+			foreach (var handler in _handlers)
+				handler.Detach();
+			_handlers.Clear();
+			_control.HandleCreated -= OnHandleCreated;
+			_control.HandleDestroyed -= OnHandleDestroyed;
+			ReleaseHandle();
+		}
+	}
+
+	public abstract class GestureHandler<TWidget> : WidgetHandler<object, TWidget>, IWinFormsGestureHandler
+		where TWidget : Gesture
+	{
+		bool _enabled = true;
+
+		protected new Gesture.ICallback Callback => (Gesture.ICallback)((ICallbackSource)Widget).Callback;
+
+		public bool Enabled
+		{
+			get => _enabled;
+			set => _enabled = value;
+		}
+
+		Gesture IWinFormsGestureHandler.Gesture => Widget;
+
+		void IWinFormsGestureHandler.ProcessGesture(ref Win32.GESTUREINFO info, float scale)
+		{
+			if (!_enabled)
+			{
+				Reset();
+				return;
+			}
+			HandleGesture(ref info, scale);
+		}
+
+		bool IWinFormsGestureHandler.CanProcessGesture(ref Win32.GESTUREINFO info)
+		{
+			return _enabled && CanHandleGesture(ref info);
+		}
+
+		void IWinFormsGestureHandler.ProcessWheel(SizeF delta)
+		{
+			if (_enabled)
+				HandleWheel(delta);
+		}
+
+		bool IWinFormsGestureHandler.CanProcessWheel(SizeF delta)
+		{
+			return _enabled && CanHandleWheel(delta);
+		}
+
+		public virtual void Reset()
+		{
+		}
+
+		void IWinFormsGestureHandler.AttachTo(swf.Control control) => OnAttached(control);
+
+		void IWinFormsGestureHandler.Detach() => OnDetached();
+
+		protected virtual void OnAttached(swf.Control control)
+		{
+		}
+
+		protected virtual void OnDetached()
+		{
+		}
+
+		internal virtual bool CanHandleGesture(ref Win32.GESTUREINFO info) => false;
+
+		internal abstract void HandleGesture(ref Win32.GESTUREINFO info, float scale);
+
+		internal virtual bool CanHandleWheel(SizeF delta) => false;
+
+		internal virtual void HandleWheel(SizeF delta)
+		{
+		}
+	}
+
+	public class MagnificationGestureHandler : GestureHandler<MagnificationGesture>, MagnificationGesture.IHandler
+	{
+		long _previousDistance;
+		bool _active;
+		float _magnification;
+
+		public float Magnification => _magnification;
+
+		public override void Reset()
+		{
+			_active = false;
+			_previousDistance = 0;
+		}
+
+		internal override void HandleGesture(ref Win32.GESTUREINFO info, float scale)
+		{
+			if (info.dwID != Win32.GID_ZOOM)
+			{
+				if (info.dwID == Win32.GID_END)
+					Reset();
+				return;
+			}
+
+			if ((info.dwFlags & Win32.GF_BEGIN) != 0)
+			{
+				_previousDistance = info.ullArguments;
+				_active = _previousDistance > 0;
+				return;
+			}
+
+			if (!_active || _previousDistance <= 0 || info.ullArguments <= 0)
+			{
+				_previousDistance = info.ullArguments;
+				_active = info.ullArguments > 0;
+				return;
+			}
+
+			_magnification = (float)((double)info.ullArguments / _previousDistance - 1.0);
+			_previousDistance = info.ullArguments;
+			if (_magnification == 0f)
+				return;
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+
+		internal override bool CanHandleGesture(ref Win32.GESTUREINFO info) => info.dwID == Win32.GID_ZOOM;
+	}
+
+	public class RotationGestureHandler : GestureHandler<RotationGesture>, RotationGesture.IHandler
+	{
+		double _previousAngle;
+		bool _active;
+		float _rotation;
+
+		public float Rotation => _rotation;
+
+		public override void Reset()
+		{
+			_active = false;
+			_previousAngle = 0;
+		}
+
+		// Win32 encodes the cumulative rotation angle in the low word of ullArguments.
+		// GID_ROTATE_ANGLE_FROM_ARGUMENT: counter-clockwise radians, 0 at gesture begin.
+		static double DecodeAngle(long arguments)
+		{
+			var arg = (double)(ushort)(arguments & 0xFFFF);
+			return arg / 65535.0 * 4.0 * Math.PI - 2.0 * Math.PI;
+		}
+
+		internal override void HandleGesture(ref Win32.GESTUREINFO info, float scale)
+		{
+			if (info.dwID != Win32.GID_ROTATE)
+			{
+				if (info.dwID == Win32.GID_END)
+					Reset();
+				return;
+			}
+
+			if ((info.dwFlags & Win32.GF_BEGIN) != 0)
+			{
+				_previousAngle = DecodeAngle(info.ullArguments);
+				_active = true;
+				return;
+			}
+
+			var angle = DecodeAngle(info.ullArguments);
+			if (!_active)
+			{
+				_previousAngle = angle;
+				_active = true;
+				return;
+			}
+
+			// Negate to expose degrees clockwise to match other platforms.
+			_rotation = (float)(-(angle - _previousAngle) * 180.0 / Math.PI);
+			_previousAngle = angle;
+			if (_rotation == 0f)
+				return;
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+
+		internal override bool CanHandleGesture(ref Win32.GESTUREINFO info) => info.dwID == Win32.GID_ROTATE;
+	}
+
+	public class PanGestureHandler : GestureHandler<PanGesture>, PanGesture.IHandler
+	{
+		swf.Control _control;
+		short _previousX;
+		short _previousY;
+		DateTime _previousTime;
+		bool _active;
+		PointF _translation;
+		PointF _velocity;
+		MouseButtons _mouseButtons = MouseButtons.Primary;
+		bool _mouseActive;
+		PointF _previousMousePosition;
+		DateTime _previousMouseTime;
+
+		public PointF Translation => _translation;
+		public PointF Velocity => _velocity;
+		public MouseButtons Buttons
+		{
+			get => _mouseButtons;
+			set
+			{
+				if (value == MouseButtons.None)
+					throw new ArgumentException($"{nameof(Buttons)} cannot be {nameof(MouseButtons.None)}.", nameof(value));
+				_mouseButtons = value;
+			}
+		}
+
+		public override void Reset()
+		{
+			_active = false;
+			EndMousePan();
+		}
+
+		internal override void HandleGesture(ref Win32.GESTUREINFO info, float scale)
+		{
+			if (info.dwID != Win32.GID_PAN)
+			{
+				if (info.dwID == Win32.GID_END)
+					Reset();
+				return;
+			}
+
+			if ((info.dwFlags & Win32.GF_BEGIN) != 0)
+			{
+				_previousX = info.ptsLocation.x;
+				_previousY = info.ptsLocation.y;
+				_previousTime = DateTime.UtcNow;
+				_active = true;
+				return;
+			}
+
+			if (!_active)
+			{
+				_previousX = info.ptsLocation.x;
+				_previousY = info.ptsLocation.y;
+				_previousTime = DateTime.UtcNow;
+				_active = true;
+				return;
+			}
+
+			var dx = info.ptsLocation.x - _previousX;
+			var dy = info.ptsLocation.y - _previousY;
+			var now = DateTime.UtcNow;
+			var dt = (now - _previousTime).TotalSeconds;
+			_previousX = info.ptsLocation.x;
+			_previousY = info.ptsLocation.y;
+			_previousTime = now;
+
+			if (dx == 0 && dy == 0)
+				return;
+
+			var invScale = scale > 0 ? 1f / scale : 1f;
+			var logicalDx = dx * invScale;
+			var logicalDy = dy * invScale;
+			_translation = new PointF(logicalDx, logicalDy);
+			_velocity = dt > 0 ? new PointF((float)(logicalDx / dt), (float)(logicalDy / dt)) : PointF.Empty;
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+
+		internal override bool CanHandleGesture(ref Win32.GESTUREINFO info)
+		{
+			return info.dwID == Win32.GID_PAN;
+		}
+
+		protected override void OnAttached(swf.Control control)
+		{
+			_control = control;
+			_control.MouseDown += OnMouseDown;
+			_control.MouseMove += OnMouseMove;
+			_control.MouseUp += OnMouseUp;
+			_control.MouseCaptureChanged += OnMouseCaptureChanged;
+		}
+
+		protected override void OnDetached()
+		{
+			if (_control == null)
+				return;
+			_control.MouseDown -= OnMouseDown;
+			_control.MouseMove -= OnMouseMove;
+			_control.MouseUp -= OnMouseUp;
+			_control.MouseCaptureChanged -= OnMouseCaptureChanged;
+			EndMousePan();
+			_control = null;
+		}
+
+		void OnMouseDown(object sender, swf.MouseEventArgs e)
+		{
+			if (!Enabled || !AreMouseButtonsPressed())
+				return;
+
+			_mouseActive = true;
+			_previousMousePosition = e.ToEto(_control).Location;
+			_previousMouseTime = DateTime.UtcNow;
+			_control.Capture = true;
+		}
+
+		void OnMouseMove(object sender, swf.MouseEventArgs e)
+		{
+			if (!_mouseActive)
+				return;
+
+			if (!Enabled || !AreMouseButtonsPressed())
+			{
+				EndMousePan();
+				return;
+			}
+
+			var position = e.ToEto(_control).Location;
+			var now = DateTime.UtcNow;
+			var translation = position - _previousMousePosition;
+			var dt = (now - _previousMouseTime).TotalSeconds;
+
+			_previousMousePosition = position;
+			_previousMouseTime = now;
+
+			if (translation.X == 0 && translation.Y == 0)
+				return;
+
+			_translation = translation;
+			_velocity = dt > 0 ? new PointF((float)(translation.X / dt), (float)(translation.Y / dt)) : PointF.Empty;
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+
+		void OnMouseUp(object sender, swf.MouseEventArgs e)
+		{
+			if (_mouseActive && !AreMouseButtonsPressed())
+				EndMousePan();
+		}
+
+		void OnMouseCaptureChanged(object sender, EventArgs e)
+		{
+			if (_control?.Capture == false)
+				_mouseActive = false;
+		}
+
+		void EndMousePan()
+		{
+			_mouseActive = false;
+			if (_control?.Capture == true)
+				_control.Capture = false;
+		}
+
+		bool AreMouseButtonsPressed()
+		{
+			var buttons = swf.Control.MouseButtons.ToEto();
+			return (buttons & _mouseButtons) == _mouseButtons;
+		}
+	}
+
+	public class ScrollGestureHandler : GestureHandler<ScrollGesture>, ScrollGesture.IHandler
+	{
+		DateTime _previousTime;
+		SizeF _delta;
+		PointF _velocity;
+
+		public SizeF Delta => _delta;
+		public PointF Velocity => _velocity;
+
+		public override void Reset()
+		{
+			_previousTime = default;
+			_velocity = PointF.Empty;
+		}
+
+		internal override void HandleGesture(ref Win32.GESTUREINFO info, float scale)
+		{
+			if (info.dwID == Win32.GID_END)
+				Reset();
+		}
+
+		internal override void HandleWheel(SizeF delta)
+		{
+			if (delta.IsZero)
+				return;
+
+			delta = new SizeF(delta.Width * Widget.WheelScrollAmount, delta.Height * Widget.WheelScrollAmount);
+
+			var now = DateTime.UtcNow;
+			var dt = _previousTime == default ? 0 : (now - _previousTime).TotalSeconds;
+			_previousTime = now;
+
+			_delta = delta;
+			_velocity = dt > 0 ? new PointF((float)(delta.Width / dt), (float)(delta.Height / dt)) : PointF.Empty;
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+
+		internal override bool CanHandleWheel(SizeF delta) => !delta.IsZero;
+	}
+}

--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -844,5 +844,8 @@ namespace Eto.WinForms.Forms
 		public bool IsMouseCaptured => throw new NotImplementedException();
 		public bool CaptureMouse() => throw new NotImplementedException();
 		public void ReleaseMouseCapture() => throw new NotImplementedException();
+		public void AddGesture(Gesture item) { }
+		public void ClearGestures() { }
+		public void RemoveGesture(Gesture item) { }
 	}
 }

--- a/src/Eto.WinForms/Forms/WindowsControl.cs
+++ b/src/Eto.WinForms/Forms/WindowsControl.cs
@@ -1163,5 +1163,54 @@ namespace Eto.WinForms.Forms
 			MouseCaptured = false;
 		}
 
+		Eto.WinForms.Forms.Controls.WinFormsGestureCoordinator _gestureCoordinator;
+
+		public virtual void AddGesture(Gesture item)
+		{
+			if (item == null)
+				throw new ArgumentNullException(nameof(item));
+
+			var handler = ((IHandlerSource)item).Handler as Eto.WinForms.Forms.Controls.IWinFormsGestureHandler;
+			if (handler == null)
+				throw new NotSupportedException(string.Format(System.Globalization.CultureInfo.CurrentCulture, "Gesture '{0}' is not supported on WinForms", item.GetType().FullName));
+
+			if (_gestureCoordinator == null)
+				_gestureCoordinator = new Eto.WinForms.Forms.Controls.WinFormsGestureCoordinator(ContainerControl);
+			_gestureCoordinator.Register(handler);
+		}
+
+		public virtual void ClearGestures()
+		{
+			if (_gestureCoordinator == null)
+				return;
+
+			foreach (var gesture in Widget.Gestures)
+			{
+				if (((IHandlerSource)gesture).Handler is Eto.WinForms.Forms.Controls.IWinFormsGestureHandler handler)
+					_gestureCoordinator.Unregister(handler);
+			}
+			DisposeCoordinatorIfEmpty();
+		}
+
+		public virtual void RemoveGesture(Gesture item)
+		{
+			if (item == null || _gestureCoordinator == null)
+				return;
+			if (((IHandlerSource)item).Handler is Eto.WinForms.Forms.Controls.IWinFormsGestureHandler handler)
+			{
+				_gestureCoordinator.Unregister(handler);
+				DisposeCoordinatorIfEmpty();
+			}
+		}
+
+		void DisposeCoordinatorIfEmpty()
+		{
+			if (_gestureCoordinator != null && _gestureCoordinator.Count == 0)
+			{
+				_gestureCoordinator.Dispose();
+				_gestureCoordinator = null;
+			}
+		}
+
 	}
 }

--- a/src/Eto.WinForms/Platform.cs
+++ b/src/Eto.WinForms/Platform.cs
@@ -117,6 +117,12 @@ namespace Eto.WinForms
 			p.Add<CollectionEditor.IHandler>(() => new ThemedCollectionEditorHandler());
 			p.Add<NativeControlHost.IHandler>(() => new NativeControlHandler());
 
+			// Forms.Gestures
+			p.Add<MagnificationGesture.IHandler>(() => new MagnificationGestureHandler());
+			p.Add<RotationGesture.IHandler>(() => new RotationGestureHandler());
+			p.Add<PanGesture.IHandler>(() => new PanGestureHandler());
+			p.Add<ScrollGesture.IHandler>(() => new ScrollGestureHandler());
+
 			// Forms.Menu
 			p.Add<CheckMenuItem.IHandler>(() => new CheckMenuItemHandler());
 			p.Add<ContextMenu.IHandler>(() => new ContextMenuHandler());

--- a/src/Eto.WinForms/ScrollMessageFilter.cs
+++ b/src/Eto.WinForms/ScrollMessageFilter.cs
@@ -18,7 +18,7 @@ namespace Eto.WinForms
 
 		public bool PreFilterMessage(ref swf.Message m)
 		{
-			if (m.Msg == (int)Win32.WM.MOUSEWHEEL)
+			if (m.Msg == (int)Win32.WM.MOUSEWHEEL || m.Msg == (int)Win32.WM.MOUSEHWHEEL)
 			{
 				var c = swf.Control.FromHandle(m.HWnd);
 				if (c == null)

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -173,6 +173,10 @@ namespace Eto
 			MBUTTONUP = 0x0208,
 			MBUTTONDBLCLK = 0x0209,
 			MOUSEWHEEL = 0x20A,
+			MOUSEHWHEEL = 0x20E,
+
+			GESTURE = 0x0119,
+			GESTURENOTIFY = 0x011A,
 
 			CUT = 0x0300,
 			COPY = 0x0301,
@@ -340,6 +344,67 @@ namespace Eto
 
 		[DllImport("user32.dll")]
 		public static extern bool GetWindowRect(IntPtr hWnd, out RECT lpRect);
+
+		[StructLayout(LayoutKind.Sequential)]
+		public struct POINTS
+		{
+			public short x;
+			public short y;
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		public struct GESTUREINFO
+		{
+			public int cbSize;
+			public int dwFlags;
+			public int dwID;
+			public IntPtr hwndTarget;
+			public POINTS ptsLocation;
+			public int dwInstanceID;
+			public int dwSequenceID;
+			public long ullArguments;
+			public int cbExtraArgs;
+		}
+
+		[StructLayout(LayoutKind.Sequential)]
+		public struct GESTURECONFIG
+		{
+			public int dwID;
+			public int dwWant;
+			public int dwBlock;
+		}
+
+		public const int GID_BEGIN = 1;
+		public const int GID_END = 2;
+		public const int GID_ZOOM = 3;
+		public const int GID_PAN = 4;
+		public const int GID_ROTATE = 5;
+		public const int GID_TWOFINGERTAP = 6;
+		public const int GID_PRESSANDTAP = 7;
+
+		public const int GF_BEGIN = 0x00000001;
+		public const int GF_INERTIA = 0x00000002;
+		public const int GF_END = 0x00000004;
+
+		public const int GC_ALLGESTURES = 0x00000001;
+		public const int GC_ZOOM = 0x00000001;
+		public const int GC_PAN = 0x00000001;
+		public const int GC_PAN_WITH_SINGLE_FINGER_VERTICALLY = 0x00000002;
+		public const int GC_PAN_WITH_SINGLE_FINGER_HORIZONTALLY = 0x00000004;
+		public const int GC_PAN_WITH_GUTTER = 0x00000008;
+		public const int GC_PAN_WITH_INERTIA = 0x00000010;
+
+		[DllImport("user32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool GetGestureInfo(IntPtr hGestureInfo, ref GESTUREINFO pGestureInfo);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool CloseGestureInfoHandle(IntPtr hGestureInfo);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool SetGestureConfig(IntPtr hwnd, int dwReserved, int cIDs, [In] GESTURECONFIG[] pGestureConfig, int cbSize);
 
 		[DllImport("user32.dll", SetLastError = true)]
 		public static extern uint GetWindowLong(IntPtr hWnd, GWL nIndex);

--- a/src/Eto.WinUI/Forms/WinUIFrameworkElement.cs
+++ b/src/Eto.WinUI/Forms/WinUIFrameworkElement.cs
@@ -169,6 +169,10 @@ public abstract partial class WinUIFrameworkElement<TControl, TWidget, TCallback
 		throw new NotImplementedException();
 	}
 
+	public virtual void AddGesture(Gesture item) { }
+	public virtual void ClearGestures() { }
+	public virtual void RemoveGesture(Gesture item) { }
+
 	public virtual void ResumeLayout()
 	{
 	}

--- a/src/Eto.Wpf/Forms/Controls/GestureHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GestureHandler.cs
@@ -1,0 +1,640 @@
+namespace Eto.Wpf.Forms.Controls
+{
+	interface IWpfGestureHandler : Gesture.IHandler
+	{
+		Gesture Gesture { get; }
+		bool CanHandleDelta(swi.ManipulationDeltaEventArgs e);
+		bool CanHandleWheel(SizeF delta);
+		void AttachTo(sw.UIElement element);
+		void Detach();
+	}
+
+	public abstract class GestureHandler<TWidget> : WidgetHandler<object, TWidget>, IWpfGestureHandler
+		where TWidget : Gesture
+	{
+		sw.UIElement _element;
+		bool _enabled = true;
+
+		protected new Gesture.ICallback Callback => (Gesture.ICallback)((ICallbackSource)Widget).Callback;
+
+		public bool Enabled
+		{
+			get => _enabled;
+			set => _enabled = value;
+		}
+
+		Gesture IWpfGestureHandler.Gesture => Widget;
+
+		protected sw.UIElement Element => _element;
+
+		public void AttachTo(sw.UIElement element)
+		{
+			Detach();
+			_element = element;
+			_element.IsManipulationEnabled = true;
+			_element.ManipulationStarting += OnManipulationStarting;
+			_element.ManipulationDelta += OnManipulationDelta;
+			OnAttached(_element);
+		}
+
+		public void Detach()
+		{
+			if (_element == null)
+				return;
+			OnDetaching(_element);
+			_element.ManipulationStarting -= OnManipulationStarting;
+			_element.ManipulationDelta -= OnManipulationDelta;
+			_element = null;
+		}
+
+		protected virtual void OnAttached(sw.UIElement element)
+		{
+		}
+
+		protected virtual void OnDetaching(sw.UIElement element)
+		{
+		}
+
+		void OnManipulationStarting(object sender, swi.ManipulationStartingEventArgs e)
+		{
+			e.ManipulationContainer = _element;
+			e.Mode = swi.ManipulationModes.All;
+		}
+
+		void OnManipulationDelta(object sender, swi.ManipulationDeltaEventArgs e)
+		{
+			if (!_enabled || !CanRecognize(e))
+				return;
+			HandleDelta(e);
+		}
+
+		bool CanRecognize(swi.ManipulationDeltaEventArgs e)
+		{
+			var control = Widget.Control;
+			if (control == null)
+				return true;
+
+			foreach (var gesture in control.Gestures)
+			{
+				if (((IHandlerSource)gesture).Handler is IWpfGestureHandler handler && handler.CanHandleDelta(e))
+					return handler.Gesture == Widget || handler.Gesture.CanRecognizeSimultaneouslyWith(Widget);
+			}
+			return true;
+		}
+
+		bool IWpfGestureHandler.CanHandleDelta(swi.ManipulationDeltaEventArgs e)
+		{
+			return _enabled && CanHandleDelta(e);
+		}
+
+		bool IWpfGestureHandler.CanHandleWheel(SizeF delta)
+		{
+			return _enabled && CanHandleWheel(delta);
+		}
+
+		protected abstract bool CanHandleDelta(swi.ManipulationDeltaEventArgs e);
+
+		protected abstract void HandleDelta(swi.ManipulationDeltaEventArgs e);
+
+		protected virtual bool CanHandleWheel(SizeF delta) => false;
+
+		/// <summary>
+		/// Checks whether this gesture is allowed to activate from a wheel event given the other gestures attached to the control.
+		/// </summary>
+		protected bool CanRecognizeWheel(SizeF delta)
+		{
+			var control = Widget.Control;
+			if (control == null)
+				return true;
+
+			foreach (var gesture in control.Gestures)
+			{
+				if (((IHandlerSource)gesture).Handler is IWpfGestureHandler handler && handler.CanHandleWheel(delta))
+					return handler.Gesture == Widget || handler.Gesture.CanRecognizeSimultaneouslyWith(Widget);
+			}
+			return true;
+		}
+	}
+
+	public class MagnificationGestureHandler : GestureHandler<MagnificationGesture>, MagnificationGesture.IHandler
+	{
+		const int WM_MOUSEWHEEL = 0x020A;
+		const int MK_CONTROL = 0x0008;
+
+		float _magnification;
+		bool _enableWheelMagnification = true;
+		float _wheelMagnificationStep = 0.1f;
+		swin.HwndSource _source;
+		bool _hooked;
+
+		public float Magnification => _magnification;
+
+		/// <summary>
+		/// Gets or sets a value indicating whether Ctrl+MouseWheel events activate the gesture. Defaults to true.
+		/// </summary>
+		/// <remarks>
+		/// On Windows, precision-touchpad pinch gestures are synthesized by the OS as Ctrl+<c>WM_MOUSEWHEEL</c>
+		/// with the delta quantized to <c>WHEEL_DELTA</c> (120) chunks for apps that haven't opted into pointer input.
+		/// Plain WPF apps fall into that bucket, so pinch will feel coarser than in Edge/Chromium even though both
+		/// paths come through the same hook here. Regular wheel events (no Ctrl) are ignored and left to
+		/// <see cref="ScrollGesture"/>.
+		/// </remarks>
+		public bool EnableWheelMagnification
+		{
+			get => _enableWheelMagnification;
+			set
+			{
+				if (_enableWheelMagnification == value)
+					return;
+				_enableWheelMagnification = value;
+				UpdateHook();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the magnification factor applied per <c>WHEEL_DELTA</c> (120) of wheel movement when handling Ctrl+Wheel. Defaults to 0.1 (10% per detent).
+		/// </summary>
+		public float WheelMagnificationStep
+		{
+			get => _wheelMagnificationStep;
+			set => _wheelMagnificationStep = value;
+		}
+
+		protected override bool CanHandleDelta(swi.ManipulationDeltaEventArgs e)
+		{
+			var scale = e.DeltaManipulation.Scale;
+			var factor = (scale.X + scale.Y) / 2.0;
+			return factor > 0 && !double.IsNaN(factor) && factor != 1.0;
+		}
+
+		protected override void HandleDelta(swi.ManipulationDeltaEventArgs e)
+		{
+			var scale = e.DeltaManipulation.Scale;
+			var factor = (scale.X + scale.Y) / 2.0;
+			if (factor <= 0 || double.IsNaN(factor))
+				return;
+			_magnification = (float)(factor - 1.0);
+			if (_magnification == 0f)
+				return;
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+
+		protected override bool CanHandleWheel(SizeF delta)
+		{
+			return _enableWheelMagnification && !delta.IsZero && IsZoomModifierActive();
+		}
+
+		protected override void OnAttached(sw.UIElement element)
+		{
+			if (element is sw.FrameworkElement fe)
+			{
+				fe.Loaded += OnLoaded;
+				fe.Unloaded += OnUnloaded;
+			}
+			UpdateHook();
+		}
+
+		protected override void OnDetaching(sw.UIElement element)
+		{
+			if (element is sw.FrameworkElement fe)
+			{
+				fe.Loaded -= OnLoaded;
+				fe.Unloaded -= OnUnloaded;
+			}
+			RemoveHook();
+		}
+
+		void OnLoaded(object sender, sw.RoutedEventArgs e) => UpdateHook();
+		void OnUnloaded(object sender, sw.RoutedEventArgs e) => RemoveHook();
+
+		void UpdateHook()
+		{
+			if (_enableWheelMagnification && Element != null)
+				AddHook();
+			else
+				RemoveHook();
+		}
+
+		void AddHook()
+		{
+			if (_hooked || Element == null)
+				return;
+			_source = sw.PresentationSource.FromVisual(Element) as swin.HwndSource;
+			if (_source == null)
+				return;
+			_source.AddHook(HwndHook);
+			_hooked = true;
+		}
+
+		void RemoveHook()
+		{
+			if (!_hooked || _source == null)
+				return;
+			_source.RemoveHook(HwndHook);
+			_source = null;
+			_hooked = false;
+		}
+
+		IntPtr HwndHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+		{
+			if (msg != WM_MOUSEWHEEL || !Enabled || !_enableWheelMagnification)
+				return IntPtr.Zero;
+			if (Element?.IsMouseOver != true)
+				return IntPtr.Zero;
+
+			// wParam: HIWORD = signed delta, LOWORD = modifier flags (MK_CONTROL etc.).
+			var wParamLong = (long)wParam;
+			if (((int)wParamLong & MK_CONTROL) == 0)
+				return IntPtr.Zero;
+
+			var delta = (short)((wParamLong >> 16) & 0xFFFF);
+			if (delta == 0)
+				return IntPtr.Zero;
+
+			var normalized = delta / WpfConversions.WheelDelta;
+			if (!CanRecognizeWheel(new SizeF(0, normalized)))
+				return IntPtr.Zero;
+
+			var step = normalized * _wheelMagnificationStep;
+			if (step == 0f)
+				return IntPtr.Zero;
+
+			_magnification = step;
+			Callback.OnActivated(Widget, EventArgs.Empty);
+			// Suppress WPF wheel processing for this Ctrl+Wheel message so parent ScrollViewers don't also scroll.
+			handled = true;
+			return IntPtr.Zero;
+		}
+
+		static bool IsZoomModifierActive()
+		{
+			return (swi.Keyboard.Modifiers & swi.ModifierKeys.Control) == swi.ModifierKeys.Control;
+		}
+	}
+
+	public class RotationGestureHandler : GestureHandler<RotationGesture>, RotationGesture.IHandler
+	{
+		float _rotation;
+
+		public float Rotation => _rotation;
+
+		protected override bool CanHandleDelta(swi.ManipulationDeltaEventArgs e)
+		{
+			var rotation = e.DeltaManipulation.Rotation;
+			return rotation != 0 && !double.IsNaN(rotation);
+		}
+
+		protected override void HandleDelta(swi.ManipulationDeltaEventArgs e)
+		{
+			// DeltaManipulation.Rotation is the per-delta rotation in degrees, clockwise positive.
+			var rotation = e.DeltaManipulation.Rotation;
+			if (rotation == 0 || double.IsNaN(rotation))
+				return;
+			_rotation = (float)rotation;
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+	}
+
+	public class PanGestureHandler : GestureHandler<PanGesture>, PanGesture.IHandler
+	{
+		PointF _translation;
+		PointF _velocity;
+		bool _enableMousePan = true;
+		MouseButtons _mouseButtons = MouseButtons.Primary;
+		bool _mousePanHooked;
+		bool _mousePanActive;
+		sw.Point _lastMousePosition;
+		DateTime _lastMouseTime;
+
+		public PointF Translation => _translation;
+		public PointF Velocity => _velocity;
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the gesture should also activate from mouse button down/move/up events on the attached element.
+		/// </summary>
+		/// <remarks>
+		/// When enabled, pressing the buttons specified by <see cref="Buttons"/> on the element captures the mouse and reports translation/velocity on each move until one of the buttons is released.
+		/// This is independent of the touch/trackpad manipulation events that always drive the gesture.
+		/// </remarks>
+		public bool EnableMousePan
+		{
+			get => _enableMousePan;
+			set
+			{
+				if (_enableMousePan == value)
+					return;
+				_enableMousePan = value;
+				UpdateMouseHooks();
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the mouse buttons that activate the gesture when <see cref="EnableMousePan"/> is true. Defaults to <see cref="MouseButtons.Primary"/>.
+		/// </summary>
+		/// <remarks>
+		/// All specified buttons must be held down for the pan to activate, and releasing any one of them ends the pan.
+		/// </remarks>
+		public MouseButtons Buttons
+		{
+			get => _mouseButtons;
+			set
+			{
+				if (_mouseButtons == value)
+					return;
+				_mouseButtons = value;
+				CancelMousePan();
+			}
+		}
+
+		protected override bool CanHandleDelta(swi.ManipulationDeltaEventArgs e)
+		{
+			var t = e.DeltaManipulation.Translation;
+			return t.X != 0 || t.Y != 0;
+		}
+
+		protected override void HandleDelta(swi.ManipulationDeltaEventArgs e)
+		{
+			var t = e.DeltaManipulation.Translation;
+			if (t.X == 0 && t.Y == 0)
+				return;
+			_translation = new PointF((float)t.X, (float)t.Y);
+			var v = e.Velocities.LinearVelocity;
+			_velocity = new PointF((float)(v.X * 1000.0), (float)(v.Y * 1000.0));
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+
+		protected override void OnAttached(sw.UIElement element)
+		{
+			UpdateMouseHooks();
+		}
+
+		protected override void OnDetaching(sw.UIElement element)
+		{
+			DetachMouseEvents(element);
+		}
+
+		void UpdateMouseHooks()
+		{
+			var element = Element;
+			if (_enableMousePan && element != null)
+				AttachMouseEvents(element);
+			else if (element != null)
+				DetachMouseEvents(element);
+		}
+
+		void AttachMouseEvents(sw.UIElement element)
+		{
+			if (_mousePanHooked)
+				return;
+			element.PreviewMouseDown += OnMouseDown;
+			element.PreviewMouseMove += OnMouseMove;
+			element.PreviewMouseUp += OnMouseUp;
+			element.LostMouseCapture += OnLostMouseCapture;
+			_mousePanHooked = true;
+		}
+
+		void DetachMouseEvents(sw.UIElement element)
+		{
+			if (!_mousePanHooked)
+				return;
+			element.PreviewMouseDown -= OnMouseDown;
+			element.PreviewMouseMove -= OnMouseMove;
+			element.PreviewMouseUp -= OnMouseUp;
+			element.LostMouseCapture -= OnLostMouseCapture;
+			_mousePanHooked = false;
+			CancelMousePan();
+		}
+
+		void CancelMousePan()
+		{
+			if (!_mousePanActive)
+				return;
+			_mousePanActive = false;
+			Element?.ReleaseMouseCapture();
+		}
+
+		void OnMouseDown(object sender, swi.MouseButtonEventArgs e)
+		{
+			if (!Enabled || _mousePanActive)
+				return;
+			// Only start once the button that completes the required set is pressed, and all required buttons are down.
+			if ((GetChangedButton(e) & _mouseButtons) == 0)
+				return;
+			if ((GetPressedButtons(e) & _mouseButtons) != _mouseButtons)
+				return;
+			var element = Element;
+			if (element == null)
+				return;
+			_mousePanActive = true;
+			_lastMousePosition = e.GetPosition(element);
+			_lastMouseTime = DateTime.UtcNow;
+			element.CaptureMouse();
+		}
+
+		void OnMouseMove(object sender, swi.MouseEventArgs e)
+		{
+			if (!Enabled || !_mousePanActive)
+				return;
+			var element = Element;
+			if (element == null)
+				return;
+			var position = e.GetPosition(element);
+			var dx = position.X - _lastMousePosition.X;
+			var dy = position.Y - _lastMousePosition.Y;
+			var now = DateTime.UtcNow;
+			var dt = (now - _lastMouseTime).TotalSeconds;
+			_lastMousePosition = position;
+			_lastMouseTime = now;
+			if (dx == 0 && dy == 0)
+				return;
+			_translation = new PointF((float)dx, (float)dy);
+			_velocity = dt > 0 ? new PointF((float)(dx / dt), (float)(dy / dt)) : PointF.Empty;
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+
+		void OnMouseUp(object sender, swi.MouseButtonEventArgs e)
+		{
+			// Releasing any one of the required buttons breaks the "all down" requirement and ends the pan.
+			if (!_mousePanActive || (GetChangedButton(e) & _mouseButtons) == 0)
+				return;
+			_mousePanActive = false;
+			Element?.ReleaseMouseCapture();
+		}
+
+		void OnLostMouseCapture(object sender, swi.MouseEventArgs e)
+		{
+			_mousePanActive = false;
+		}
+
+		static MouseButtons GetChangedButton(swi.MouseButtonEventArgs e)
+		{
+			switch (e.ChangedButton)
+			{
+				case swi.MouseButton.Left:
+					return MouseButtons.Primary;
+				case swi.MouseButton.Right:
+					return MouseButtons.Alternate;
+				case swi.MouseButton.Middle:
+					return MouseButtons.Middle;
+				default:
+					return MouseButtons.None;
+			}
+		}
+
+		static MouseButtons GetPressedButtons(swi.MouseEventArgs e)
+		{
+			var buttons = MouseButtons.None;
+			if (e.LeftButton == swi.MouseButtonState.Pressed)
+				buttons |= MouseButtons.Primary;
+			if (e.RightButton == swi.MouseButtonState.Pressed)
+				buttons |= MouseButtons.Alternate;
+			if (e.MiddleButton == swi.MouseButtonState.Pressed)
+				buttons |= MouseButtons.Middle;
+			return buttons;
+		}
+	}
+
+	public class ScrollGestureHandler : WidgetHandler<object, ScrollGesture>, ScrollGesture.IHandler, IWpfGestureHandler
+	{
+		const int WM_MOUSEHWHEEL = 0x020E;
+
+		sw.UIElement _element;
+		swin.HwndSource _source;
+		bool _enabled = true;
+		DateTime _previousTime;
+		SizeF _delta;
+		PointF _velocity;
+
+		protected new Gesture.ICallback Callback => (Gesture.ICallback)((ICallbackSource)Widget).Callback;
+
+		public bool Enabled
+		{
+			get => _enabled;
+			set => _enabled = value;
+		}
+
+		Gesture IWpfGestureHandler.Gesture => Widget;
+
+		public SizeF Delta => _delta;
+		public PointF Velocity => _velocity;
+
+		public void AttachTo(sw.UIElement element)
+		{
+			Detach();
+			_element = element;
+			_element.PreviewMouseWheel += OnPreviewMouseWheel;
+			if (_element is sw.FrameworkElement frameworkElement)
+			{
+				frameworkElement.Loaded += OnLoaded;
+				frameworkElement.Unloaded += OnUnloaded;
+			}
+			AddHook();
+		}
+
+		public void Detach()
+		{
+			if (_element == null)
+				return;
+			_element.PreviewMouseWheel -= OnPreviewMouseWheel;
+			if (_element is sw.FrameworkElement frameworkElement)
+			{
+				frameworkElement.Loaded -= OnLoaded;
+				frameworkElement.Unloaded -= OnUnloaded;
+			}
+			RemoveHook();
+			_element = null;
+		}
+
+		void OnLoaded(object sender, sw.RoutedEventArgs e)
+		{
+			AddHook();
+		}
+
+		void OnUnloaded(object sender, sw.RoutedEventArgs e)
+		{
+			RemoveHook();
+		}
+
+		void AddHook()
+		{
+			if (_element == null || _source != null)
+				return;
+			_source = sw.PresentationSource.FromVisual(_element) as swin.HwndSource;
+			_source?.AddHook(HwndHook);
+		}
+
+		void RemoveHook()
+		{
+			if (_source == null)
+				return;
+			_source.RemoveHook(HwndHook);
+			_source = null;
+		}
+
+		IntPtr HwndHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+		{
+			if (msg == WM_MOUSEHWHEEL && Enabled && _element?.IsMouseOver == true)
+				ActivateIfAllowed(new SizeF(-GetWheelDelta(wParam) / WpfConversions.WheelDelta * Widget.WheelScrollAmount, 0));
+			return IntPtr.Zero;
+		}
+
+		void OnPreviewMouseWheel(object sender, swi.MouseWheelEventArgs e)
+		{
+			if (Enabled)
+				ActivateIfAllowed(new SizeF(0, (float)e.Delta / WpfConversions.WheelDelta * Widget.WheelScrollAmount));
+		}
+
+		void ActivateIfAllowed(SizeF delta)
+		{
+			if (!CanRecognize(delta))
+				return;
+			Activate(delta);
+		}
+
+		bool CanRecognize(SizeF delta)
+		{
+			var control = Widget.Control;
+			if (control == null)
+				return true;
+
+			foreach (var gesture in control.Gestures)
+			{
+				if (((IHandlerSource)gesture).Handler is IWpfGestureHandler handler && handler.CanHandleWheel(delta))
+					return handler.Gesture == Widget || handler.Gesture.CanRecognizeSimultaneouslyWith(Widget);
+			}
+			return true;
+		}
+
+		void Activate(SizeF delta)
+		{
+			if (delta.IsZero)
+				return;
+
+			var now = DateTime.UtcNow;
+			var dt = _previousTime == default ? 0 : (now - _previousTime).TotalSeconds;
+			_previousTime = now;
+
+			_delta = delta;
+			_velocity = dt > 0 ? new PointF((float)(delta.Width / dt), (float)(delta.Height / dt)) : PointF.Empty;
+			Callback.OnActivated(Widget, EventArgs.Empty);
+		}
+
+		static int GetWheelDelta(IntPtr wParam)
+		{
+			return (short)(((long)wParam >> 16) & 0xFFFF);
+		}
+
+		bool IWpfGestureHandler.CanHandleDelta(swi.ManipulationDeltaEventArgs e)
+		{
+			return false;
+		}
+
+		bool IWpfGestureHandler.CanHandleWheel(SizeF delta)
+		{
+			// Defer Ctrl+Wheel to gestures that claim it (e.g. MagnificationGesture for precision touchpad pinches).
+			if ((swi.Keyboard.Modifiers & swi.ModifierKeys.Control) == swi.ModifierKeys.Control)
+				return false;
+			return Enabled && !delta.IsZero;
+		}
+	}
+}

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -97,6 +97,7 @@ namespace Eto.Wpf.Forms
 		bool _needsThemeChanged;
 		Size? newSize;
 		sw.Size parentMinimumSize;
+		HwndSource _mouseHWheelSource;
 		bool isMouseOver;
 		bool isMouseCaptured;
 		public bool XScale { get; private set; }
@@ -476,6 +477,9 @@ namespace Eto.Wpf.Forms
 					break;
 				case Eto.Forms.Control.MouseWheelEvent:
 					ContainerControl.PreviewMouseWheel += HandlePreviewMouseWheel;
+					ContainerControl.Loaded += HandleMouseWheelLoaded;
+					ContainerControl.Unloaded += HandleMouseWheelUnloaded;
+					AddMouseHWheelHook();
 					break;
 				case Eto.Forms.Control.SizeChangedEvent:
 					ContainerControl.SizeChanged += HandleSizeChanged;
@@ -578,6 +582,51 @@ namespace Eto.Wpf.Forms
 			var args = e.ToEto(Control);
 			Callback.OnMouseWheel(Widget, args);
 			e.Handled = args.Handled;
+		}
+
+		const int WM_MOUSEHWHEEL = 0x020E;
+
+		private void HandleMouseWheelLoaded(object sender, sw.RoutedEventArgs e)
+		{
+			AddMouseHWheelHook();
+		}
+
+		private void HandleMouseWheelUnloaded(object sender, sw.RoutedEventArgs e)
+		{
+			RemoveMouseHWheelHook();
+		}
+
+		void AddMouseHWheelHook()
+		{
+			if (_mouseHWheelSource != null || ContainerControl == null)
+				return;
+			_mouseHWheelSource = sw.PresentationSource.FromVisual(ContainerControl) as HwndSource;
+			_mouseHWheelSource?.AddHook(MouseHWheelHook);
+		}
+
+		void RemoveMouseHWheelHook()
+		{
+			if (_mouseHWheelSource == null)
+				return;
+			_mouseHWheelSource.RemoveHook(MouseHWheelHook);
+			_mouseHWheelSource = null;
+		}
+
+		IntPtr MouseHWheelHook(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+		{
+			if (msg != WM_MOUSEHWHEEL || Control == null || ContainerControl?.IsMouseOver != true)
+				return IntPtr.Zero;
+
+			var delta = -GetWheelDelta(wParam) / WpfConversions.WheelDelta;
+			var args = new MouseEventArgs(Mouse.Buttons, Keyboard.Modifiers, PointFromScreen(Mouse.Position), new SizeF(delta, 0));
+			Callback.OnMouseWheel(Widget, args);
+			handled = args.Handled;
+			return IntPtr.Zero;
+		}
+
+		static int GetWheelDelta(IntPtr wParam)
+		{
+			return (short)(((long)wParam >> 16) & 0xFFFF);
 		}
 
 		private void HandleIsVisibleChanged(object sender, sw.DependencyPropertyChangedEventArgs e)
@@ -1254,5 +1303,33 @@ namespace Eto.Wpf.Forms
 			return ContainerControl.CaptureMouse();
 		}
 		public void ReleaseMouseCapture() => ContainerControl.ReleaseMouseCapture();
+		public virtual void AddGesture(Gesture item)
+		{
+			if (item == null)
+				throw new ArgumentNullException(nameof(item));
+
+			var handler = ((IHandlerSource)item).Handler as Eto.Wpf.Forms.Controls.IWpfGestureHandler;
+			if (handler == null)
+				throw new NotSupportedException($"Gesture '{item.GetType().FullName}' is not supported on WPF");
+
+			handler.AttachTo(ContainerControl);
+		}
+
+		public virtual void ClearGestures()
+		{
+			foreach (var gesture in Widget.Gestures)
+			{
+				if (((IHandlerSource)gesture).Handler is Eto.Wpf.Forms.Controls.IWpfGestureHandler handler)
+					handler.Detach();
+			}
+		}
+
+		public virtual void RemoveGesture(Gesture item)
+		{
+			if (item == null)
+				return;
+			if (((IHandlerSource)item).Handler is Eto.Wpf.Forms.Controls.IWpfGestureHandler handler)
+				handler.Detach();
+		}
 	}
 }

--- a/src/Eto.Wpf/Platform.cs
+++ b/src/Eto.Wpf/Platform.cs
@@ -101,6 +101,10 @@ namespace Eto.Wpf
 			p.Add<RadialGradientBrush.IHandler>(() => new RadialGradientBrushHandler());
 			p.Add<SystemColors.IHandler>(() => new SystemColorsHandler());
 			p.Add<FormattedText.IHandler>(() => new FormattedTextHandler());
+			p.Add<MagnificationGesture.IHandler>(() => new MagnificationGestureHandler());
+			p.Add<RotationGesture.IHandler>(() => new RotationGestureHandler());
+			p.Add<PanGesture.IHandler>(() => new PanGestureHandler());
+			p.Add<ScrollGesture.IHandler>(() => new ScrollGestureHandler());
 
 			// Forms.Cells
 			p.Add<CheckBoxCell.IHandler>(() => new CheckBoxCellHandler());

--- a/src/Eto.iOS/Forms/IosView.cs
+++ b/src/Eto.iOS/Forms/IosView.cs
@@ -334,6 +334,9 @@ namespace Eto.iOS.Forms
 			get { return null; }
 			set { }
 		}
+
+		public virtual void AddGesture(Gesture item) { }
+		public virtual void ClearGestures() { }
+		public virtual void RemoveGesture(Gesture item) { }
 	}
 }
-

--- a/src/Eto/Forms/Controls/Control.cs
+++ b/src/Eto/Forms/Controls/Control.cs
@@ -23,6 +23,58 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 		}
 	}
 
+	static readonly object GesturesKey = new object();
+
+	/// <summary>
+	/// Gets the gestures attached to this control.
+	/// </summary>
+	public Collection<Gesture> Gestures => Properties.Create(GesturesKey, () => new GestureCollection(this));
+
+	class GestureCollection : Collection<Gesture>
+	{
+		public GestureCollection(Control control)
+		{
+			this.control = control;
+		}
+
+		private readonly Control control;
+
+		protected override void InsertItem(int index, Gesture item)
+		{
+			control.Handler.AddGesture(item);
+			item.Control = control;
+			base.InsertItem(index, item);
+		}
+
+		protected override void ClearItems()
+		{
+			foreach (var item in this)
+			{
+				item.Control = null;
+			}
+			control.Handler.ClearGestures();
+			base.ClearItems();
+		}
+
+		protected override void RemoveItem(int index)
+		{
+			var item = this[index];
+			control.Handler.RemoveGesture(item);
+			item.Control = null;
+			base.RemoveItem(index);
+		}
+
+		protected override void SetItem(int index, Gesture item)
+		{
+			var oldItem = this[index];
+			control.Handler.AddGesture(item);
+			control.Handler.RemoveGesture(oldItem);
+			oldItem.Control = null;
+			item.Control = control;
+			base.SetItem(index, item);
+		}
+	}
+
 	/// <summary>
 	/// Gets a value indicating that the control is loaded onto a form, that is it has been created, added to a parent, and shown
 	/// </summary>
@@ -2106,6 +2158,20 @@ public partial class Control : BindableWidget, IMouseInputSource, IKeyboardInput
 		/// Releases the mouse capture after a call to <see cref="CaptureMouse"/>.
 		/// </summary>
 		void ReleaseMouseCapture();
+		/// <summary>
+		/// Adds a gesture to the control.
+		/// </summary>
+		/// <param name="item">Gesture to add.</param>
+		void AddGesture(Gesture item);
+		/// <summary>
+		/// Removes all gestures from the control.
+		/// </summary>
+		void ClearGestures();
+		/// <summary>
+		/// Removes a gesture from the control.
+		/// </summary>
+		/// <param name="item">Gesture to remove.</param>
+		void RemoveGesture(Gesture item);
 	}
 	#endregion
 }

--- a/src/Eto/Forms/Controls/ThemedControlHandler.cs
+++ b/src/Eto/Forms/Controls/ThemedControlHandler.cs
@@ -481,6 +481,24 @@ public class ThemedControlHandler<TControl, TWidget, TCallback> : WidgetHandler<
 	/// <inheritdoc />
 	public void ReleaseMouseCapture() => Control.ReleaseMouseCapture();
 
+	/// <inheritdoc />
+	public virtual void AddGesture(Gesture item)
+	{
+		Control.Gestures.Add(item);
+	}
+
+	/// <inheritdoc />
+	public virtual void ClearGestures()
+	{
+		Control.Gestures.Clear();
+	}
+
+	/// <inheritdoc />
+	public virtual void RemoveGesture(Gesture item)
+	{
+		Control.Gestures.Remove(item);
+	}
+
 	#endregion
 
 }

--- a/src/Eto/Forms/Gesture/Gesture.cs
+++ b/src/Eto/Forms/Gesture/Gesture.cs
@@ -1,0 +1,240 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Event arguments for determining if two gestures can be recognized simultaneously.
+/// </summary>
+public class GestureRecognitionEventArgs : EventArgs
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="GestureRecognitionEventArgs"/> class.
+	/// </summary>
+	/// <param name="otherGesture">The other gesture being recognized.</param>
+	/// <param name="allow">Initial value indicating whether simultaneous recognition is allowed.</param>
+	public GestureRecognitionEventArgs(Gesture otherGesture, bool allow)
+	{
+		OtherGesture = otherGesture;
+		Allow = allow;
+	}
+
+	/// <summary>
+	/// Gets the other gesture being recognized.
+	/// </summary>
+	public Gesture OtherGesture { get; }
+
+	/// <summary>
+	/// Gets or sets a value indicating whether simultaneous recognition is allowed.
+	/// </summary>
+	public bool Allow { get; set; }
+}
+
+/// <summary>
+/// Base class for platform gestures that can be attached to a <see cref="Control"/>.
+/// </summary>
+[Handler(typeof(IHandler))]
+public abstract class Gesture : Widget
+{
+	static readonly object AllowedGestureTypesKey = new object();
+	static readonly object AllowedGesturesKey = new object();
+	static readonly object CanRecognizeSimultaneouslyKey = new object();
+
+	new IHandler Handler => (IHandler)base.Handler;
+
+	Control _control;
+	
+	/// <summary>
+	/// Gets or sets a value indicating whether this gesture can be recognized.
+	/// </summary>
+	public bool Enabled
+	{
+		get => Handler.Enabled;
+		set => Handler.Enabled = value;
+	}
+	
+	/// <summary>
+	/// Gets the control that this gesture is attached to, or null if not attached to a control.
+	/// </summary>
+	public Control Control
+	{
+		get => _control;
+		internal set => _control = value;
+	}
+
+	/// <summary>
+	/// Occurs when determining whether this gesture can recognize simultaneously with another gesture.
+	/// </summary>
+	/// <remarks>
+	/// Simultaneous recognition requires both gestures to allow the pairing.
+	/// </remarks>
+	public event EventHandler<GestureRecognitionEventArgs> CanRecognizeSimultaneously
+	{
+		add { Properties.AddEvent(CanRecognizeSimultaneouslyKey, value); }
+		remove { Properties.RemoveEvent(CanRecognizeSimultaneouslyKey, value); }
+	}
+
+	/// <summary>
+	/// Allows this gesture to recognize simultaneously with gestures of the specified type.
+	/// </summary>
+	/// <typeparam name="TGesture">Type of gesture to allow.</typeparam>
+	public void AllowSimultaneousWith<TGesture>()
+		where TGesture : Gesture
+	{
+		AllowSimultaneousWith(typeof(TGesture));
+	}
+
+	/// <summary>
+	/// Allows this gesture to recognize simultaneously with gestures of the specified type.
+	/// </summary>
+	/// <param name="gestureType">Type of gesture to allow.</param>
+	public void AllowSimultaneousWith(Type gestureType)
+	{
+		if (gestureType == null)
+			throw new ArgumentNullException(nameof(gestureType));
+		if (!typeof(Gesture).IsAssignableFrom(gestureType))
+			throw new ArgumentException($"Type must derive from {nameof(Gesture)}.", nameof(gestureType));
+
+		Properties.Create<HashSet<Type>>(AllowedGestureTypesKey).Add(gestureType);
+	}
+
+	/// <summary>
+	/// Allows this gesture and the specified gesture to recognize simultaneously.
+	/// </summary>
+	/// <param name="gesture">Gesture to allow.</param>
+	/// <remarks>
+	/// This adds the pairing to both gestures.
+	/// </remarks>
+	public void AllowSimultaneousWith(Gesture gesture)
+	{
+		if (gesture == null)
+			throw new ArgumentNullException(nameof(gesture));
+
+		Properties.Create<HashSet<Gesture>>(AllowedGesturesKey).Add(gesture);
+		gesture.Properties.Create<HashSet<Gesture>>(AllowedGesturesKey).Add(this);
+	}
+
+	/// <summary>
+	/// Removes a previously allowed simultaneous gesture type.
+	/// </summary>
+	/// <typeparam name="TGesture">Type of gesture to remove.</typeparam>
+	public void DisallowSimultaneousWith<TGesture>()
+		where TGesture : Gesture
+	{
+		DisallowSimultaneousWith(typeof(TGesture));
+	}
+
+	/// <summary>
+	/// Removes a previously allowed simultaneous gesture type.
+	/// </summary>
+	/// <param name="gestureType">Type of gesture to remove.</param>
+	public void DisallowSimultaneousWith(Type gestureType)
+	{
+		if (gestureType == null)
+			throw new ArgumentNullException(nameof(gestureType));
+		Properties.Get<HashSet<Type>>(AllowedGestureTypesKey)?.Remove(gestureType);
+	}
+
+	/// <summary>
+	/// Removes a previously allowed simultaneous gesture pairing.
+	/// </summary>
+	/// <param name="gesture">Gesture pairing to remove.</param>
+	/// <remarks>
+	/// This removes the pairing from both gestures.
+	/// </remarks>
+	public void DisallowSimultaneousWith(Gesture gesture)
+	{
+		if (gesture == null)
+			throw new ArgumentNullException(nameof(gesture));
+
+		Properties.Get<HashSet<Gesture>>(AllowedGesturesKey)?.Remove(gesture);
+		gesture.Properties.Get<HashSet<Gesture>>(AllowedGesturesKey)?.Remove(this);
+	}
+
+	/// <summary>
+	/// Determines whether this gesture allows simultaneous recognition with the specified gesture.
+	/// </summary>
+	/// <param name="otherGesture">Other gesture being recognized.</param>
+	/// <returns>True if this gesture allows simultaneous recognition with <paramref name="otherGesture"/>.</returns>
+	public bool AllowsSimultaneousRecognition(Gesture otherGesture)
+	{
+		if (otherGesture == null)
+			return false;
+
+		var allow = Properties.Get<HashSet<Gesture>>(AllowedGesturesKey)?.Contains(otherGesture) == true
+			|| Properties.Get<HashSet<Type>>(AllowedGestureTypesKey)?.Any(type => type.IsInstanceOfType(otherGesture)) == true;
+
+		var args = new GestureRecognitionEventArgs(otherGesture, allow);
+		Properties.TriggerEvent(CanRecognizeSimultaneouslyKey, this, args);
+		allow = args.Allow;
+
+		return allow;
+	}
+
+	/// <summary>
+	/// Determines whether this gesture and another gesture mutually allow simultaneous recognition.
+	/// </summary>
+	/// <param name="otherGesture">Other gesture being recognized.</param>
+	/// <returns>True if both gestures allow simultaneous recognition with each other.</returns>
+	public bool CanRecognizeSimultaneouslyWith(Gesture otherGesture)
+	{
+		return otherGesture != null
+			&& AllowsSimultaneousRecognition(otherGesture)
+			&& otherGesture.AllowsSimultaneousRecognition(this);
+	}
+	
+	private readonly object ActivatedKey = new object();
+
+	/// <summary>
+	/// Occurs when the gesture has been recognized by the platform.
+	/// </summary>
+	public event EventHandler<EventArgs> Activated
+	{
+		add { Properties.AddEvent(ActivatedKey, value); }
+		remove { Properties.RemoveEvent(ActivatedKey, value); }
+	}
+
+	/// <summary>
+	/// Raises the <see cref="Activated"/> event.
+	/// </summary>
+	/// <param name="e">Event arguments.</param>
+	protected virtual void OnActivated(EventArgs e)
+	{
+		Properties.TriggerEvent(ActivatedKey, this, e);
+	}
+
+	/// <summary>
+	/// Handler interface for <see cref="Gesture"/>.
+	/// </summary>
+	public new interface IHandler : Widget.IHandler
+	{
+		/// <summary>
+		/// Gets or sets a value indicating whether this gesture can be recognized.
+		/// </summary>
+		bool Enabled { get; set; }
+	}
+
+	/// <inheritdoc />
+	protected override object GetCallback() => Callback.Instance;
+
+	/// <summary>
+	/// Callback interface for <see cref="Gesture"/>.
+	/// </summary>
+	public new interface ICallback : Widget.ICallback
+	{
+		/// <summary>
+		/// Raises the <see cref="Activated"/> event.
+		/// </summary>
+		/// <param name="widget">Gesture widget.</param>
+		/// <param name="e">Event arguments.</param>
+		void OnActivated(Gesture widget, EventArgs e);
+	}
+
+	class Callback : ICallback
+	{
+		public static readonly Callback Instance = new Callback();
+
+		public void OnActivated(Gesture widget, EventArgs e)
+		{
+			using (widget.Platform.Context)
+				widget.OnActivated(e);
+		}
+	}
+}

--- a/src/Eto/Forms/Gesture/MagnificationGesture.cs
+++ b/src/Eto/Forms/Gesture/MagnificationGesture.cs
@@ -1,0 +1,25 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Gesture for trackpad or touchscreen pinch magnification.
+/// </summary>
+[Handler(typeof(IHandler))]
+public class MagnificationGesture : Gesture
+{
+	new IHandler Handler => (IHandler)base.Handler;
+
+	/// <summary>
+	/// Gets the current magnification delta for the gesture activation.
+	/// </summary>
+	public float Magnification => Handler.Magnification;
+	/// <summary>
+	/// Handler interface for <see cref="MagnificationGesture"/>.
+	/// </summary>
+	public new interface IHandler : Gesture.IHandler
+	{
+		/// <summary>
+		/// Gets the current magnification delta for the gesture activation.
+		/// </summary>
+		float Magnification { get; }
+	}
+}

--- a/src/Eto/Forms/Gesture/PanGesture.cs
+++ b/src/Eto/Forms/Gesture/PanGesture.cs
@@ -1,0 +1,62 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Gesture for pan translation, typically activated by dragging with the mouse or a single finger on a touch screen.
+/// </summary>
+/// <remarks>
+/// Scroll-wheel and trackpad scroll input is exposed through <see cref="ScrollGesture"/>.
+/// </remarks>
+[Handler(typeof(IHandler))]
+public class PanGesture : Gesture
+{
+	new IHandler Handler => (IHandler)base.Handler;
+
+	/// <summary>
+	/// Gets the current translation delta for the gesture activation.
+	/// </summary>
+	public PointF Translation => Handler.Translation;
+
+	/// <summary>
+	/// Gets the current velocity for the gesture activation.
+	/// </summary>
+	public PointF Velocity => Handler.Velocity;
+
+	/// <summary>
+	/// Gets or sets the mouse buttons that can activate the pan gesture.
+	/// </summary>
+	/// <remarks>
+	/// The default value is <see cref="MouseButtons.Primary"/>. All specified buttons must be down
+	/// for the pan gesture to activate.
+	/// </remarks>
+	public MouseButtons Buttons
+	{
+		get => Handler.Buttons;
+		set
+		{
+			if (value == MouseButtons.None)
+				throw new ArgumentException($"{nameof(Buttons)} cannot be {nameof(MouseButtons.None)}.", nameof(value));
+			Handler.Buttons = value;
+		}
+	}
+
+	/// <summary>
+	/// Handler interface for <see cref="PanGesture"/>.
+	/// </summary>
+	public new interface IHandler : Gesture.IHandler
+	{
+		/// <summary>
+		/// Gets the current translation delta for the gesture activation.
+		/// </summary>
+		PointF Translation { get; }
+
+		/// <summary>
+		/// Gets the current velocity for the gesture activation.
+		/// </summary>
+		PointF Velocity { get; }
+
+		/// <summary>
+		/// Gets or sets the mouse buttons that can activate the pan gesture.
+		/// </summary>
+		MouseButtons Buttons { get; set; }
+	}
+}

--- a/src/Eto/Forms/Gesture/RotationGesture.cs
+++ b/src/Eto/Forms/Gesture/RotationGesture.cs
@@ -1,0 +1,30 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Gesture for trackpad or touchscreen two-finger rotation.
+/// </summary>
+[Handler(typeof(IHandler))]
+public class RotationGesture : Gesture
+{
+	new IHandler Handler => (IHandler)base.Handler;
+
+	/// <summary>
+	/// Gets the current rotation delta, in degrees, for the gesture activation.
+	/// </summary>
+	/// <remarks>
+	/// Positive values indicate clockwise rotation, negative values counter-clockwise.
+	/// The value is the change since the last activation, not the absolute rotation since the gesture began.
+	/// </remarks>
+	public float Rotation => Handler.Rotation;
+
+	/// <summary>
+	/// Handler interface for <see cref="RotationGesture"/>.
+	/// </summary>
+	public new interface IHandler : Gesture.IHandler
+	{
+		/// <summary>
+		/// Gets the current rotation delta, in degrees, for the gesture activation.
+		/// </summary>
+		float Rotation { get; }
+	}
+}

--- a/src/Eto/Forms/Gesture/ScrollGesture.cs
+++ b/src/Eto/Forms/Gesture/ScrollGesture.cs
@@ -1,0 +1,56 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Gesture for multidimensional scrolling, such as with a mouse wheel or two finger trackpad scroll input.
+/// </summary>
+[Handler(typeof(IHandler))]
+public class ScrollGesture : Gesture
+{
+	static readonly object WheelScrollAmountKey = new object();
+
+	new IHandler Handler => (IHandler)base.Handler;
+
+	/// <summary>
+	/// Gets the default logical distance represented by one wheel notch.
+	/// </summary>
+	public const float DefaultWheelScrollAmount = 48f;
+
+	/// <summary>
+	/// Gets or sets the logical distance represented by one wheel notch.
+	/// </summary>
+	/// <remarks>
+	/// This is used to normalize wheel-style input to logical coordinates. Precise scrolling input
+	/// that already reports logical deltas, such as macOS trackpad scrolling, is not scaled.
+	/// </remarks>
+	public float WheelScrollAmount
+	{
+		get => Properties.Get<float?>(WheelScrollAmountKey) ?? DefaultWheelScrollAmount;
+		set => Properties.Set(WheelScrollAmountKey, value);
+	}
+
+	/// <summary>
+	/// Gets the current scroll delta for the gesture activation, in logical coordinates.
+	/// </summary>
+	public SizeF Delta => Handler.Delta;
+
+	/// <summary>
+	/// Gets the current scroll velocity for the gesture activation, in logical coordinates per second.
+	/// </summary>
+	public PointF Velocity => Handler.Velocity;
+
+	/// <summary>
+	/// Handler interface for <see cref="ScrollGesture"/>.
+	/// </summary>
+	public new interface IHandler : Gesture.IHandler
+	{
+		/// <summary>
+		/// Gets the current scroll delta for the gesture activation, in logical coordinates.
+		/// </summary>
+		SizeF Delta { get; }
+
+		/// <summary>
+		/// Gets the current scroll velocity for the gesture activation, in logical coordinates per second.
+		/// </summary>
+		PointF Velocity { get; }
+	}
+}

--- a/test/Eto.Test/Sections/Behaviors/GesturesSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/GesturesSection.cs
@@ -1,0 +1,311 @@
+namespace Eto.Test.Sections.Behaviors
+{
+	[Section("Behaviors", "Gestures")]
+	public class GesturesSection : Panel
+	{
+		readonly Drawable drawable;
+		readonly Label scaleLabel;
+		readonly Label magnificationLabel;
+		readonly Label rotationLabel;
+		readonly Label angleLabel;
+		readonly Label translationLabel;
+		readonly Label velocityLabel;
+		readonly Label scrollDeltaLabel;
+		readonly Label scrollVelocityLabel;
+		readonly CheckBox allowSimultaneousGesturesCheckBox;
+		readonly MagnificationGesture magnificationGesture;
+		readonly RotationGesture rotateGesture;
+		readonly PanGesture panGesture;
+		readonly ScrollGesture scrollGesture;
+		float scale = 1f;
+		float lastMagnification;
+		float angle;
+		float lastRotation;
+		PointF offset;
+		PointF lastTranslation;
+		PointF lastVelocity;
+		SizeF lastScrollDelta;
+		PointF lastScrollVelocity;
+
+		public GesturesSection()
+		{
+			scaleLabel = new Label();
+			magnificationLabel = new Label();
+			rotationLabel = new Label();
+			angleLabel = new Label();
+			translationLabel = new Label();
+			velocityLabel = new Label();
+			scrollDeltaLabel = new Label();
+			scrollVelocityLabel = new Label();
+			allowSimultaneousGesturesCheckBox = new CheckBox { Text = "Allow Simultaneous Gestures", Checked = true };
+			allowSimultaneousGesturesCheckBox.CheckedChanged += (sender, e) => SetSimultaneousGestures(allowSimultaneousGesturesCheckBox.Checked == true);
+
+			drawable = new Drawable
+			{
+				Size = new Size(520, 360),
+				BackgroundColor = Colors.White
+			};
+			drawable.Paint += Drawable_Paint;
+			drawable.CanFocus = true;
+			drawable.MouseDown += (sender, e) => Log.Write(this, $"MouseDown: {e.Buttons} at {e.Location}");
+			// drawable.MouseMove += (sender, e) => Log.Write(this, $"MouseMove: {e.Buttons} at {e.Location}");
+			drawable.MouseUp += (sender, e) => Log.Write(this, $"MouseUp: {e.Buttons} at {e.Location}");
+			drawable.MouseWheel += (sender, e) => Log.Write(this, $"MouseWheel: {e.Delta} at {e.Location}");
+
+			if (Platform.Supports<MagnificationGesture>())
+			{
+				magnificationGesture = new MagnificationGesture();
+				magnificationGesture.Activated += MagnificationGesture_Activated;
+				drawable.Gestures.Add(magnificationGesture);
+			}
+
+			if (Platform.Supports<RotationGesture>())
+			{
+				rotateGesture = new RotationGesture();
+				rotateGesture.Activated += RotateGesture_Activated;
+				drawable.Gestures.Add(rotateGesture);
+			}
+
+			if (Platform.Supports<PanGesture>())
+			{
+				panGesture = new PanGesture();
+				panGesture.Activated += PanGesture_Activated;
+				drawable.Gestures.Add(panGesture);
+			}
+
+			if (Platform.Supports<ScrollGesture>())
+			{
+				scrollGesture = new ScrollGesture();
+				scrollGesture.Activated += ScrollGesture_Activated;
+				drawable.Gestures.Add(scrollGesture);
+			}
+
+			SetSimultaneousGestures(allowSimultaneousGesturesCheckBox.Checked == true);
+			var panMouseButtonsSelector = panGesture != null ? CreatePanMouseButtonsSelector() : null;
+			var wheelScrollAmountControl = scrollGesture != null ? CreateWheelScrollAmountControl() : null;
+
+			var resetButton = new Button { Text = "Reset" };
+			resetButton.Click += (sender, e) =>
+			{
+				scale = 1f;
+				lastMagnification = 0f;
+				angle = 0f;
+				lastRotation = 0f;
+				offset = PointF.Empty;
+				lastTranslation = PointF.Empty;
+				lastVelocity = PointF.Empty;
+				lastScrollDelta = SizeF.Empty;
+				lastScrollVelocity = PointF.Empty;
+				UpdateLabels();
+				drawable.Invalidate();
+			};
+
+			UpdateLabels();
+
+			Content = new DynamicLayout
+			{
+				Padding = new Padding(10),
+				DefaultSpacing = new Size(5, 5),
+				Rows =
+				{
+					new Label { Text = "Pinch over the drawable to scale the drawing. Rotate with two fingers to spin it. Pan to move it." },
+					new TableLayout(
+						TableLayout.Horizontal(10, scaleLabel, magnificationLabel, resetButton, allowSimultaneousGesturesCheckBox, panMouseButtonsSelector, null),
+						TableLayout.Horizontal(10, angleLabel, rotationLabel, null),
+						TableLayout.Horizontal(10, translationLabel, velocityLabel, null),
+						TableLayout.Horizontal(10, scrollDeltaLabel, scrollVelocityLabel, wheelScrollAmountControl, null),
+						drawable
+					),
+					null
+				}
+			};
+		}
+
+		Control CreateWheelScrollAmountControl()
+		{
+			var stepper = new NumericStepper
+			{
+				MinValue = 0,
+				MaxValue = 500,
+				Increment = 1,
+				DecimalPlaces = 1,
+				Value = scrollGesture.WheelScrollAmount,
+				Width = 70
+			};
+			stepper.ValueChanged += (sender, e) => scrollGesture.WheelScrollAmount = (float)stepper.Value;
+
+			return TableLayout.Horizontal(5, new Label { Text = "Wheel Scroll Amount:" }, stepper);
+		}
+
+		Control CreatePanMouseButtonsSelector()
+		{
+			var menuItem = new MenuSegmentedItem { CanSelect = false };
+			var menu = new ContextMenu();
+
+			void AddMouseButtonsItem(MouseButtons buttons)
+			{
+				var item = new ButtonMenuItem { Text = FormatMouseButtons(buttons) };
+				item.Click += (sender, e) =>
+				{
+					panGesture.Buttons = buttons;
+					menuItem.Text = "Pan Mouse: " + FormatMouseButtons(buttons);
+				};
+				menu.Items.Add(item);
+			}
+
+			AddMouseButtonsItem(MouseButtons.Primary);
+			AddMouseButtonsItem(MouseButtons.Alternate);
+			AddMouseButtonsItem(MouseButtons.Middle);
+			AddMouseButtonsItem(MouseButtons.Primary | MouseButtons.Alternate);
+			AddMouseButtonsItem(MouseButtons.Primary | MouseButtons.Middle);
+			AddMouseButtonsItem(MouseButtons.Alternate | MouseButtons.Middle);
+			AddMouseButtonsItem(MouseButtons.Primary | MouseButtons.Alternate | MouseButtons.Middle);
+
+			menuItem.Menu = menu;
+			menuItem.Text = "Pan Mouse: " + FormatMouseButtons(panGesture.Buttons);
+
+			return new SegmentedButton
+			{
+				SelectionMode = SegmentedSelectionMode.None,
+				Items = { menuItem }
+			};
+		}
+
+		static string FormatMouseButtons(MouseButtons buttons)
+		{
+			return buttons.ToString().Replace(", ", " + ");
+		}
+
+		void SetSimultaneousGestures(bool allow)
+		{
+			if (magnificationGesture != null && rotateGesture != null)
+				SetSimultaneousGestures(magnificationGesture, rotateGesture, allow);
+			if (magnificationGesture != null && panGesture != null)
+				SetSimultaneousGestures(magnificationGesture, panGesture, allow);
+			if (rotateGesture != null && panGesture != null)
+				SetSimultaneousGestures(rotateGesture, panGesture, allow);
+			if (scrollGesture != null && panGesture != null)
+				SetSimultaneousGestures(scrollGesture, panGesture, allow);
+		}
+
+		static void SetSimultaneousGestures(Gesture first, Gesture second, bool allow)
+		{
+			if (allow)
+				first.AllowSimultaneousWith(second);
+			else
+				first.DisallowSimultaneousWith(second);
+		}
+
+		void MagnificationGesture_Activated(object sender, EventArgs e)
+		{
+			lastMagnification = magnificationGesture.Magnification;
+			scale *= 1f + lastMagnification;
+			scale = Math.Max(0.25f, Math.Min(5f, scale));
+			UpdateLabels();
+			drawable.Invalidate();
+		}
+
+		void RotateGesture_Activated(object sender, EventArgs e)
+		{
+			lastRotation = rotateGesture.Rotation;
+			angle += lastRotation;
+			UpdateLabels();
+			drawable.Invalidate();
+		}
+
+		void PanGesture_Activated(object sender, EventArgs e)
+		{
+			lastTranslation = panGesture.Translation;
+			lastVelocity = panGesture.Velocity;
+			offset += lastTranslation;
+			UpdateLabels();
+			drawable.Invalidate();
+		}
+
+		void ScrollGesture_Activated(object sender, EventArgs e)
+		{
+			lastScrollDelta = scrollGesture.Delta;
+			lastScrollVelocity = scrollGesture.Velocity;
+			offset += new PointF(lastScrollDelta.Width, lastScrollDelta.Height);
+			UpdateLabels();
+			drawable.Invalidate();
+		}
+
+		void UpdateLabels()
+		{
+			scaleLabel.Text = string.Format("Scale: {0:0.00}x", scale);
+			magnificationLabel.Text = string.Format("Magnification: {0:+0.000;-0.000;0.000}", lastMagnification);
+			angleLabel.Text = string.Format("Angle: {0:0.0}°", angle);
+			rotationLabel.Text = string.Format("Rotation: {0:+0.000;-0.000;0.000}°", lastRotation);
+			translationLabel.Text = string.Format("Translation: {0:+0.0;-0.0;0.0}, {1:+0.0;-0.0;0.0}", lastTranslation.X, lastTranslation.Y);
+			velocityLabel.Text = string.Format("Velocity: {0:+0.0;-0.0;0.0}, {1:+0.0;-0.0;0.0}", lastVelocity.X, lastVelocity.Y);
+			scrollDeltaLabel.Text = string.Format("Scroll Delta: {0:+0.0;-0.0;0.0}, {1:+0.0;-0.0;0.0}", lastScrollDelta.Width, lastScrollDelta.Height);
+			scrollVelocityLabel.Text = string.Format("Scroll Velocity: {0:+0.0;-0.0;0.0}, {1:+0.0;-0.0;0.0}", lastScrollVelocity.X, lastScrollVelocity.Y);
+		}
+
+		void Drawable_Paint(object sender, PaintEventArgs e)
+		{
+			var g = e.Graphics;
+			var bounds = new RectangleF(drawable.Size);
+			var center = bounds.Center;
+
+			DrawBackground(g, bounds);
+
+			g.SaveTransform();
+			g.TranslateTransform(offset);
+			g.TranslateTransform(center);
+			g.ScaleTransform(scale);
+			g.RotateTransform(angle);
+			g.TranslateTransform(-center);
+
+			DrawScaledDrawing(g, center);
+
+			g.RestoreTransform();
+			DrawOverlay(g, bounds);
+		}
+
+		void DrawBackground(Graphics g, RectangleF bounds)
+		{
+			g.FillRectangle(Colors.White, bounds);
+
+			using (var gridPen = new Pen(Color.FromArgb(0xe8, 0xec, 0xf0), 1))
+			using (var axisPen = new Pen(Color.FromArgb(0x9a, 0xa8, 0xb3), 1))
+			{
+				for (int x = 0; x <= bounds.Width; x += 24)
+					g.DrawLine(gridPen, x, 0, x, bounds.Height);
+				for (int y = 0; y <= bounds.Height; y += 24)
+					g.DrawLine(gridPen, 0, y, bounds.Width, y);
+
+				g.DrawLine(axisPen, bounds.Width / 2, 0, bounds.Width / 2, bounds.Height);
+				g.DrawLine(axisPen, 0, bounds.Height / 2, bounds.Width, bounds.Height / 2);
+			}
+		}
+
+		void DrawScaledDrawing(Graphics g, PointF center)
+		{
+			var rect = new RectangleF(center.X - 85, center.Y - 55, 170, 110);
+			using (var outlinePen = new Pen(Colors.DarkSlateBlue, 3))
+			using (var accentPen = new Pen(Colors.OrangeRed, 4))
+			using (var crossPen = new Pen(Colors.DarkGreen, 2))
+			{
+				g.FillEllipse(Color.FromArgb(0x9b, 0xd7, 0xea), rect);
+				g.DrawEllipse(outlinePen, rect);
+				g.DrawLine(accentPen, center.X - 120, center.Y, center.X + 120, center.Y);
+				g.DrawLine(accentPen, center.X, center.Y - 90, center.X, center.Y + 90);
+
+				g.DrawRectangle(crossPen, center.X - 42, center.Y - 42, 84, 84);
+				g.DrawLine(crossPen, center.X - 42, center.Y - 42, center.X + 42, center.Y + 42);
+				g.DrawLine(crossPen, center.X + 42, center.Y - 42, center.X - 42, center.Y + 42);
+			}
+		}
+
+		void DrawOverlay(Graphics g, RectangleF bounds)
+		{
+			using (var borderPen = new Pen(Color.FromArgb(0x7c, 0x89, 0x94), 1))
+			{
+				g.DrawRectangle(borderPen, bounds);
+			}
+			g.DrawText(SystemFonts.Label(), Colors.Black, 8, 8, "MagnificationGesture + PanGesture + RotateGesture + ScrollGesture");
+		}
+	}
+}


### PR DESCRIPTION
Adds a cross-platform gesture API for controls via Control.Gestures, with support for magnification, rotation, pan, and scroll gestures.

- Added **Gesture** as the shared base type with Enabled, Activated, attached Control, and simultaneous-recognition controls.
- Added concrete gesture types:
  - **MagnificationGesture** for pinch/zoom deltas.
  - **RotationGesture** for rotation deltas in degrees.
  - **PanGesture** for translation/velocity, including configurable mouse buttons.
  - **ScrollGesture** for multidimensional scroll deltas/velocity, with configurable WheelScrollAmount.

- Implemented gesture backends for Mac, WPF, WinForms, and GTK.
- Added platform registration so Platform.Supports<TGesture>() works for gesture types.
- Added attach/remove/clear gesture plumbing to control handlers.
- Added a Gestures test section demonstrating pinch, rotate, pan, scroll, simultaneous gesture recognition, pan mouse button selection, and wheel scroll amount adjustment.