### PR TITLE
Eto.Gtk: use IMContextSimple for native text widgets

### DIFF
--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -796,7 +796,13 @@ namespace Eto.GtkSharp.Forms
 				{
 					if (context != null)
 						return context;
-					context = new Gtk.IMMulticontext();
+					// Native TextBox/TextArea already own a system-IM (ibus) context on
+					// their GtkEntry/GtkTextView; a second focused IMMulticontext steals
+					// their input. Only Drawables (custom-drawn text) need a full IME
+					// here -- native widgets use the standalone IMContextSimple.
+					context = (Handler != null && HandlesDrawableComposition(Handler))
+						? (Gtk.IMContext)new Gtk.IMMulticontext()
+						: new Gtk.IMContextSimple();
 					context.UsePreedit = true;
 					context.PreeditStart += (o, args) =>
 					{


### PR DESCRIPTION
The ime-apis change switched GtkControl's per-control IM context from IMContextSimple to a full IMMulticontext. A native TextBox (GtkEntry) / TextArea (GtkTextView) already owns a focused IMMulticontext routing to the system IM (ibus); focusing a second one makes the two compete. Eto's context wins the keystroke, commits it to Eto's Commit handler (which does not insert into the native widget), and the widget's own IM is starved -- so typed characters never appear (caret blinks, no TextChanged). Reproduced on Fedora/ibus.

Only Drawables (custom-drawn text) need Eto's full IME context for composition; native text widgets are routed back to the standalone IMContextSimple, which does not contend for system-IM focus. The Drawable composition path keeps the IMMulticontext.