### PR TITLE
Wpf/Mac: Suppress key events during IME composition

### DIFF
--- a/src/Eto.Mac/Forms/Controls/MacEventView.cs
+++ b/src/Eto.Mac/Forms/Controls/MacEventView.cs
@@ -38,7 +38,7 @@ namespace Eto.Mac.Forms.Controls
 			var handler = control?.Handler as IMacViewHandler;
 			if (handler == null)
 				return false;
-
+				
 			var kpea = theEvent.ToEtoKeyEventArgs();
 			handler.OnKeyDown(kpea);
 			return kpea.Handled;
@@ -112,7 +112,7 @@ namespace Eto.Mac.Forms.Controls
 				return false;
 
 			var kpea = theEvent.ToEtoKeyEventArgs();
-			handler.Callback.OnKeyUp(control, kpea);
+			handler.OnKeyUp(kpea);
 			return kpea.Handled;
 		}
 

--- a/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextAreaHandler.cs
@@ -39,6 +39,13 @@ namespace Eto.Mac.Forms.Controls
 		public override void DidChangeSelection(NSNotification notification)
 		{
 			var handler = Handler;
+
+			if (notification.Object is NSTextView textView && textView.HasMarkedText)
+			{
+				// While an IME composition is in progress the input method owns the keystroke (building, navigating, or committing the composition), so don't surface it as a KeyDown to the app. This matches WPF/Windows, where IME-processed keys aren't raised as key events.
+				return;
+			}
+			
 			var selection = handler.Selection;
 			if (handler.SuppressSelectionChanged == 0 && selection != Handler.lastSelection)
 			{
@@ -118,6 +125,13 @@ namespace Eto.Mac.Forms.Controls
 
 		public override void OnKeyDown(KeyEventArgs e)
 		{
+			if (Control.HasMarkedText)
+			{
+				// While an IME composition is in progress the input method owns the keystroke (building, navigating, or committing the composition), so don't surface it as a KeyDown to the app. This matches WPF/Windows, where IME-processed keys aren't raised as key events.
+				// The KeyDown event is sent for the first key, but not for subsequent keys. Only the last KeyUp for Enter key is sent, but not the KeyDown.
+				return;
+			}
+
 			if (!AcceptsTab)
 			{
 				if (e.KeyData == Keys.Tab)
@@ -139,6 +153,18 @@ namespace Eto.Mac.Forms.Controls
 				return;
 			}
 			base.OnKeyDown(e);
+		}
+		
+		public override void OnKeyUp(KeyEventArgs e)
+		{
+			if (Control.HasMarkedText)
+			{
+				// While an IME composition is in progress the input method owns the keystroke (building, navigating, or committing the composition), so don't surface it as a KeyDown to the app. This matches WPF/Windows, where IME-processed keys aren't raised as key events.
+				// Only the last KeyUp for Enter key is sent, but not the KeyDown.
+				return;
+			}
+
+			base.OnKeyUp(e);
 		}
 
 		public NSScrollView Scroll { get; private set; }

--- a/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/TextBoxHandler.cs
@@ -262,7 +262,7 @@ namespace Eto.Mac.Forms.Controls
 		protected override SizeF GetNaturalSize(SizeF availableSize)
 		{
 			var size = base.GetNaturalSize(availableSize);
-			size.Width = Math.Max(100, size.Height);
+			size.Width = Math.Max(100, size.Width);
 			return size;
 		}
 
@@ -322,6 +322,30 @@ namespace Eto.Mac.Forms.Controls
 			var args = new TextChangingEventArgs(oldText, newText, TextChangeSource.Programmatic);
 			Callback.OnTextChanging(Widget, args);
 			return args.Cancel;
+		}
+
+		public override void OnKeyDown(KeyEventArgs e)
+		{
+			if (Control.CurrentEditor is NSTextView textView && textView.HasMarkedText)
+			{
+				// While an IME composition is in progress the input method owns the keystroke (building, navigating, or committing the composition), so don't surface it as a KeyDown to the app. This matches WPF/Windows, where IME-processed keys aren't raised as key events.
+				// When starting a composition, the KeyDown event is sent for the first key, but not for subsequent keys. Only the last KeyUp for Enter key is sent, but not the KeyDown.
+				return;
+			}
+
+			base.OnKeyDown(e);
+		}
+		
+		public override void OnKeyUp(KeyEventArgs e)
+		{
+			if (Control.CurrentEditor is NSTextView textView && textView.HasMarkedText)
+			{
+				// While an IME composition is in progress the input method owns the keystroke (building, navigating, or committing the composition), so don't surface it as a KeyDown to the app. This matches WPF/Windows, where IME-processed keys aren't raised as key events.
+				// Only the last KeyUp for Enter key is sent, but not the KeyDown.
+				return;
+			}
+
+			base.OnKeyUp(e);
 		}
 	}
 }

