### PR TITLE
Gtk: Fix Tree/GridView.GetPreferredSize()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,49 @@ dotnet test --project test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj -f net10
   `PreferredSizeShouldAccountForAllRowsWhenLargerThanWindow`, anything via
   `ShownAsync`/`Form`/`Paint`) actually execute.
 
+## Screenshotting a window to diagnose visual/layout bugs
+
+When a test "passes" but the rendered output looks wrong (clipping, wrong size, misplaced
+widgets), capture the actual pixels and look at them. There are usually **no OS screenshot tools**
+(`scrot`, `import`, `grim`, …) available, so grab the window from the backend's own native API
+inside a tiny standalone Eto app.
+
+**Cross-platform strategy (backend-agnostic):**
+
+- Write a small console `.csproj` (`net10.0`, `OutputType=Exe`) that **`<Reference>`s the built
+  DLLs** for the backend under test (see per-backend note below). Build the platform lib you're
+  editing first, e.g. `dotnet build src/Eto.Gtk/Eto.Gtk.csproj -f net10.0`.
+- Build the form exactly as the test does, `Show()` it, then in a timer/dispatch callback (after
+  it has actually mapped/rendered) take the screenshot and `app.Quit()`.
+- Run it, then `Read` the PNG (the Read tool renders images) to actually *see* the output.
+- **Gotcha:** `dotnet bin/.../app.dll` loads its dependencies from that **same `bin` output dir**,
+  not from wherever your `<HintPath>` points — after rebuilding a platform DLL you must copy it
+  into the app's `bin/Debug/net10.0/` for the change to take effect.
+- Toggle deep diagnostics from native code with an env var (e.g.
+  `Environment.GetEnvironmentVariable("ETO_X") == "1"` → `Console.Error.WriteLine(...)`) so you can
+  dump internal measurements without editing call sites. Remove them before finishing.
+
+**The actual pixel-grab is backend-specific** — reach `form.ControlObject`/`.NativeHandle` for the
+native window and use that toolkit's capture API:
+
+- **Gtk** (verified — Linux/XWayland here; run with `DISPLAY=:0 GDK_BACKEND=x11`):
+
+  ```csharp
+  var native = form.ControlObject as Gtk.Widget;
+  var gdkWin = native?.Window ?? (native?.Toplevel as Gtk.Window)?.Window;
+  var pb = new Gdk.Pixbuf(gdkWin, 0, 0, gdkWin.Width, gdkWin.Height); // Gdk.Pixbuf.FromWindow
+  pb.Save("/path/out.png", "png");
+  ```
+
+- **Mac** (not yet tried here): render the `NSView`/`NSWindow` — `NSView.BitmapImageRepForCachingDisplay`
+  with `CacheDisplay`, or `CGWindowListCreateImage` for the whole window — then write via
+  `NSBitmapImageRep.AsTiff()`/PNG representation.
+- **Wpf** (not yet tried): `RenderTargetBitmap.Render(visual)` → `PngBitmapEncoder` to a file.
+- **WinForms** (not yet tried): `Control.DrawToBitmap(bmp, rect)`, or `Graphics.CopyFromScreen` for
+  on-screen pixels → `Bitmap.Save(..., ImageFormat.Png)`.
+
+Only the Gtk path above has been exercised; treat the others as starting points to verify.
+
 ## Test project layout (non-obvious)
 
 - Unit-test **source `.cs` files live in `test/Eto.Test/UnitTests/`** (compiled as part of
@@ -46,6 +89,21 @@ The test + platform projects pick a backend by TargetFramework:
 Core `Eto` project targets `netstandard2.0;net6.0;net8.0;net10.0`.
 Platform backends live in `src/Eto.<Platform>/` (Gtk, Mac, Wpf, WinForms, WinUI, iOS,
 Android, Direct2D). Solution: `src/Eto.slnx`.
+
+## Gtk preferred-size gotchas (non-obvious)
+
+- **GTK returns a *stale* preferred size on the first size request after `ShowAll` on an
+  unrealized/unmapped widget** (esp. `GtkTreeView`); the settled value only comes back on a
+  *subsequent* request. `GtkControl.GetPreferredSizeForControl` primes this with a throwaway
+  `GetPreferredSize` call (GTK3 only) so measuring a control before it's shown is correct — and
+  so a control's standalone `GetPreferredSize()` matches its size when measured inside a
+  container (the invariant `ControlsShouldHavePreferredSize` enforces).
+- **`GtkTreeView` cell renderers report size `0` until the tree is mapped on a *real* on-screen
+  window** — realizing, pumping the event loop, and even `Gtk.OffscreenWindow` do *not* make
+  them measure. So grid height can't be measured natively before first show; `GridHandler`
+  computes it explicitly from row count × row height (falling back to the Pango font line height
+  when the renderers report 0) and feeds it into `EtoScrolledWindow.OnGetPreferredHeight` so both
+  direct and in-container measurements are correct.
 
 ## Code style
 

--- a/src/Eto.Gtk/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridHandler.cs
@@ -61,6 +61,13 @@ namespace Eto.GtkSharp.Forms.Controls
 			{
 				base.OnGetPreferredHeight(out minimum_height, out natural_height);
 				var h = Handler;
+
+				// GtkTreeView under-reports its height until it has been mapped; make the natural height
+				// account for all rows so the grid measures correctly before it is ever shown (both when
+				// measured directly and when measured as part of a parent container).
+				if (h is GridHandler<TWidget, TCallback> gridHandler)
+					natural_height = Math.Max(natural_height, gridHandler.CalculateContentHeight());
+
 				if (h != null)
 				{
 					var size = h.UserPreferredSize;
@@ -770,6 +777,101 @@ namespace Eto.GtkSharp.Forms.Controls
 		}
 
 		public abstract int GetRowOfItem(object item);
+
+		// Number of rows currently displayed (all rows for a flat grid, expanded rows for a tree).
+		protected abstract int NumberOfRows { get; }
+
+		// Height of a single row, including the RowHeight floor that the cell renderers apply plus
+		// the inter-row spacing GtkTreeView adds between rows.
+		int GetContentRowHeight()
+		{
+			// Ask each cell renderer how tall it wants to be. While the tree is mapped this is exact,
+			// but while it is unmapped the renderers report 0 (they only measure once they've been
+			// rendered on a real window), so fall back to the font line height below.
+			int cellHeight = 0;
+			foreach (Gtk.TreeViewColumn column in Control.Columns)
+			{
+				if (!column.Visible)
+					continue;
+				column.CellGetSize(Gdk.Rectangle.Zero, out _, out _, out _, out var height);
+				cellHeight = Math.Max(cellHeight, height);
+			}
+			if (cellHeight == 0)
+				cellHeight = GetFontRowHeight();
+
+			int rowHeight = Math.Max(RowHeight, cellHeight);
+			if (rowHeight > 0)
+				rowHeight += RowSeparatorHeight;
+			return rowHeight;
+		}
+
+		// The height a text cell renderer needs for a single line, derived from the tree's font.
+		// Unlike the cell renderers, a Pango layout reports a stable line height regardless of whether
+		// the tree is mapped, so this lets us estimate the row height before the tree is ever shown.
+		int GetFontRowHeight()
+		{
+			// include ascender/descender glyphs so we get the full line height
+			using (var layout = Control.CreatePangoLayout("Xygj"))
+			{
+				layout.GetPixelSize(out _, out var lineHeight);
+				return lineHeight + CellVerticalPadding;
+			}
+		}
+
+		// GtkCellRendererText's default vertical padding (ypad = 2, top and bottom).
+		const int CellVerticalPadding = 4;
+
+		// GtkTreeView's default "vertical-separator" style property, the spacing added between rows.
+		// The exact allocated height wins via Math.Max once the tree is mapped; this only refines
+		// the estimate used while unmapped.
+		const int RowSeparatorHeight = 2;
+
+		// Vertical space taken by the ScrolledWindow's frame (the ShadowType.In border drawn around
+		// the tree). The style context reports this regardless of mapped state.
+		int GetFrameHeight()
+		{
+			if (ScrolledWindow.ShadowType == Gtk.ShadowType.None)
+				return 0;
+			var border = ScrolledWindow.StyleContext.GetBorder(Gtk.StateFlags.Normal);
+			var height = border.Top + border.Bottom;
+			return height > 0 ? height : DefaultFrameHeight;
+		}
+
+		// Fallback border thickness (1px top + 1px bottom) when the theme doesn't report a frame border.
+		const int DefaultFrameHeight = 2;
+
+		// The natural height needed to display every row plus the header and frame. GtkTreeView derives
+		// its height from lazily-validated rows, which only happens while it is mapped -- so a native
+		// measurement taken while unmapped (or after the data store changed while unmapped) reports a
+		// stale minimal height. This computes the height explicitly from the row count and per-row
+		// height so it is correct regardless of realized/mapped state, and feeds the ScrolledWindow's
+		// native height request (see EtoScrolledWindow) so containers measure it correctly too.
+		internal int CalculateContentHeight()
+		{
+			var rowCount = NumberOfRows;
+			var rowHeight = GetContentRowHeight();
+			if (rowCount <= 0 || rowHeight <= 0)
+				return 0;
+			var height = rowCount * rowHeight;
+			if (ShowHeader)
+				height += GetHeaderHeight();
+			height += GetFrameHeight();
+			return height;
+		}
+
+		int GetHeaderHeight()
+		{
+			int max = 0;
+			foreach (Gtk.TreeViewColumn column in Control.Columns)
+			{
+				if (column.Button != null)
+				{
+					column.Button.GetPreferredHeight(out _, out var nat);
+					max = Math.Max(max, nat);
+				}
+			}
+			return max;
+		}
 	}
 }
 

