### PR TITLE
Update to using Microsoft Testing Platform for unit tests

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -26,10 +26,10 @@ csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = false:silent
 csharp_space_around_binary_operators = before_and_after
 
-[*.{csproj,vbproj,fsproj,proj,targets,props}]
+[*.{csproj,vbproj,fsproj,proj,targets,props,slnx}]
 indent_style = space
 indent_size = 2
-tab_size = 2
+tab_width = 2
 
 [*.yml]
 indent_style = space

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -131,6 +131,16 @@
 			}
 		},
 		{
+			"label": "build-unittests",
+			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj",
+			"type": "shell",
+			"group": "build",
+			"problemMatcher": "$msCompile",
+			"presentation": {
+				"clear": true
+			}
+		},
+		{
 			"label": "build-sdk-test",
 			"command": "dotnet build ${config:var.buildProperties} /p:Configuration=${config:var.configuration} ${workspaceFolder}/samples/SdkTest/SdkTest.csproj",
 			"type": "shell",
@@ -157,6 +167,16 @@
 			"problemMatcher": [],
 			"presentation": {
 				"clear": true
+			}
+		},
+		{
+			"label": "test non-manual",
+			"type": "shell",
+			"command": "dotnet test --project ${workspaceFolder}/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj --filter \"TestCategory!=ManualTest&Name=DialogTests\"",
+			"problemMatcher": "$msCompile",
+			"presentation": {
+				"clear": true,
+				"focus": true
 			}
 		},
 		{

--- a/build/Common.Build.props
+++ b/build/Common.Build.props
@@ -21,7 +21,7 @@
 
     <!-- Ignore errors/warnings about semver 2.0 when packing CI builds and lowercase aliases -->
     <NoWarn>$(NoWarn);NU5105;CS8981;NETSDK1138;SYSLIB0050;SYSLIB0051;NETSDK1202;NETSDK1135</NoWarn>
-    <LangVersion Condition="$(MSBuildProjectExtension) == '.csproj'">12</LangVersion>
+    <LangVersion Condition="$(MSBuildProjectExtension) == '.csproj'">default</LangVersion>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>
     <ValidateXcodeVersion>false</ValidateXcodeVersion>
   </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,5 @@
+{
+    "test": {
+        "runner": "Microsoft.Testing.Platform"
+    }
+}

--- a/src/Eto.Gtk/Forms/WindowHandler.cs
+++ b/src/Eto.Gtk/Forms/WindowHandler.cs
@@ -9,7 +9,7 @@ namespace Eto.GtkSharp.Forms
 			if (windowStack != null)
 			{
 				// doesn't work on Mac or Windows.. 🤔
-				foreach (var gdkWindow in windowStack.Reverse())
+				foreach (var gdkWindow in Enumerable.Reverse(windowStack))
 				{
 					screenWindowStackWorks = true;
 					if (!gdkWindow.FrameExtents.Contains((int)point.X, (int)point.Y))

--- a/src/Eto.Mac/Forms/ApplicationHandler.cs
+++ b/src/Eto.Mac/Forms/ApplicationHandler.cs
@@ -343,6 +343,23 @@ namespace Eto.Mac.Forms
 			}
 		}
 
+		internal void EnsureActivated(bool showInTaskbar, bool showActivated, Icon icon)
+		{
+			if (showInTaskbar && NSApplication.SharedApplication.ActivationPolicy == NSApplicationActivationPolicy.Prohibited)
+			{
+				// use the window icon as the app icon if the app is not in the dock yet
+				if (icon != null)
+					NSApplication.SharedApplication.ApplicationIconImage = icon.ToNS();
+				
+				// ensure the dock icon is visible (so we can get a menu, etc)
+				NSApplication.SharedApplication.ActivationPolicy = NSApplicationActivationPolicy.Regular;
+
+				// make the application active so the window is shown in front of other apps
+				if (showActivated)
+					NSApplication.SharedApplication.Activate();
+			}
+		}
+
 		public Keys CommonModifier => Keys.Application;
 
 		public Keys AlternateModifier => Keys.Alt;

--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -143,6 +143,7 @@ namespace Eto.Mac.Forms
 
 		public virtual void ShowModal()
 		{
+			ApplicationHandler.Instance.EnsureActivated(ShowInTaskbar, true, Icon);
 			Control.LayoutIfNeeded();
 			Callback.OnLoadComplete(Widget, EventArgs.Empty);
 			MacView.InMouseTrackingLoop = false;
@@ -162,6 +163,7 @@ namespace Eto.Mac.Forms
 
 		public virtual Task ShowModalAsync()
 		{
+			ApplicationHandler.Instance.EnsureActivated(ShowInTaskbar, true, Icon);
 			Control.LayoutIfNeeded();
 			Callback.OnLoadComplete(Widget, EventArgs.Empty);
 			MacView.InMouseTrackingLoop = false;

--- a/src/Eto.Mac/Forms/FormHandler.cs
+++ b/src/Eto.Mac/Forms/FormHandler.cs
@@ -58,6 +58,8 @@ namespace Eto.Mac.Forms
 
 		public virtual void Show()
 		{
+			ApplicationHandler.Instance.EnsureActivated(ShowInTaskbar, ShowActivated, Icon);
+			
 			Control.LayoutIfNeeded();
 			Callback.OnLoadComplete(Widget, EventArgs.Empty);
 			var visible = Control.IsVisible;

--- a/src/Eto.Mac/Platform.cs
+++ b/src/Eto.Mac/Platform.cs
@@ -268,11 +268,18 @@ namespace Eto.Mac
 		{
 			return new NSAutoreleasePool();
 		}
+		
+		public bool RequireAppBundle { get; set; }
 
 		public override bool IsValid
 		{
 			get
 			{
+				if (NSApplication.SharedApplication == null)
+					return false;
+				if (!RequireAppBundle)
+					return true;
+					
 				var bundle = NSBundle.MainBundle;
 				if (bundle == null)
 					return false;

--- a/src/Eto.slnx
+++ b/src/Eto.slnx
@@ -23,6 +23,8 @@
     <Project Path="../lib/monomac/src/MonoMac.csproj" />
   </Folder>
   <Folder Name="/test/">
+    <Project Path="../test/Eto.Test/Eto.Test.csproj" />
+    <Project Path="../test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj" />
     <Project Path="../test/Eto.Test.Gtk/Eto.Test.Gtk.csproj" />
     <Project Path="../test/Eto.Test.Mac/Eto.Test.Mac64.csproj" />
     <Project Path="../test/Eto.Test.Mac/Eto.Test.macOS.csproj">
@@ -44,7 +46,6 @@
       <Build Solution="*|Linux" Project="false" />
       <Build Solution="*|Mac" Project="false" />
     </Project>
-    <Project Path="../test/Eto.Test/Eto.Test.csproj" />
   </Folder>
   <Project Path="Eto.Forms.Templates/Eto.Forms.Templates.csproj" />
   <Project Path="Eto.Gtk/Eto.Gtk.csproj" />

--- a/src/global.json
+++ b/src/global.json
@@ -1,0 +1,5 @@
+{
+  "test": {
+    "runner": "Microsoft.Testing.Platform"
+  }
+}

--- a/test/Eto.Test.Gtk/Eto.Test.Gtk2.csproj
+++ b/test/Eto.Test.Gtk/Eto.Test.Gtk2.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
   </ItemGroup>
   
 </Project>

--- a/test/Eto.Test.Gtk/Eto.Test.Gtk3.csproj
+++ b/test/Eto.Test.Gtk/Eto.Test.Gtk3.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
   </ItemGroup>
   
 </Project>

--- a/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.Mac64.csproj
@@ -54,7 +54,7 @@
     <ProjectReference Include="..\..\lib\monomac\src\MonoMac.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
   </ItemGroup>
   
   <ItemGroup>

--- a/test/Eto.Test.Mac/Eto.Test.macOS.csproj
+++ b/test/Eto.Test.Mac/Eto.Test.macOS.csproj
@@ -37,7 +37,7 @@
     <ProjectReference Include="..\..\src\Eto.Mac\Eto.macOS.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="TestIcon.icns" />

--- a/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj
+++ b/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>net48;net10.0;net10.0-windows</TargetFrameworks>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <OutputType>Exe</OutputType>
+
+    <IsTestProject>true</IsTestProject>
+    <EnableNUnitRunner>true</EnableNUnitRunner>
+    <GenerateTestingPlatformEntryPoint>false</GenerateTestingPlatformEntryPoint>
+    <EnableMicrosoftTestingPlatform>true</EnableMicrosoftTestingPlatform>
+    <TestingPlatformDotnetTestSupport>true</TestingPlatformDotnetTestSupport>
+    <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="4.6.1" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageReference Include="Microsoft.Testing.Platform" Version="2.2.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Eto.Test\Eto.Test.csproj" />
+    <ProjectReference Include="..\..\src\Eto.Wpf\Eto.Wpf.csproj" Condition="$(TargetFramework) == 'net10.0-windows' or $(TargetFramework) == 'net48' " PrivateAssets="all" />
+    <ProjectReference Include="..\..\src\Eto.Gtk\Eto.Gtk.csproj" Condition="$(TargetFramework) == 'net10.0'" PrivateAssets="all" />
+    <ProjectReference Include="..\..\src\Eto.Mac\Eto.Mac64.csproj" Condition="$(TargetFramework) == 'net10.0'" PrivateAssets="all" />
+  </ItemGroup>
+
+</Project>

--- a/test/Eto.Test.UnitTests/Program.cs
+++ b/test/Eto.Test.UnitTests/Program.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Testing.Platform.Builder;
+using NUnit.Framework;
+using NUnit.VisualStudio.TestAdapter.TestingPlatformAdapter;
+
+namespace Eto.Test.UnitTests;
+
+
+internal static class Program
+{
+	static IEnumerable<Assembly> GetTestAssemblies()
+	{
+		yield return typeof(Eto.Test.MainForm).Assembly;
+	}
+
+	[STAThread]
+	public static int Main(string[] args)
+	{
+		using var app = new Application();
+		
+		var exitCodeSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+		app.Initialized += (sender, e) =>
+		{
+			var context = SynchronizationContext.Current;
+			_ = Task.Run(async () =>
+			{
+				SynchronizationContext.SetSynchronizationContext(context);
+				await RunTestsAndQuitAsync(app, args, exitCodeSource);
+			});
+		};
+		app.Run();
+
+		return exitCodeSource.Task.Result;
+	}
+
+	private static async Task RunTestsAndQuitAsync(Application app, string[] args, TaskCompletionSource<int> exitCodeSource)
+	{
+		try
+		{
+			var options = new TestApplicationOptions();
+			ITestApplicationBuilder builder = await Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync(args);
+			builder.AddNUnit(GetTestAssemblies);
+
+			using ITestApplication testApplication = await builder.BuildAsync();
+			int exitCode = await testApplication.RunAsync();
+			exitCodeSource.TrySetResult(exitCode);
+		}
+		catch (Exception ex)
+		{
+			exitCodeSource.TrySetException(ex);
+		}
+		finally
+		{
+			app.Invoke(() => app.Quit()); // quit app after tests complete
+		}
+	}
+}

--- a/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
+++ b/test/Eto.Test.WinForms/Eto.Test.WinForms.csproj
@@ -55,7 +55,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
   	<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.2957.106" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
+++ b/test/Eto.Test.Wpf/Eto.Test.Wpf.csproj
@@ -57,7 +57,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
   	<PackageReference Include="Microsoft.Web.WebView2" Version="1.0.1938.49" />
   </ItemGroup>
   <ItemGroup>

--- a/test/Eto.Test/Eto.Test.csproj
+++ b/test/Eto.Test/Eto.Test.csproj
@@ -3,7 +3,8 @@
     <TargetFrameworks>net48;net10.0;net10.0-windows</TargetFrameworks>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);PCL</DefineConstants>
-    <UseWpf Condition="$(TargetFramework) == 'net8.0-windows'">true</UseWpf>
+    <OutputType>Library</OutputType>
+      
   </PropertyGroup>
   
   <PropertyGroup>
@@ -39,9 +40,7 @@
     <ProjectReference Include="..\..\src\Eto.Serialization.Json\Eto.Serialization.Json.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="System.Diagnostics.Process" Version="4.3.0" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="System.ComponentModel.Annotations" Version="5.0.0" />

--- a/test/Eto.Test/Sections/UnitTestPanel.cs
+++ b/test/Eto.Test/Sections/UnitTestPanel.cs
@@ -423,6 +423,12 @@ namespace Eto.Test.Sections
 
 		public int TotalCount => Results.Sum(r => r.TotalCount);
 
+		public int InitiatedCount => Results.Sum(r => r.InitiatedCount);
+
+		public int CompletedCount => Results.Sum(r => r.CompletedCount);
+
+		public int AssertionResultCount => Results.Sum(r => r.AssertionResultCount);
+
 		public TNode AddToXml(TNode parentNode, bool recursive) => throw new NotImplementedException();
 
 		public TNode ToXml(bool recursive) => null;

--- a/test/Eto.Test/UnitTests/Forms/Controls/PanelTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/PanelTests.cs
@@ -18,8 +18,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 				Assert.That(panel1, Is.SameAs(label.VisualParent), "#2");
 
 				panel1.Content = null;
-				Assert.That(null, Is.SameAs(label.Parent), "#2");
-				Assert.That(null, Is.SameAs(label.VisualParent), "#3");
+				Assert.That(label.Parent, Is.Null, "#2");
+				Assert.That(label.VisualParent, Is.Null, "#3");
 
 				panel2.Content = label;
 				Assert.That(panel2, Is.SameAs(label.Parent), "#3");

--- a/test/Eto.Test/UnitTests/Forms/MaskedTextProvider/NumericMaskedTextProviderTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/MaskedTextProvider/NumericMaskedTextProviderTests.cs
@@ -61,7 +61,7 @@ namespace Eto.Test.UnitTests.Forms.MaskedTextProvider
 
 			provider.DecimalPlaces = 3;
 			Assert.That(provider.DecimalPlaces, Is.EqualTo(3));
-			Assert.That(provider.MaximumDecimalPlaces, Is.EqualTo(3));
+			Assert.That(provider.MaximumDecimalPlaces, Is.GreaterThanOrEqualTo(3));
 
 			provider.MaximumDecimalPlaces = 1;
 			Assert.That(provider.DecimalPlaces, Is.EqualTo(1));

--- a/test/Eto.Test/UnitTests/Forms/WindowTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/WindowTests.cs
@@ -264,6 +264,7 @@ public abstract class WindowTests<T> : TestBase
 			Content = parent
 		};
 		bool? visibleAfterShown = null;
+		bool? wasClosed = null;
 		SizeF? preferredSize = null;
 		Size? shownSize = null;
 		Size? loadCompleteSize = null;
@@ -273,22 +274,24 @@ public abstract class WindowTests<T> : TestBase
 			preferredSize = window.GetPreferredSize();
 
 		window.LoadComplete += (sender, e) =>
-	  {
-		  loadCompleteSize = window.Size;
-		  loadCompleteChildSize = child.Size;
-		  if (inLoadComplete)
-			  preferredSize = window.GetPreferredSize();
-	  };
-		window.Shown +=
-		async
-		 (sender, e) =>
-	  {
-		  shownSize = window.Size;
-		  shownChildSize = child.Size;
-		  await Task.Delay(100);
-		  visibleAfterShown = window.Visible;
-		  window.Close();
-	  };
+		{
+			loadCompleteSize = window.Size;
+			loadCompleteChildSize = child.Size;
+			if (inLoadComplete)
+				preferredSize = window.GetPreferredSize();
+		};
+		window.Shown += async (sender, e) =>
+		{
+			shownSize = window.Size;
+			shownChildSize = child.Size;
+			await Task.Delay(100);
+			visibleAfterShown = window.Visible;
+			window.Close();
+		};
+		window.Closed += (sender, e) =>
+		{
+			wasClosed = true;
+		};
 
 		// await Task.Delay(100);
 
@@ -319,6 +322,8 @@ public abstract class WindowTests<T> : TestBase
 		Assert.That(visibleAfterShown, Is.Not.Null, "#4.1 VisibleWhenShown not set");
 		Assert.That(visibleAfterShown, Is.True, "#4.2 Window was not visible when shown");
 		Assert.That(visibleBeforeShown, Is.False, "#4.3 Visible should not be true before shown");
+		
+		Assert.That(wasClosed, Is.True, "#5.1 Closed event was not triggered");
 	});
 
 	[Test]

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -35,15 +35,22 @@ namespace Eto.Test.UnitTests
 
 				var result = Application.Instance.Invoke(() =>
 				{
+					var uiSynchronizationContext = SynchronizationContext.Current;
 					try
 					{
 						context.EstablishExecutionEnvironment();
+						SynchronizationContext.SetSynchronizationContext(
+							SafeSynchronizationContext.Create(uiSynchronizationContext, context));
 						return innerCommand.Execute(context);
 					}
 					catch (Exception ex)
 					{
 						exception = ex;
 						return null;
+					}
+					finally
+					{
+						SynchronizationContext.SetSynchronizationContext(uiSynchronizationContext);
 					}
 				});
 
@@ -57,12 +64,12 @@ namespace Eto.Test.UnitTests
 		}
 	}
 
