### PR TITLE
Mac: ScrollGesture should not activate for MouseWheel

### DIFF
--- a/src/Eto.Mac/Forms/Controls/GestureHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GestureHandler.cs
@@ -223,7 +223,9 @@ namespace Eto.Mac.Forms.Controls
 			get => enabled;
 			set => enabled = value;
 		}
-
+		
+		public bool UseMouseWheel { get; set; }
+		
 		public SizeF Delta => delta;
 
 		public PointF Velocity => velocity;
@@ -233,6 +235,9 @@ namespace Eto.Mac.Forms.Controls
 		public bool OnScrollWheel(NSEvent theEvent)
 		{
 			if (!Enabled)
+				return false;
+				
+			if (!UseMouseWheel && !theEvent.HasPreciseScrollingDeltas)
 				return false;
 
 			delta = theEvent.HasPreciseScrollingDeltas

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -329,7 +329,9 @@ namespace Eto.Mac.Forms
 			{
 				if (handler.Widget?.IsDisposed != false) return;
 				var theEvent = Messaging.GetNSObject<NSEvent>(e);
-				TriggerScrollWheelGestures(handler, theEvent);
+				if (TriggerScrollWheelGestures(handler, theEvent))
+					return;
+					
 				var args = MacConversions.GetMouseEvent(handler, theEvent, true);
 				if (!args.Delta.IsZero)
 				{
@@ -344,7 +346,7 @@ namespace Eto.Mac.Forms
 				Messaging.void_objc_msgSendSuper_IntPtr(obj.SuperHandle, sel, e);
 		}
 
-		static void TriggerScrollWheelGestures(IMacViewHandler handler, NSEvent theEvent)
+		static bool TriggerScrollWheelGestures(IMacViewHandler handler, NSEvent theEvent)
 		{
 			var gestures = handler.Widget.Gestures
 				.Select(gesture => ((IHandlerSource)gesture).Handler as IMacScrollWheelGestureHandler)
@@ -354,8 +356,12 @@ namespace Eto.Mac.Forms
 			foreach (var gesture in gestures)
 			{
 				if (gesture == firstGesture || firstGesture.Gesture.CanRecognizeSimultaneouslyWith(gesture.Gesture))
-					gesture.OnScrollWheel(theEvent);
+				{
+					if (gesture.OnScrollWheel(theEvent))
+						return true;
+				}
 			}
+			return false;
 		}
 
 		static int _interpretingKeyEvents;


### PR DESCRIPTION
and MouseWheel event should not be called when ScrollGesture is used.

This allows you to use MouseWheel to handle legacy mice, and ScrollGesture to handle precise trackpads, by default.  This will also prevent MouseWheel from firing when using a ScrollGesture so it can have different logic.