### PR TITLE
Eto.Gtk: treat null TextArea.Text as empty string

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TextAreaHandler.cs
@@ -125,7 +125,11 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				var sel = Selection;
 				suppressSelectionAndTextChanged++;
-				Control.Buffer.Text = value;
+				// gtk_text_buffer_set_text asserts non-null; treat null as ""
+				// to match Win/Mac/WPF semantics. Eto bindings (e.g. data-context
+				// bound string properties that default to null) routinely
+				// deliver null here.
+				Control.Buffer.Text = value ?? string.Empty;
 				if (tag != null)
 					Control.Buffer.ApplyTag(tag, Control.Buffer.StartIter, Control.Buffer.EndIter);
 				Callback.OnTextChanged(Widget, EventArgs.Empty);


### PR DESCRIPTION
gtk_text_buffer_set_text asserts non-null, so assigning null to TextArea.Text fires a Gtk-CRITICAL and is a no-op. Win/Mac/WPF all map null to "" silently; bringing Eto.Gtk in line. Eto bindings on string properties whose backing fields default to null (very common via TextBinding.BindDataContext) hit this constantly otherwise.