### PR TITLE
Wpf: Fix sizing of Tree/GridView content when not in autosized window

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -172,7 +172,7 @@
 		{
 			"label": "test non-manual",
 			"type": "shell",
-			"command": "dotnet test --project ${workspaceFolder}/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj --filter \"TestCategory!=ManualTest&Name=DialogTests\"",
+			"command": "dotnet test --project ${workspaceFolder}/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj --filter \"TestCategory!=ManualTest\"",
 			"problemMatcher": "$msCompile",
 			"presentation": {
 				"clear": true,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,11 +24,29 @@ dotnet test --project test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj -f net10
 - **Always pass `-f`** — the project multi-targets `net48;net10.0;net10.0-windows`.
   On Linux/macOS use `-f net10.0`; the Windows-only TFMs won't build there.
 - Test runner is Microsoft.Testing.Platform (set in `global.json`), NUnit 4.
+- **Reflection gotcha (net48 vs net):** `Type.GetType("Ns.Type, PresentationCore")` (partial assembly
+  name) resolves on .NET but returns **null** on .NET Framework, so tests that reflect over WPF types
+  (e.g. finding the native `ScrollViewer`) silently no-op on net48. Search loaded assemblies instead:
+  `AppDomain.CurrentDomain.GetAssemblies().Select(a => a.GetType(fullName)).FirstOrDefault(t => t != null)`.
 - **Windowed/GUI tests run without special setup on all platforms** (Linux, Mac, Windows) as
   long as a display is available — on Linux that's a real X display (e.g. `DISPLAY=:0`; no
   `xvfb-run` needed). Tests that `Show()`/`Close()` windows (e.g.
   `PreferredSizeShouldAccountForAllRowsWhenLargerThanWindow`, anything via
   `ShownAsync`/`Form`/`Paint`) actually execute.
+- **Wpf gotcha (fixed in `Eto.Test.UnitTests/Program.cs`) — showing a themed control like
+  `TreeGridView` under the test host used to crash with a bogus `FileLoadException: Could not load
+  file or assembly 'Eto.Wpf.Aero2'` (`E_POINTER`) → `NullReferenceException` in
+  `NUnit.Engine.Internal.RuntimeLibrariesStrategy.TryToResolve`.** Laying out a themed Eto.Wpf
+  control makes WPF probe an *external* per-OS-theme satellite assembly (`Eto.Wpf.Aero2`, etc.)
+  before falling back to the embedded `themes/generic.xaml`; that satellite never exists and in the
+  real app the probe just returns "not found", but the NUnit test host's assembly `Resolving`
+  handler throws an NRE instead of returning null, surfacing as a fatal load error during layout.
+  Fix: `Program.Main` registers an `AssemblyLoadContext.Default.Resolving` handler FIRST (before
+  NUnit's) that throws `FileNotFoundException` for `Eto.*` theme-satellite names (`.Aero2`, `.Aero`,
+  `.AeroLite`, `.Classic`, `.Luna`, `.Royale`, `.Generic`) so WPF falls back cleanly and NUnit's
+  broken handler never runs (`#if NET` — .NET-Core test host only). Was deterministic per grid type
+  (GridView fine, TreeGridView crashed), observed on arm64. (Surfaced writing the b46b9827
+  scrollable-fill regression tests.)
 
 ## Screenshotting a window to diagnose visual/layout bugs
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -740,7 +740,7 @@ namespace Eto.WinForms.Forms
 		}
 
 		public bool MovableByWindowBackground { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-		public bool AutoSize { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+		public bool AutoSize { get => false; set => throw new NotImplementedException(); }
 
 		public void DoDragDrop(DataObject data, DragEffects allowedAction, Image image, PointF offset)
 		{

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -120,10 +120,17 @@ namespace Eto.Wpf.Forms
 			var size = UserPreferredSize;
 			var control = ContainerControl;
 
-			if (ContainsScrollViewer)
+			var parentWindow = Widget.ParentWindow;
+			if (ContainsScrollViewer && parentWindow?.AutoSize == true && parentWindow.WindowState == WindowState.Normal)
 			{
-				// enclosed scrollable does not size appropriately on Arrange, so we need to 
-				// constrain the size here to prevent it from using the available space incorrectly.
+				// The enclosed scrollable is measured with this constraint, which becomes its viewport size.
+				// In an auto-sizing window the content is probed with the monitor size, so without constraining
+				// to the preferred size here the scroll viewer would measure its content as fitting that huge
+				// space and not show scrollbars. When NOT auto-sizing, the constraint is the real space the
+				// control will be arranged to, so we must NOT constrain it or the content won't expand to fill
+				// the scrollable area when the control is scaled larger than its preferred size.
+				// Also skip when the auto-size window is maximized: it then has a fixed (screen) size the content
+				// should fill, so constraining to the preferred size would pin the content until it's re-measured.
 				if (!double.IsPositiveInfinity(constraint.Width) && size.Width >= 0 && size.Width < constraint.Width)
 					constraint.Width = size.Width;
 				if (!double.IsPositiveInfinity(constraint.Height) && size.Height >= 0 && size.Height < constraint.Height)

--- a/test/Eto.Test.UnitTests/Program.cs
+++ b/test/Eto.Test.UnitTests/Program.cs
@@ -1,6 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
+#if NET
+using System.Runtime.Loader;
+#endif
 using System.Threading.Tasks;
 using Microsoft.Testing.Platform.Builder;
 using NUnit.Framework;
@@ -19,8 +24,10 @@ internal static class Program
 	[STAThread]
 	public static int Main(string[] args)
 	{
+		AvoidThemeSatelliteResolverCrash();
+
 		using var app = new Application();
-		
+
 		var exitCodeSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
 
 		app.Initialized += (sender, e) =>
@@ -35,6 +42,28 @@ internal static class Program
 		app.Run();
 
 		return exitCodeSource.Task.Result;
+	}
+
+	static readonly string[] WpfThemeSuffixes = { ".Aero2", ".Aero", ".AeroLite", ".Classic", ".Luna", ".Royale", ".Generic" };
+
+	// When a themed Eto.Wpf control (e.g. TreeGridView) is laid out, WPF probes for an external per-OS-theme
+	// satellite assembly (e.g. "Eto.Wpf.Aero2") before falling back to the embedded themes/generic.xaml. That
+	// satellite never exists; in a normal app the probe just yields "not found" and WPF falls back. But under the
+	// NUnit test host, its assembly Resolving handler throws a NullReferenceException instead of returning null,
+	// which surfaces as a fatal FileLoadException during layout and crashes the test. Registering our own handler
+	// FIRST (before NUnit's) lets us short-circuit those Eto theme probes with the normal FileNotFoundException so
+	// WPF falls back cleanly and NUnit's broken handler never runs.
+	static void AvoidThemeSatelliteResolverCrash()
+	{
+#if NET
+		AssemblyLoadContext.Default.Resolving += (context, name) =>
+		{
+			var n = name.Name;
+			if (n != null && n.StartsWith("Eto.", StringComparison.Ordinal) && WpfThemeSuffixes.Any(s => n.EndsWith(s, StringComparison.Ordinal)))
+				throw new FileNotFoundException($"Eto theme satellite '{n}' does not exist; using generic theme.");
+			return null;
+		};
+#endif
 	}
 
 	private static async Task RunTestsAndQuitAsync(Application app, string[] args, TaskCompletionSource<int> exitCodeSource)

--- a/test/Eto.Test/NativeHostControls.cs
+++ b/test/Eto.Test/NativeHostControls.cs
@@ -34,6 +34,11 @@ namespace Eto.Test
 		}
 		static INativeHostControls Handler => Platform.Instance.CreateShared<INativeHostControls>();
 
-		public static IEnumerable<NativeHostTest> GetNativeHostTests() => Handler.GetNativeHostTests();
+		public static IEnumerable<NativeHostTest> GetNativeHostTests()
+		{
+			if (!Platform.Instance.Supports<INativeHostControls>())
+				return Enumerable.Empty<NativeHostTest>();
+			return Handler.GetNativeHostTests();
+		}
     }
 }

--- a/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Controls/GridTests.cs
@@ -683,5 +683,114 @@ namespace Eto.Test.UnitTests.Forms.Controls
 
 			return grid;
 		});
