### PR TITLE
FileDialog: Preserve the current working directory

### DIFF
--- a/src/Eto.Gtk/Forms/GtkFileDialog.cs
+++ b/src/Eto.Gtk/Forms/GtkFileDialog.cs
@@ -108,9 +108,7 @@ namespace Eto.GtkSharp.Forms
 #endif
 
 			DialogResult response = ((Gtk.ResponseType)result).ToEto ();
-			if (response == DialogResult.Ok && !string.IsNullOrEmpty(Control.CurrentFolder))
-				System.IO.Directory.SetCurrentDirectory(Control.CurrentFolder);
-			
+
 			return response;
 		}
 

--- a/src/Eto.Gtk/Forms/GtkFileDialog.cs
+++ b/src/Eto.Gtk/Forms/GtkFileDialog.cs
@@ -1,5 +1,14 @@
 namespace Eto.GtkSharp.Forms
 {
+	// Remembers the last folder used by any file/folder dialog so subsequent dialogs
+	// open where the user left off, without modifying the process working directory.
+	static class GtkFileDialogHelper
+	{
+		public static string LastUsedFolder;
+
+		public static string InitialFolder => LastUsedFolder ?? System.IO.Directory.GetCurrentDirectory();
+	}
+
 	public abstract class GtkFileDialog<TControl, TWidget> : WidgetHandler<TControl, TWidget>, FileDialog.IHandler
 #if GTKCORE
 		where TControl: Gtk.FileChooserNative
@@ -108,6 +117,8 @@ namespace Eto.GtkSharp.Forms
 #endif
 
 			DialogResult response = ((Gtk.ResponseType)result).ToEto ();
+			if (response == DialogResult.Ok && !string.IsNullOrEmpty(Control.CurrentFolder))
+				GtkFileDialogHelper.LastUsedFolder = Control.CurrentFolder;
 
 			return response;
 		}

--- a/src/Eto.Gtk/Forms/OpenFileDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/OpenFileDialogHandler.cs
@@ -18,7 +18,7 @@ namespace Eto.GtkSharp.Forms
 			Control.AddButton(Gtk.Stock.Open, Gtk.ResponseType.Ok);
 			Control.DefaultResponse = Gtk.ResponseType.Ok;
 #endif
-			Control.SetCurrentFolder(System.IO.Directory.GetCurrentDirectory());
+			Control.SetCurrentFolder(GtkFileDialogHelper.InitialFolder);
 		}
 
 		public bool MultiSelect

--- a/src/Eto.Gtk/Forms/SaveFileDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/SaveFileDialogHandler.cs
@@ -17,7 +17,7 @@ namespace Eto.GtkSharp.Forms
 			Control.DefaultResponse = Gtk.ResponseType.Ok;
 #endif
 			Control.DoOverwriteConfirmation = true;
-			Control.SetCurrentFolder(System.IO.Directory.GetCurrentDirectory());
+			Control.SetCurrentFolder(GtkFileDialogHelper.InitialFolder);
 		}
 	}
 }

--- a/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
@@ -16,7 +16,7 @@ namespace Eto.GtkSharp.Forms
 			Control.AddButton(Gtk.Stock.Open, Gtk.ResponseType.Ok);
 			Control.DefaultResponse = Gtk.ResponseType.Ok;
 #endif
-			Control.SetCurrentFolder(System.IO.Directory.GetCurrentDirectory());
+			Control.SetCurrentFolder(GtkFileDialogHelper.InitialFolder);
 		}
 
 
@@ -33,7 +33,9 @@ namespace Eto.GtkSharp.Forms
 #endif
 
 			DialogResult response = ((Gtk.ResponseType)result).ToEto();
-			
+			if (response == DialogResult.Ok && !string.IsNullOrEmpty(Control.CurrentFolder))
+				GtkFileDialogHelper.LastUsedFolder = Control.CurrentFolder;
+
 			return response;
 		}
 

--- a/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/SelectFolderDialogHandler.cs
@@ -33,8 +33,7 @@ namespace Eto.GtkSharp.Forms
 #endif
 
 			DialogResult response = ((Gtk.ResponseType)result).ToEto();
-			if (response == DialogResult.Ok) System.IO.Directory.SetCurrentDirectory(Control.CurrentFolder);
-
+			
 			return response;
 		}
 

--- a/src/Eto.WinForms/Forms/WindowsFileDialog.cs
+++ b/src/Eto.WinForms/Forms/WindowsFileDialog.cs
@@ -84,6 +84,7 @@ namespace Eto.WinForms.Forms
 				parent.Focus();
 
 			SetFilters();
+			Control.RestoreDirectory = true;
 
 			swf.DialogResult dr;
 			if (parent != null)

--- a/src/Eto.WinForms/Forms/WindowsFileDialog.cs
+++ b/src/Eto.WinForms/Forms/WindowsFileDialog.cs
@@ -4,6 +4,12 @@ namespace Eto.WinForms.Forms
 		where TControl : swf.FileDialog
 		where TWidget : FileDialog
 	{
+		protected override void Initialize()
+		{
+			base.Initialize();
+			Control.RestoreDirectory = true;
+		}
+
 		public string FileName
 		{
 			get { return Control.FileName; }
@@ -84,7 +90,6 @@ namespace Eto.WinForms.Forms
 				parent.Focus();
 
 			SetFilters();
-			Control.RestoreDirectory = true;
 
 			swf.DialogResult dr;
 			if (parent != null)

--- a/src/Eto.Wpf/Forms/WpfFileDialog.cs
+++ b/src/Eto.Wpf/Forms/WpfFileDialog.cs
@@ -64,6 +64,7 @@ namespace Eto.Wpf.Forms
 			if (parent?.HasFocus == false)
 				parent.Focus();
 			SetFilters();
+			Control.RestoreDirectory = true;
 			return base.ShowDialog(parent);
 		}
 

--- a/src/Eto.Wpf/Forms/WpfFileDialog.cs
+++ b/src/Eto.Wpf/Forms/WpfFileDialog.cs
@@ -6,6 +6,12 @@ namespace Eto.Wpf.Forms
 		where TControl: mw.FileDialog
 		where TWidget: FileDialog
 	{
+		protected override void Initialize()
+		{
+			base.Initialize();
+			Control.RestoreDirectory = true;
+		}
+
 		public string FileName
 		{
 			get { return Control.FileName; }
@@ -64,7 +70,6 @@ namespace Eto.Wpf.Forms
 			if (parent?.HasFocus == false)
 				parent.Focus();
 			SetFilters();
-			Control.RestoreDirectory = true;
 			return base.ShowDialog(parent);
 		}
 


### PR DESCRIPTION
File selection dialogs should not modify the application's global working directory: this is unexpected and inconsistent between platforms. This PR preserves the current directory across GTK, WinForms, and WPF after a file or folder dialog is closed. Mac, Android, iOS already do not change it, so they were left unchanged.