### PR TITLE
Add clipboard changed event

### DIFF
--- a/src/Eto.Gtk/Forms/ClipboardHandler.cs
+++ b/src/Eto.Gtk/Forms/ClipboardHandler.cs
@@ -1,7 +1,7 @@
 using Eto.GtkSharp.Drawing;
 namespace Eto.GtkSharp.Forms
 {
-	public class ClipboardHandler : WidgetHandler<Gtk.Clipboard, Clipboard>, Clipboard.IHandler
+	public class ClipboardHandler : WidgetHandler<Gtk.Clipboard, Clipboard, Clipboard.ICallback>, Clipboard.IHandler
 	{
 		delegate void GetClipboardData(ClipboardData data,Gtk.SelectionData selection);
 
@@ -34,6 +34,7 @@ namespace Eto.GtkSharp.Forms
 		Gtk.TargetList targets = new Gtk.TargetList();
 
 		readonly List<ClipboardData> clipboard = new List<ClipboardData>();
+		bool changedAttached;
 
 		public ClipboardHandler()
 		{
@@ -41,6 +42,51 @@ namespace Eto.GtkSharp.Forms
 		}
 
 		protected override bool DisposeControl => false;
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Clipboard.ChangedEvent:
+					if (changedAttached)
+						break;
+					Control.OwnerChange += Connector.HandleOwnerChange;
+					changedAttached = true;
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && changedAttached)
+			{
+				Control.OwnerChange -= Connector.HandleOwnerChange;
+				changedAttached = false;
+			}
+			base.Dispose(disposing);
+		}
+
+		protected new ClipboardConnector Connector => (ClipboardConnector)base.Connector;
+
+		protected override WeakConnector CreateConnector()
+		{
+			return new ClipboardConnector();
+		}
+
+		protected class ClipboardConnector : WeakConnector
+		{
+			public new ClipboardHandler Handler => (ClipboardHandler)base.Handler;
+
+			public void HandleOwnerChange(object sender, Gtk.OwnerChangeArgs e)
+			{
+				var handler = Handler;
+				if (handler != null)
+					handler.Callback.OnChanged(handler.Widget, EventArgs.Empty);
+			}
+		}
 
 		void Update()
 		{
@@ -296,4 +342,3 @@ namespace Eto.GtkSharp.Forms
 		}
 	}
 }
-

