### PR TITLE
Gtk: Fix critical when using Tree/GridView and ListBox

### DIFF
--- a/src/Eto.Gtk/Forms/Cells/CellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/CellHandler.cs
@@ -9,7 +9,7 @@ namespace Eto.GtkSharp.Forms.Cells
 
 		void BeginCellEditing(Gtk.TreePath path, int column);
 
-		void SetColumnMap(int dataIndex, int column);
+		void SetColumnMap(int dataIndex, int column, GLib.GType type);
 
 		int RowHeight { get; set; }
 
@@ -119,9 +119,9 @@ namespace Eto.GtkSharp.Forms.Cells
 			}
 		}
 
-		protected int SetColumnMap(int dataIndex)
+		protected int SetColumnMap(int dataIndex, GLib.GType type)
 		{
-			Source.SetColumnMap(dataIndex, ColumnIndex);
+			Source.SetColumnMap(dataIndex, ColumnIndex, type);
 			return dataIndex;
 		}
 

--- a/src/Eto.Gtk/Forms/Cells/CheckBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/CheckBoxCellHandler.cs
@@ -83,7 +83,7 @@ namespace Eto.GtkSharp.Forms.Cells
 		protected override void BindCell(ref int dataIndex)
 		{
 			Column.Control.ClearAttributes(Control);
-			SetColumnMap(dataIndex);
+			SetColumnMap(dataIndex, GLib.GType.Boolean);
 			Column.Control.AddAttribute(Control, "active", dataIndex++);
 			base.BindCell(ref dataIndex);
 		}

--- a/src/Eto.Gtk/Forms/Cells/ComboBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ComboBoxCellHandler.cs
@@ -95,7 +95,7 @@ namespace Eto.GtkSharp.Forms.Cells
 		protected override void BindCell(ref int dataIndex)
 		{
 			Column.Control.ClearAttributes(Control);
-			SetColumnMap(dataIndex);
+			SetColumnMap(dataIndex, GLib.GType.String);
 			Column.Control.AddAttribute(Control, "text", dataIndex++);
 			base.BindCell(ref dataIndex);
 		}

