### PR TITLE
Fix wrapping of CheckBox when using Display (GDI) font rendering

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/EtoAccessLabel.cs
+++ b/src/Eto.Wpf/Forms/Controls/EtoAccessLabel.cs
@@ -151,7 +151,7 @@ public class EtoAccessLabel : swc.Label
 			swi.AccessKeyManager.Unregister(_accessKey, this);
 			_accessKey = null;
 		}
-			
+
 		if (string.IsNullOrEmpty(_text))
 		{
 			Content = null;
@@ -207,6 +207,18 @@ public class EtoAccessLabel : swc.Label
 		else
 			Content = new swc.TextBlock { Text = text, TextWrapping = _textWrapping, TextAlignment = _textAlignment, TextDecorations = _textDecorations };
 	}
+
+	protected override sw.Size MeasureOverride(sw.Size constraint)
+	{
+		var size = base.MeasureOverride(constraint);
+		 
+		 // add a little extra width to avoid WPF bug wrapping with Display (GDI) font rendering in some DPI settings (e.g. 150%, 175%)
+		var textFormattingMode = swm.TextOptions.GetTextFormattingMode(this);
+		if (textFormattingMode == swm.TextFormattingMode.Display)
+			size.Width += 1;
+		return size;
+	}
+
 
 
 }

--- a/src/Eto.Wpf/Forms/Controls/LabelHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/LabelHandler.cs
@@ -7,9 +7,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		protected override sw.Size MeasureOverride(sw.Size constraint)
 		{
-			var size = Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
-			size.Width += 1;
-			return size;
+			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
 		}
 	}
 


### PR DESCRIPTION
This is not usually a problem when using default font/text rendering, but when you have WPF configured to use TextFormattingMode.Display (GDI font rendering), then it would measure incorrectly (particularly in odd DPIs like 150% and 175%), causing the CheckBox to wrap.  Adding an extra (logical) pixel to its width helps with this.  This was also done for Label previously, but now it only does it when the Display text formatting is enabled for the control.