### PR TITLE
Wpf: Set TextBox CaretBrush when setting TextColor

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -461,6 +461,14 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected override swc.ContextMenu GetDefaultContextMenu() => TextAreaHandler.CreateDefaultContextMenu();
 
-
+		public override Color TextColor
+		{
+			get => base.TextColor;
+			set
+			{
+				base.TextColor = value;
+				TextBox.CaretBrush = value.ToWpfBrush(TextBox.CaretBrush);
+			}
+		}
 	}
 }


### PR DESCRIPTION
Otherwise sometimes the caret can be not set to the correct color, e.g. when having a transparent background.