### PR TITLE
Add a flag to hide Autofill etc

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,74 @@ P/Invoke is a no-op here (needs a focused toplevel under a WM). There's **no win
   the shared `Eto.Test` project) — that's where you edit tests.
 - You **run** them via `test/Eto.Test.UnitTests/` — a thin runner project (only `Program.cs`)
   that references `Eto.Test.csproj`. Don't look for test code there.
+- **Backend-specific tests go in `test/Eto.Test.<Platform>/UnitTests/`** (e.g.
+  `test/Eto.Test.Mac/UnitTests/`, namespace `Eto.Test.Mac.UnitTests`, deriving from the shared
+  `Eto.Test.UnitTests.TestBase`). Put a test there rather than P/Invoking or reflecting your way to
+  native APIs from the shared project — those projects reference the backend and its bindings
+  directly (`Eto.Mac.Messaging`, `ObjCExtensions`, MonoMac types via global usings; note `Messaging`
+  is ambiguous with `MonoMac.ObjCRuntime.Messaging`, so qualify it as `Eto.Mac.Messaging`).
+- They run **both** ways: `Eto.Test.UnitTests` references the platform test apps and its
+  `Program.GetTestAssemblies()` yields each one (gated on `Platform.Instance.IsMac`/`IsGtk`/…), so
+  `dotnet test` picks them up; and the Eto.Test GUI app's **Unit Tests section** runs them via
+  `app.TestAssemblies.Add(typeof(Startup).Assembly)` in each platform's `Startup`. Discovery is
+  per-assembly, so a new fixture in an existing `Eto.Test.<Platform>/UnitTests/` folder needs no
+  registration. `dotnet test ... -- --platform=mac|gtk|wpf|winforms` overrides platform detection.
+
+## Mac: `AddMethod`/`ClassAddProtocol` are per-CLASS, not per-instance
+
+`MacBase.AddMethod` and `ObjCExtensions.ClassAddProtocol` both resolve `Class.GetHandle(view.GetType())`,
+so anything they add applies to **every instance of that native class, app-wide, forever**. The delegate
+bodies compensate by looking the handler up per instance (`MacBase.GetHandler(obj)`), but *conformance*
+does not — e.g. hooking `TextInput` on one `Drawable` used to make every `EtoDrawableView` conform to
+`NSTextInputClient`, so the OS treated them all as text input (AutoFill in their context menus).
+`MacViewTextInput` handles this by also overriding `inputContext`/`conformsToProtocol:` to answer per
+instance from `IMacViewHandler.HandlesTextInput`. Apply the same pattern for any new class-level state.
+
+**`e.Handled = true` in `MouseDown` silently kills the control's `ContextMenu` on Mac.**
+`MacView.TriggerMouseDown` only forwards to `objc_msgSendSuper` when `!args.Handled`, and it's that super
+call to `rightMouseDown:` that makes AppKit show the view's menu. A handler that blanket-sets `Handled`
+must exclude `MouseButtons.Alternate` (see `DrawableSection.InputMethodDrawable`).
+
+**Verifying such overrides needs raw `objc_msgSend`.** MonoMac's managed members (`NSView.InputContext`,
+`NSObject.ConformsToProtocol`, …) dispatch via `objc_msgSendSuper` for *managed subclasses*
+(`IsDirectBinding == false`), which skips the very override you added — so the managed API reports the
+un-overridden answer and the fix looks broken. Use `Eto.Mac.Messaging.*_objc_msgSend*` on `view.Handle`
+instead (see `Eto.Test.Mac/UnitTests/DrawableTests.IsTextInputClient`). AppKit itself calls through
+normal dispatch, so it does see the override.
+
+## Adding a member to a widget's `IHandler`
+
+Handler interfaces have no default implementations (core targets `netstandard2.0`), so a new member
+must be implemented in **every** registered backend or the build breaks. For a given widget, find
+them via `grep -rn "<Widget>.IHandler" src/ --include="*.cs"` — note `Eto.iOS`/`Eto.WinUI` often have
+theirs commented out in `Platform.cs` and so need nothing. On macOS/Linux you can only compile
+`Eto`, `Eto.Gtk` and `Eto.Mac`; `Eto.Wpf`/`Eto.WinForms` need Windows (net48 also needs the targeting
+pack) and `Eto.Android` needs the android workload — so those edits go in unverified by compile.
+
+Note this is a binary-breaking change for any third-party handler implementation.
+
+## `CheckBoxList` / `EnumCheckBoxList` gotcha
+
+**`SelectedValues`/`SelectedKeys` silently no-op until the control is loaded.** The setters iterate
+an internal `buttons` list that isn't populated until `CheckBoxList.OnLoad` assigns
+`DataStore = CreateDefaultItems()` — and that happens *after* `base.OnLoad` raises the `Load` event,
+so a `Load` handler is still too early. Set an initial selection from `LoadComplete` (or after
+touching `.Items`, which materializes the data store), never from the constructor.
+
+Also, `EnumCheckBoxList`'s `AddValue` filter matches on the enum **value**, not the name, so it can't
+tell apart two members that share a value — filtering out an aggregate like `All` also drops any
+single flag that happens to equal it, and the list can come up empty. Same reason `Enum.GetNames`
+reports both names for that value.
+
+## `[Flags]` enums that mean "everything, including future values"
+
+Enum members are inlined into consumers as **compile-time constants**, so redefining an aggregate
+(`All = A` → `All = A | B`) silently leaves already-compiled callers passing the old bits. Where a
+value means "all of it, whatever gets added later", give it every bit: `All = ~0` (see
+`ContextMenuSystemItems`; the BCL does the same with `EventKeywords.All = -1`). Handlers must then
+test `value != None` rather than `value.HasFlag(All)`, which only matches when *every* bit is set.
+`ToString()` still prints `All`, since exact member matches win over bitfield decomposition.
+Note `MenuBarSystemItems.All = Common | Quit` predates this and has the older shape.
 
 ## Platform / TFM mapping
 

