### PR TITLE
Mac: Avoid crash if a drag drop cannot be started with DoDragDrop

### DIFF
--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -1462,6 +1462,8 @@ namespace Eto.Mac.Forms
 			MacView.InMouseTrackingLoop = false;
 
 			var session = ContainerControl.BeginDraggingSession(draggingItems, NSApplication.SharedApplication.CurrentEvent, source);
+			if (session == null) // could not start dragging, likely because the mouse event was not a mouse down
+				return;
 			handler.Apply(session.DraggingPasteboard);
 
 			SetupDragPasteboard(session.DraggingPasteboard);


### PR DESCRIPTION
For example, you cannot start a drag/drop when the mouse isn't down.  If you do you will get a NRE.  This protects from incorrectly calling DoDragDrop in the wrong states.