### PR TITLE
Gtk: Implement child window positioning for WindowStyle.None on Wayland

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ packages/
 .DS_Store
 *.proj.Backup.tmp
 ._.*
+*settings.local.json

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,129 +1,134 @@
 {
-   "version": "0.2.0",
-   "configurations": [
-        {
-            "name": "Eto.Test.Mac64",
-            "type": "coreclr",
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"name": "Eto.Test.Mac64",
+			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-mac64",
-            "program": "${workspaceFolder}/artifacts/test/Eto.Test.Mac64/${config:var.configuration}/net10.0/Eto.Test.Mac64.app/Contents/MacOS/Eto.Test.Mac64",
+			"program": "${workspaceFolder}/artifacts/test/Eto.Test.Mac64/${config:var.configuration}/net10.0/Eto.Test.Mac64.app/Contents/MacOS/Eto.Test.Mac64",
 			// "targetArchitecture": "x86_64", // uncomment to test intel on M1
-            "args": [],
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart",
+			"args": [],
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart",
 			"justMyCode": false
-        },
+		},
 		{
-            "name": "Eto.Test.macOS",
-            "type": "coreclr",
+			"name": "Eto.Test.macOS",
+			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-macos",
 			"program": "${workspaceFolder}/artifacts/test/Eto.Test.macOS/${config:var.configuration}/net10.0-macos/osx-arm64/Eto.Test.macOS.app/Contents/MacOS/Eto.Test.macOS",
-            "args": [],
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart",
+			"args": [],
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart",
 			"justMyCode": false
-        },
-        {
-            "name": "Eto.Test.Gtk",
+		},
+		{
+			"name": "Eto.Test.Gtk",
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-gtk",
-            "program": "${workspaceFolder}/artifacts/test/Eto.Test.Gtk/${config:var.configuration}/net10.0/Eto.Test.Gtk.dll",
-            "args": [],
+			"program": "${workspaceFolder}/artifacts/test/Eto.Test.Gtk/${config:var.configuration}/net10.0/Eto.Test.Gtk.dll",
+			"args": [],
 			"osx": {
 				"env": {
 					"DYLD_FALLBACK_LIBRARY_PATH": "/opt/homebrew/lib"
 				}
 			},
-            "console": "internalConsole",
-            "stopAtEntry": false,
-            "internalConsoleOptions": "openOnSessionStart",
+			"env": {
+                // "GDK_BACKEND": "x11",
+				// "WAYLAND_DEBUG": "1",
+				// "G_DEBUG_MESSAGES": "all"
+			},
+			"console": "internalConsole",
+			"stopAtEntry": false,
+			"internalConsoleOptions": "openOnSessionStart",
 			"justMyCode": false,
-        },
-        {
-            "name": "Eto.Test.Gtk - mono",
+		},
+		{
+			"name": "Eto.Test.Gtk - mono",
 			"type": "mono",
 			"request": "launch",
 			"preLaunchTask": "build-gtk",
-            "program": "${workspaceFolder}/artifacts/test/Eto.Test.Gtk/${config:var.configuration}/net48/Eto.Test.Gtk.exe",
+			"program": "${workspaceFolder}/artifacts/test/Eto.Test.Gtk/${config:var.configuration}/net48/Eto.Test.Gtk.exe",
 			"passDebugOptionsViaEnvironmentVariable": true,
-            "args": [],
+			"args": [],
 			"osx": {
 				"env": {
 					"DYLD_FALLBACK_LIBRARY_PATH": "/opt/homebrew/lib"
 				}
 			},
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart"
-        },
-        {
-            "name": "Eto.Test.Gtk2",
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart"
+		},
+		{
+			"name": "Eto.Test.Gtk2",
 			"type": "mono",
 			"request": "launch",
 			"preLaunchTask": "build-gtk2",
-            "program": "${workspaceFolder}/artifacts/test/Eto.Test.Gtk2/${config:var.configuration}/net48/Eto.Test.Gtk2.exe",
+			"program": "${workspaceFolder}/artifacts/test/Eto.Test.Gtk2/${config:var.configuration}/net48/Eto.Test.Gtk2.exe",
 			"passDebugOptionsViaEnvironmentVariable": true,
-            "args": [],
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart"
-        },
-        {
-            "name": "Eto.Test.Wpf",
+			"args": [],
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart"
+		},
+		{
+			"name": "Eto.Test.Wpf",
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-wpf",
-            "program": "${workspaceFolder}/artifacts/test/Eto.Test.Wpf/${config:var.configuration}/net10.0-windows/Eto.Test.Wpf.exe",
+			"program": "${workspaceFolder}/artifacts/test/Eto.Test.Wpf/${config:var.configuration}/net10.0-windows/Eto.Test.Wpf.exe",
 			// "targetArchitecture": "x86_64",
-            "args": [],
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart",
+			"args": [],
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart",
 			"justMyCode": false
-        },
-        {
-            "name": "Eto.Test.Wpf - .NET 4.8",
+		},
+		{
+			"name": "Eto.Test.Wpf - .NET 4.8",
 			"type": "clr",
 			"request": "launch",
 			"preLaunchTask": "build-wpf",
-            "program": "${workspaceFolder}/artifacts/test/Eto.Test.Wpf/${config:var.configuration}/net48/Eto.Test.Wpf.exe",
+			"program": "${workspaceFolder}/artifacts/test/Eto.Test.Wpf/${config:var.configuration}/net48/Eto.Test.Wpf.exe",
 			"targetArchitecture": "x86_64",
-            "args": [],
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart",
+			"args": [],
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart",
 			"justMyCode": false
-        },
-        {
-            "name": "Eto.Test.WinForms",
+		},
+		{
+			"name": "Eto.Test.WinForms",
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-winforms",
-            "program": "${workspaceFolder}/artifacts/test/Eto.Test.WinForms/${config:var.configuration}/net10.0-windows/Eto.Test.WinForms.exe",
-            "args": [],
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart",
+			"program": "${workspaceFolder}/artifacts/test/Eto.Test.WinForms/${config:var.configuration}/net10.0-windows/Eto.Test.WinForms.exe",
+			"args": [],
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart",
 			"justMyCode": false
 		},
-        {
-            "name": "Eto.Test.WinForms - .NET 4.8",
+		{
+			"name": "Eto.Test.WinForms - .NET 4.8",
 			"type": "clr",
 			"request": "launch",
 			"preLaunchTask": "build-winforms",
-            "program": "${workspaceFolder}/artifacts/test/Eto.Test.WinForms/${config:var.configuration}/net48/Eto.Test.WinForms.exe",
+			"program": "${workspaceFolder}/artifacts/test/Eto.Test.WinForms/${config:var.configuration}/net48/Eto.Test.WinForms.exe",
 			"targetArchitecture": "x86_64",
-            "args": [],
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart",
+			"args": [],
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart",
 			"justMyCode": false
 		},
-        {
-            "name": "Eto.Test.Direct2D",
+		{
+			"name": "Eto.Test.Direct2D",
 			"type": "coreclr",
 			"request": "launch",
 			"preLaunchTask": "build-direct2d",
-            "program": "${workspaceFolder}/artifacts/test/Eto.Test.Direct2D/${config:var.configuration}/net10.0-windows/Eto.Test.Direct2D.exe",
-            "args": [],
-            "console": "internalConsole",
-            "internalConsoleOptions": "openOnSessionStart",
+			"program": "${workspaceFolder}/artifacts/test/Eto.Test.Direct2D/${config:var.configuration}/net10.0-windows/Eto.Test.Direct2D.exe",
+			"args": [],
+			"console": "internalConsole",
+			"internalConsoleOptions": "openOnSessionStart",
 			"justMyCode": false
 		},
 	]

--- a/src/Eto.Gtk/Forms/GtkWindow.cs
+++ b/src/Eto.Gtk/Forms/GtkWindow.cs
@@ -84,6 +84,7 @@ namespace Eto.GtkSharp.Forms
 		Gtk.AccelGroup accelGroup;
 		Rectangle? restoreBounds;
 		Point? currentLocation;
+		Point? initialLocation;
 		Size minimumSize;
 		WindowState state;
 		WindowStyle style;
@@ -267,6 +268,14 @@ namespace Eto.GtkSharp.Forms
 
 		protected virtual Gdk.WindowTypeHint DefaultTypeHint => Gdk.WindowTypeHint.Normal;
 
+		// Type hint applied to undecorated / non-resizable windows. Overridable so
+		// FloatingForm can request a menu-style popup hint instead of Utility: on
+		// Wayland GTK maps popup hints as xdg_popup surfaces (which don't take
+		// keyboard focus from their parent), whereas a Utility toplevel grabs focus
+		// and makes focus-sensitive popups (autocomplete, tooltips) dismiss
+		// themselves the moment they appear.
+		protected virtual Gdk.WindowTypeHint UndecoratedTypeHint => Gdk.WindowTypeHint.Utility;
+
 		void SetTypeHint()
 		{
 			if (WindowStyle == WindowStyle.Default && (Minimizable || Maximizable))
@@ -275,7 +284,7 @@ namespace Eto.GtkSharp.Forms
 			}
 			else
 			{
-				Control.TypeHint = Gdk.WindowTypeHint.Utility;
+				Control.TypeHint = UndecoratedTypeHint;
 			}
 		}
 
@@ -349,6 +358,12 @@ namespace Eto.GtkSharp.Forms
 		private void Control_Realized(object sender, EventArgs e)
 		{
 			Control.Realized -= Control_Realized;
+			if (initialLocation != null)
+			{
+				TryMovePopupToRect(initialLocation.Value);
+				initialLocation = null;
+			}
+			
 			Size size;
 			if (clientSize.HasValue)
 			{
@@ -726,14 +741,54 @@ namespace Eto.GtkSharp.Forms
 			{
 				if (currentLocation != null)
 					return currentLocation.Value;
+				if (initialLocation != null)
+					return initialLocation.Value;
 				int x, y;
 				Control.GetPosition(out x, out y);
 				return new Point(x, y);
 			}
 			set
 			{
-				Control.Move(value.X, value.Y);
+				// On Wayland an xdg_popup surface has no global coordinate space:
+				// gtk_window_move is ignored and the popup lands at its parent's
+				// origin. Position popups relative to their transient parent via
+				// gdk_window_move_to_rect instead. On X11/XWayland absolute Move
+				// works (and popups are override-redirect), so keep using it there.
+				if (!TryMovePopupToRect(value))
+					Control.Move(value.X, value.Y);
 			}
+		}
+
+		static bool IsWaylandDisplay =>
+			(Gdk.Display.Default?.Name ?? string.Empty).StartsWith("wayland", StringComparison.OrdinalIgnoreCase);
+
+		// Anchor a Wayland popup's top-left at `location`, which is in the transient
+		// parent's coordinate space -- exactly what Eto's RectangleToScreen yields
+		// on Wayland (a toplevel's surface origin is 0,0). Returns false when this
+		// isn't a realized Wayland popup with a parent, so the caller falls back to
+		// absolute Move.
+		bool TryMovePopupToRect(Point location)
+		{
+			if (!IsWaylandDisplay)
+				return false;
+
+			var gdkWindow = Control.Window;
+			if (gdkWindow == null || Control.TransientFor == null)
+			{
+				initialLocation = location;
+				return false;
+			}
+
+			var rect = new NativeMethods.GdkRect { X = location.X, Y = location.Y, Width = 1, Height = 1 };
+			NativeMethods.gdk_window_move_to_rect(
+				gdkWindow.Handle,
+				ref rect,
+				NativeMethods.Gravity.GDK_GRAVITY_NORTH_WEST,
+				NativeMethods.Gravity.GDK_GRAVITY_NORTH_WEST,
+				NativeMethods.AnchorHint.None,
+				0, 0);
+
+			return true;
 		}
 
 		public WindowState WindowState
@@ -829,7 +884,7 @@ namespace Eto.GtkSharp.Forms
 			}
 		}
 