--- a/src/Eto.Android/ContextMenuHandler.cs
+++ b/src/Eto.Android/ContextMenuHandler.cs
@@ -103,5 +103,8 @@ namespace Eto.Android
 		{
 			items.Clear();
 		}
+
+		// Android does not add any system items to a popup menu, so this is only stored to round-trip the value.
+		public ContextMenuSystemItems IncludeSystemItems { get; set; } = ContextMenuSystemItems.All;
 	}
 }

--- a/src/Eto.Gtk/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Gtk/Forms/Menu/ContextMenuHandler.cs
@@ -112,6 +112,9 @@ namespace Eto.GtkSharp.Forms.Menu
 			Changed?.Invoke(this, EventArgs.Empty);
 		}
 
+		// Gtk does not add any system items to a context menu, so this is only stored to round-trip the value.
+		public ContextMenuSystemItems IncludeSystemItems { get; set; } = ContextMenuSystemItems.All;
+
 		protected override Keys GetShortcut()
 		{
 			return Keys.None;

--- a/src/Eto.Mac/Forms/MacFieldEditor.cs
+++ b/src/Eto.Mac/Forms/MacFieldEditor.cs
@@ -230,16 +230,20 @@ namespace Eto.Mac.Forms
 			pendingSource = null;
 		}
 
+		static readonly IntPtr selMenuForEvent = Selector.GetHandle("menuForEvent:");
+
 		[Export("menuForEvent:")]
 		public NSMenu OnMenuForEvent(NSEvent theEvent)
 		{
-			var handler = MacViewHandler;
-			if (handler != null)
-			{
-				var nativeMenu = (handler.Widget.ContextMenu?.Handler as ContextMenuHandler)?.Control;
+			var nativeMenu = (MacViewHandler?.Widget.ContextMenu?.Handler as ContextMenuHandler)?.Control;
+			if (nativeMenu != null)
 				return nativeMenu;
-			}
-			return null;
+
+			// Fall back to the standard editing menu (Cut/Copy/Paste, Spelling, etc) when there is no ContextMenu,
+			// otherwise the control gets no menu at all - it is the field editor that supplies it for an NSTextField,
+			// not the NSTextField itself.  NSTextView hides NSView.MenuForEvent(NSEvent) with a different overload,
+			// so the base implementation has to be called directly.
+			return Messaging.GetNSObject<NSMenu>(Messaging.IntPtr_objc_msgSendSuper_IntPtr(SuperHandle, selMenuForEvent, theEvent.Handle));
 		}
 
 

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -137,6 +137,7 @@ namespace Eto.Mac.Forms
 		int SuppressMouseEvents { get; set; }
 		bool TextInputCancelled { get; set; }
 		bool TextInputImplemented { get; }
+		bool HandlesTextInput { get; }
 		bool UseNSBoxBackgroundColor { get; set; }
 		bool Enabled { get; set; }
 
@@ -175,6 +176,7 @@ namespace Eto.Mac.Forms
 		public static readonly object AcceptsFirstMouse_Key = new object();
 		public static readonly object TextInputCancelled_Key = new object();
 		public static readonly object TextInputImplemented_Key = new object();
+		public static readonly object HandlesTextInput_Key = new object();
 		public static readonly object AutoAttachNative_Key = new object();
 		public static readonly IntPtr selMouseDown = Selector.GetHandle("mouseDown:");
 		public static readonly IntPtr selMouseUp = Selector.GetHandle("mouseUp:");
@@ -1758,6 +1760,12 @@ namespace Eto.Mac.Forms
 		{
 			get => Widget.Properties.Get<bool>(MacView.TextInputImplemented_Key);
 			private set => Widget.Properties.Set(MacView.TextInputImplemented_Key, value);
+		}
+
+		public bool HandlesTextInput
+		{
+			get => Widget.Properties.Get<bool>(MacView.HandlesTextInput_Key);
+			private set => Widget.Properties.Set(MacView.HandlesTextInput_Key, value);
 		}
 
 		public virtual void UpdateLayout()

--- a/src/Eto.Mac/Forms/MacViewTextInput.cs
+++ b/src/Eto.Mac/Forms/MacViewTextInput.cs
@@ -104,6 +104,37 @@ namespace Eto.Mac.Forms
 				Messaging.void_objc_msgSendSuper_IntPtr(obj.SuperHandle, sel, selector);
 		}
 
