### PR TITLE
Eto.Gtk: implement AlwaysShowMnemonic

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk3.cs
+++ b/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk3.cs
@@ -13,6 +13,7 @@ namespace Eto.GtkSharp.Forms.Controls
 	{
 		readonly Gtk.AccelLabel label;
 		string _text;
+		bool _alwaysShowMnemonic;
 
 		Gtk.Image gtkimage;
 
@@ -59,9 +60,15 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				_text = value;
 				if (label.UseUnderline)
+				{
 					label.TextWithMnemonic = _text.ToPlatformMnemonic();
+					label.Pattern = _alwaysShowMnemonic ? GtkMnemonicHelper.ToPatternWithMnemonicUnderline(_text) : null;
+				}
 				else
+				{
+					label.Pattern = null;
 					label.Text = _text;
+				}
 				SetImagePosition();
 			}
 		}
@@ -199,8 +206,15 @@ namespace Eto.GtkSharp.Forms.Controls
 		
 		public bool AlwaysShowMnemonic
 		{
-			get => false;
-			set { /* not supported in GTK */ }
+			get => _alwaysShowMnemonic;
+			set
+			{
+				if (_alwaysShowMnemonic == value)
+					return;
+				_alwaysShowMnemonic = value;
+				if (_text != null)
+					Text = _text;
+			}
 		}
 
 		protected override void SetSize(Size size)

--- a/src/Eto.Gtk/Forms/Controls/CheckBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/CheckBoxHandler.cs
@@ -3,6 +3,7 @@ namespace Eto.GtkSharp.Forms.Controls
 	public class CheckBoxHandler : GtkControl<Gtk.CheckButton, CheckBox, CheckBox.ICallback>, CheckBox.IHandler
 	{
 		readonly Gtk.EventBox box;
+		bool _alwaysShowMnemonic;
 
 		public override Gtk.Widget ContainerControl => box;
 
@@ -64,6 +65,9 @@ namespace Eto.GtkSharp.Forms.Controls
 			set {
 				var needsFont = Control.Child == null && Widget.Properties.ContainsKey(GtkControl.Font_Key);
 				Control.Label = Control.UseUnderline ? value.ToPlatformMnemonic() : value;
+				var label = Control.Child as Gtk.Label;
+				if (label != null)
+					label.Pattern = Control.UseUnderline && _alwaysShowMnemonic ? GtkMnemonicHelper.ToPatternWithMnemonicUnderline(value) : null;
 				if (needsFont)
 					Control.Child?.SetFont(Font.ToPango());
 			}
@@ -130,8 +134,14 @@ namespace Eto.GtkSharp.Forms.Controls
 		
 		public bool AlwaysShowMnemonic
 		{
-			get => false;
-			set { /* not supported in GTK */ }
+			get => _alwaysShowMnemonic;
+			set
+			{
+				if (_alwaysShowMnemonic == value)
+					return;
+				_alwaysShowMnemonic = value;
+				Text = Text;
+			}
 		}
 
 		public override void AttachEvent(string id)

--- a/src/Eto.Gtk/Forms/Controls/GtkMnemonicHelper.cs
+++ b/src/Eto.Gtk/Forms/Controls/GtkMnemonicHelper.cs
@@ -1,0 +1,36 @@
+namespace Eto.GtkSharp.Forms.Controls
+{
+	static class GtkMnemonicHelper
+	{
+		// Eto's mnemonic format is "&X" (and "&&" for a literal "&"). Gtk.Label.Pattern
+		// uses '_' for underlined display characters and spaces for all others.
+		public static string ToPatternWithMnemonicUnderline(string text)
+		{
+			if (string.IsNullOrEmpty(text))
+				return string.Empty;
+
+			var sb = new System.Text.StringBuilder(text.Length);
+			bool foundMnemonic = false;
+			for (int i = 0; i < text.Length; i++)
+			{
+				char c = text[i];
+				if (c == '&' && i + 1 < text.Length && text[i + 1] == '&')
+				{
+					sb.Append(' ');
+					i++;
+				}
+				else if (c == '&' && !foundMnemonic && i + 1 < text.Length)
+				{
+					sb.Append('_');
+					i++;
+					foundMnemonic = true;
+				}
+				else
+				{
+					sb.Append(' ');
+				}
+			}
+			return sb.ToString();
+		}
+	}
+}

--- a/src/Eto.Gtk/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/LabelHandler.cs
@@ -5,6 +5,7 @@ namespace Eto.GtkSharp.Forms.Controls
 	public class LabelHandler : GtkControl<LabelHandler.EtoLabel, Label, Label.ICallback>, Label.IHandler
 	{
 		string _text;
+		bool _alwaysShowMnemonic;
 		readonly Gtk.EventBox eventBox;
 		TextAlignment horizontalAlign = TextAlignment.Left;
 		VerticalAlignment verticalAlign = VerticalAlignment.Top;
@@ -196,9 +197,17 @@ namespace Eto.GtkSharp.Forms.Controls
 				Control.ResetWidth();
 				_text = value;
 				if (Control.UseUnderline)
+				{
 					Control.TextWithMnemonic = _text.ToPlatformMnemonic();
+					// Keep Gtk's mnemonic behavior via TextWithMnemonic, and
+					// use the label pattern only to make the underline visible.
+					Control.Pattern = _alwaysShowMnemonic ? GtkMnemonicHelper.ToPatternWithMnemonicUnderline(_text) : null;
+				}
 				else
+				{
+					Control.Pattern = null;
 					Control.Text = _text;
+				}
 				InvalidateMeasure();
 			}
 		}
@@ -260,8 +269,15 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public bool AlwaysShowMnemonic
 		{
-			get => false;
-			set { /* not supported in GTK */ }
+			get => _alwaysShowMnemonic;
+			set
+			{
+				if (_alwaysShowMnemonic == value)
+					return;
+				_alwaysShowMnemonic = value;
+				if (_text != null)
+					Text = _text;
+			}
 		}
 	}
 }

--- a/src/Eto.Gtk/Forms/Controls/RadioButtonHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/RadioButtonHandler.cs
@@ -5,6 +5,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		Gtk.EventBox _box;
 		Gtk.AccelLabel _label;
 		string _text;
+		bool _alwaysShowMnemonic;
 
 		protected override Gtk.Widget FontControl => _label;
 
@@ -79,9 +80,15 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				_text = value;
 				if (_label.UseUnderline)
+				{
 					_label.TextWithMnemonic = _text.ToPlatformMnemonic();
+					_label.Pattern = _alwaysShowMnemonic ? GtkMnemonicHelper.ToPatternWithMnemonicUnderline(_text) : null;
+				}
 				else
+				{
+					_label.Pattern = null;
 					_label.Text = _text;
+				}
 				UpdateLabel();
 			}
 		}
@@ -118,8 +125,15 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public bool AlwaysShowMnemonic
 		{
-			get => false;
-			set { /* not supported in GTK */ }
+			get => _alwaysShowMnemonic;
+			set
+			{
+				if (_alwaysShowMnemonic == value)
+					return;
+				_alwaysShowMnemonic = value;
+				if (_text != null)
+					Text = _text;
+			}
 		}
 	}
 }


### PR DESCRIPTION
AlwaysShowMnemonic was a hardcoded no-op (// not supported in GTK). Gtk's standard mnemonic underline is keyed off the Alt key -- it only appears while Alt is held -- so callers asking for AlwaysShowMnemonic got nothing visible.

This was implemented by using the Pattern property to specify the character to show the underline on Button, Label, CheckBox, and RadioButton.