### PR TITLE
Fix FileName getting shortened on Win

### DIFF
--- a/src/Eto.Gtk/Forms/GtkFileDialog.cs
+++ b/src/Eto.Gtk/Forms/GtkFileDialog.cs
@@ -8,15 +8,19 @@ namespace Eto.GtkSharp.Forms
 #endif
 		where TWidget: FileDialog
 	{
+		// Cache the full path so FileName round-trips it; cleared on OK so the chosen path wins.
+		string fileName;
+
 		public virtual string FileName
 		{
 #if GTKCORE
-			get => Control.Filename ?? Control.CurrentName;
+			get => fileName ?? Control.Filename ?? Control.CurrentName;
 #else
-			get => Control.Filename;
+			get => fileName ?? Control.Filename;
 #endif
 			set
 			{
+				fileName = string.IsNullOrEmpty(value) ? null : value;
 				if (string.IsNullOrEmpty(value))
 				{
 					Control.UnselectAll();
@@ -108,9 +112,13 @@ namespace Eto.GtkSharp.Forms
 #endif
 
 			DialogResult response = ((Gtk.ResponseType)result).ToEto ();
-			if (response == DialogResult.Ok && !string.IsNullOrEmpty(Control.CurrentFolder))
-				System.IO.Directory.SetCurrentDirectory(Control.CurrentFolder);
-			
+			if (response == DialogResult.Ok)
+			{
+				fileName = null;
+				if (!string.IsNullOrEmpty(Control.CurrentFolder))
+					System.IO.Directory.SetCurrentDirectory(Control.CurrentFolder);
+			}
+
 			return response;
 		}
 

--- a/src/Eto.Gtk/Forms/OpenFileDialogHandler.cs
+++ b/src/Eto.Gtk/Forms/OpenFileDialogHandler.cs
@@ -6,8 +6,6 @@ namespace Eto.GtkSharp.Forms
 	public class OpenFileDialogHandler : GtkFileDialog<Gtk.FileChooserDialog, OpenFileDialog>, OpenFileDialog.IHandler
 #endif
 	{
-		string fileName;
-
 		public OpenFileDialogHandler()
 		{
 #if GTKCORE
@@ -31,25 +29,5 @@ namespace Eto.GtkSharp.Forms
 		{
 			get { return Control.Filenames; }
 		}
-
-		public override string FileName
-		{
-			get => base.FileName ?? fileName;
-			set => base.FileName = fileName = value;
-		}
-
-		public override DialogResult ShowDialog(Window parent)
-		{
-			var result = base.ShowDialog(parent);
-			
-			// When cancelling, Control.Filename all of the sudden returns a value but is just the folder.
-			// so, combine it with the desired file name, if one was set.
-			if (result == DialogResult.Ok)
-				fileName = null;
-			else if (!string.IsNullOrEmpty(fileName) && string.IsNullOrEmpty(Path.GetDirectoryName(fileName)))
-				Control.SetFilename(Path.Combine(base.FileName, fileName));
-			return result;
-		}
-
 	}
 }

--- a/src/Eto.WinForms/Forms/WindowsFileDialog.cs
+++ b/src/Eto.WinForms/Forms/WindowsFileDialog.cs
@@ -12,7 +12,7 @@ namespace Eto.WinForms.Forms
 				var dir = Path.GetDirectoryName(value);
 				if (!string.IsNullOrEmpty(dir))
 					Control.InitialDirectory = dir;
-				Control.FileName = Path.GetFileName(value);
+				Control.FileName = value;
 			}
 		}
 

--- a/src/Eto.Wpf/Forms/WpfFileDialog.cs
+++ b/src/Eto.Wpf/Forms/WpfFileDialog.cs
@@ -15,7 +15,7 @@ namespace Eto.Wpf.Forms
 				if (!string.IsNullOrEmpty(dir))
 					Control.InitialDirectory = dir;
 
-				Control.FileName = Path.GetFileName(value);
+				Control.FileName = value;
 			}
 		}
 


### PR DESCRIPTION
The Windows SaveFileDialog returns a full filepath in the `FileName` property, but when I set the same full path, it shortens it.

OSX does not do this -> https://github.com/picoe/Eto/blob/develop/src/Eto.Mac/Forms/MacFileDialog.cs

I think GTK does? But this still seems odd.

https://github.com/picoe/Eto/blob/develop/src/Eto.Gtk/Forms/GtkFileDialog.cs