-		protected override void GrabFocus() => Control.GetWindow().Focus(0);
+		protected override void GrabFocus() => Control.GrabFocus();
 
 		public void BringToFront()
 		{

--- a/src/Eto.Gtk/NativeMethods.cs
+++ b/src/Eto.Gtk/NativeMethods.cs
@@ -37,6 +37,32 @@ namespace Eto.GtkSharp
 			WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START = 0,
 			WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_END = 1
 		}
+		
+		// GdkAnchorHints / GdkGravity values. move_to_rect isn't exposed by the
+		// GtkSharp managed binding, so it's P/Invoked here. This lives in the
+		// non-generic type because [DllImport] can't be applied inside a generic
+		// class (CS7042).
+		[Flags]
+		public enum Gravity : int
+		{
+			GDK_GRAVITY_NORTH_WEST = 1
+		}
+		
+		[Flags]
+		public enum AnchorHint : int
+		{
+			None = 0,
+			GDK_ANCHOR_SLIDE_X = 1 << 2,
+			GDK_ANCHOR_SLIDE_Y = 1 << 3,
+			GDK_ANCHOR_FLIP_X = 1 << 4,
+			GDK_ANCHOR_FLIP_Y = 1 << 5,
+			GDK_ANCHOR_RESIZE_X = 1 << 6,
+			GDK_ANCHOR_RESIZE_Y = 1 << 7
+		}
+		
+		[StructLayout(LayoutKind.Sequential)]
+		public struct GdkRect { public int X, Y, Width, Height; }
+
 
 
 		static class NMWindows