+
+		[Test, ManualTest]
+		public void GridShouldExpandToFillContainerLargerThanPreferredSize() => ManualForm(
+			"The grid rows should fill the ENTIRE height (and width) of the window, not just the top-left portion.\n"
+			+ "There should be NO blank/empty space below or to the right of the rows, and a vertical scrollbar should be shown.",
+			form =>
+		{
+			form.ClientSize = new Size(500, 400);
+
+			var grid = new T();
+			grid.ShowHeader = false;
+			// preferred size is intentionally smaller than the window so the grid must expand to fill it.
+			grid.Size = new Size(150, 100);
+
+			grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell { Binding = Binding.Property((GridTestItem m) => m.Text) }, AutoSize = true });
+			grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell(0), Expand = true, AutoSize = true });
+
+			var list = new TreeGridItemCollection();
+			for (int i = 0; i < 100; i++)
+			{
+				list.Add(new GridTestItem { Text = $"Item {i}", Values = new[] { $"col {i}.2", $"col {i}.3", $"col {i}.4", $"col {i}.5" } });
+			}
+			SetDataStore(grid, list);
+
+			return grid;
+		});
+
+		// Automatic regression coverage for the b46b9827 scrollable-fill regression. The fix lives in the shared
+		// WpfFrameworkElement.MeasureOverride, so the enclosed WPF ScrollViewer's viewport should track the grid's
+		// actual (arranged) size: a viewport much smaller than the control means the content doesn't fill the
+		// scrollable area (the regression); much larger means it measured against the auto-size monitor probe and
+		// won't scroll correctly. These inspect the native ScrollViewer via reflection, so they only run on WPF.
+		// Resolve a WPF type from the loaded assemblies by full name. Type.GetType with a partial assembly name
+		// (e.g. "...,PresentationCore") resolves on .NET but returns null on .NET Framework, so search instead.
+		static Type WpfType(string fullName) => AppDomain.CurrentDomain.GetAssemblies()
+			.Select(a => a.GetType(fullName))
+			.FirstOrDefault(t => t != null);
+
+		static object WpfFindScrollViewer(object visual)
+		{
+			var vth = WpfType("System.Windows.Media.VisualTreeHelper");
+			var svType = WpfType("System.Windows.Controls.ScrollViewer");
+			if (vth == null || svType == null || visual == null)
+				return null;
+			if (svType.IsInstanceOfType(visual))
+				return visual;
+			var count = (int)vth.GetMethod("GetChildrenCount").Invoke(null, new[] { visual });
+			for (int i = 0; i < count; i++)
+			{
+				var found = WpfFindScrollViewer(vth.GetMethod("GetChild").Invoke(null, new object[] { visual, i }));
+				if (found != null)
+					return found;
+			}
+			return null;
+		}
+
+		static double WpfGetDouble(object o, string prop) => o == null ? double.NaN : Convert.ToDouble(o.GetType().GetProperty(prop).GetValue(o));
+
+		void AssertViewportTracksActualSize(bool autoSize)
+		{
+			if (!Platform.Instance.IsWpf)
+				Assert.Inconclusive("Inspects the native WPF ScrollViewer viewport; WPF only");
+
+			ShownAsync(form =>
+			{
+				if (autoSize)
+				{
+					form.Resizable = true;
+					form.AutoSize = true;
+				}
+				else
+				{
+					form.ClientSize = new Size(500, 400);
+				}
+
+				var grid = new T { ShowHeader = false, Size = new Size(150, 100) };
+				grid.Columns.Add(new GridColumn { DataCell = new TextBoxCell { Binding = Binding.Property((GridTestItem m) => m.Text) }, AutoSize = true });
+
+				var list = new TreeGridItemCollection();
+				for (int i = 0; i < 100; i++)
+					list.Add(new GridTestItem { Text = $"Item {i}" });
+				SetDataStore(grid, list);
+
+				// stretch + expand so the grid fills the window (larger than its 150x100 preferred size)
+				form.Content = new StackLayout { HorizontalContentAlignment = HorizontalAlignment.Stretch, Items = { new StackLayoutItem(grid, true) } };
+				return grid;
+			}, async grid =>
+			{
+				await Task.Delay(700);
+				var control = grid.ControlObject;
+				var sv = WpfFindScrollViewer(control);
+				Assert.That(sv, Is.Not.Null, "Could not find the ScrollViewer in the grid");
+
+				var actualWidth = WpfGetDouble(control, "ActualWidth");
+				var viewportWidth = WpfGetDouble(sv, "ViewportWidth");
+
+				// The viewport (in pixels) should track the control's actual width - not clamped down to the
+				// ~150px preferred size (content wouldn't fill the scrollable area), nor blown up to the
+				// auto-size monitor-sized probe (scroll bars wouldn't reflect the visible area).
+				Assert.That(viewportWidth, Is.GreaterThan(actualWidth * 0.6).And.LessThan(actualWidth * 1.2),
+					$"ScrollViewer viewport width ({viewportWidth}) should track the grid's actual width ({actualWidth})");
+			}, timeout: -1);
+		}
+
+		[Test]
+		public void ContentShouldFillScrollableAreaWhenLargerThanPreferredSize() => AssertViewportTracksActualSize(autoSize: false);
+
+		[Test]
+		public void ContentShouldFillScrollableAreaInAutoSizedWindow() => AssertViewportTracksActualSize(autoSize: true);
 	}
 }


### PR DESCRIPTION
This fixes some regressions from #2922 that caused GridView and TreeGridView to have their contents clipped at a smaller size than its scrollable region.