--- a/src/Eto.Gtk/Forms/Controls/GridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GridViewHandler.cs
@@ -168,6 +168,8 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		public override int GetRowOfItem(object item) => collection?.IndexOf(item) ?? -1;
 
+		protected override int NumberOfRows => collection?.Count ?? 0;
+
 		public EnumerableChangedHandler<object> Collection
 		{
 			get { return collection; }

--- a/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/TreeGridViewHandler.cs
@@ -514,6 +514,8 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 			return -1;
 		}
+
+		protected override int NumberOfRows => DataStore?.GetExpandedRowCount() ?? 0;
 		
 
 		public void ReloadData()

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -1322,6 +1322,13 @@ namespace Eto.GtkSharp.Forms
 				else
 					ContainerControl.ShowAll();
 
+#if GTK3
+				// GTK returns a stale (minimal) size on the first size request after ShowAll -- some
+				// widgets (e.g. GtkTreeView) only settle their preferred size on a subsequent request.
+				// Prime it here so the measurement below returns the settled value for controls that
+				// haven't been shown yet.
+				control.GetPreferredSize(out _, out _);
+#endif
 			}
 #if GTK3
 			var requestMode = ContainerControl.RequestMode;

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridViewTests.cs
@@ -308,7 +308,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 		public void PreferredSizeShouldAccountForAllRowsWhenLargerThanWindow(WindowStyle windowStyle, bool positionRelativeToParent) => Async(10000, async () =>
 		{
 			const int rowHeight = 20;
-			const int rowCount = 3;
+			const int rowCount = 5;
 			const int largerRowCount = 10;
 
 			static ObservableCollection<DataItem> CreateRows(int rows)
@@ -327,6 +327,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			grid.DataStore = CreateRows(rowCount);
 
 			Window parent = Application.Instance.MainForm;
+			bool closeParent = false;
 			var form = new FloatingForm
 			{
 				WindowStyle = windowStyle,
@@ -346,6 +347,7 @@ namespace Eto.Test.UnitTests.Forms.Controls
 						// a WindowStyle.None form (e.g. a popup) is typically owned by and
 						// positioned relative to a parent window
 						var parentForm = new Form { Content = new Panel(), ClientSize = new Size(400, 400), Location = new Point(100, 100) };
+						closeParent = true;
 						parentForm.Show();
 						parent = parentForm;
 						await Task.Delay(100);
@@ -381,7 +383,8 @@ namespace Eto.Test.UnitTests.Forms.Controls
 			finally
 			{
 				form.Close();
-				// parent?.Close();
+				if (closeParent)
+					parent?.Close();
 			}
 		});
 	}


### PR DESCRIPTION
The preferred size of a GridView or TreeGridView would not update after changing its data store.  This does not fix the preferred width before it has been shown which ends up too narrow, but the height should at least be correct.