-    [SetUpFixture]
-    public class EtoTestSetup
-    {
+	[SetUpFixture]
+	public class EtoTestSetup
+	{
 		static bool _initialized;
 		static bool _appWasCreated;
-		
+
 		/// <summary>
 		/// Timeout for application initialization
 		/// </summary>
@@ -106,11 +113,11 @@ namespace Eto.Test.UnitTests
 						var testPlatformAssembly = $"{names[0]}.Test.{names[1]}";
 						var platformTypeName = platformType.Substring(0, platformType.IndexOf(','));
 						var platformDir = new DirectoryInfo(Path.Combine(dir.FullName, "test", testPlatformAssembly, "Debug"));
-						#if NET
+#if NET
 						platformDir = platformDir.EnumerateDirectories().FirstOrDefault(r => !r.Name.StartsWith("net4"));
-						#else
+#else
 						platformDir = platformDir.EnumerateDirectories().FirstOrDefault(r => r.Name.StartsWith("net4"));
-						#endif
+#endif
 						var platformPath = Path.Combine(platformDir.FullName, $"{platformAssembly}.dll");
 						if (File.Exists(platformPath))
 						{
@@ -120,7 +127,7 @@ namespace Eto.Test.UnitTests
 								platform = Activator.CreateInstance(type) as Platform;
 						}
 					}
-					
+
 				}
 #endif
 				Platform.Initialize(platform ?? Platform.Detect);
