### PR TITLE
Fix autosize and scrollable content width

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ScrollableHandler.cs
@@ -4,6 +4,10 @@ namespace Eto.Wpf.Forms.Controls
 	{
 		public ScrollableHandler Handler { get; set; }
 
+		// real viewport width from the last arrange (scrollbar- and screen-safe), used to measure
+		// expanded content at the width it will actually be displayed at.
+		double _lastViewportWidth = double.NaN;
+
 		public swc.Primitives.IScrollInfo GetScrollInfo() => ScrollInfo;
 
 		protected override sw.Size MeasureOverride(sw.Size constraint)
@@ -13,7 +17,40 @@ namespace Eto.Wpf.Forms.Controls
 			// reset to preferred size to calculate scroll sizes initially based on that
 			content.Width = Handler.scrollSize.Width;
 			content.Height = Handler.scrollSize.Height;
+
+			// When content is expanded to fill the viewport width, measure it at that width so its
+			// extent (and especially its height) reflects the width it is actually displayed at.
+			// Otherwise wrapping content (labels, checkboxes, etc.) reports the taller height it would
+			// have at its narrower preferred width, inflating the vertical scroll extent even though it
+			// is shown wider and shorter.
+			if (Handler.ExpandContentWidth && double.IsNaN(content.Width))
+				ConstrainExpandedWidth(content, _lastViewportWidth);
+
 			return base.MeasureOverride(constraint);
+		}
+
+		// Constrain the content to the viewport width when it either fits within it (so it just
+		// expands to fill) or reflows to fit it — i.e. measuring at the viewport width makes the
+		// content taller, as happens with wrapping labels/checkboxes. Content that is wider and does
+		// NOT reflow (a rigid, too-wide control) is left unconstrained so it still scrolls
+		// horizontally, per ExpandContentWidth's documented behavior.
+		static void ConstrainExpandedWidth(sw.FrameworkElement content, double viewport)
+		{
+			if (double.IsNaN(viewport) || double.IsInfinity(viewport) || viewport <= 0)
+				return;
+
+			content.Measure(new sw.Size(double.PositiveInfinity, double.PositiveInfinity));
+			var naturalWidth = content.DesiredSize.Width;
+			var naturalHeight = content.DesiredSize.Height;
+
+			var constrain = naturalWidth <= viewport + 0.5;
+			if (!constrain)
+			{
+				content.Measure(new sw.Size(viewport, double.PositiveInfinity));
+				constrain = content.DesiredSize.Height > naturalHeight + 0.5;
+			}
+			if (constrain)
+				content.Width = viewport;
 		}
 
 		protected override sw.Size ArrangeOverride(sw.Size arrangeSize)
@@ -23,10 +60,22 @@ namespace Eto.Wpf.Forms.Controls
 			// expand to width or height of viewport, now that we know which scrollbars are mandatory
 			var desiredSize = content.DesiredSize;
 
+			// ScrollInfo.ViewportWidth/Height give the visible area with scrollbar thickness
+			// already removed, which is what we want to expand the content to. However, when this
+			// scrollable lives in a SizeToContent window, the measure pass runs with the monitor
+			// work-area as its constraint, leaving ViewportWidth/Height equal to the screen size.
+			// Clamp to the actual arrange size so the content isn't expanded to fill the screen.
+			// In a normally constrained layout ViewportWidth <= arrangeSize.Width, so this is a no-op.
+			var viewportWidth = Math.Min(ScrollInfo.ViewportWidth, arrangeSize.Width);
+			var viewportHeight = Math.Min(ScrollInfo.ViewportHeight, arrangeSize.Height);
+
+			// remember the real viewport width so the next measure can size expanded content to it
+			_lastViewportWidth = viewportWidth;
+
 			if (Handler.ExpandContentWidth)
-				content.Width = Math.Max(desiredSize.Width, ScrollInfo.ViewportWidth);
+				content.Width = Math.Max(desiredSize.Width, viewportWidth);
 			if (Handler.ExpandContentHeight)
-				content.Height = Math.Max(desiredSize.Height, ScrollInfo.ViewportHeight);
+				content.Height = Math.Max(desiredSize.Height, viewportHeight);
 
 			return base.ArrangeOverride(arrangeSize);
 		}
@@ -40,7 +89,6 @@ namespace Eto.Wpf.Forms.Controls
 		Size? _lastSize;
 
 		public sw.FrameworkElement ContentControl => scroller;
-
 
 		public override Color BackgroundColor
 		{

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -435,6 +435,8 @@ namespace Eto.Wpf.Forms
 				return;
 
 			Control.SizeToContent = sizing;
+			Control.InvalidateMeasure();
+			Control.UpdateLayout();
 		}
 
 		static readonly object AutoSize_Key = new object();

