### PR TITLE
Gtk: encode bitmaps in memory instead of a temp file

### DIFF
--- a/src/Eto.Gtk/Drawing/BitmapHandler.cs
+++ b/src/Eto.Gtk/Drawing/BitmapHandler.cs
@@ -177,19 +177,8 @@ namespace Eto.GtkSharp.Drawing
 		public void Save(Stream stream, ImageFormat format)
 		{
 			EnsureData();
-			string fileName = Guid.NewGuid().ToString();
-			Control.Save(fileName, format.ToGdk());
-			Stream fileStream = File.OpenRead(fileName);
-			var buffer = new byte[4096];
-
-			int size = fileStream.Read(buffer, 0, buffer.Length);
-			while (size > 0)
-			{
-				stream.Write(buffer, 0, size);
-				size = fileStream.Read(buffer, 0, buffer.Length);
-			}
-			fileStream.Close();
-			File.Delete(fileName);
+			var buffer = Control.SaveToBuffer(format.ToGdk());
+			stream.Write(buffer, 0, buffer.Length);
 		}
 
 		public override Size Size


### PR DESCRIPTION
Not sure why GTK `BitmapHandler.Save` used a path which saved a file to a disk, then read it and deleted, but directly writing to the stream seems to work. Am I missing something here?