@@ -171,16 +178,16 @@ namespace Eto.Test.UnitTests
 			}
 			_initialized = true;
 		}
-		
-        [OneTimeSetUp]
-        public void GlobalSetup()
-        {
-			Initialize();
-        }
 
-        [OneTimeTearDown]
-        public void GlobalTeardown()
-        {
+		[OneTimeSetUp]
+		public void GlobalSetup()
+		{
+			Initialize();
+		}
+
+		[OneTimeTearDown]
+		public void GlobalTeardown()
+		{
 			if (!_appWasCreated)
 				return;
 			Application.Instance?.AsyncInvoke(() =>
@@ -209,7 +216,7 @@ namespace Eto.Test.UnitTests
 		/// Default timeout for form operations
 		/// </summary>
 		protected const int DefaultTimeout = 4000;
-		
+
 
 		static Application Application
 		{
@@ -235,15 +242,18 @@ namespace Eto.Test.UnitTests
 			var application = Application;
 			Exception exception = null;
 			var context = TestExecutionContext.CurrentContext;
-			
+
 			void finished() => ev.Set();
-			
+
 			void run()
 			{
 				evStart.Set();
+				var uiSynchronizationContext = SynchronizationContext.Current;
 				try
 				{
 					context.EstablishExecutionEnvironment();
+					SynchronizationContext.SetSynchronizationContext(
+						SafeSynchronizationContext.Create(uiSynchronizationContext, context));
 					test(application, finished);
 				}
 				catch (Exception ex)
@@ -251,13 +261,17 @@ namespace Eto.Test.UnitTests
 					exception = ex;
 					ev.Set();
 				}
+				finally
+				{
+					SynchronizationContext.SetSynchronizationContext(uiSynchronizationContext);
+				}
 			}
 
 			if (application != null)
 				application.AsyncInvoke(run);
 			else
 				run();
-				
+
 			if (!evStart.WaitOne(DefaultTimeout))
 				Assert.Fail("Could not start test in time");
 
@@ -342,7 +356,7 @@ namespace Eto.Test.UnitTests
 		}
 
 		public static void Async(Func<Task> test) => Async(DefaultTimeout, test);
-		
+
 		public static void Async(int timeout, Func<Task> test)
 		{
 			Exception exception = null;
@@ -451,7 +465,7 @@ namespace Eto.Test.UnitTests
 						passButton.Click += (sender, e) => form.Close();
 						focusControl = passButton;
 						row.Cells.Add(passButton);
-						
+
 						form.KeyDown += (sender, e) =>
 						{
 							if (e.KeyData == Keys.Enter)
@@ -618,7 +632,7 @@ namespace Eto.Test.UnitTests
 				timeout
 			);
 		}
-		
+
 		/// <summary>
 		/// Test operations on a form once it is shown
 		/// </summary>
@@ -891,7 +905,7 @@ namespace Eto.Test.UnitTests
 					numericStepper.Value = 100;
 				else if (control is TabControl tabControl)
 				{
-					tabControl.Pages.Add(new TabPage { Text = "Tab 1", Content = new Panel { Size = new Size(100, 100), Content = "Hello" }  });
+					tabControl.Pages.Add(new TabPage { Text = "Tab 1", Content = new Panel { Size = new Size(100, 100), Content = "Hello" } });
 					tabControl.Pages.Add(new TabPage { Text = "Tab 2" });
 					tabControl.Pages.Add(new TabPage { Text = "Tab 3" });
 				}


### PR DESCRIPTION
This uses [Microsoft Testing Platform](https://learn.microsoft.com/en-us/dotnet/core/testing/microsoft-testing-platform-intro) instead of VSTest for running unit tests.  This has the advantage of being more extensible, which means we can run our tests through dotnet test even for macOS, which requires the run loop/UI to be on the main thread.  

Now we run the application, then run the test runner on a separate thread.  Tests can use [InvokeOnUI] or Application.Instance.Invoke APIs to execute things on threads, which all existing tests already do.

This enables running/debugging unit tests through VS Code, VS, or dotnet test on all platforms, while still allowing the built-in runner in the Eto.Test application to be used as well.