--- a/src/Eto.Gtk/Forms/Cells/ImageTextCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ImageTextCellHandler.cs
@@ -104,9 +104,9 @@ namespace Eto.GtkSharp.Forms.Cells
 		{
 			Column.Control.ClearAttributes(Control);
 			Column.Control.ClearAttributes(imageCell);
-			imageDataIndex = SetColumnMap(dataIndex);
+			imageDataIndex = SetColumnMap(dataIndex, (GLib.GType)typeof(object));
 			Column.Control.AddAttribute(imageCell, "pixbuf", dataIndex++);
-			textDataIndex = SetColumnMap(dataIndex);
+			textDataIndex = SetColumnMap(dataIndex, GLib.GType.String);
 			Column.Control.AddAttribute(Control, "text", dataIndex++);
 			base.BindCell(ref dataIndex);
 

--- a/src/Eto.Gtk/Forms/Cells/ImageViewCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ImageViewCellHandler.cs
@@ -55,7 +55,7 @@ namespace Eto.GtkSharp.Forms.Cells
 		protected override void BindCell (ref int dataIndex)
 		{
 			Column.Control.ClearAttributes (Control);
-			SetColumnMap (dataIndex);
+			SetColumnMap(dataIndex, (GLib.GType)typeof(object));
 			Column.Control.AddAttribute (Control, "pixbuf", dataIndex++);
 			base.BindCell(ref dataIndex);
 		}

--- a/src/Eto.Gtk/Forms/Cells/ProgressCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/ProgressCellHandler.cs
@@ -77,9 +77,9 @@
 		protected override void BindCell(ref int dataIndex)
 		{
 			Column.Control.ClearAttributes(Control);
-			valueCol = SetColumnMap(dataIndex);
+			valueCol = SetColumnMap(dataIndex, GLib.GType.Int);
 			Column.Control.AddAttribute(Control, "value", dataIndex++);
-			SetColumnMap(dataIndex);
+			SetColumnMap(dataIndex, GLib.GType.Boolean);
 			Column.Control.AddAttribute(Control, "hasValue", dataIndex++);
 			base.BindCell(ref dataIndex);
 		}

--- a/src/Eto.Gtk/Forms/Cells/TextBoxCellHandler.cs
+++ b/src/Eto.Gtk/Forms/Cells/TextBoxCellHandler.cs
@@ -164,7 +164,7 @@ namespace Eto.GtkSharp.Forms.Cells
 		protected override void BindCell(ref int dataIndex)
 		{
 			Column.Control.ClearAttributes(Control);
-			SetColumnMap(dataIndex);
+			SetColumnMap(dataIndex, GLib.GType.String);
 			Column.Control.AddAttribute(Control, "text", dataIndex++);
 			base.BindCell(ref dataIndex);
 		}

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -18,7 +18,7 @@ namespace Eto.GtkSharp.Forms.Controls
 	{
 		ColumnCollection columns;
 		Gtk.TreeViewColumn spacingColumn;
-		readonly Dictionary<int, int> columnMap = new Dictionary<int, int>();
+		readonly Dictionary<int, (int column, GLib.GType type)> columnMap = new();
 
 		protected bool SkipSelectedChange { get; set; }
 
@@ -27,7 +27,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		Gtk.TreeView IGridHandler.Tree => Control;
 
-		protected Dictionary<int, int> ColumnMap { get { return columnMap; } }
+		protected Dictionary<int, (int column, GLib.GType type)> ColumnMap { get { return columnMap; } }
 
 		public override Gtk.Widget ContainerControl => ScrolledWindow;
 
@@ -500,9 +500,9 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public abstract Gtk.TreePath GetPathAtRow(int row);
 
-		public void SetColumnMap(int dataIndex, int column)
+		public void SetColumnMap(int dataIndex, int column, GLib.GType type)
 		{
-			columnMap[dataIndex] = column;
+			columnMap[dataIndex] = (column, type);
 		}
 
 		public void EndCellEditing(Gtk.TreePath path, int column)

--- a/src/Eto.Gtk/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridViewHandler.cs
@@ -1,4 +1,5 @@
 using Eto.GtkSharp.Forms.Cells;
+
 namespace Eto.GtkSharp.Forms.Controls
 {
 	public class GridViewHandler : GridHandler<GridView, GridView.ICallback>, GridView.IHandler, ICellDataSource, IGtkEnumerableModelHandler<object>
@@ -140,17 +141,32 @@ namespace Eto.GtkSharp.Forms.Controls
 			if (dataColumn == RowDataColumn)
 				return new GLib.Value(row);
 			if (dataColumn == ItemDataColumn)
-				return new GLib.Value(item);
-			int column;
-			if (ColumnMap.TryGetValue(dataColumn, out column))
 			{
-				var colHandler = (GridColumnHandler)Widget.Columns[column].Handler;
+				var gtype = (GLib.GType)typeof(object);
+				var val = new GLib.Value(gtype);
+				val.Val = item;
+				return val;
+			}
+			if (ColumnMap.TryGetValue(dataColumn, out var map))
+			{
+				var colHandler = (GridColumnHandler)Widget.Columns[map.column].Handler;
 				return colHandler.GetValue(item, dataColumn, row);
 			}
 			return new GLib.Value((string)null);
 		}
 
-		public override int GetRowOfItem(object item) =>collection?.IndexOf(item) ?? -1;
+		public GLib.GType GetColumnType(int col)
+		{
+			if (col == RowDataColumn)
+				return GLib.GType.Int;
+			if (col == ItemDataColumn)
+				return (GLib.GType)typeof(object);
+			if (ColumnMap.TryGetValue(col, out var map))
+				return map.type;
+			return GLib.GType.String;
+		}
+
+		public override int GetRowOfItem(object item) => collection?.IndexOf(item) ?? -1;
 
 		public EnumerableChangedHandler<object> Collection
 		{

--- a/src/Eto.Gtk/Forms/Controls/GtkEnumerableModel.cs
+++ b/src/Eto.Gtk/Forms/Controls/GtkEnumerableModel.cs
@@ -1,14 +1,14 @@
+using GLib;
+
 namespace Eto.GtkSharp.Forms.Controls
 {
 	public interface IGtkEnumerableModelHandler<TItem>
 		where TItem: class
 	{
 		EnumerableChangedHandler<TItem> Collection { get; }
-
 		int NumberOfColumns { get; }
-
 		GLib.Value GetColumnValue(TItem item, int column, int row);
-
+		GType GetColumnType(int col);
 		int GetRowOfItem(TItem item);
 	}
 
@@ -70,8 +70,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public GLib.GType GetColumnType(int col)
 		{
-			GLib.GType result = GLib.GType.String;
-			return result;
+			return Handler.GetColumnType(col);
 		}
 
 		public int GetRow(Gtk.TreeIter iter)

--- a/src/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ListBoxHandler.cs
@@ -1,4 +1,5 @@
 using Eto.GtkSharp.Drawing;
+
 namespace Eto.GtkSharp.Forms.Controls
 {
 	public class ListBoxHandler : GtkControl<Gtk.TreeView, ListBox, ListBox.ICallback>, ListBox.IHandler, IGtkEnumerableModelHandler<object>
@@ -102,6 +103,19 @@ namespace Eto.GtkSharp.Forms.Controls
 					return new GLib.Value(Widget.ItemTextBinding?.GetValue(item) ?? string.Empty);
 				case 1:
 					return new GLib.Value(Widget.ItemImageBinding?.GetValue(item).ToGdk());
+				default:
+					throw new InvalidOperationException();
+			}
+		}
+
+		public GLib.GType GetColumnType(int col)
+		{
+			switch (col)
+			{
+				case 0:
+					return GLib.GType.String;
+				case 1:
+					return Gdk.Pixbuf.GType;
 				default:
 					throw new InvalidOperationException();
 			}
@@ -211,11 +225,11 @@ namespace Eto.GtkSharp.Forms.Controls
 					Control.QueueDraw();
 			}
 		}
-		
+
 		public IIndirectBinding<string> ItemKeyBinding { get; set; }
-		
+
 		public IIndirectBinding<Image> ItemImageBinding { get; set; }
-		
+
 		internal static readonly object Border_Key = new object();
 		public BorderType Border
 		{

--- a/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
@@ -433,7 +433,7 @@ namespace Eto.GtkSharp.Forms.Controls
 		}
 
 		protected override void SetSelectedRows(IEnumerable<int> value)
-		
+
 		{
 			Control.Selection.UnselectAll();
 			var dataStore = DataStore;
@@ -467,25 +467,40 @@ namespace Eto.GtkSharp.Forms.Controls
 				}
 			}
 		}