@@ -268,6 +294,9 @@ namespace Eto.GtkSharp
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
+
+			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static void gdk_window_move_to_rect(IntPtr window, ref GdkRect rect, Gravity rect_anchor, Gravity window_anchor, AnchorHint anchor_hints, int rect_anchor_dx, int rect_anchor_dy);
 			[DllImport(libpango, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool pango_font_has_char(IntPtr font, int wc);
 			[DllImport(libpangocairo, CallingConvention = CallingConvention.Cdecl)]
@@ -519,6 +548,9 @@ namespace Eto.GtkSharp
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
+
+			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static void gdk_window_move_to_rect(IntPtr window, ref GdkRect rect, Gravity rect_anchor, Gravity window_anchor, AnchorHint anchor_hints, int rect_anchor_dx, int rect_anchor_dy);
 			[DllImport(libpango, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool pango_font_has_char(IntPtr font, int wc);
 			[DllImport(libpangocairo, CallingConvention = CallingConvention.Cdecl)]
@@ -770,6 +802,9 @@ namespace Eto.GtkSharp
 
 			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
 			public extern static IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height);
+
+			[DllImport(libgdk, CallingConvention = CallingConvention.Cdecl)]
+			public extern static void gdk_window_move_to_rect(IntPtr window, ref GdkRect rect, Gravity rect_anchor, Gravity window_anchor, AnchorHint anchor_hints, int rect_anchor_dx, int rect_anchor_dy);
 			[DllImport(libpango, CallingConvention = CallingConvention.Cdecl)]
 			public extern static bool pango_font_has_char(IntPtr font, int wc);
 			[DllImport(libpangocairo, CallingConvention = CallingConvention.Cdecl)]
@@ -1424,6 +1459,16 @@ namespace Eto.GtkSharp
 				return NMMac.gdk_pixbuf_get_from_window(window, x, y, width, height);
 			else
 				return NMWindows.gdk_pixbuf_get_from_window(window, x, y, width, height);
+		}
+
+		public static void gdk_window_move_to_rect(IntPtr window, ref GdkRect rect, Gravity rect_anchor, Gravity window_anchor, AnchorHint anchor_hints, int rect_anchor_dx, int rect_anchor_dy)
+		{
+			if (EtoEnvironment.Platform.IsLinux)
+				NMLinux.gdk_window_move_to_rect(window, ref rect, rect_anchor, window_anchor, anchor_hints, rect_anchor_dx, rect_anchor_dy);
+			else if (EtoEnvironment.Platform.IsMac)
+				NMMac.gdk_window_move_to_rect(window, ref rect, rect_anchor, window_anchor, anchor_hints, rect_anchor_dx, rect_anchor_dy);
+			else
+				NMWindows.gdk_window_move_to_rect(window, ref rect, rect_anchor, window_anchor, anchor_hints, rect_anchor_dx, rect_anchor_dy);
 		}
 
 		public static bool pango_font_has_char(IntPtr font, int wc)

--- a/src/Eto.Gtk/NativeMethods.tt
+++ b/src/Eto.Gtk/NativeMethods.tt
@@ -91,6 +91,7 @@ var gdkmethods = new[]
 	"bool gdk_cairo_get_clip_rectangle(IntPtr context, IntPtr rect)",
     "IntPtr gdk_get_default_root_window()",
     "IntPtr gdk_pixbuf_get_from_window(IntPtr window, int x, int y, int width, int height)",
+	"void gdk_window_move_to_rect(IntPtr window, ref GdkRect rect, Gravity rect_anchor, Gravity window_anchor, AnchorHint anchor_hints, int rect_anchor_dx, int rect_anchor_dy)",
 };
 
 var pangomethods = new[]
@@ -169,6 +170,32 @@ namespace Eto.GtkSharp
 			WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_START = 0,
 			WEBKIT_USER_SCRIPT_INJECT_AT_DOCUMENT_END = 1
 		}