+		// The NSTextInputClient protocol is added to the *class*, not the instance, so every control of that type
+		// conforms as soon as any single one of them handles the TextInput event.  The two overrides below report
+		// the truth per instance so the system only treats the controls that actually handle text input as text
+		// input - otherwise it adds things like AutoFill to the context menu of every control of that type.
+		static bool HandlesTextInput(IntPtr sender)
+		{
+			return MacBase.GetHandler(Runtime.GetNSObject(sender)) is IMacViewHandler handler && handler.HandlesTextInput;
+		}
+
+		internal static IntPtr InputContext_Selector = Selector.GetHandle("inputContext");
+		internal static MarshalDelegates.Func_IntPtr_IntPtr_IntPtr InputContext_Delegate = InputContext;
+		static IntPtr InputContext(IntPtr sender, IntPtr sel)
+		{
+			if (!HandlesTextInput(sender))
+				return IntPtr.Zero;
+
+			var obj = Runtime.GetNSObject(sender);
+			return Messaging.IntPtr_objc_msgSendSuper(obj.SuperHandle, sel);
+		}
+
+		internal static IntPtr ConformsToProtocol_Selector = Selector.GetHandle("conformsToProtocol:");
+		internal static MarshalDelegates.Func_IntPtr_IntPtr_IntPtr_bool ConformsToProtocol_Delegate = ConformsToProtocol;
+		static bool ConformsToProtocol(IntPtr sender, IntPtr sel, IntPtr protocol)
+		{
+			if (protocol == NSTextInputClientProtocol_Handle && !HandlesTextInput(sender))
+				return false;
+
+			var obj = Runtime.GetNSObject(sender);
+			return Messaging.bool_objc_msgSendSuper_IntPtr(obj.SuperHandle, sel, protocol);
+		}
+
 		internal static IntPtr NSTextInputClientProtocol_Handle = ObjCExtensions.GetProtocolHandle("NSTextInputClient");
 
 		static Selector selString = new Selector("string");
@@ -135,11 +166,15 @@ namespace Eto.Mac.Forms
 		public bool EnsureTextInputImplemented(NSView view = null)
 		{
 			view = view ?? TextInputControl;
-			
+
+			// this control actually handles text input, as opposed to merely being an instance of a class that
+			// had the NSTextInputClient protocol added to it by another control.  See MacViewTextInput.InputContext.
+			HandlesTextInput = true;
+
 			// determine whether we need to call InterpretKeyEvents ourselves or if it is already handled by the super class (e.g. NSTextView)
 			// for NSTextField (TextBox, etc), we handle the TextInput event via MacFieldEditor
 			TextInputImplemented = !ObjCExtensions.ClassConformsToProtocol(view.GetSuperclass(), MacViewTextInput.NSTextInputClientProtocol_Handle);
-			
+
 			// if it already conforms to the protocol, add the insertText:replacementRange method only
 			if (view.ConformsToProtocol(MacViewTextInput.NSTextInputClientProtocol_Handle))
 			{
@@ -164,7 +199,12 @@ namespace Eto.Mac.Forms
 			AddMethod(MacViewTextInput.CharacterIndexForPoint_Selector, MacViewTextInput.CharacterIndexForPoint_Delegate, "Q@:{CGPoint=gg}", view);
 			AddMethod(MacViewTextInput.FirstRectForCharacterRange_Selector, MacViewTextInput.FirstRectForCharacterRange_Delegate, "{CGRect=gggg}@:{NSRange=QQ}^{NSRange=QQ}", view);
 			AddMethod(MacViewTextInput.DoCommandBySelector_Selector, MacViewTextInput.DoCommandBySelector_Delegate, "v@:#", view);
-			
+
+			// the protocol above is added to the class, so keep the instances of it that don't handle text input
+			// from being treated as a text input client
+			AddMethod(MacViewTextInput.InputContext_Selector, MacViewTextInput.InputContext_Delegate, "@@:", view);
+			AddMethod(MacViewTextInput.ConformsToProtocol_Selector, MacViewTextInput.ConformsToProtocol_Delegate, "B@:@", view);
+
 			AddMethod(MacView.selInsertTextReplacementRange, MacView.TriggerTextInput_Delegate, "v@:@{NSRange=QQ}", view);
 			return true;
 		}

--- a/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
@@ -115,6 +115,8 @@ namespace Eto.Mac.Forms.Menu
 			var view = relativeTo?.GetContainerView();
 			MacView.InMouseTrackingLoop = false;
 
+			Control.AllowsContextMenuPlugIns = Widget.IncludeSystemItems.HasFlag(ContextMenuSystemItems.All);
+
 			if (location != null || view == null)
 			{
 				CGPoint cglocation;

--- a/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
@@ -110,12 +110,18 @@ namespace Eto.Mac.Forms.Menu
 			Control.RemoveAllItems();
 		}
 
+		public ContextMenuSystemItems IncludeSystemItems
+		{
+			// NSMenu.AllowsContextMenuPlugIns defaults to true, which matches ContextMenuSystemItems.All.
+			// Note All has every bit set, so test against None rather than using HasFlag(All) here.
+			get => Control.AllowsContextMenuPlugIns ? ContextMenuSystemItems.All : ContextMenuSystemItems.None;
+			set => Control.AllowsContextMenuPlugIns = value != ContextMenuSystemItems.None;
+		}
+
 		public void Show(Control relativeTo, PointF? location)
 		{
 			var view = relativeTo?.GetContainerView();
 			MacView.InMouseTrackingLoop = false;
-
-			Control.AllowsContextMenuPlugIns = Widget.IncludeSystemItems.HasFlag(ContextMenuSystemItems.All);
 
 			if (location != null || view == null)
 			{

--- a/src/Eto.Mac/Messaging.cs
+++ b/src/Eto.Mac/Messaging.cs
@@ -18,6 +18,9 @@ namespace Eto.Mac
 		}
 
 		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
+		public static extern IntPtr IntPtr_objc_msgSendSuper(IntPtr receiver, IntPtr selector);
+
+		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]
 		public static extern IntPtr IntPtr_objc_msgSendSuper_IntPtr(IntPtr receiver, IntPtr selector, IntPtr arg1);
 		
 		[DllImport(LIBOBJC_DYLIB, EntryPoint = "objc_msgSendSuper")]

--- a/src/Eto.WinForms/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.WinForms/Forms/Menu/ContextMenuHandler.cs
@@ -81,6 +81,9 @@ namespace Eto.WinForms.Forms.Menu
 			Control.Items.Clear();
 		}
 