-
+		
 		public GLib.Value GetColumnValue(ITreeGridItem item, int dataColumn, int row, Gtk.TreeIter iter)
 		{
 			// yes, we can get the row.. but it slows down the TreeGridView too much when there are many items
 			// This is only used when formatting the cell, and all other platforms return row=-1 with TreeGridView
 			if (dataColumn == RowDataColumn)
-				return new GLib.Value(row); 
-				// return new GLib.Value(model.GetRowIndexOfIter(iter));
+				return new GLib.Value(row);
+			// return new GLib.Value(model.GetRowIndexOfIter(iter));
 
 			if (dataColumn == ItemDataColumn)
-				return new GLib.Value(item);
-
-			int column;
-			if (ColumnMap.TryGetValue(dataColumn, out column))
 			{
-				var colHandler = (GridColumnHandler)Widget.Columns[column].Handler;
+				var gtype = (GLib.GType)typeof(object);
+				var val = new GLib.Value(gtype);
+				val.Val = item;
+				return val;
+			}
+
+			if (ColumnMap.TryGetValue(dataColumn, out var map))
+			{
+				var colHandler = (GridColumnHandler)Widget.Columns[map.column].Handler;
 				return colHandler.GetValue(item, dataColumn, row);
 			}
 			return new GLib.Value((string)null);
+		}
+		
+		public GLib.GType GetColumnType(int col)
+		{
+			if (col == RowDataColumn)
+				return GLib.GType.Int;
+			if (col == ItemDataColumn)
+				return (GLib.GType)typeof(object);
+			if (ColumnMap.TryGetValue(col, out var map))
+				return map.type;
+			return GLib.GType.String;
 		}
 
 		public override int GetRowOfItem(object item)

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
@@ -275,5 +275,32 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			if (exception != null)
 				ExceptionDispatchInfo.Capture(exception).Throw();
 		}