--- a/src/Eto.Mac/Forms/MacFieldEditor.cs
+++ b/src/Eto.Mac/Forms/MacFieldEditor.cs
@@ -151,7 +151,7 @@ namespace Eto.Mac.Forms
 			var handler = settingMarkedText ? null : Handler as IMacTextBoxHandler;
 			if (handler != null)
 			{
-				var source = GetChangeSource(replacementString);
+				var source = GetChangeSource();
 				pendingSource = null;
 				var args = new TextChangingEventArgs(replacementString, affectedCharRange.ToEto(), source);
 				handler.Callback.OnTextChanging(handler.Widget, args);
@@ -187,7 +187,7 @@ namespace Eto.Mac.Forms
 		// ShouldChangeText delegate, so the semantic source is derived here: an action method
 		// (paste:/cut:) sets it explicitly, otherwise it's inferred from the composition state
 		// and finally the current event as a coarse fallback.
-		TextChangeSource GetChangeSource(string replacementString)
+		TextChangeSource GetChangeSource()
 		{
 			if (pendingSource != null)
 				return pendingSource.Value;

--- a/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/TextBoxHandler.cs
@@ -129,18 +129,21 @@ namespace Eto.Wpf.Forms.Controls
 
 		static Func<char, bool> testIsNonWord = ch => char.IsWhiteSpace(ch) || char.IsPunctuation(ch);
 
-		static Clipboard clipboard;
+		protected override bool SuppressKeyEvents => base.SuppressKeyEvents || DisableTextChanged > 0;
 
 		public override void AttachEvent(string id)
 		{
 			switch (id)
 			{
+				case Eto.Forms.Control.KeyDownEvent:
+				case Eto.Forms.Control.KeyUpEvent:
+					base.AttachEvent(id);
+					HandleEvent(Eto.Forms.TextBox.TextChangingEvent);
+					break;
 				case TextControl.TextChangedEvent:
 					TextBox.TextChanged += TextBox_TextChanged;
 					break;
 				case Eto.Forms.TextBox.TextChangingEvent:
-					if (clipboard == null)
-						clipboard = new Clipboard();
 					bool didUpdate = false;
 
 					swi.TextCompositionManager.AddPreviewTextInputStartHandler(TextBox, (sender, e) =>
@@ -194,13 +197,13 @@ namespace Eto.Wpf.Forms.Controls
 							if (tia.Cancel)
 							{
 								if (command == swi.ApplicationCommands.Cut)
-									clipboard.Text = text;
+									Clipboard.Instance.Text = text;
 								e.Handled = true;
 							}
 						}
 						else if (command == swi.ApplicationCommands.Paste)
 						{
-							var text = clipboard.Text;
+							var text = Clipboard.Instance.Text;
 							var tia = new TextChangingEventArgs(text, Selection, TextChangeSource.Paste);
 							Callback.OnTextChanging(Widget, tia);
 							e.Handled = tia.Cancel;

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -193,6 +193,8 @@ namespace Eto.Wpf.Forms
 
 		public virtual bool UseDragDropPreview => UseMousePreview;
 
+		protected virtual bool SuppressKeyEvents => false;
+
 		public sw.Size ParentMinimumSize
 		{
 			get { return parentMinimumSize; }
@@ -871,6 +873,9 @@ namespace Eto.Wpf.Forms
 
 		void HandleKeyDown(object sender, swi.KeyEventArgs e)
 		{
+			if (SuppressKeyEvents)
+				return;
+
 			var args = e.ToEto(KeyEventType.KeyDown);
 			if (args.KeyData != Keys.None)
 			{
@@ -881,6 +886,9 @@ namespace Eto.Wpf.Forms
 
 		void HandleKeyUp(object sender, swi.KeyEventArgs e)
 		{
+			if (SuppressKeyEvents)
+				return;
+			
 			var args = e.ToEto(KeyEventType.KeyUp);
 			if (args.KeyData != Keys.None)
 			{

--- a/test/Eto.Test/Sections/Controls/TextAreaSection.cs
+++ b/test/Eto.Test/Sections/Controls/TextAreaSection.cs
@@ -313,6 +313,10 @@ namespace Eto.Test.Sections.Controls
 			control.SelectionChanged += (sender, e) => Log.Write(control, "SelectionChanged, Selection: {0}", control.Selection);
 
 			control.CaretIndexChanged += (sender, e) => Log.Write(control, "CaretIndexChanged, CaretIndex: {0}", control.CaretIndex);
+
+			control.KeyDown += (sender, e) => Log.Write(control, $"KeyDown: {e.KeyData}");
+			
+			control.KeyUp += (sender, e) => Log.Write(control, $"KeyUp: {e.KeyData}");
 		}
 	}
 }

--- a/test/Eto.Test/Sections/Controls/TextBoxSection.cs
+++ b/test/Eto.Test/Sections/Controls/TextBoxSection.cs
@@ -101,7 +101,11 @@ namespace Eto.Test.Sections.Controls
 					e.Handled = true;
 					Log.Write(control, $"Selection: {control.Selection}");
 				}
+				else
+					Log.Write(control, $"KeyDown: {e.KeyData}");
 			};
+
+			control.KeyUp += (sender, e) => Log.Write(control, $"KeyUp: {e.KeyData}");
 		}
 	}
 }


### PR DESCRIPTION
When a user is composing text with IME, we should suppress key events (and selection/caret change events on WPF) as the OS composition should be responsible for handling things at that point.  We may only get the first KeyDown before composition (Mac), and the last KeyUp (Enter), but nothing in-between.