+		// WinForms does not add any system items to a context menu, so this is only stored to round-trip the value.
+		public ContextMenuSystemItems IncludeSystemItems { get; set; } = ContextMenuSystemItems.All;
+
 		public void Show(Control relativeTo, PointF? location)
 		{
 			if (relativeTo != null)

--- a/src/Eto.Wpf/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Wpf/Forms/Menu/ContextMenuHandler.cs
@@ -71,6 +71,9 @@ namespace Eto.Wpf.Forms.Menu
 			Control.Items.Clear();
 		}
 
+		// Wpf does not add any system items to a context menu, so this is only stored to round-trip the value.
+		public ContextMenuSystemItems IncludeSystemItems { get; set; } = ContextMenuSystemItems.All;
+
 		public void Show(Control relativeTo, PointF? location)
 		{
 			if (relativeTo != null)

--- a/src/Eto/Forms/Menu/ContextMenu.cs
+++ b/src/Eto/Forms/Menu/ContextMenu.cs
@@ -15,7 +15,7 @@ public interface IContextMenuHost
 }
 
 /// <summary>
-/// Flags for the groups of system <see cref="MenuBar"/> items
+/// Flags for the groups of system <see cref="ContextMenu"/> items
 /// </summary>
 [Flags]
 public enum ContextMenuSystemItems
@@ -24,11 +24,17 @@ public enum ContextMenuSystemItems
 	/// Do not add any system items to the menu
 	/// </summary>
 	None = 0,
-	
+
 	/// <summary>
-	/// Add all system-defined menu bar items
+	/// Add all system-defined context menu items that apply to the control.
 	/// </summary>
-	All = 1
+	/// <remarks>
+	/// This deliberately has every bit set so that it keeps meaning "everything" as more specific values are
+	/// added, including for code compiled against an earlier version of Eto.  For the same reason, handlers should
+	/// test for the absence of items with <c>value != None</c> rather than <c>value.HasFlag(All)</c>, which would
+	/// only match when every bit is set.
+	/// </remarks>
+	All = ~0
 }
 
 /// <summary>
@@ -155,9 +161,21 @@ public class ContextMenu : Menu, ISubmenu
 	/// Gets or sets which system items will be automatically included with the menu.
 	/// </summary>
 	/// <remarks>
-	/// Some operating systems, such as OS X include contextual menu items such as AutoFill
+	/// Some operating systems, such as macOS, add their own contextual menu items - AutoFill, Services, and the like -
+	/// to any context menu shown for (or assigned to) a control.
+	///
+	/// Set this to <see cref="ContextMenuSystemItems.None"/> to show only the items you have added to <see cref="Items"/>.
+	///
+	/// This applies both to menus shown via <see cref="Show(Control, PointF?)"/> and to menus assigned to a control
+	/// using <see cref="Control.ContextMenu"/>.
 	/// </remarks>
-	public ContextMenuSystemItems IncludeSystemItems { get; set; } = ContextMenuSystemItems.All;
+	/// <value>The system items to include with the menu.  Defaults to <see cref="ContextMenuSystemItems.All"/></value>
+	[DefaultValue(ContextMenuSystemItems.All)]
+	public ContextMenuSystemItems IncludeSystemItems
+	{
+		get => Handler.IncludeSystemItems;
+		set => Handler.IncludeSystemItems = value;
+	}
 
 	/// <summary>
 	/// Called when the menu is assigned to a control/window
@@ -328,5 +346,16 @@ public class ContextMenu : Menu, ISubmenu
 		/// <param name="relativeTo">Control to show the menu relative to, or null to use screen co-ordinates for <paramref name="location"/></param>
 		/// <param name="location">Location to place the upper left of the context menu, or null to use the mouse position</param>
 		void Show(Control relativeTo, PointF? location);
+
+		/// <summary>
+		/// Gets or sets which system items will be automatically included with the menu.
+		/// </summary>
+		/// <remarks>
+		/// This must be applied to the native menu immediately so that it also takes effect for menus assigned to a
+		/// control via <see cref="Control.ContextMenu"/>, which are shown by the operating system without going through
+		/// <see cref="Show(Control, PointF?)"/>.
+		/// </remarks>
+		/// <value>The system items to include with the menu.  Defaults to <see cref="ContextMenuSystemItems.All"/></value>
+		ContextMenuSystemItems IncludeSystemItems { get; set; }
 	}
 }

--- a/src/Eto/Forms/Menu/ContextMenu.cs
+++ b/src/Eto/Forms/Menu/ContextMenu.cs
@@ -15,6 +15,23 @@ public interface IContextMenuHost
 }
 
 /// <summary>
+/// Flags for the groups of system <see cref="MenuBar"/> items
+/// </summary>
+[Flags]
+public enum ContextMenuSystemItems
+{
+	/// <summary>
+	/// Do not add any system items to the menu
+	/// </summary>
+	None = 0,
+	
+	/// <summary>
+	/// Add all system-defined menu bar items
+	/// </summary>
+	All = 1
+}
+
+/// <summary>
 /// Represents a context menu that can be shown typically when users right click or press the menu key on a control
 /// </summary>
 /// <copyright>(c) 2014 by Curtis Wensley</copyright>
@@ -133,6 +150,14 @@ public class ContextMenu : Menu, ISubmenu
 		OnLoad(EventArgs.Empty);
 		Handler.Show(relativeTo, location);
 	}