+		
+		// GdkAnchorHints / GdkGravity values. move_to_rect isn't exposed by the
+		// GtkSharp managed binding, so it's P/Invoked here. This lives in the
+		// non-generic type because [DllImport] can't be applied inside a generic
+		// class (CS7042).
+		[Flags]
+		public enum Gravity : int
+		{
+			GDK_GRAVITY_NORTH_WEST = 1
+		}
+		
+		[Flags]
+		public enum AnchorHint : int
+		{
+			None = 0,
+			GDK_ANCHOR_SLIDE_X = 1 << 2,
+			GDK_ANCHOR_SLIDE_Y = 1 << 3,
+			GDK_ANCHOR_FLIP_X = 1 << 4,
+			GDK_ANCHOR_FLIP_Y = 1 << 5,
+			GDK_ANCHOR_RESIZE_X = 1 << 6,
+			GDK_ANCHOR_RESIZE_Y = 1 << 7
+		}
+		
+		[StructLayout(LayoutKind.Sequential)]
+		public struct GdkRect { public int X, Y, Width, Height; }
+
 
 <#
 	for (int i = 0; i < pclass.Length; i++)

--- a/src/Eto/Forms/Window.cs
+++ b/src/Eto/Forms/Window.cs
@@ -248,8 +248,16 @@ public abstract class Window : Panel
 	/// Gets or sets the location of the window
 	/// </summary>
 	/// <remarks>
