### PR TITLE
Mac: Default ShowInTaskbar to true

### DIFF
--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -664,11 +664,9 @@ namespace Eto.Mac.Forms
 			}
 		}
 
-		public bool ShowInTaskbar
-		{
-			get;
-			set;
-		}
+		// Defaults to true to match the documented behavior (and the Windows platform handler):
+		// windows show in the taskbar/Dock unless explicitly told not to.
+		public bool ShowInTaskbar { get; set; } = true;
 
 		public bool Closeable
 		{


### PR DESCRIPTION
Mac windows currently default ShowInTaskbar to false, contrary to the documented behavior and other desktop platforms. Default it to true while preserving explicit opt-out.