### PR TITLE
Wpf: Fix using icons with ListBox

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/ListBoxHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ListBoxHandler.cs
@@ -19,7 +19,7 @@ namespace Eto.Wpf.Forms.Controls
 				typeof(EtoListBox),
 				new sw.FrameworkPropertyMetadata(null));
 
-		public IIndirectBinding<Image> ItemImageBinding
+		public IIndirectBinding<Image> ImageBinding
 		{
 			get { return (IIndirectBinding<Image>)GetValue(ImageBindingProperty); }
 			set { SetValue(ImageBindingProperty, value); }
@@ -27,7 +27,7 @@ namespace Eto.Wpf.Forms.Controls
 
 		public static readonly sw.DependencyProperty ImageBindingProperty =
 			sw.DependencyProperty.Register(
-				nameof(ItemImageBinding),
+				nameof(ImageBinding),
 				typeof(IIndirectBinding<Image>),
 				typeof(EtoListBox),
 				new sw.FrameworkPropertyMetadata(null));
@@ -147,10 +147,10 @@ namespace Eto.Wpf.Forms.Controls
 
 		public IIndirectBinding<Image> ItemImageBinding
 		{
-			get => Control.ItemImageBinding;
+			get => Control.ImageBinding;
 			set
 			{
-				Control.ItemImageBinding = value;
+				Control.ImageBinding = value;
 				Control.InvalidateVisual();
 			}
 		}


### PR DESCRIPTION
These broke when reworking how the item template was set up into xaml instead of code.