-	/// Note that in multi-monitor setups, the origin of the location is at the upper-left of <see cref="Eto.Forms.Screen.PrimaryScreen"/>. <br/>
-	/// Also note, that on Linux systems running GTK via Wayland, this will always point to <c>0, 0</c>, and setting it to different values will have no effect.
+	/// Note that in multi-monitor setups, the origin of the location is at the upper-left 
+	/// of <see cref="Eto.Forms.Screen.PrimaryScreen"/>.
+	/// 
+	/// Also note, that on Linux systems running GTK via Wayland, the location is relative 
+	/// to the <see cref="Owner"/> when one is set and the <see cref="WindowStyle"/> is 
+	/// <see cref="WindowStyle.None"/>; otherwise it will always point to <c>0, 0</c> and 
+	/// setting it to different values will have no effect.
+	/// 
+	/// Using <see cref="Control.PointToScreen"/> on a control within the <see cref="Owner"/> 
+	/// can be used to position the window relative to specific elements of the owner.
 	/// </remarks>
 	public new Point Location
 	{
@@ -720,8 +728,16 @@ public abstract class Window : Panel
 		/// Gets or sets the location of the window
 		/// </summary>
 		/// <remarks>
-		/// Note that in multi-monitor setups, the origin of the location is at the upper-left of <see cref="Eto.Forms.Screen.PrimaryScreen"/> <br/>
-		/// Also note, that on Linux systems running GTK via Wayland, this will always point to <c>0, 0</c>, and setting it to different values will have no effect.
+		/// Note that in multi-monitor setups, the origin of the location is at the upper-left 
+		/// of <see cref="Eto.Forms.Screen.PrimaryScreen"/>.
+		/// 
+		/// Also note, that on Linux systems running GTK via Wayland, the location is relative 
+		/// to the <see cref="Owner"/> when one is set and the <see cref="WindowStyle"/> is 
+		/// <see cref="WindowStyle.None"/>; otherwise it will always point to <c>0, 0</c> and 
+		/// setting it to different values will have no effect.
+		/// 
+		/// Using <see cref="Control.PointToScreen"/> on a control within the <see cref="Owner"/> 
+		/// can be used to position the window relative to specific elements of the owner.
 		/// </remarks>
 		new Point Location { get; set; }
 

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
@@ -302,5 +302,87 @@ namespace Eto.Test.UnitTests.Forms.Controls
 
 			Assert.That(output, Does.Not.Contain("CRITICAL"), $"A critical warning was emitted while rendering a List<string> data store:{Environment.NewLine}{output}");
 		}
