### PR TITLE
Eto.Gtk: render fonts via Pango AttrFontDesc instead of OverrideFont

### DIFF
--- a/src/Eto.Gtk/Drawing/FontHandler.cs
+++ b/src/Eto.Gtk/Drawing/FontHandler.cs
@@ -126,8 +126,24 @@ namespace Eto.GtkSharp.Drawing
 				if (attributes == null)
 				{
 					attributes = new Pango.AttrList();
-					attributes.Insert(new Pango.AttrUnderline(FontDecoration.HasFlag(FontDecoration.Underline) ? Pango.Underline.Single : Pango.Underline.None));
-					attributes.Insert(new Pango.AttrStrikethrough(FontDecoration.HasFlag(FontDecoration.Strikethrough)));
+					// Only insert decoration attributes when actually requested.
+					// Inserting AttrUnderline(None) / AttrStrikethrough(false)
+					// over the whole text range would override any per-span
+					// underline/strikethrough that consumers set via Pango
+					// markup (e.g. Gtk.Label.Markup = "<u>X</u>foo"), wiping
+					// it out the moment Font is reassigned.
+					if (FontDecoration.HasFlag(FontDecoration.Underline))
+						attributes.Insert(new Pango.AttrUnderline(Pango.Underline.Single));
+					if (FontDecoration.HasFlag(FontDecoration.Strikethrough))
+						attributes.Insert(new Pango.AttrStrikethrough(true));
+					// Widget consumers (Gtk.Label.Attributes etc.) honor what's in
+					// this AttrList but don't pick up the layout's default
+					// FontDescription. Historically the FontDescription was
+					// communicated via Widget.OverrideFont, which is a deprecated
+					// no-op on Gtk 3.20+. AttrFontDesc carries the whole
+					// description -- family, size, weight, style -- in one shot.
+					if (Control != null)
+						attributes.Insert(new Pango.AttrFontDesc(Control));
 				}
 				return attributes;
 			}


### PR DESCRIPTION
Setting Eto Font on a Gtk widget went through GtkControl.Font -> Widget.OverrideFont, which has been a deprecated no-op on Gtk 3.20+. The fallback for Gtk.Label and friends was Control.Attributes from FontHandler.Attributes, but that AttrList only carried underline / strikethrough decoration -- family, size, weight, and style silently fell through to the system theme default. Bold/italic UI fonts rendered as plain regular text on modern Gtk.

FontHandler.Attributes now inserts a Pango.AttrFontDesc(Control) covering the whole text range, so the FontDescription's family, size, weight, and style actually reach the layout. Decoration attributes (underline, strikethrough) are now only inserted when actually requested -- inserting AttrUnderline(None) over the whole text range would override per-span underlines that consumers set via Pango markup (e.g. Gtk.Label.Markup = "<u>X</u>foo"), wiping them out the moment Font is reassigned.