### PR TITLE
Don't use TryGetData<object>

### DIFF
--- a/src/Eto.WinForms/Forms/ClipboardHandler.cs
+++ b/src/Eto.WinForms/Forms/ClipboardHandler.cs
@@ -105,12 +105,9 @@ namespace Eto.WinForms.Forms
 
 		protected override object InnerGetData(string type)
 		{
-#if NET10_0_OR_GREATER
-			swf.Clipboard.TryGetData<object>(type, out var data);
-			return data;
-#else
+#pragma warning disable WFDEV005
 			return swf.Clipboard.GetData(type);
-#endif
+#pragma warning restore WFDEV005
 		}
 
 

--- a/src/Eto.Wpf/Forms/DataObjectHandler.cs
+++ b/src/Eto.Wpf/Forms/DataObjectHandler.cs
@@ -60,11 +60,9 @@ namespace Eto.WinForms.Forms
 			try
 			{
 				// WPF can throw exceptions here for FileContents, maybe others.
-#if NET10_0_OR_GREATER
-				Control.TryGetData<object>(type, out var data);
-#else
+#pragma warning disable WFDEV005
 				var data = Control.GetData(type);
-#endif
+#pragma warning restore WFDEV005
 				if (data != null)
 					return data;
 			}


### PR DESCRIPTION
This fails as it requires a concrete type. For now keep using the obsolete method and suppress the warnings.

Fixes #3004