+
+		[TestCase(WindowStyle.Default, false)]
+		[TestCase(WindowStyle.None, true)]
+		public void PreferredSizeShouldAccountForAllRowsWhenLargerThanWindow(WindowStyle windowStyle, bool positionRelativeToParent) => Async(10000, async () =>
+		{
+			const int rowHeight = 20;
+			const int rowCount = 3;
+			const int largerRowCount = 10;
+
+			static ObservableCollection<DataItem> CreateRows(int rows)
+			{
+				var collection = new ObservableCollection<DataItem>();
+				for (int i = 0; i < rows; i++)
+					collection.Add(new DataItem(i) { TextValue = $"Item {i}" });
+				return collection;
+			}
+
+			var grid = new GridView { ShowHeader = false, RowHeight = rowHeight };
+			grid.Columns.Add(new GridColumn
+			{
+				DataCell = new TextBoxCell { Binding = Binding.Property((DataItem m) => m.TextValue) }
+			});
+			grid.DataStore = CreateRows(rowCount);
+
+			Window parent = Application.Instance.MainForm;
+			var form = new FloatingForm
+			{
+				WindowStyle = windowStyle,
+				Content = grid,
+				ShowInTaskbar = false,
+				ShowActivated = false,
+				CanFocus = false
+			};
+			// size the child form to fit its content
+			form.Size = Size.Ceiling(grid.GetPreferredSize());
+			try
+			{
+				if (positionRelativeToParent)
+				{
+					if (parent == null)
+					{
+						// a WindowStyle.None form (e.g. a popup) is typically owned by and
+						// positioned relative to a parent window
+						var parentForm = new Form { Content = new Panel(), ClientSize = new Size(400, 400), Location = new Point(100, 100) };
+						parentForm.Show();
+						parent = parentForm;
+						await Task.Delay(100);
+					}
+					form.Owner = parent;
+					form.Location = parent.Location + new Size(20, 20);
+				}
+
+				var shown = WaitEventAsync<EventArgs>(h => form.Shown += h);
+				form.Show();
+				await shown;
+				await Task.Delay(1000);
+
+				var preferredSize = grid.GetPreferredSize();
+
+				// The preferred size should reflect the content needed to display every row.
+				Assert.That(preferredSize.Height, Is.GreaterThanOrEqualTo(rowCount * rowHeight), "#1 Preferred height should account for all rows");
+
+				// Hide the same window, swap in a larger list, re-size the child form to the new
+				// content, then re-show it and ensure the preferred size grows to account for the
+				// additional rows.
+				form.Visible = false;
+				await Task.Delay(100);
+				grid.DataStore = CreateRows(largerRowCount);
+				form.Size = Size.Ceiling(grid.GetPreferredSize());
+				form.Visible = true;
+				await Task.Delay(1000);
+
+				var largerSize = grid.GetPreferredSize();
+				Assert.That(largerSize.Height, Is.GreaterThanOrEqualTo(largerRowCount * rowHeight), "#2 Preferred height should account for all rows in the larger list");
+				Assert.That(largerSize.Height, Is.GreaterThan(preferredSize.Height), "#3 Preferred height should be larger when re-shown with more rows");
+			}
+			finally
+			{
+				form.Close();
+				// parent?.Close();
+			}
+		});
 	}
 }

--- a/test/Eto.Test/UnitTests/TestBase.cs
+++ b/test/Eto.Test/UnitTests/TestBase.cs
@@ -748,7 +748,10 @@ namespace Eto.Test.UnitTests
 			where TEventArgs : EventArgs
 		{
 			var tcs = new TaskCompletionSource<TEventArgs>();
-			hookEvent((sender, e) => tcs.SetResult(e));
+			// The event may fire more than once (e.g. a window shown, hidden, then shown
+			// again), so complete only on the first invocation to avoid transitioning the
+			// task to a completed state twice.
+			hookEvent((sender, e) => tcs.TrySetResult(e));
 			return tcs.Task;
 		}
 


### PR DESCRIPTION
Wayland does not allow you to position windows at all unless they are child windows.  So, if you are showing a window with WindowStyle.None and an owner it will position it relative to the main window, which is useful for popup windows for things like an autocomplete form, etc.