+
+		[Test]
+		public void UsingStringListAsDataStoreShouldNotEmitCriticalWarnings()
+		{
+			var output = StandardErrorCapture.Capture(() =>
+			{
+				ShownAsync(form =>
+				{
+					var grid = new GridView { Size = new Size(200, 200) };
+					grid.Columns.Add(new GridColumn
+					{
+						HeaderText = "Text",
+						DataCell = new TextBoxCell { Binding = Binding.Property((string s) => s) }
+					});
+					grid.DataStore = new List<string> { "Item 1", "Item 2", "Item 3", "Item 4", "Item 5" };
+					return grid;
+				}, async grid =>
+				{
+					// let the grid render its cells - that's when GTK emits the critical if the data store is unsupported
+					await Task.Delay(500);
+					grid.ReloadData(Enumerable.Range(0, 5));
+					await Task.Delay(500);
+				});
+			});
+
+			Assert.That(output, Does.Not.Contain("CRITICAL"), $"A critical warning was emitted while rendering a List<string> data store:{Environment.NewLine}{output}");
+		}
 	}
 }

--- a/test/Eto.Test/UnitTests/StandardErrorCapture.cs
+++ b/test/Eto.Test/UnitTests/StandardErrorCapture.cs
@@ -1,0 +1,75 @@
+namespace Eto.Test.UnitTests
+{
+	/// <summary>
+	/// Helper to capture what is written to the process' standard error stream while running an action.
+	/// </summary>
+	/// <remarks>
+	/// GTK/GLib criticals and warnings are written directly to the native stderr file descriptor,
+	/// bypassing <see cref="Console.Error"/>, so on unix we redirect fd 2 to a temp file to catch them.
+	/// On other platforms (where there is no GTK to warn) we simply capture <see cref="Console.Error"/>.
+	/// </remarks>
+	public static class StandardErrorCapture
+	{
+		[DllImport("libc", SetLastError = true)]
+		static extern int dup(int oldfd);
+
+		[DllImport("libc", SetLastError = true)]
+		static extern int dup2(int oldfd, int newfd);
+
+		[DllImport("libc", SetLastError = true)]
+		static extern int close(int fd);
+
+		[DllImport("libc")]
+		static extern int fflush(IntPtr stream);
+
+		/// <summary>
+		/// Runs <paramref name="action"/> while capturing everything written to the process' standard
+		/// error stream and returns the captured text.
+		/// </summary>
+		public static string Capture(Action action)
+		{
+			if (!(RuntimeInformation.IsOSPlatform(OSPlatform.Linux) || RuntimeInformation.IsOSPlatform(OSPlatform.OSX)))
+			{
+				var writer = new StringWriter();
+				var previous = Console.Error;
+				Console.SetError(writer);
+				try
+				{
+					action();
+				}
+				finally
+				{
+					Console.SetError(previous);
+				}
+				return writer.ToString();
+			}
+
+			var tempFile = Path.GetTempFileName();
+			var savedStderr = dup(2); // keep a copy of the real stderr so we can restore it
+			try
+			{
+				using (var fs = new FileStream(tempFile, FileMode.Create, FileAccess.Write, FileShare.ReadWrite))
+				{
+					// on unix a SafeFileHandle wraps the file descriptor
+					var fd = fs.SafeFileHandle.DangerousGetHandle().ToInt32();
+					dup2(fd, 2); // point fd 2 (stderr) at the temp file
+					try
+					{
+						action();
+						fflush(IntPtr.Zero); // flush all C stdio streams so GLib output lands in the file
+					}
+					finally
+					{
+						dup2(savedStderr, 2); // restore the real stderr
+					}
+				}
+				return File.ReadAllText(tempFile);
+			}
+			finally
+			{
+				close(savedStderr);
+				try { File.Delete(tempFile); } catch { }
+			}
+		}
+	}
+}


### PR DESCRIPTION
When you use a `List<string>` for a TreeGridView, it would throw critical errors in Gtk.  This fixes it up so the column types match up with the actual column values, and wraps the value item as a GType from system.object, instead of deriving from the current item's type.  This would cause problems with strings as it would return a GType of gchararray so getting the string object instance back wouldn't work.