+
+	/// <summary>
+	/// Gets or sets which system items will be automatically included with the menu.
+	/// </summary>
+	/// <remarks>
+	/// Some operating systems, such as OS X include contextual menu items such as AutoFill
+	/// </remarks>
+	public ContextMenuSystemItems IncludeSystemItems { get; set; } = ContextMenuSystemItems.All;
 
 	/// <summary>
 	/// Called when the menu is assigned to a control/window

--- a/test/Eto.Test.Mac/UnitTests/DrawableTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/DrawableTests.cs
@@ -24,6 +24,52 @@ namespace Eto.Test.Mac.UnitTests
 			return drawable;
 
 		});
-        
-    }
+
+		/// <summary>
+		/// The NSTextInputClient protocol has to be added to the native class of the control, not the instance, so
+		/// hooking up TextInput on one Drawable used to make every Drawable in the app look like a text input to the
+		/// system - which adds items such as AutoFill to their context menus.
+		/// </summary>
+		[Test]
+		public void TextInputShouldOnlyApplyToTheControlThatHandlesIt()
+		{
+			Drawable withTextInput = null;
+			Drawable withoutTextInput = null;
+			Shown(form =>
+			{
+				withTextInput = new Drawable { Size = new Size(50, 50), CanFocus = true };
+				withTextInput.TextInput += (sender, e) => { };
+				withoutTextInput = new Drawable { Size = new Size(50, 50), CanFocus = true };
+
+				form.Content = new StackLayout { Items = { withTextInput, withoutTextInput } };
+			},
+			() =>
+			{
+				// created after the protocol was already added to the class
+				var createdAfter = new Drawable { Size = new Size(50, 50), CanFocus = true };
+
+				Assert.That(IsTextInputClient(withTextInput), Is.True, "#1 - Drawable handling TextInput should be a text input client");
+				Assert.That(IsTextInputClient(withoutTextInput), Is.False, "#2 - Drawable not handling TextInput should not be a text input client");
+				Assert.That(IsTextInputClient(createdAfter), Is.False, "#3 - Drawable created afterwards should not be a text input client");
+			});
+		}
+
+		static readonly IntPtr s_textInputClientProtocol = Eto.Mac.ObjCExtensions.GetProtocolHandle("NSTextInputClient");
+		static readonly IntPtr s_conformsToProtocol = Selector.GetHandle("conformsToProtocol:");
+		static readonly IntPtr s_inputContext = Selector.GetHandle("inputContext");
+
+		/// <summary>
+		/// Asks the native view whether the system considers it a text input client.  This has to go through
+		/// objc_msgSend since the managed NSView members dispatch to the superclass for managed subclasses, which
+		/// would bypass the very overrides being tested here.
+		/// </summary>
+		static bool IsTextInputClient(Control control)
+		{
+			var handle = ((NSView)control.ControlObject).Handle;
+			var conforms = Eto.Mac.Messaging.bool_objc_msgSend_IntPtr(handle, s_conformsToProtocol, s_textInputClientProtocol);
+			var inputContext = Eto.Mac.Messaging.IntPtr_objc_msgSend(handle, s_inputContext);
+			Assert.That(conforms, Is.EqualTo(inputContext != IntPtr.Zero), "conformsToProtocol: and inputContext should agree");
+			return conforms;
+		}
+	}
 }

--- a/test/Eto.Test.Mac/UnitTests/TextBoxTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/TextBoxTests.cs
@@ -1,0 +1,59 @@
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+
+namespace Eto.Test.Mac.UnitTests
+{
+	[TestFixture]
+	public class TextBoxTests : TestBase
+	{
+		/// <summary>
+		/// It is the field editor that supplies a text field's menu, not the NSTextField, so the field editor must
+		/// fall back to the standard editing menu when the TextBox has no ContextMenu of its own - otherwise right
+		/// clicking it shows nothing at all.
+		/// </summary>
+		[Test]
+		public void RightClickShouldShowDefaultMenuWithoutContextMenu()
+		{
+			TextBox textBox = null;
+			ContextMenu contextMenu = null;
+			Shown(form =>
+			{
+				textBox = new TextBox { Text = "Some Text" };
+				contextMenu = new ContextMenu(new ButtonMenuItem { Text = "Custom Item 1" });
+				form.Content = textBox;
+			},
+			() =>
+			{
+				textBox.Focus();
+
+				var defaultItems = GetFieldEditorMenuItemCount(textBox);
+				Assert.That(defaultItems, Is.GreaterThan(0), "#1 - Should fall back to the standard editing menu");
+
+				textBox.ContextMenu = contextMenu;
+				Assert.That(GetFieldEditorMenuItemCount(textBox), Is.EqualTo(1), "#2 - ContextMenu should replace the default menu");
+
+				textBox.ContextMenu = null;
+				Assert.That(GetFieldEditorMenuItemCount(textBox), Is.EqualTo(defaultItems), "#3 - Should go back to the standard editing menu");
+			});
+		}
+
+		static readonly IntPtr s_menuForEvent = Selector.GetHandle("menuForEvent:");
+
+		/// <summary>
+		/// Asks the native field editor which menu it would show for a right click.  This has to go through
+		/// objc_msgSend since the managed NSView members dispatch to the superclass for managed subclasses, which
+		/// would bypass the very override being tested here.
+		/// </summary>
+		static int GetFieldEditorMenuItemCount(TextBox textBox)
+		{
+			var editor = ((NSControl)textBox.ControlObject).CurrentEditor;
+			Assert.That(editor, Is.Not.Null, "TextBox should have a field editor while focused");
+
+			// the location doesn't matter, menuForEvent: just needs a real event
+			var theEvent = NSEvent.MouseEvent(NSEventType.RightMouseDown, CGPoint.Empty, 0, 0, 0, null, 0, 1, 1);
+
+			var menu = Eto.Mac.Messaging.IntPtr_objc_msgSend_IntPtr(editor.Handle, s_menuForEvent, theEvent.Handle);
+			return menu == IntPtr.Zero ? 0 : (int)Runtime.GetNSObject<NSMenu>(menu).Count;
+		}
+	}
+}