--- a/test/Eto.Test/UnitTests/Forms/Controls/ScrollableTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/ScrollableTests.cs
@@ -5,6 +5,121 @@ namespace Eto.Test.UnitTests.Forms.Controls
 	[TestFixture]
 	public class ScrollableTests : TestBase
 	{
+		[Test]
+		public void AutoSizedWindowShouldNotExpandToScreen()
+		{
+			// An auto-sized window stays SizeToContent on WPF, which measures its content with the monitor
+			// work-area as the constraint. The Scrollable must size to its content, not blow up to the
+			// width/height of the screen, and (with the default ExpandContentWidth/Height) its content must
+			// expand exactly to the viewport, not past it. AutoSize=true is required to reproduce: without
+			// it the window reverts to a fixed size after load and a corrective layout pass hides the bug.
+			// See ScrollableHandler.ArrangeOverride.
+			Form theForm = null;
+			Panel content = null;
+			Shown(form =>
+			{
+				theForm = form;
+				form.AutoSize = true;
+				content = new Panel { Size = new Size(100, 100), BackgroundColor = Colors.Blue };
+				return new Scrollable { Content = content };
+			},
+			scrollable =>
+			{
+				var screen = Screen.PrimaryScreen.Bounds.Size;
+				Assert.Multiple(() =>
+				{
+					Assert.That(theForm.Width, Is.LessThan(screen.Width / 2), "#1 Window width should size to content, not the screen");
+					Assert.That(theForm.Height, Is.LessThan(screen.Height / 2), "#2 Window height should size to content, not the screen");
+					// the content should expand to exactly the viewport, not overflow it (e.g. to the screen size)
+					Assert.That(content.Size, Is.EqualTo(scrollable.ClientSize), "#3 Content should expand to the viewport, not past it");
+				});
+			});
+		}
+
+		[Test]
+		public void ExpandedWidthShouldNotInflateScrollHeight()
+		{
+			// When ExpandContentWidth expands content that has a narrower preferred width to fill the
+			// viewport, wrapping content (labels, checkboxes) is displayed wider — and therefore shorter —
+			// than at its preferred width. The vertical scroll extent must reflect that shorter, displayed
+			// height rather than the taller height the content would have at its narrow preferred width.
+			Label label = null;
+			Scrollable theScrollable = null;
+			Shown(form =>
+			{
+				form.ClientSize = new Size(300, 220);
+				label = new Label
+				{
+					Text = "This is a long label that wraps to many lines when narrow but fits in fewer lines when wider",
+					Wrap = WrapMode.Word
+				};
+				// content with a small preferred width that ExpandContentWidth will stretch to the viewport
+				var content = new StackLayout
+				{
+					HorizontalContentAlignment = HorizontalAlignment.Stretch,
+					Width = 120,
+					Items = { label }
+				};
+				theScrollable = new Scrollable
+				{
+					Content = content,
+					ExpandContentWidth = true,
+					ExpandContentHeight = false
+				};
+				return theScrollable;
+			},
+			scrollable =>
+			{
+				Assert.Multiple(() =>
+				{
+					// content is expanded past its 120px preferred width to fill the viewport
+					Assert.That(scrollable.Content.Size.Width, Is.GreaterThan(120), "#1 Content should expand to the viewport width");
+					// the scroll extent height matches the displayed content height, not the inflated narrow-width height
+					Assert.That(scrollable.ScrollSize.Height, Is.EqualTo(scrollable.Content.Size.Height).Within(1), "#2 Scroll height should match the displayed content height");
+				});
+			});
+		}
+
+		[Test]
+		public void AutoSizedWindowWithScrollableShouldNotInflateHeight()
+		{
+			// An auto-sized window sizes its height to the scroll content. If the Scrollable reports an
+			// inflated extent height (from measuring expanded content at its narrow preferred width) the
+			// window becomes too tall. This is the same root cause as ExpandedWidthShouldNotInflateScrollHeight,
+			// but reproduced through a window's SizeToContent rather than a fixed viewport.
+			Label label = null;
+			Scrollable theScrollable = null;
+			Shown(form =>
+			{
+				form.AutoSize = true;
+				form.Width = 400;
+				label = new Label
+				{
+					Text = "This is a long label that wraps to many lines when narrow but fits in fewer lines when wider",
+					Wrap = WrapMode.Word
+				};
+				var content = new StackLayout
+				{
+					HorizontalContentAlignment = HorizontalAlignment.Stretch,
+					Width = 150,
+					Items = { label }
+				};
+				theScrollable = new Scrollable
+				{
+					Content = content,
+					ExpandContentWidth = true,
+					ExpandContentHeight = false
+				};
+				return theScrollable;
+			},
+			scrollable =>
+			{
+				// the scroll extent (which drives the auto-sized window height) must match the displayed
+				// content height, not the taller height the content has at its narrow preferred width
+				Assert.That(scrollable.ScrollSize.Height, Is.EqualTo(scrollable.Content.Size.Height).Within(1), "Scroll height should match the displayed content height in an auto-sized window");
+			});
+		}
+
 		[Test, ManualTest]
 		public void TwoScrollablesShouldNotClipControls()
 		{


### PR DESCRIPTION
This fixes long standing issue(s) when the preferred size of the Scrollable.Content is smaller than the scrollable when ExpandWidth = true, and contains wrapping labels/content.  

Also when the form was autosized, it would expand the width of the content to the width of the screen, even though there are no visible scrollbars.