--- a/src/Eto.Mac/Forms/ClipboardHandler.cs
+++ b/src/Eto.Mac/Forms/ClipboardHandler.cs
@@ -3,9 +3,51 @@ namespace Eto.Mac.Forms
 {
 	public class ClipboardHandler : DataObjectHandler<Clipboard, Clipboard.ICallback>, Clipboard.IHandler
 	{
+		UITimer changeTimer;
+		nint changeCount = -1;
+
 		protected override NSPasteboard CreateControl() => NSPasteboard.GeneralPasteboard;
 
 		protected override bool DisposeControl => false;
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Clipboard.ChangedEvent:
+					changeCount = Control.ChangeCount;
+					changeTimer ??= new UITimer { Interval = 0.2 };
+					changeTimer.Elapsed -= ChangeTimer_Elapsed;
+					changeTimer.Elapsed += ChangeTimer_Elapsed;
+					changeTimer.Start();
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		void ChangeTimer_Elapsed(object sender, EventArgs e)
+		{
+			var current = Control.ChangeCount;
+			if (current == changeCount)
+				return;
+
+			changeCount = current;
+			Callback.OnChanged(Widget, EventArgs.Empty);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && changeTimer != null)
+			{
+				changeTimer.Stop();
+				changeTimer.Elapsed -= ChangeTimer_Elapsed;
+				changeTimer.Dispose();
+				changeTimer = null;
+			}
+			base.Dispose(disposing);
+		}
 
 		/*
 		public DataObject DataObject
@@ -25,4 +67,3 @@ namespace Eto.Mac.Forms
 
 	}
 }
-

--- a/src/Eto.WinForms/Forms/ClipboardHandler.cs
+++ b/src/Eto.WinForms/Forms/ClipboardHandler.cs
@@ -3,9 +3,68 @@ namespace Eto.WinForms.Forms
 {
 	public class ClipboardHandler : DataObjectHandler<Clipboard, Clipboard.ICallback>, Clipboard.IHandler
 	{
+		ClipboardListener changeListener;
+
 		public ClipboardHandler()
 		{
 			Control = new swf.DataObject();
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Clipboard.ChangedEvent:
+					changeListener ??= new ClipboardListener(this);
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && changeListener != null)
+			{
+				changeListener.Dispose();
+				changeListener = null;
+			}
+			base.Dispose(disposing);
+		}
+
+		class ClipboardListener : swf.NativeWindow, IDisposable
+		{
+			readonly ClipboardHandler handler;
+			bool registered;
+
+			public ClipboardListener(ClipboardHandler handler)
+			{
+				this.handler = handler;
+				CreateHandle(new swf.CreateParams());
+				registered = Win32.AddClipboardFormatListener(Handle);
+			}
+
+			protected override void WndProc(ref swf.Message m)
+			{
+				if ((uint)m.Msg == (uint)Win32.WM.CLIPBOARDUPDATE)
+					handler.Callback.OnChanged(handler.Widget, EventArgs.Empty);
+
+				base.WndProc(ref m);
+			}
+
+			public void Dispose()
+			{
+				if (Handle != IntPtr.Zero)
+				{
+					if (registered)
+					{
+						Win32.RemoveClipboardFormatListener(Handle);
+						registered = false;
+					}
+					DestroyHandle();
+				}
+			}
 		}
 
 		protected override bool InnerContainsFileDropList => swf.Clipboard.ContainsFileDropList();
@@ -66,4 +125,3 @@ namespace Eto.WinForms.Forms
 		public override bool Contains(string type) => swf.Clipboard.ContainsData(type);
 	}
 }
-

--- a/src/Eto.WinForms/Forms/TableLayoutHandler.cs
+++ b/src/Eto.WinForms/Forms/TableLayoutHandler.cs
@@ -254,6 +254,9 @@ namespace Eto.WinForms.Forms
 
 		void FillEmptyCells()
 		{
+			if (views == null || views.GetLength(0) == 0 || views.GetLength(1) == 0)
+				return;
+
 			for (int x = 1; x < views.GetLength(0); x++)
 			{
 				if (Control.GetControlFromPosition(x, 0) == null && views[x, 0] == null)

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -178,6 +178,7 @@ namespace Eto
 			COPY = 0x0301,
 			PASTE = 0x0302,
 			CLEAR = 0x0303,
+			CLIPBOARDUPDATE = 0x031D,
 
 			ERASEBKGND = 0x14,
 
@@ -674,6 +675,14 @@ namespace Eto
 
 		[DllImport("user32.dll")]
 		public static extern bool DestroyWindow(IntPtr hWnd);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool AddClipboardFormatListener(IntPtr hwnd);
+
+		[DllImport("user32.dll", SetLastError = true)]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool RemoveClipboardFormatListener(IntPtr hwnd);
 
 		[DllImport("User32.dll", SetLastError = true)]
 		public static extern int SetWindowRgn(IntPtr hWnd, IntPtr hRgn, bool bRedraw);

--- a/src/Eto.Wpf/Forms/ClipboardHandler.cs
+++ b/src/Eto.Wpf/Forms/ClipboardHandler.cs
@@ -8,10 +8,75 @@ namespace Eto.Wpf.Forms
 		const string EndHtmlPrefix = "EndHTML:";
 		const string StartFragmentPrefix = "StartFragment:";
 		const string EndFragmentPrefix = "EndFragment:";
+		ClipboardListener changeListener;
 
 		public ClipboardHandler()
 		{
 			Control = new sw.DataObject();
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Clipboard.ChangedEvent:
+					changeListener ??= new ClipboardListener(this);
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && changeListener != null)
+			{
+				changeListener.Dispose();
+				changeListener = null;
+			}
+			base.Dispose(disposing);
+		}
+
+		class ClipboardListener : IDisposable
+		{
+			readonly ClipboardHandler handler;
+			readonly swin.HwndSource source;
+			bool registered;
+
+			public ClipboardListener(ClipboardHandler handler)
+			{
+				this.handler = handler;
+
+				var parameters = new swin.HwndSourceParameters("EtoClipboardListener")
+				{
+					Width = 0,
+					Height = 0,
+					WindowStyle = 0
+				};
+				source = new swin.HwndSource(parameters);
+				source.AddHook(WndProc);
+				registered = Win32.AddClipboardFormatListener(source.Handle);
+			}
+
+			IntPtr WndProc(IntPtr hwnd, int msg, IntPtr wParam, IntPtr lParam, ref bool handled)
+			{
+				if ((uint)msg == (uint)Win32.WM.CLIPBOARDUPDATE)
+					handler.Callback.OnChanged(handler.Widget, EventArgs.Empty);
+
+				return IntPtr.Zero;
+			}
+
+			public void Dispose()
+			{
+				if (registered)
+				{
+					Win32.RemoveClipboardFormatListener(source.Handle);
+					registered = false;
+				}
+				source.RemoveHook(WndProc);
+				source.Dispose();
+			}
 		}
 
 		public override sw.IDataObject ReadingDataObject => sw.Clipboard.GetDataObject();

--- a/src/Eto.Wpf/Forms/DataObjectHandler.cs
+++ b/src/Eto.Wpf/Forms/DataObjectHandler.cs
@@ -179,7 +179,18 @@ namespace Eto.WinForms.Forms
 						return img;
 				}
 				if (Contains(sw.DataFormats.Dib) && GetObjectData(sw.DataFormats.Dib) is Stream stream)
-					return Win32.FromDIB(stream);
+				{
+					try
+					{
+						if (stream.CanSeek)
+							stream.Position = 0;
+						return Win32.FromDIB(stream);
+					}
+					catch (IOException)
+					{
+						// Invalid or truncated DIB data should be treated as unavailable.
+					}
+				}
 				return null;
 			}
 			set
@@ -335,7 +346,18 @@ namespace Eto.WinForms.Forms
 					}
 				}
 
-				return GetAsData(GetObjectData(type)) ?? GetAsData(GetStream(type));
+				var data = GetAsData(GetObjectData(type));
+				if (data != null)
+					return data;
+
+				try
+				{
+					return GetAsData(GetStream(type));
+				}
+				catch
+				{
+					return null;
+				}
 			}
 			return null;
 		}

--- a/src/Eto.Wpf/Win32.dib.cs
+++ b/src/Eto.Wpf/Win32.dib.cs
@@ -41,9 +41,8 @@ namespace Eto
 						var g = ms.ReadByte();
 						var r = ms.ReadByte();
 						var a = ms.ReadByte();
-						var af = a / 255f;
-						if (af > 0)
-							bd.SetPixel(x, y, new Color(r / af, g / af, b / af, af));
+						if (a > 0)
+							bd.SetPixel(x, y, Color.FromPremultipliedArgb(r, g, b, a));
 					}
 			}
 			return bmp;

--- a/src/Eto.iOS/Forms/ClipboardHandler.cs
+++ b/src/Eto.iOS/Forms/ClipboardHandler.cs
@@ -5,13 +5,43 @@ using Eto.iOS.Drawing;
 
 namespace Eto.iOS.Forms
 {
-	public class ClipboardHandler : WidgetHandler<UIPasteboard, Clipboard>, Clipboard.IHandler
+	public class ClipboardHandler : WidgetHandler<UIPasteboard, Clipboard, Clipboard.ICallback>, Clipboard.IHandler
 	{
 		nint changeCount;
+		NSObject changedObserver;
 
 		public ClipboardHandler()
 		{
 			Control = UIPasteboard.General;
+		}
+
+		public override void AttachEvent(string id)
+		{
+			switch (id)
+			{
+				case Clipboard.ChangedEvent:
+					changedObserver ??= NSNotificationCenter.DefaultCenter.AddObserver(UIPasteboard.ChangedNotification, HandleChanged, Control);
+					break;
+				default:
+					base.AttachEvent(id);
+					break;
+			}
+		}
+
+		void HandleChanged(NSNotification notification)
+		{
+			Callback.OnChanged(Widget, EventArgs.Empty);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing && changedObserver != null)
+			{
+				NSNotificationCenter.DefaultCenter.RemoveObserver(changedObserver);
+				changedObserver.Dispose();
+				changedObserver = null;
+			}
+			base.Dispose(disposing);
 		}
 
 		void ClearIfNeeded()
@@ -114,4 +144,3 @@ namespace Eto.iOS.Forms
 
 	}
 }
-

--- a/src/Eto/Forms/Clipboard.cs
+++ b/src/Eto/Forms/Clipboard.cs
@@ -15,6 +15,34 @@ public class Clipboard : Widget, IDataObject
 	static readonly object Clipboard_Key = new object();
 
 	/// <summary>
+	/// Identifier for handlers when attaching the <see cref="Changed"/> event.
+	/// </summary>
+	public const string ChangedEvent = "Clipboard.Changed";
+
+	/// <summary>
+	/// Occurs when the system clipboard contents have changed.
+	/// </summary>
+	public event EventHandler<EventArgs> Changed
+	{
+		add { Properties.AddHandlerEvent(ChangedEvent, value); }
+		remove { Properties.RemoveEvent(ChangedEvent, value); }
+	}
+
+	/// <summary>
+	/// Raises the <see cref="Changed"/> event.
+	/// </summary>
+	/// <param name="e">Event arguments.</param>
+	protected virtual void OnChanged(EventArgs e)
+	{
+		Properties.TriggerEvent(ChangedEvent, this, e);
+	}
+
+	static Clipboard()
+	{
+		EventLookup.Register<Clipboard>(c => c.OnChanged(null), Clipboard.ChangedEvent);
+	}
+
+	/// <summary>
 	/// Gets the shared clipboard instance
 	/// </summary>
 	/// <value>The clipboard instance.</value>
@@ -306,5 +334,34 @@ public class Clipboard : Widget, IDataObject
 		/// <param name="value">Value returned</param>
 		/// <returns>True if the value was returned, false otherwise</returns>
 		bool TryGetObject(string type, Type objectType, out object value);
+	}
+
+	/// <summary>
+	/// Callback interface for <see cref="Clipboard"/>.
+	/// </summary>
+	public new interface ICallback : Widget.ICallback
+	{
+		/// <summary>
+		/// Raises the <see cref="Changed"/> event.
+		/// </summary>
+		void OnChanged(Clipboard widget, EventArgs e);
+	}
+
+	static readonly object callback = new Callback();
+
+	/// <inheritdoc/>
+	protected override object GetCallback() => callback;
+
+	/// <summary>
+	/// Callback implementation for handlers of <see cref="Clipboard"/>.
+	/// </summary>
+	protected class Callback : ICallback
+	{
+		/// <inheritdoc cref="ICallback.OnChanged"/>.
+		public void OnChanged(Clipboard widget, EventArgs e)
+		{
+			using (widget.Platform.Context)
+				widget.OnChanged(e);
+		}
 	}
 }

--- a/test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ClipboardSection.cs
@@ -3,7 +3,11 @@ namespace Eto.Test.Sections.Behaviors
 	[Section("Behaviors", "Clipboard")]
 	public class ClipboardSection : Panel
 	{
+		const string CustomObjectType = "my.custom.object";
 		Scrollable pasteData = new Scrollable();
+		Clipboard monitoredClipboard;
+		ToggleButton monitorChangesButton;
+		int changeCount;
 
 		public ClipboardSection()
 		{
@@ -34,7 +38,7 @@ namespace Eto.Test.Sections.Behaviors
 			var copyObjectButton = new Button { Text = "Copy Object" };
 			copyObjectButton.Click += (sender, e) =>
 			{
-				new Clipboard().SetObject(new DragDropSection.CustomSerializableType { Name = "Woot" }, "my.custom.object");
+				new Clipboard().SetObject(new DragDropSection.CustomSerializableType { Name = "Woot" }, CustomObjectType);
 				Update();
 			};
 
@@ -49,6 +53,15 @@ namespace Eto.Test.Sections.Behaviors
 				Update();
 			};
 
+			monitorChangesButton = new ToggleButton { Text = "Monitor Changes" };
+			monitorChangesButton.CheckedChanged += (sender, e) =>
+			{
+				if (monitorChangesButton.Checked == true)
+					StartMonitoring();
+				else
+					StopMonitoring();
+			};
+
 			Content = new StackLayout
 			{
 				HorizontalContentAlignment = HorizontalAlignment.Stretch,
@@ -58,16 +71,58 @@ namespace Eto.Test.Sections.Behaviors
 					new StackLayout
 					{
 						Orientation = Orientation.Horizontal,
+						VerticalContentAlignment = VerticalAlignment.Stretch,
 						Spacing = 5,
 						Padding = new Padding(10),
-						Items = { copyTextButton, copyHtmlButton, copyImageButton, copyCustomButton, copyObjectButton, pasteTextButton, clearButton }
+						Items = { copyTextButton, copyHtmlButton, copyImageButton, copyCustomButton, copyObjectButton, pasteTextButton, clearButton, monitorChangesButton }
 					},
 					new StackLayoutItem(pasteData, expand: true)
 				}
 			};
 		}
-		
-		TextArea ReadOnlyTextArea(string text) => new TextArea { Text = text, ReadOnly = true, Border = BorderType.None, BackgroundColor = Colors.Transparent };
+
+		protected override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+			if (monitorChangesButton.Checked == true)
+				StartMonitoring();
+		}
+
+		protected override void OnUnLoad(EventArgs e)
+		{
+			StopMonitoring();
+			base.OnUnLoad(e);
+		}
+
+		void StartMonitoring()
+		{
+			if (monitoredClipboard != null)
+				return;
+
+			monitoredClipboard = new Clipboard();
+			monitoredClipboard.Changed += Clipboard_Changed;
+			Log.Write(monitoredClipboard, "Clipboard monitoring started");
+		}
+
+		void StopMonitoring()
+		{
+			if (monitoredClipboard != null)
+			{
+				monitoredClipboard.Changed -= Clipboard_Changed;
+				monitoredClipboard.Dispose();
+				monitoredClipboard = null;
+				Log.Write(this, "Clipboard monitoring stopped");
+			}
+		}
+
+		void Clipboard_Changed(object sender, EventArgs e)
+		{
+			changeCount++;
+			Log.Write(sender, $"Clipboard changed ({changeCount})");
+			Update();
+		}
+
+		TextArea ReadOnlyTextArea(string text) => new TextArea { Text = text, ReadOnly = true, Border = BorderType.None };
 
 		void Update()
 		{
@@ -133,18 +188,21 @@ namespace Eto.Test.Sections.Behaviors
 					{
 						panel.Items.Add($"- Error getting data: {ex.Message}");
 					}
-					try
+					if (type == CustomObjectType)
 					{
-						var obj = clipboard.GetObject(type);
-						if (obj != null && str == null && data == null)
+						try
 						{
-							panel.Items.Add($"- Object, Type: {obj.GetType()}:");
-							panel.Items.Add(ReadOnlyTextArea(obj.ToString()));
+							var obj = clipboard.GetObject(type);
+							if (obj != null)
+							{
+								panel.Items.Add($"- Object, Type: {obj.GetType()}:");
+								panel.Items.Add(ReadOnlyTextArea(obj.ToString()));
+							}
 						}
-					}
-					catch (Exception ex)
-					{
-						panel.Items.Add($"- Error getting object: {ex.Message}");
+						catch (Exception ex)
+						{
+							panel.Items.Add($"- Error getting object: {ex.Message}");
+						}
 					}
 				}
 			}
@@ -152,4 +210,3 @@ namespace Eto.Test.Sections.Behaviors
 		}
 	}
 }
-


### PR DESCRIPTION
Adds a `Clipboard.Changed` event to notify applications when the system clipboard contents change.

Implementations are included for WinForms, WPF, GTK, macOS, and iOS. Manually tested on WPF, WinForms, GTK, and macOS.

Also:
- Adds clipboard change monitoring to the Clipboard test section.
    - **WinForms/WPF:** Registers a hidden native window with `AddClipboardFormatListener` and handles `WM_CLIPBOARDUPDATE`.
    - **GTK:** Uses the clipboard owner-change notification.
    - **macOS:** Polls the pasteboard change count while the event has subscribers.
    - **iOS:** Observes pasteboard change notifications.
- Improves handling of unsupported Windows clipboard formats.
- Fixes Windows DIB stream positioning and premultiplied-alpha conversion.
- Prevents empty WinForms layouts from causing an indexing exception.