### PR TITLE
Fix wrapping with TextArea

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextAreaHandler.cs
@@ -5,9 +5,40 @@ namespace Eto.Wpf.Forms.Controls
 	{
 		public IWpfFrameworkElement Handler { get; set; }
 
+		// the width the text was last laid out (wrapped) at
+		double _formattedWidth = double.NaN;
+
 		protected override sw.Size MeasureOverride(sw.Size constraint)
 		{
-			return Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+			var size = Handler?.MeasureOverride(constraint, base.MeasureOverride) ?? base.MeasureOverride(constraint);
+
+			// The handler constrains the measure to the preferred width so the text box doesn't grow to
+			// its content (or the monitor work-area in an auto-sized window). A WPF TextBox wraps its text
+			// at the width it is measured at, so that would leave the text wrapped at the narrow preferred
+			// width instead of the width the control is actually displayed at. Re-lay out the text at the
+			// real displayed width (the last arranged width) so it wraps to fill the control. ArrangeOverride
+			// invalidates the measure when that width changes so this converges.
+			// Measure at the real displayed height as well (not infinity): measuring at infinite height makes
+			// the internal ScrollViewer report its viewport as the full content height, so it thinks nothing
+			// needs scrolling and vertical scrolling stops working.
+			if (TextWrapping == sw.TextWrapping.Wrap && ActualWidth > 0)
+			{
+				base.MeasureOverride(new sw.Size(ActualWidth, ActualHeight));
+				_formattedWidth = ActualWidth;
+			}
+			return size;
+		}
+
+		protected override sw.Size ArrangeOverride(sw.Size arrangeBounds)
+		{
+			var result = base.ArrangeOverride(arrangeBounds);
+
+			// If the displayed width changed (or the text hasn't been laid out to a width yet), it needs
+			// to be re-wrapped to the new width (see MeasureOverride). The negated compare also handles
+			// the initial NaN case, where a direct `> 0.5` compare would be false.
+			if (TextWrapping == sw.TextWrapping.Wrap && !(Math.Abs(_formattedWidth - arrangeBounds.Width) <= 0.5))
+				InvalidateMeasure();
+			return result;
 		}
 	}
 

--- a/test/Eto.Test.Wpf/UnitTests/TextAreaWrapScrollTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/TextAreaWrapScrollTests.cs
@@ -1,0 +1,43 @@
+using Eto.Drawing;
+using Eto.Forms;
+using Eto.Test.UnitTests;
+using Eto.Wpf.Forms.Controls;
+using NUnit.Framework;
+
+namespace Eto.Test.Wpf.UnitTests;
+
+[TestFixture]
+public class TextAreaWrapScrollTests : TestBase
+{
+	static string LongWrappingText()
+	{
+		// long lines that wrap, and lots of them, so the content far exceeds a small viewport
+		var sb = new System.Text.StringBuilder();
+		for (int i = 0; i < 60; i++)
+			sb.AppendLine($"Line {i}: this is a fairly long line of text that should wrap across multiple display lines when the control is narrow enough to force word wrapping.");
+		return sb.ToString();
+	}
+
+	// A wrapped TextArea whose content is taller than the control must still scroll vertically.
+	// Regression test for the wrapping fix, which re-measured the text at an infinite height and
+	// caused the internal ScrollViewer to treat the whole content as its viewport (no scrolling).
+	[Test]
+	public void WrappedTextAreaShouldScrollVertically() => Shown(form =>
+	{
+		form.ClientSize = new Size(250, 150);
+		return new TextArea { Wrap = true, Text = LongWrappingText() };
+	}, textArea =>
+	{
+		var box = ((TextAreaHandler)textArea.Handler).Control;
+		box.UpdateLayout();
+
+		Assert.That(box.TextWrapping, Is.EqualTo(sw.TextWrapping.Wrap), "#1 text should be wrapping");
+		Assert.That(box.ExtentHeight, Is.GreaterThan(box.ViewportHeight),
+			"#2 wrapped content should be taller than the viewport so it can scroll");
+
+		box.ScrollToEnd();
+		box.UpdateLayout();
+		Assert.That(box.VerticalOffset, Is.GreaterThan(0),
+			"#3 scrolling to the end should move the vertical offset");
+	});
+}


### PR DESCRIPTION
This was a regression from previous commits to fix autosizing of windows and scrollable work more reliably when dealing with wrapping text. 