--- a/test/Eto.Test/Sections/Behaviors/ContextMenuSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/ContextMenuSection.cs
@@ -7,6 +7,7 @@ namespace Eto.Test.Sections.Behaviors
 		public bool UseLocation { get; set; }
 
 		PointF location = new PointF(100, 100);
+		EnumCheckBoxList<ContextMenuSystemItems> systemItems;
 
 		public ContextMenuSection() : this(false)
 		{
@@ -24,7 +25,17 @@ namespace Eto.Test.Sections.Behaviors
 
 			var locationInput = PointControl(() => location, p => location = p);
 
+			var systemItemsControl = CreateSystemItemsControl();
+
 			var contextMenuLabel = CreateContextMenuLabel();
+
+			// assigned directly to a control, so it is shown by the OS instead of via ContextMenu.Show()
+			var contextMenuTextBox = new TextBox
+			{
+				Text = "TextBox with assigned ContextMenu",
+				Width = 300,
+				ContextMenu = CreateMenu()
+			};
 
 			var showInDialog = new Button { Text = "Show in Dialog" };
 			showInDialog.Click += (sender, e) =>
@@ -40,13 +51,39 @@ namespace Eto.Test.Sections.Behaviors
 			layout.BeginCentered();
 			layout.AddAutoSized(relativeToLabelCheckBox);
 			layout.AddSeparateRow(useLocationCheckBox, locationInput);
+			layout.AddSeparateRow("IncludeSystemItems:", systemItemsControl);
 			if (!inDialog)
 				layout.AddAutoSized(showInDialog);
 			layout.EndCentered();
 
-			layout.AddCentered(contextMenuLabel, yscale: true);
+			layout.AddSpace();
+			layout.AddCentered(contextMenuLabel);
+			layout.AddCentered(contextMenuTextBox);
+			layout.AddSpace();
 
 			Content = layout;
+		}
+
+		Control CreateSystemItemsControl()
+		{
+			systemItems = new EnumCheckBoxList<ContextMenuSystemItems>();
+			// the check boxes aren't created until the control is loaded, so the initial selection can only be
+			// set once they exist - setting it in the constructor silently does nothing.
+			systemItems.LoadComplete += (sender, e) => systemItems.SelectedValues = new[] { ContextMenuSystemItems.All };
+			systemItems.SelectedValuesChanged += (sender, e) =>
+			{
+				if (_menu != null)
+					_menu.IncludeSystemItems = GetSystemItems();
+			};
+			return systemItems;
+		}
+
+		ContextMenuSystemItems GetSystemItems()
+		{
+			var value = ContextMenuSystemItems.None;
+			foreach (var item in systemItems.SelectedValues)
+				value |= item;
+			return value;
 		}
 
 		Control PointControl(Func<PointF> getValue, Action<PointF> setValue)

