### PR TITLE
Gtk: Fix setting size when allocation is 1,1 on Wayland

### DIFF
--- a/src/Eto.Gtk/Forms/GtkWindow.cs
+++ b/src/Eto.Gtk/Forms/GtkWindow.cs
@@ -920,7 +920,10 @@ namespace Eto.GtkSharp.Forms
 				var window = Control.GetWindow();
 				if (window == null)
 					return Size.Empty;
-				return window.FrameExtents.Size.ToEto() - Control.Allocation.Size.ToEto();
+				var allocationSize = Control.Allocation.Size.ToEto();
+				if (allocationSize.Width <= 1 || allocationSize.Height <= 1)
+					return Size.Empty;
+				return window.FrameExtents.Size.ToEto() - allocationSize;
 			}
 		}
 

--- a/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/WindowsSection.cs
@@ -10,7 +10,7 @@ namespace Eto.Test.Sections.Behaviors
 		Button focusButton;
 		EnumRadioButtonList<WindowStyle> styleCombo;
 		EnumRadioButtonList<WindowState> stateCombo;
-		EnumRadioButtonList<WindowType> typeRadio;
+		EnumRadioButtonList<WindowType> typeRadio = new();
 		CheckBox setOwnerCheckBox;
 		CheckBox createMenuBar;
 		EnumCheckBoxList<MenuBarSystemItems> systemMenuItems;
@@ -188,8 +188,6 @@ namespace Eto.Test.Sections.Behaviors
 
 		Control CreateTypeControl()
 		{
-			typeRadio = new EnumRadioButtonList<WindowType>();
-
 			typeRadio.SelectedValueBinding.BindDataContext((SettingsWindow m) => m.WindowType);
 			typeRadio.BindDataContext(c => c.Enabled, Binding.Delegate((object m) => m is SettingsWindow));
 			return typeRadio;
@@ -366,7 +364,7 @@ namespace Eto.Test.Sections.Behaviors
 			var showActivatedCheckBox = new CheckBox { Text = "ShowActivated" };
 			showActivatedCheckBox.BindDataContext(c => c.ThreeState, (SettingsWindow s) => s.ThreeState);
 			showActivatedCheckBox.CheckedBinding.BindDataContext((Form w) => w.ShowActivated);
-			showActivatedCheckBox.Bind(c => c.Enabled, typeRadio, Binding.Property((RadioButtonList t) => t.SelectedKey).ToBool("dialog").Convert(v => !v));
+			showActivatedCheckBox.Bind(c => c.Enabled, typeRadio, Binding.Property((EnumRadioButtonList<WindowType> t) => t.SelectedValue).Convert(r => r != WindowType.Dialog));
 			return showActivatedCheckBox;
 
 		}


### PR DESCRIPTION
When in Wayland and the window is not visible it gets an allocated size of 1,1, so the calculation of the WindowDecorationSize would be incorrect.

Also fixes the ShowActivated check box state on the WindowSection test.