### PR TITLE
Mac: Bring focused windows to the foreground

### DIFF
--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -944,7 +944,14 @@ namespace Eto.Mac.Forms
 			}
 		}
 
-		public override void Focus() => Control.MakeKeyAndOrderFront(Control);
+		public override void Focus()
+		{
+			// Activate the NSApplication first so the window actually comes to the foreground.
+			// MakeKeyAndOrderFront alone is not enough when the process is in the background
+			// (e.g. after transitioning from Accessory to Regular activation policy).
+			NSApplication.SharedApplication.Activate();
+			Control.MakeKeyAndOrderFront(Control);
+		}
 
 		public string Id { get; set; }
 


### PR DESCRIPTION
MakeKeyAndOrderFront does not activate a background macOS application, so Window.Focus() may fail to foreground the requested window. Activate the application first, then make the window key and bring it forward.