--- a/test/Eto.Test/Sections/Controls/DrawableSection.cs
+++ b/test/Eto.Test/Sections/Controls/DrawableSection.cs
@@ -14,7 +14,7 @@ namespace Eto.Test.Sections.Controls
 					TableLayout.HorizontalScaled(
 						10,
 						new TableLayout(
-							"Default",
+							"Default (right click)",
 							Default()
 						),
 						new TableLayout(
@@ -68,7 +68,10 @@ namespace Eto.Test.Sections.Controls
 		{
 			var control = new Drawable
 			{
-				Size = new Size(50, 50)
+				Size = new Size(50, 50),
+				// this drawable does not handle TextInput, so the system should not add items such as
+				// AutoFill to its menu - compare with the IME Input drawable below, which does.
+				ContextMenu = CreateContextMenu("Default")
 			};
 			control.Paint += delegate(object sender, PaintEventArgs pe)
 			{
@@ -77,6 +80,18 @@ namespace Eto.Test.Sections.Controls
 			LogEvents(control, "Default");
 
 			return control;
+		}
+
+		ContextMenu CreateContextMenu(string name)
+		{
+			var menu = new ContextMenu();
+			for (var i = 1; i <= 2; i++)
+			{
+				var item = new ButtonMenuItem { Text = $"Custom Item {i}" };
+				item.Click += (sender, e) => Log.Write(name, $"Clicked {((ButtonMenuItem)sender).Text}");
+				menu.Items.Add(item);
+			}
+			return menu;
 		}
 
 		Control WithBackground()
@@ -288,11 +303,14 @@ namespace Eto.Test.Sections.Controls
 			var text = string.Empty;
 			var compositionText = string.Empty;
 			var compositionActive = false;
+			var contextMenu = CreateContextMenu("IME Input");
 			var drawable = new Drawable
 			{
 				CanFocus = true,
 				Size = new Size(420, 60),
-				BackgroundColor = Colors.White
+				BackgroundColor = Colors.White,
+				// this drawable handles TextInput, so the system may add its own items (AutoFill, etc) to the menu
+				ContextMenu = contextMenu
 			};
 			var font = SystemFonts.Default();
 
@@ -346,7 +364,8 @@ namespace Eto.Test.Sections.Controls
 				else
 					drawable.CancelTextComposition();
 				drawable.Focus();
-				e.Handled = true;
+				// don't handle the alternate button, otherwise the platform never gets to show the ContextMenu
+				e.Handled = e.Buttons != MouseButtons.Alternate;
 			};
 			drawable.TextInput += (sender, e) =>
 			{
@@ -385,6 +404,18 @@ namespace Eto.Test.Sections.Controls
 
 			updateCaret();
 
+			var includeSystemItems = new EnumCheckBoxList<ContextMenuSystemItems>();
+			// the check boxes aren't created until the control is loaded, so the initial selection can only be
+			// set once they exist - setting it in the constructor silently does nothing.
+			includeSystemItems.LoadComplete += (sender, e) => includeSystemItems.SelectedValues = new[] { ContextMenuSystemItems.All };
+			includeSystemItems.SelectedValuesChanged += (sender, e) =>
+			{
+				var value = ContextMenuSystemItems.None;
+				foreach (var item in includeSystemItems.SelectedValues)
+					value |= item;
+				contextMenu.IncludeSystemItems = value;
+			};
+
 			return new StackLayout
 			{
 				HorizontalContentAlignment = HorizontalAlignment.Stretch,
@@ -392,6 +423,10 @@ namespace Eto.Test.Sections.Controls
 				Items =
 				{
 					"Click inside the drawable and type with an IME. The candidate/composition UI should follow the caret.",
+					"Right click it to show its ContextMenu. Since this drawable handles TextInput, the system may add"
+						+ " its own items (AutoFill, etc)\nunless IncludeSystemItems is cleared. The 'Default' drawable"
+						+ " above does not handle TextInput, so it should never show them.",
+					new StackLayout { Orientation = Orientation.Horizontal, Spacing = 6, Items = { "IncludeSystemItems:", includeSystemItems } },
 					drawable
 				}
 			};

--- a/test/Eto.Test/Sections/Controls/TextAreaSection.cs
+++ b/test/Eto.Test/Sections/Controls/TextAreaSection.cs
@@ -15,6 +15,7 @@ namespace Eto.Test.Sections.Controls
 
 			if (text.ContextMenu != null)
 			{
+				// text.ContextMenu.IncludeSystemItems = ContextMenuSystemItems.None;
 				text.ContextMenu.Items.Insert(0, new ButtonMenuItem(TestItemClick) { Text = "Test" });
 				text.ContextMenu.Items.Insert(1, new SeparatorMenuItem());
 			}

--- a/test/Eto.Test/UnitTests/Forms/ContextMenuTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/ContextMenuTests.cs
@@ -1,0 +1,184 @@
+using NUnit.Framework;
+using System.Reflection;
+
+namespace Eto.Test.UnitTests.Forms;
+
+[TestFixture]
+public class ContextMenuTests : TestBase
+{
+	[Test, InvokeOnUI]
+	public void IncludeSystemItemsShouldDefaultToAll()
+	{
+		var menu = new ContextMenu();
+		Assert.That(menu.IncludeSystemItems, Is.EqualTo(ContextMenuSystemItems.All));
+	}
+
+	[TestCase(ContextMenuSystemItems.None)]
+	[TestCase(ContextMenuSystemItems.All)]
+	[InvokeOnUI]
+	public void IncludeSystemItemsShouldRoundTrip(ContextMenuSystemItems items)
+	{
+		var menu = new ContextMenu();
+		menu.IncludeSystemItems = items;
+		Assert.That(menu.IncludeSystemItems, Is.EqualTo(items));
+	}
+
+	/// <summary>
+	/// <see cref="ContextMenuSystemItems.All"/> has every bit set so that it keeps meaning "everything" as more
+	/// specific values are added - including for code already compiled against an earlier version, since enum
+	/// members are inlined as constants.  Redefining it as an OR of the named values would break that.
+	/// </summary>
+	[Test]
+	public void AllShouldIncludeValuesAddedInTheFuture()
+	{
+		var notYetDefined = (ContextMenuSystemItems)(1 << 20);
+		Assert.That(ContextMenuSystemItems.All.HasFlag(notYetDefined), Is.True);
+		Assert.That(ContextMenuSystemItems.All, Is.Not.EqualTo(ContextMenuSystemItems.None));
+	}
+
+	/// <summary>
+	/// The value must be pushed to the native menu as soon as it is set, not when the menu is shown, otherwise it
+	/// would never be applied to a menu assigned to a control via <see cref="Control.ContextMenu"/> since those are
+	/// shown by the OS without going through <see cref="ContextMenu.Show(Control, PointF?)"/>.
+	/// </summary>
+	[Test, InvokeOnUI]
+	public void IncludeSystemItemsShouldApplyToNativeMenuWithoutShowing()
+	{
+		if (!Platform.Instance.IsMac)
+			Assert.Ignore("Only macOS adds its own items to a context menu");
+
+		var menu = new ContextMenu(new ButtonMenuItem { Text = "Item 1" });
+		Assert.That(GetNativeAllowsSystemItems(menu), Is.True, "#1 - System items should be allowed by default");
+
+		menu.IncludeSystemItems = ContextMenuSystemItems.None;
+		Assert.That(GetNativeAllowsSystemItems(menu), Is.False, "#2 - Should be applied to the native menu immediately");
+
+		menu.IncludeSystemItems = ContextMenuSystemItems.All;
+		Assert.That(GetNativeAllowsSystemItems(menu), Is.True, "#3 - Should be applied to the native menu immediately");
+	}
+
+	[Test, InvokeOnUI]
+	public void IncludeSystemItemsShouldApplyWhenAssignedToControl()
+	{
+		var menu = new ContextMenu(new ButtonMenuItem { Text = "Item 1" }) { IncludeSystemItems = ContextMenuSystemItems.None };
+		var textBox = new TextBox { ContextMenu = menu };
+
+		Assert.That(textBox.ContextMenu, Is.SameAs(menu), "#1 - Menu should be returned as-is when assigned");
+		Assert.That(textBox.ContextMenu.IncludeSystemItems, Is.EqualTo(ContextMenuSystemItems.None), "#2");
+
+		if (Platform.Instance.IsMac)
+			Assert.That(GetNativeAllowsSystemItems(menu), Is.False, "#3 - Native menu assigned to the control should not allow system items");
+	}
+
+	/// <summary>
+	/// Reads NSMenu.AllowsContextMenuPlugIns without referencing the Mac backend from this shared project.
+	/// </summary>
+	static bool GetNativeAllowsSystemItems(ContextMenu menu)
+	{
+		var control = menu.ControlObject;
+		var property = control?.GetType().GetProperty("AllowsContextMenuPlugIns", BindingFlags.Public | BindingFlags.Instance);
+		Assert.That(property, Is.Not.Null, "Could not find NSMenu.AllowsContextMenuPlugIns on the native menu");
+		return (bool)property.GetValue(control);
+	}
+
+	[Test, ManualTest]
+	public void SystemItemsShouldOnlyBeIncludedWhenSpecified()
+	{
+		ManualForm(
+			"Right click each text box.\n"
+			+ "The top one should show ONLY 'Custom Item 1/2'.\n"
+			+ "The bottom one should also show system items (AutoFill, Services, ...) on macOS.",
+			form =>
+			{
+				var without = new TextBox
+				{
+					Text = "IncludeSystemItems = None",
+					ContextMenu = CreateMenu(ContextMenuSystemItems.None)
+				};
+				var with = new TextBox
+				{
+					Text = "IncludeSystemItems = All",
+					ContextMenu = CreateMenu(ContextMenuSystemItems.All)
+				};
+
+				return new StackLayout
+				{
+					Spacing = 10,
+					HorizontalContentAlignment = HorizontalAlignment.Stretch,
+					Items = { without, with }
+				};
+			});
+	}
+
+	[Test, ManualTest]
+	public void SystemItemsShouldNotBeIncludedWhenShownManually()
+	{
+		ManualForm(
+			"Right click the text box.  It should show ONLY 'Custom Item 1/2'.",
+			form =>
+			{
+				var menu = CreateMenu(ContextMenuSystemItems.None);
+				var textBox = new TextBox { Text = "Shown via ContextMenu.Show()" };
+				textBox.MouseDown += (sender, e) =>
+				{
+					if (e.Buttons == MouseButtons.Alternate)
+					{
+						menu.Show(textBox);
+						e.Handled = true;
+					}
+				};
+				return textBox;
+			});
+	}
+
+	/// <summary>
+	/// A Drawable only accepts text input when its TextInput event is hooked up, so only that one should get the
+	/// system's text input items - even though on macOS both share the same native class.
+	/// </summary>
+	[Test, ManualTest]
+	public void SystemItemsShouldNotBeIncludedForControlsThatDontTakeTextInput()
+	{
+		ManualForm(
+			"Right click each box.\n"
+			+ "The top one handles TextInput, so it may show system items (AutoFill, ...) on macOS.\n"
+			+ "The bottom one does NOT, so it should show ONLY 'Custom Item 1/2'.",
+			form =>
+			{
+				var withTextInput = CreateDrawable("Handles TextInput", Colors.SteelBlue);
+				withTextInput.TextInput += (sender, e) => Log.Write(sender, $"TextInput: {e.Text}");
+				var withoutTextInput = CreateDrawable("No TextInput", Colors.DarkSlateGray);
+
+				return new StackLayout
+				{
+					Spacing = 10,
+					HorizontalContentAlignment = HorizontalAlignment.Stretch,
+					Items = { withTextInput, withoutTextInput }
+				};
+			});
+	}
+
+	static Drawable CreateDrawable(string text, Color color)
+	{
+		var drawable = new Drawable
+		{
+			Size = new Size(250, 60),
+			CanFocus = true,
+			ContextMenu = CreateMenu(ContextMenuSystemItems.All)
+		};
+		drawable.Paint += (sender, e) =>
+		{
+			e.Graphics.FillRectangle(color, e.ClipRectangle);
+			e.Graphics.DrawText(SystemFonts.Default(), Colors.White, 4, 4, text);
+		};
+		return drawable;
+	}
+
+	static ContextMenu CreateMenu(ContextMenuSystemItems includeSystemItems)
+	{
+		var menu = new ContextMenu(
+			new ButtonMenuItem { Text = "Custom Item 1" },
+			new ButtonMenuItem { Text = "Custom Item 2" });
+		menu.IncludeSystemItems = includeSystemItems;
+		return menu;
+	}
+}


### PR DESCRIPTION
On Mac the ContextMenus often have AutoFill and I find it overzealous in many circumstances.
This PR adds an enum flag which matches the `Menu` item.

<img width="357" height="366" alt="image" src="https://github.com/user-attachments/assets/e2b5de60-a4ed-4579-bb40-c9ec7ea50919" />

This also fixes the issue where the context menu was no longer appearing on a TextBox.