### PR TITLE
DragDropLib fixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,12 @@ jobs:
     - name: Run unit tests (Wpf)
       timeout-minutes: 30
       continue-on-error: true # TODO: remove once the existing test failures are fixed
-      run: dotnet test --project test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj -f net10.0-windows -c ${{ env.BuildConfiguration }} --no-build --filter "TestCategory!=ManualTest" -- --platform=wpf
+      run: dotnet test --project test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj -f net10.0-windows -c ${{ env.BuildConfiguration }} --no-build --filter "TestCategory!=ManualTest" -- --platform=wpf --report-trx --report-trx-filename wpf.trx
+
+    - name: Test summary (Wpf)
+      if: ${{ always() }}
+      shell: pwsh
+      run: ./build/TestSummary.ps1 -Title "Unit tests (Wpf)" -FileName wpf.trx
 
     - name: Upload log files
       if: ${{ failure() }}
@@ -156,7 +161,12 @@ jobs:
     - name: Run unit tests (Mac)
       timeout-minutes: 30
       continue-on-error: true # TODO: remove once the existing test failures are fixed
-      run: dotnet test --project test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj -f net10.0 -c ${{ env.BuildConfiguration }} --no-build --filter "TestCategory!=ManualTest" -- --platform=mac
+      run: dotnet test --project test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj -f net10.0 -c ${{ env.BuildConfiguration }} --no-build --filter "TestCategory!=ManualTest" -- --platform=mac --report-trx --report-trx-filename mac.trx
+
+    - name: Test summary (Mac)
+      if: ${{ always() }}
+      shell: pwsh
+      run: ./build/TestSummary.ps1 -Title "Unit tests (Mac)" -FileName mac.trx
 
     - name: Upload log files
       if: ${{ failure() }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,7 +29,7 @@ jobs:
         dotnet-version: ${{ env.DotNetVersion }}
 
     - name: Create global.json
-      run: echo '{"sdk":{"version":"${{ env.DotNetVersion }}"}}' > global.json
+      run: echo '{"sdk":{"version":"${{ env.DotNetVersion }}"},"test":{"runner":"Microsoft.Testing.Platform"}}' > global.json
 
     - name: Build
       run: dotnet build ${{ env.BuildParameters }} /p:Platform=Windows /t:Build /bl:artifacts/log/Build.Windows.binlog
@@ -54,6 +54,17 @@ jobs:
         name: samples-win
         path: artifacts/samples/*/${{ env.BuildConfiguration }}/**/*
 
+    # These are GUI tests that create real windows, so they need a desktop session to run in.
+    # Windows runners already provide one, so no extra setup is needed here - only the timeout
+    # guard so a test that blocks waiting on the UI can't hang the job for its full 6 hours.
+    # --no-build (which implies --no-restore) runs exactly the binaries the Build step produced
+    # above; without it dotnet test rebuilds them without Platform/BuildVersion set, so the tested
+    # assemblies would be recompiled with a different version stamp than the uploaded artifacts.
+    - name: Run unit tests (Wpf)
+      timeout-minutes: 30
+      continue-on-error: true # TODO: remove once the existing test failures are fixed
+      run: dotnet test --project test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj -f net10.0-windows -c ${{ env.BuildConfiguration }} --no-build --filter "TestCategory!=ManualTest" -- --platform=wpf
+
     - name: Upload log files
       if: ${{ failure() }}
       uses: actions/upload-artifact@v6
@@ -76,7 +87,7 @@ jobs:
         dotnet-version: ${{ env.DotNetVersion }}
 
     - name: Create global.json
-      run: del global.json || echo '{"sdk":{"version":"${{ env.DotNetVersion }}"}}' > global.json
+      run: del global.json || echo '{"sdk":{"version":"${{ env.DotNetVersion }}"},"test":{"runner":"Microsoft.Testing.Platform"}}' > global.json
       
     - name: Clear nuget cache
       run: dotnet nuget locals all --clear
@@ -137,6 +148,15 @@ jobs:
         path: |
           artifacts/test/Eto.Test.Mac64/${{ env.BuildConfiguration }}/**/Eto.Test.Mac64.dmg
           artifacts/test/Eto.Test.macOS/${{ env.BuildConfiguration }}/**/Eto.Test.macOS*.pkg
+
+    # These are GUI tests that create real windows, so they need a desktop session to run in. The
+    # macOS runners are auto-logged in to one, so AppKit can reach the window server without any
+    # extra setup - only the timeout guard so a test that blocks waiting on the UI can't hang the
+    # job for its full 6 hours. See the Wpf step above for why --no-build is used.
+    - name: Run unit tests (Mac)
+      timeout-minutes: 30
+      continue-on-error: true # TODO: remove once the existing test failures are fixed
+      run: dotnet test --project test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj -f net10.0 -c ${{ env.BuildConfiguration }} --no-build --filter "TestCategory!=ManualTest" -- --platform=mac
 
     - name: Upload log files
       if: ${{ failure() }}

--- a/build/TestSummary.ps1
+++ b/build/TestSummary.ps1
@@ -1,0 +1,158 @@
+<#
+.SYNOPSIS
+    Renders trx test results into a GitHub Actions job summary.
+
+.DESCRIPTION
+    Reads the trx report(s) written by the unit test run and appends a markdown summary to
+    $env:GITHUB_STEP_SUMMARY - a totals table plus a collapsible entry per failed test - so
+    results can be read from the run page without digging through the raw job log. Failures are
+    also emitted as workflow error annotations, which surface them on the PR diff when the trx
+    stack trace points at a file in the repository.
+
+    Writes to stdout when run outside of Actions, so it can be tested locally:
+        pwsh build/TestSummary.ps1 -Title "Unit tests (Mac)"
+#>
+[CmdletBinding()]
+param(
+	# Heading for this run, e.g. "Unit tests (Wpf)".
+	[Parameter(Mandatory)][string]$Title,
+	# Directory searched (recursively) for trx reports.
+	[string]$ResultsRoot = 'artifacts/test',
+	# Name/pattern of the trx report(s) to read.
+	[string]$FileName = '*.trx',
+	# Cap the per-test detail so a badly broken run can't blow the 1MB summary limit.
+	[int]$MaxFailures = 50,
+	# GitHub only displays the first handful of annotations per step, so don't bother emitting more.
+	[int]$MaxAnnotations = 10
+)
+
+$ErrorActionPreference = 'Stop'
+
+$summary = [System.Text.StringBuilder]::new()
+function Add-Line([string]$text = '') { [void]$summary.AppendLine($text) }
+
+# Fenced code blocks are used for failure details, so make sure the content can't end one early.
+function Format-Block([string]$text)
+{
+	if ([string]::IsNullOrWhiteSpace($text)) { return $null }
+	return $text.Replace('```', "'''").TrimEnd()
+}
+
+$files = @(Get-ChildItem -Path $ResultsRoot -Recurse -Filter $FileName -File -ErrorAction SilentlyContinue)
+
+Add-Line "## $Title"
+Add-Line
+
+if ($files.Count -eq 0)
+{
+	# No report at all means the host died before it could write one (a crash, or a timeout kill),
+	# which is worth calling out - the totals table would otherwise just be missing with no reason.
+	Add-Line '> [!WARNING]'
+	Add-Line "> No test results found under ``$ResultsRoot`` - the test run likely crashed or timed out before writing a report. See the job log."
+	Write-Output "::warning title=$Title::No test results found, the run likely crashed or timed out before writing a report"
+}
+else
+{
+	$ns = @{ t = 'http://microsoft.com/schemas/VisualStudio/TeamTest/2010' }
+	$total = 0; $passed = 0; $failed = 0; $skipped = 0
+	$seconds = 0.0
+	$failures = [System.Collections.Generic.List[object]]::new()
+
+	foreach ($file in $files)
+	{
+		$xml = [xml](Get-Content -LiteralPath $file.FullName -Raw)
+
+		$counters = Select-Xml -Xml $xml -Namespace $ns -XPath '/t:TestRun/t:ResultSummary/t:Counters' | Select-Object -First 1
+		if ($counters)
+		{
+			$c = $counters.Node
+			$total += [int]$c.total
+			$passed += [int]$c.passed
+			$failed += [int]$c.failed
+			# trx splits "didn't run" across several counters; for a summary they're all just skipped.
+			$skipped += [int]$c.notExecuted + [int]$c.inconclusive + [int]$c.notRunnable
+		}
+
+		$times = Select-Xml -Xml $xml -Namespace $ns -XPath '/t:TestRun/t:Times' | Select-Object -First 1
+		if ($times -and $times.Node.start -and $times.Node.finish)
+		{
+			$seconds += ([datetime]$times.Node.finish - [datetime]$times.Node.start).TotalSeconds
+		}
+
+		# testName in the results is only the method (with its test case arguments), so pull the
+		# class name from the definitions to make each failure identifiable on its own.
+		$classNames = @{}
+		foreach ($def in (Select-Xml -Xml $xml -Namespace $ns -XPath '//t:TestDefinitions/t:UnitTest'))
+		{
+			$method = $def.Node.TestMethod
+			if ($method) { $classNames[$def.Node.id] = $method.className }
+		}
+
+		foreach ($result in (Select-Xml -Xml $xml -Namespace $ns -XPath "//t:UnitTestResult[@outcome='Failed']"))
+		{
+			$node = $result.Node
+			$class = $classNames[$node.testId]
+			$failures.Add([pscustomobject]@{
+					Name       = if ($class) { "$class.$($node.testName)" } else { $node.testName }
+					Message    = Format-Block $node.Output.ErrorInfo.Message
+					StackTrace = Format-Block $node.Output.ErrorInfo.StackTrace
+				})
+		}
+	}
+
+	$outcome = if ($failed -gt 0) { "❌ $failed failed" } elseif ($total -eq 0) { '⚠️ no tests ran' } else { '✅ passed' }
+
+	Add-Line '| Result | Total | Passed | Failed | Skipped | Duration |'
+	Add-Line '|:---|---:|---:|---:|---:|---:|'
+	Add-Line "| $outcome | $total | $passed | $failed | $skipped | $([math]::Round($seconds, 1))s |"
+	Add-Line
+
+	$shown = 0
+	foreach ($failure in $failures)
+	{
+		if ($shown -ge $MaxFailures)
+		{
+			Add-Line "_...and $($failures.Count - $MaxFailures) more, see the job log._"
+			break
+		}
+		$shown++
+
+		Add-Line "<details><summary>❌ <code>$($failure.Name)</code></summary>"
+		Add-Line
+		Add-Line '```'
+		if ($failure.Message) { Add-Line $failure.Message }
+		if ($failure.StackTrace) { Add-Line $failure.StackTrace }
+		Add-Line '```'
+		Add-Line '</details>'
+		Add-Line
+
+		if ($shown -le $MaxAnnotations)
+		{
+			# Point the annotation at the failing line when the stack trace has one for a file that
+			# is still in the workspace, so it lands on the PR diff rather than just the job log.
+			$location = ''
+			if ($failure.StackTrace -match '\sin\s(?<file>.+):line\s(?<line>\d+)')
+			{
+				$path = $Matches.file
+				$root = if ($env:GITHUB_WORKSPACE) { $env:GITHUB_WORKSPACE } else { (Get-Location).Path }
+				if ($path.StartsWith($root, [StringComparison]::OrdinalIgnoreCase))
+				{
+					$relative = $path.Substring($root.Length).TrimStart('/', '\').Replace('\', '/')
+					$location = "file=$relative,line=$($Matches.line),"
+				}
+			}
+			# Annotations are single line, and '::' would be read as another command token.
+			$message = ($failure.Message -replace '\s+', ' ').Replace('::', ':').Trim()
+			Write-Output "::error $($location)title=$Title::$($failure.Name): $message"
+		}
+	}
+}
+
+if ($env:GITHUB_STEP_SUMMARY)
+{
+	Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $summary.ToString()
+}
+else
+{
+	Write-Output $summary.ToString()
+}

--- a/src/Eto.Wpf/CustomControls/DragDropLib.Wpf.cs
+++ b/src/Eto.Wpf/CustomControls/DragDropLib.Wpf.cs
@@ -301,7 +301,7 @@ namespace System.Windows
 			}
 		}
 
-		/// <summary>Some text
+		/// <summary>
 		/// Provides a default GiveFeedback event handler for drag sources.
 		/// </summary>
 		/// <param name="data">The associated data object for the event.</param>

--- a/src/Eto.Wpf/CustomControls/DragDropLib.cs
+++ b/src/Eto.Wpf/CustomControls/DragDropLib.cs
@@ -1,13 +1,35 @@
-
 // originally from : https://blogs.msdn.microsoft.com/adamroot/2008/02/19/shell-style-drag-and-drop-in-net-part-3/
 // downloads link from: https://stackoverflow.com/questions/36239516/real-implementation-of-the-shell-style-drag-and-drop-in-net-wpf-and-winforms
 // modified to properly set standard cursors without hard coding copy/link/move/etc labels.
+//
+// Fixes vs. the original:
+//   1. GetManagedData wrapped the medium's HGLOBAL in an IStream with
+//      fDeleteOnRelease=true and *also* called ReleaseStgMedium on the medium, so the
+//      HGLOBAL was freed while the stream still owned it: a use-after-free while
+//      reading it, then a second free when the stream was released. That corrupts the
+//      process heap, which later surfaces as an access violation (reported as
+//      System.ExecutionEngineException) in an unrelated ReleaseStgMedium call. The
+//      stream now only borrows the HGLOBAL and the medium is released exactly once.
+//   2. DataObject.SetData always stores a *duplicate* of the medium, so nothing outside
+//      this class can end the lifetime of a resource held in `storage` and leave
+//      ClearStorage releasing a dangling handle.
+//   3. GetData / GetDataHere no longer report S_OK together with a zeroed STGMEDIUM for
+//      a format we don't have -- a COM caller (the shell's drag image manager, for one)
+//      takes that as valid data. They return DV_E_FORMATETC instead.
+//   4. Advise sinks are handed their own copy of the medium instead of the live entry
+//      out of `storage`.
+//   5. RaiseDataChanged no longer enumerates `connections` while ADVF_ONLYONCE handling
+//      removes entries from it.
+//   6. Dispose is idempotent and suppresses finalization.
+//   7. GetMediumFromObject sizes the HGLOBAL by the serialized length rather than the
+//      MemoryStream's capacity, so no uninitialized tail is published.
+//   8. Doc-comment typos cleaned up.
 
 #region DragDropLibCore\DragDropHelper.cs
 
 namespace DragDropLib
 {
-		[ComImport]
+	[ComImport]
 	[Guid("4657278A-411B-11d2-839A-00C04FD918D0")]
 	class DragDropHelper { }
 }
@@ -170,19 +192,18 @@ namespace System.Runtime.InteropServices.ComTypes
 		/// <summary>
 		/// Sets the drop description for the drag image manager.
 		/// </summary>
-		/// <param name="dataObject">TheSome text DataObject to set.</param>
+		/// <param name="dataObject">The DataObject to set.</param>
 		/// <param name="dropDescription">The drop description.</param>
 		public static void SetDropDescription(this IDataObject dataObject, DropDescription dropDescription)
 		{
 			ComTypes.FORMATETC formatETC;
 			FillFormatETC(DropDescriptionFormat, TYMED.TYMED_HGLOBAL, out formatETC);
 
-			// We need to set the drop description as an HSome textGLOBAL.
-			// Allocate space ...
+			// We need to set the drop description as an HGLOBAL.
 			IntPtr pDD = Marshal.AllocHGlobal(Marshal.SizeOf(typeof(DropDescription)));
+			bool ownershipTransferred = false;
 			try
 			{
-				// ... and marshal the data
 				Marshal.StructureToPtr(dropDescription, pDD, false);
 
 				// The medium wraps the HGLOBAL
@@ -191,15 +212,16 @@ namespace System.Runtime.InteropServices.ComTypes
 				medium.tymed = ComTypes.TYMED.TYMED_HGLOBAL;
 				medium.unionmember = pDD;
 
-				// Set the data
+				// Set the data with release=true so the DataObject takes ownership of pDD.
 				ComTypes.IDataObject dataObjectCOM = (ComTypes.IDataObject)dataObject;
 				dataObjectCOM.SetData(ref formatETC, ref medium, true);
+				ownershipTransferred = true;
 			}
-			catch
+			finally
 			{
-				// If we failed, we need to free the HGLOBAL memory
-				Marshal.FreeHGlobal(pDD);
-				throw;
+				// Only free if SetData didn't successfully take ownership.
+				if (!ownershipTransferred)
+					Marshal.FreeHGlobal(pDD);
 			}
 		}
 
@@ -343,63 +365,76 @@ namespace System.Runtime.InteropServices.ComTypes
 			FORMATETC formatETC;
 			FillFormatETC(format, TYMED.TYMED_HGLOBAL, out formatETC);
 
+			if (0 != dataObject.QueryGetData(ref formatETC))
+				return null;
+
 			// Get the data as a stream
 			STGMEDIUM medium;
 			dataObject.GetData(ref formatETC, out medium);
 
-			IStream nativeStream;
+			// We own `medium` and release it exactly once, below. The IStream only borrows
+			// the HGLOBAL (fDeleteOnRelease: false) -- letting it own the handle as well
+			// would free it twice, and would be wrong outright when the medium carries a
+			// pUnkForRelease that is responsible for the handle.
 			try
 			{
-				int hr = CreateStreamOnHGlobal(medium.unionmember, true, out nativeStream);
-				if (hr != 0)
-				{
+				if (medium.tymed != TYMED.TYMED_HGLOBAL || medium.unionmember == IntPtr.Zero)
 					return null;
+
+				IStream nativeStream;
+				int hr = CreateStreamOnHGlobal(medium.unionmember, false, out nativeStream);
+				if (hr != 0 || nativeStream == null)
+					return null;
+
+				try
+				{
+					STATSTG statstg;
+					nativeStream.Stat(out statstg, 0);
+					if (statstg.cbSize > int.MaxValue)
+						throw new NotSupportedException();
+					byte[] buf = new byte[statstg.cbSize];
+					nativeStream.Read(buf, (int)statstg.cbSize, IntPtr.Zero);
+					MemoryStream dataStream = new MemoryStream(buf);
+
+					// Check for our stamp
+					int sizeOfGuid = Marshal.SizeOf(typeof(Guid));
+					byte[] guidBytes = new byte[sizeOfGuid];
+					if (dataStream.Length >= sizeOfGuid)
+					{
+						if (sizeOfGuid == dataStream.Read(guidBytes, 0, sizeOfGuid))
+						{
+							Guid guid = new Guid(guidBytes);
+							if (ManagedDataStamp.Equals(guid))
+							{
+								// Stamp matched, so deserialize
+								DataContractSerializer typeSerializer = new DataContractSerializer(typeof(Type));
+								Type dataType = (Type)typeSerializer.ReadObject(dataStream);
+								DataContractSerializer objectSerializer = new DataContractSerializer(dataType);
+								object data2 = objectSerializer.ReadObject(dataStream);
+								if (data2.GetType() == dataType)
+									return data2;
+								else if (data2 is string)
+									return ConvertDataFromString((string)data2, dataType);
+								else
+									return null;
+							}
+						}
+					}
+
+					// Stamp didn't match... attempt to reset the seek pointer
+					if (dataStream.CanSeek)
+						dataStream.Position = 0;
+					return null;
+				}
+				finally
+				{
+					Marshal.ReleaseComObject(nativeStream);
 				}
 			}
 			finally
 			{
 				ReleaseStgMedium(ref medium);
 			}
-
-
-			// Convert the native stream to a managed stream            
-			STATSTG statstg;
-			nativeStream.Stat(out statstg, 0);
-			if (statstg.cbSize > int.MaxValue)
-				throw new NotSupportedException();
-			byte[] buf = new byte[statstg.cbSize];
-			nativeStream.Read(buf, (int)statstg.cbSize, IntPtr.Zero);
-			MemoryStream dataStream = new MemoryStream(buf);
-
-			// Check for our stamp
-			int sizeOfGuid = Marshal.SizeOf(typeof(Guid));
-			byte[] guidBytes = new byte[sizeOfGuid];
-			if (dataStream.Length >= sizeOfGuid)
-			{
-				if (sizeOfGuid == dataStream.Read(guidBytes, 0, sizeOfGuid))
-				{
-					Guid guid = new Guid(guidBytes);
-					if (ManagedDataStamp.Equals(guid))
-					{
-						// Stamp matched, so deserialize
-						DataContractSerializer typeSerializer = new DataContractSerializer(typeof(Type));
-						Type dataType = (Type)typeSerializer.ReadObject(dataStream);
-						DataContractSerializer objectSerializer = new DataContractSerializer(dataType);
-						object data2 = objectSerializer.ReadObject(dataStream);
-						if (data2.GetType() == dataType)
-							return data2;
-						else if (data2 is string)
-							return ConvertDataFromString((string)data2, dataType);
-						else
-							return null;
-					}
-				}
-			}
-
-			// Stamp didn't match... attempt to reset the seek pointer
-			if (dataStream.CanSeek)
-				dataStream.Position = 0;
-			return null;
 		}
 
 		#region Helper methods
@@ -435,8 +470,7 @@ namespace System.Runtime.InteropServices.ComTypes
 			// We'll serialize to a managed stream temporarily
 			MemoryStream stream = new MemoryStream();
 
-			// Write an indentifying stamp, so we can recognize this as custom
-			// marshaled data.
+			// Write an identifying stamp so we can recognize this as custom marshaled data.
 			stream.Write(ManagedDataStamp.ToByteArray(), 0, Marshal.SizeOf(typeof(Guid)));
 
 			// Now serialize the data. Note, if the data is not directly serializable,
@@ -448,12 +482,15 @@ namespace System.Runtime.InteropServices.ComTypes
 			DataContractSerializer objectSerializer = new DataContractSerializer(data.GetType());
 			objectSerializer.WriteObject(stream, GetAsSerializable(data));
 
-			// Now copy to an HGLOBAL
+			// IMPORTANT: size by the number of bytes actually written, not by
+			// GetBuffer().Length -- the buffer is the MemoryStream's capacity, so using its
+			// length would publish an uninitialized tail past the serialized data.
 			byte[] bytes = stream.GetBuffer();
-			IntPtr p = Marshal.AllocHGlobal(bytes.Length);
+			int length = (int)stream.Length;
+			IntPtr p = Marshal.AllocHGlobal(length);
 			try
 			{
-				Marshal.Copy(bytes, 0, p, bytes.Length);
+				Marshal.Copy(bytes, 0, p, length);
 			}
 			catch
 			{
@@ -537,7 +574,7 @@ namespace DragDropLib
 	/// Implements the COM version of IDataObject including SetData.
 	/// </summary>
 	/// <remarks>
-	/// <para>Use this object when using shell (or other unmanged) features
+	/// <para>Use this object when using shell (or other unmanaged) features
 	/// that utilize the clipboard and/or drag and drop.</para>
 	/// <para>The System.Windows.DataObject (.NET 3.0) and
 	/// System.Windows.Forms.DataObject do not support SetData from their COM
@@ -564,14 +601,19 @@ namespace DragDropLib
 
 		#endregion // Unmanaged functions
 
-		// Our internal storage is a simple list
-		private IList<KeyValuePair<FORMATETC, STGMEDIUM>> storage;
+		// Our internal storage is a simple list.
+		// internal rather than private so the unit tests can assert on which handles this object
+		// actually owns -- the class itself is already internal, so this widens nothing.
+		internal IList<KeyValuePair<FORMATETC, STGMEDIUM>> storage;
 
 		// Keeps a progressive unique connection id
 		private int nextConnectionId = 1;
 
 		// List of advisory connections
 		private IDictionary<int, AdviseEntry> connections;
+
+		// Guards against double-dispose / dispose-then-finalize (0 = live, 1 = disposed)
+		private int disposed;
 
 		// Represents an advisory connection entry.
 		private class AdviseEntry
@@ -606,7 +648,7 @@ namespace DragDropLib
 		}
 
 		/// <summary>
-		/// Clears the internal storage array.
+		/// Clears the internal storage array, releasing every entry.
 		/// </summary>
 		/// <remarks>
 		/// ClearStorage is called by the IDisposable.Dispose method implementation
@@ -614,6 +656,9 @@ namespace DragDropLib
 		/// </remarks>
 		private void ClearStorage()
 		{
+			if (storage == null)
+				return;
+
 			lock (storage)
 			{
 				foreach (KeyValuePair<FORMATETC, STGMEDIUM> pair in storage)
@@ -631,6 +676,7 @@ namespace DragDropLib
 		public void Dispose()
 		{
 			Dispose(true);
+			GC.SuppressFinalize(this);
 		}
 
 		/// <summary>
@@ -641,10 +687,9 @@ namespace DragDropLib
 		/// is finalizing the release of the object instance.</param>
 		private void Dispose(bool disposing)
 		{
-			if (disposing)
-			{
-				// No managed objects to release
-			}
+			// Dispose and the finalizer can race, so claim the flag atomically.
+			if (Interlocked.Exchange(ref disposed, 1) != 0)
+				return;
 
 			// Always release unmanaged objects
 			ClearStorage();
@@ -760,15 +805,17 @@ namespace DragDropLib
 		{
 			// Locate the data
 			KeyValuePair<FORMATETC, STGMEDIUM> dataEntry;
-			if (GetDataEntry(ref format, out dataEntry))
+			if (!GetDataEntry(ref format, out dataEntry))
 			{
-				STGMEDIUM source = dataEntry.Value;
-				medium = CopyMedium(ref source);
-				return;
+				// Don't hand back an empty medium with S_OK: this is a COM server, so
+				// returning normally reports success and a caller -- the shell's drag image
+				// manager, for one -- will then treat the zeroed STGMEDIUM as valid data.
+				medium = default(STGMEDIUM);
+				throw Marshal.GetExceptionForHR(DV_E_FORMATETC);
 			}
 
-			// Didn't find it. Return an empty data medium.
-			medium = default(STGMEDIUM);
+			STGMEDIUM source = dataEntry.Value;
+			medium = CopyMedium(ref source);
 		}
 
 		/// <summary>
@@ -823,29 +870,57 @@ namespace DragDropLib
 		/// <param name="release">If true, ownership of the medium's memory will be transferred
 		/// to this object. If false, a copy of the medium will be created and maintained, and
 		/// the caller is responsible for the memory of the medium it provided.</param>
+		/// <remarks>Either way we keep a duplicate of the medium rather than the caller's
+		/// handle, and release the caller's when ownership was transferred to us.</remarks>
 		public void SetData(ref FORMATETC formatIn, ref STGMEDIUM medium, bool release)
 		{
 			lock (storage)
 			{
-				// If the format exists in our storage, remove it prior to resetting it
-				foreach (KeyValuePair<FORMATETC, STGMEDIUM> pair in storage)
+				// Storage must own a resource whose lifetime nothing outside this class can
+				// end. Keeping the caller's handle is not enough for that: a consumer that
+				// releases what it was handed, or a caller that gives us a handle it also
+				// keeps (or gives us the same handle twice under formats that don't compare
+				// equal below), leaves an entry here dangling, and ClearStorage then
+				// releases freed memory and takes the process down.
+				//
+				// Duplicate first, so that an alias of the entry we are about to release is
+				// still valid at this point, and so a failure to copy leaves storage intact.
+				STGMEDIUM sm;
+				if (medium.unionmember == IntPtr.Zero)
 				{
+					// Nothing to duplicate -- e.g. a caller clearing a format.
+					sm = medium;
+				}
+				else
+				{
+					sm = CopyMedium(ref medium);
+
+					// release == true transferred ownership to us; we hold a duplicate now,
+					// so let the caller's original go.
+					if (release)
+						ReleaseStgMedium(ref medium);
+				}
+
+				// If the format already exists in storage, drop the old entry.
+				// Capture-then-remove to avoid mutating the collection during enumeration.
+				int existingIndex = -1;
+				for (int i = 0; i < storage.Count; i++)
+				{
+					var pair = storage[i];
 					if ((pair.Key.tymed & formatIn.tymed) > 0
 						&& pair.Key.dwAspect == formatIn.dwAspect
 						&& pair.Key.cfFormat == formatIn.cfFormat)
 					{
-						STGMEDIUM releaseMedium = pair.Value;
-						ReleaseStgMedium(ref releaseMedium);
-						storage.Remove(pair);
+						existingIndex = i;
 						break;
 					}
 				}
-
-				// If release is true, we'll take ownership of the medium.
-				// If not, we'll make a copy of it.
-				STGMEDIUM sm = medium;
-				if (!release)
-					sm = CopyMedium(ref medium);
+				if (existingIndex >= 0)
+				{
+					STGMEDIUM releaseMedium = storage[existingIndex].Value;
+					storage.RemoveAt(existingIndex);
+					ReleaseStgMedium(ref releaseMedium);
+				}
 
 				// Add it to the internal storage
 				KeyValuePair<FORMATETC, STGMEDIUM> addPair = new KeyValuePair<FORMATETC, STGMEDIUM>(formatIn, sm);
@@ -906,15 +981,33 @@ namespace DragDropLib
 		/// <param name="dataEntry">The data entry for which to raise the event.</param>
 		private void RaiseDataChanged(int connection, ref KeyValuePair<FORMATETC, STGMEDIUM> dataEntry)
 		{
-			AdviseEntry adviseEntry = connections[connection];
+			// A sink may unsubscribe others from its own callback, so don't assume the
+			// connection is still live.
+			AdviseEntry adviseEntry;
+			if (!connections.TryGetValue(connection, out adviseEntry))
+				return;
+
 			FORMATETC format = dataEntry.Key;
+
+			// Hand the sink its own copy of the medium. Per IAdviseSink::OnDataChange the
+			// medium remains ours to release, but a sink that releases it anyway must not be
+			// able to free the entry that is still sitting in storage.
+			STGMEDIUM source = dataEntry.Value;
 			STGMEDIUM medium;
-			if ((adviseEntry.advf & ADVF.ADVF_NODATA) != ADVF.ADVF_NODATA)
-				medium = dataEntry.Value;
+			if ((adviseEntry.advf & ADVF.ADVF_NODATA) != ADVF.ADVF_NODATA && source.unionmember != IntPtr.Zero)
+				medium = CopyMedium(ref source);
 			else
 				medium = default(STGMEDIUM);
 
-			adviseEntry.sink.OnDataChange(ref format, ref medium);
+			try
+			{
+				adviseEntry.sink.OnDataChange(ref format, ref medium);
+			}
+			finally
+			{
+				if (medium.tymed != TYMED.TYMED_NULL)
+					ReleaseStgMedium(ref medium);
+			}
 
 			if ((adviseEntry.advf & ADVF.ADVF_ONLYONCE) == ADVF.ADVF_ONLYONCE)
 				connections.Remove(connection);
@@ -927,7 +1020,13 @@ namespace DragDropLib
 		/// <param name="dataEntry">The relevant data entry.</param>
 		private void RaiseDataChanged(ref KeyValuePair<FORMATETC, STGMEDIUM> dataEntry)
 		{
-			foreach (KeyValuePair<int, AdviseEntry> connection in connections)
+			if (connections.Count == 0)
+				return;
+
+			// Snapshot: ADVF_ONLYONCE handling (and sinks that unsubscribe) remove entries
+			// from `connections` while we are walking it.
+			var snapshot = new List<KeyValuePair<int, AdviseEntry>>(connections);
+			foreach (KeyValuePair<int, AdviseEntry> connection in snapshot)
 			{
 				if (IsFormatCompatible(connection.Value.format, dataEntry.Key))
 					RaiseDataChanged(connection.Key, ref dataEntry);
@@ -1099,4 +1198,3 @@ namespace DragDropLib
 }
 
 #endregion // DragDropLibCore\DataObject.cs
-

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -43,6 +43,14 @@ You do not need to use any of the classes of this assembly (unless customizing t
   </ItemGroup>
 
   <ItemGroup>
+    <!-- So the WPF-specific unit tests can exercise internals directly, notably
+         DragDropLib.DataObject and the COM IDataObject extensions around it.
+         A build that strong-name signs this assembly must set $(PublicKey) so the SDK emits the
+         matching key here; a signed assembly cannot grant internals access to an unsigned one. -->
+    <InternalsVisibleTo Include="Eto.Test.Wpf" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Reference Include="Interop.SHDocVw">
       <HintPath>..\..\lib\SHDocVw\Interop.SHDocVw.dll</HintPath>
       <Private>False</Private>

--- a/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj
+++ b/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj
@@ -22,6 +22,8 @@
     <PackageReference Include="NUnit" Version="4.6.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.2.0" />
     <PackageReference Include="Microsoft.Testing.Platform" Version="2.2.3" />
+    <!-- Enables the trx report option so CI can turn the results into a job summary -->
+    <PackageReference Include="Microsoft.Testing.Extensions.TrxReport" Version="2.2.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj
+++ b/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj
@@ -32,10 +32,18 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Eto.Test\Eto.Test.csproj" />
-    <ProjectReference Include="..\Eto.Test.Wpf\Eto.Test.Wpf.csproj" Condition="$(TargetFramework) == 'net10.0-windows' or $(TargetFramework) == 'net48' " PrivateAssets="all" />
-    <ProjectReference Include="..\..\src\Eto.Wpf\Eto.Wpf.csproj" Condition="$(TargetFramework) == 'net10.0-windows' or $(TargetFramework) == 'net48' " PrivateAssets="all" />
-    <ProjectReference Include="..\..\src\Eto.Gtk\Eto.Gtk.csproj" Condition="$(TargetFramework) == 'net10.0'" PrivateAssets="all" />
-    <ProjectReference Include="..\..\src\Eto.Mac\Eto.Mac64.csproj" Condition="$(TargetFramework) == 'net10.0'" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'net10.0-windows' or $(TargetFramework) == 'net48'">
+    <ProjectReference Include="..\..\src\Eto.Wpf\Eto.Wpf.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\Eto.Test.Wpf\Eto.Test.Wpf.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\src\Eto.WinForms\Eto.WinForms.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\Eto.Test.WinForms\Eto.Test.WinForms.csproj" PrivateAssets="all" />
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'net10.0'">
+    <ProjectReference Include="..\..\src\Eto.Gtk\Eto.Gtk.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\Eto.Test.Gtk\Eto.Test.Gtk.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\..\src\Eto.Mac\Eto.Mac64.csproj" PrivateAssets="all" />
+    <ProjectReference Include="..\Eto.Test.Mac\Eto.Test.Mac64.csproj" PrivateAssets="all" />
   </ItemGroup>
 
 </Project>

--- a/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj
+++ b/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj
@@ -1,7 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net48;net10.0;net10.0-windows</TargetFrameworks>
+    <!-- The Wpf/WinForms fixtures these TFMs reference can only be built on Windows (the Wpf,
+         WinForms, Eto.Test.Wpf and Eto.Test.WinForms projects are excluded from *|Mac and *|Linux
+         in Eto.slnx), so only target them there. -->
+    <TargetFrameworks>net10.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(OSPlatform) == 'Windows'">net48;net10.0;net10.0-windows</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <OutputType>Exe</OutputType>
@@ -20,19 +24,13 @@
     <PackageReference Include="Microsoft.Testing.Platform" Version="2.2.3" />
   </ItemGroup>
 
-  <!-- The WPF-specific fixtures live in the Eto.Test.Wpf app assembly (test/Eto.Test.Wpf/UnitTests).
-       Reference it so they are discovered here too rather than only in that app's GUI test runner.
-       Only registered as a test assembly on .NET: NUnit's net48 engine runs in a separate app domain
-       and fails to load a second test assembly ("Zero tests ran" plus an appdomain unload error), so
-       there we only take the reference, which is still needed anyway: EtoTestSetup.Initialize probes
-       the Eto.Test.Wpf output directory to locate the platform. -->
-  <PropertyGroup Condition="$(TargetFramework) == 'net10.0-windows'">
-    <DefineConstants>$(DefineConstants);WPF_PLATFORM_TESTS</DefineConstants>
-  </PropertyGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Eto.Test\Eto.Test.csproj" />
   </ItemGroup>
+  <!-- The platform-specific fixtures live in the Eto.Test.<Platform> app assemblies (e.g.
+       test/Eto.Test.Wpf/UnitTests). Reference them so they are discovered here too rather than only
+       in those apps' own GUI test runners. The references are needed regardless of discovery:
+       EtoTestSetup.Initialize probes the platform app's output directory to locate the platform. -->
   <ItemGroup Condition="$(TargetFramework) == 'net10.0-windows' or $(TargetFramework) == 'net48'">
     <ProjectReference Include="..\..\src\Eto.Wpf\Eto.Wpf.csproj" PrivateAssets="all" />
     <ProjectReference Include="..\Eto.Test.Wpf\Eto.Test.Wpf.csproj" PrivateAssets="all" />

--- a/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj
+++ b/test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj
@@ -20,8 +20,19 @@
     <PackageReference Include="Microsoft.Testing.Platform" Version="2.2.3" />
   </ItemGroup>
 
+  <!-- The WPF-specific fixtures live in the Eto.Test.Wpf app assembly (test/Eto.Test.Wpf/UnitTests).
+       Reference it so they are discovered here too rather than only in that app's GUI test runner.
+       Only registered as a test assembly on .NET: NUnit's net48 engine runs in a separate app domain
+       and fails to load a second test assembly ("Zero tests ran" plus an appdomain unload error), so
+       there we only take the reference, which is still needed anyway: EtoTestSetup.Initialize probes
+       the Eto.Test.Wpf output directory to locate the platform. -->
+  <PropertyGroup Condition="$(TargetFramework) == 'net10.0-windows'">
+    <DefineConstants>$(DefineConstants);WPF_PLATFORM_TESTS</DefineConstants>
+  </PropertyGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Eto.Test\Eto.Test.csproj" />
+    <ProjectReference Include="..\Eto.Test.Wpf\Eto.Test.Wpf.csproj" Condition="$(TargetFramework) == 'net10.0-windows' or $(TargetFramework) == 'net48' " PrivateAssets="all" />
     <ProjectReference Include="..\..\src\Eto.Wpf\Eto.Wpf.csproj" Condition="$(TargetFramework) == 'net10.0-windows' or $(TargetFramework) == 'net48' " PrivateAssets="all" />
     <ProjectReference Include="..\..\src\Eto.Gtk\Eto.Gtk.csproj" Condition="$(TargetFramework) == 'net10.0'" PrivateAssets="all" />
     <ProjectReference Include="..\..\src\Eto.Mac\Eto.Mac64.csproj" Condition="$(TargetFramework) == 'net10.0'" PrivateAssets="all" />

--- a/test/Eto.Test.UnitTests/Program.cs
+++ b/test/Eto.Test.UnitTests/Program.cs
@@ -18,15 +18,33 @@ internal static class Program
 {
 	static IEnumerable<Assembly> GetTestAssemblies()
 	{
-#if WPF_PLATFORM_TESTS
 		// When more than one assembly is listed, the VSTest bridge requires the test application's
 		// own assembly to be among them.
 		yield return typeof(Program).Assembly;
-#endif
+
 		yield return typeof(Eto.Test.MainForm).Assembly;
-#if WPF_PLATFORM_TESTS
-		// platform-specific fixtures from test/Eto.Test.Wpf/UnitTests
-		yield return typeof(Eto.Test.Wpf.UnitTests.ScreenTests).Assembly;
+#if WINDOWS || NETFRAMEWORK
+		if (Platform.Instance.IsWpf)
+		{
+			// WPF-specific fixtures from test/Eto.Test.Wpf/UnitTests
+			yield return typeof(Eto.Test.Wpf.UnitTests.BitmapTests).Assembly;
+		}
+		if (Platform.Instance.IsWinForms)
+		{
+			// WinForms-specific fixtures from test/Eto.Test.WinForms/UnitTests
+			yield return typeof(Eto.Test.WinForms.UnitTests.NativeTests).Assembly;
+		}
+#elif NET
+		if (Platform.Instance.IsGtk)
+		{
+			// GTK-specific fixtures from test/Eto.Test.Gtk/UnitTests
+			yield return typeof(Eto.Test.Gtk.UnitTests.NativeParentWindowTests).Assembly;
+		}
+		if (Platform.Instance.IsMac)
+		{
+			// Mac-specific fixtures from test/Eto.Test.Mac/UnitTests
+			yield return typeof(Eto.Test.Mac.UnitTests.BitmapTests).Assembly;
+		}
 #endif
 	}
 
@@ -35,7 +53,49 @@ internal static class Program
 	{
 		AvoidThemeSatelliteResolverCrash();
 
-		using var app = new Application();
+		List<string> testArgs = new();
+		// check any of the args for platform override
+		Platform? platform = null;
+		foreach (var arg in args)
+		{
+			if (arg.StartsWith("--platform=", StringComparison.OrdinalIgnoreCase))
+			{
+				Console.WriteLine($"Overriding platform with '{arg}'");
+				var platformName = arg.Substring("--platform=".Length);
+				if (!string.IsNullOrEmpty(platformName))
+				{
+					switch (platformName.ToLowerInvariant())
+					{
+#if WINDOWS || NETFRAMEWORK
+						case "wpf":
+							platform = new Eto.Wpf.Platform();
+							break;
+						case "winforms":
+							platform = new Eto.WinForms.Platform();
+							break;
+#elif NET
+						case "gtk":
+							platform = new Eto.GtkSharp.Platform();
+							break;
+						case "mac":
+							platform = new Eto.Mac.Platform();
+							break;
+#endif
+						default:
+							throw new ArgumentException($"Unknown platform '{platformName}'");
+					}
+				}
+			}
+			else
+			{
+				testArgs.Add(arg);
+			}
+		}
+		
+		if (platform == null)
+			platform = Platform.Detect;
+
+		using var app = new Application(platform);
 
 		var exitCodeSource = new TaskCompletionSource<int>(TaskCreationOptions.RunContinuationsAsynchronously);
 
@@ -45,7 +105,7 @@ internal static class Program
 			_ = Task.Run(async () =>
 			{
 				SynchronizationContext.SetSynchronizationContext(context);
-				await RunTestsAndQuitAsync(app, args, exitCodeSource);
+				await RunTestsAndQuitAsync(app, testArgs.ToArray(), exitCodeSource);
 			});
 		};
 		app.Run();
@@ -89,11 +149,19 @@ internal static class Program
 		}
 		catch (Exception ex)
 		{
+			// log it here as well, the exception from Main is not always reported before we exit
+			Console.Error.WriteLine($"Error running tests: {ex}");
 			exitCodeSource.TrySetException(ex);
 		}
 		finally
 		{
-			app.Invoke(() => app.Quit()); // quit app after tests complete
+			// Quit the app once tests complete, exiting with the test result so a failing run actually
+			// fails the process. Environment.Exit is needed rather than returning from Main: on Mac
+			// NSApplication.Terminate() ends the process itself with exit(0) and never returns from
+			// Application.Run(), so both Main's return value and Environment.ExitCode are discarded and
+			// every run would report success. Reports are already flushed by the time we get here.
+			var exitCode = exitCodeSource.Task.IsCompletedSuccessfully ? exitCodeSource.Task.Result : 1;
+			app.Invoke(() => Environment.Exit(exitCode));
 		}
 	}
 }

--- a/test/Eto.Test.UnitTests/Program.cs
+++ b/test/Eto.Test.UnitTests/Program.cs
@@ -7,6 +7,7 @@ using System.Reflection;
 using System.Runtime.Loader;
 #endif
 using System.Threading.Tasks;
+using Microsoft.Testing.Extensions;
 using Microsoft.Testing.Platform.Builder;
 using NUnit.Framework;
 using NUnit.VisualStudio.TestAdapter.TestingPlatformAdapter;
@@ -142,6 +143,8 @@ internal static class Program
 			var options = new TestApplicationOptions();
 			ITestApplicationBuilder builder = await Microsoft.Testing.Platform.Builder.TestApplication.CreateBuilderAsync(args);
 			builder.AddNUnit(GetTestAssemblies);
+			// registered explicitly (adds the trx report options) as we don't use the generated entry point
+			builder.AddTrxReportProvider();
 
 			using ITestApplication testApplication = await builder.BuildAsync();
 			int exitCode = await testApplication.RunAsync();

--- a/test/Eto.Test.UnitTests/Program.cs
+++ b/test/Eto.Test.UnitTests/Program.cs
@@ -160,7 +160,8 @@ internal static class Program
 			// NSApplication.Terminate() ends the process itself with exit(0) and never returns from
 			// Application.Run(), so both Main's return value and Environment.ExitCode are discarded and
 			// every run would report success. Reports are already flushed by the time we get here.
-			var exitCode = exitCodeSource.Task.IsCompletedSuccessfully ? exitCodeSource.Task.Result : 1;
+			// Task.IsCompletedSuccessfully isn't available on .NET Framework, so check the status directly.
+			var exitCode = exitCodeSource.Task.Status == TaskStatus.RanToCompletion ? exitCodeSource.Task.Result : 1;
 			app.Invoke(() => Environment.Exit(exitCode));
 		}
 	}

--- a/test/Eto.Test.UnitTests/Program.cs
+++ b/test/Eto.Test.UnitTests/Program.cs
@@ -18,7 +18,16 @@ internal static class Program
 {
 	static IEnumerable<Assembly> GetTestAssemblies()
 	{
+#if WPF_PLATFORM_TESTS
+		// When more than one assembly is listed, the VSTest bridge requires the test application's
+		// own assembly to be among them.
+		yield return typeof(Program).Assembly;
+#endif
 		yield return typeof(Eto.Test.MainForm).Assembly;
+#if WPF_PLATFORM_TESTS
+		// platform-specific fixtures from test/Eto.Test.Wpf/UnitTests
+		yield return typeof(Eto.Test.Wpf.UnitTests.ScreenTests).Assembly;
+#endif
 	}
 
 	[STAThread]

--- a/test/Eto.Test.Wpf/UnitTests/DragDropLibDataObjectTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/DragDropLibDataObjectTests.cs
@@ -1,0 +1,391 @@
+using NUnit.Framework;
+using ComTypes = System.Runtime.InteropServices.ComTypes;
+using ComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
+using DragDropDataObject = DragDropLib.DataObject;
+
+namespace Eto.Test.Wpf.UnitTests
+{
+	/// <summary>
+	/// Unit tests for DragDropLib.DataObject, the COM IDataObject implementation that WPF
+	/// drag/drop is built on.
+	/// </summary>
+	/// <remarks>
+	/// These cover the memory ownership invariants behind RH-95450 / RH-97411, where dragging a
+	/// texture thumbnail a few times would take the process down with an access violation
+	/// (surfaced as System.ExecutionEngineException) inside ReleaseStgMedium while the data object
+	/// was being released. Every failure mode there was "something outside the data object ended
+	/// the lifetime of a handle the data object still had in its storage list", so that is what
+	/// these assert against.
+	/// </remarks>
+	[TestFixture]
+	public class DragDropLibDataObjectTests
+	{
+		#region Win32
+
+		[DllImport("user32.dll", CharSet = CharSet.Unicode)]
+		static extern uint RegisterClipboardFormat(string lpszFormatName);
+
+		[DllImport("ole32.dll")]
+		static extern void ReleaseStgMedium(ref ComTypes.STGMEDIUM pmedium);
+
+		[DllImport("kernel32.dll")]
+		static extern IntPtr GlobalLock(IntPtr hMem);
+
+		[DllImport("kernel32.dll")]
+		static extern bool GlobalUnlock(IntPtr hMem);
+
+		const int DV_E_FORMATETC = unchecked((int)0x80040064);
+
+		#endregion
+
+		#region Helpers
+
+		static ComTypes.FORMATETC MakeFormat(string name) => new ComTypes.FORMATETC
+		{
+			cfFormat = (short)RegisterClipboardFormat(name),
+			dwAspect = ComTypes.DVASPECT.DVASPECT_CONTENT,
+			lindex = -1,
+			ptd = IntPtr.Zero,
+			tymed = ComTypes.TYMED.TYMED_HGLOBAL
+		};
+
+		static ComTypes.STGMEDIUM MakeMedium(byte[] bytes)
+		{
+			var handle = Marshal.AllocHGlobal(bytes.Length);
+			Marshal.Copy(bytes, 0, handle, bytes.Length);
+			return new ComTypes.STGMEDIUM
+			{
+				tymed = ComTypes.TYMED.TYMED_HGLOBAL,
+				unionmember = handle,
+				pUnkForRelease = null
+			};
+		}
+
+		static ComTypes.STGMEDIUM MakeMedium(int value) => MakeMedium(BitConverter.GetBytes(value));
+
+		/// <summary>
+		/// Reads an HGLOBAL through GlobalLock, so it works whether the handle came from
+		/// AllocHGlobal or from the duplicate CopyStgMedium/OleDuplicateData produces.
+		/// </summary>
+		static byte[] ReadMedium(IntPtr handle, int length)
+		{
+			var ptr = GlobalLock(handle);
+			Assert.That(ptr, Is.Not.EqualTo(IntPtr.Zero), "Could not lock the HGLOBAL -- it is not a valid handle");
+			try
+			{
+				var bytes = new byte[length];
+				Marshal.Copy(ptr, bytes, 0, length);
+				return bytes;
+			}
+			finally
+			{
+				GlobalUnlock(handle);
+			}
+		}
+
+		static int ReadMediumInt(IntPtr handle) => BitConverter.ToInt32(ReadMedium(handle, sizeof(int)), 0);
+
+		/// <summary>
+		/// The handle held by the single entry in the data object's storage.
+		/// </summary>
+		static IntPtr OnlyStoredHandle(DragDropDataObject dataObject)
+		{
+			Assert.That(dataObject.storage, Has.Count.EqualTo(1), "expected exactly one entry in storage");
+			return dataObject.storage[0].Value.unionmember;
+		}
+
+		/// <summary>
+		/// An advise sink that deliberately misbehaves: IAdviseSink says the medium it is handed
+		/// stays the caller's to release, so a sink that releases it anyway must not be able to
+		/// reach the entry the data object still owns.
+		/// </summary>
+		class ReleasingAdviseSink : ComTypes.IAdviseSink
+		{
+			public int CallCount;
+			public IntPtr LastHandle;
+
+			public void OnDataChange(ref ComTypes.FORMATETC format, ref ComTypes.STGMEDIUM stgmedium)
+			{
+				CallCount++;
+				LastHandle = stgmedium.unionmember;
+				if (stgmedium.unionmember != IntPtr.Zero)
+					ReleaseStgMedium(ref stgmedium);
+			}
+
+			public void OnViewChange(int aspect, int index) { }
+			public void OnRename(ComTypes.IMoniker moniker) { }
+			public void OnSave() { }
+			public void OnClose() { }
+		}
+
+		#endregion
+
+		[Test]
+		public void SetDataTakingOwnershipShouldStoreItsOwnCopy()
+		{
+			var dataObject = new DragDropDataObject();
+			var format = MakeFormat("eto-test-owned");
+			var medium = MakeMedium(0x1234abcd);
+			var callerHandle = medium.unionmember;
+
+			((ComDataObject)dataObject).SetData(ref format, ref medium, true);
+
+			Assert.That(OnlyStoredHandle(dataObject), Is.Not.EqualTo(callerHandle),
+				"storage kept the caller's handle rather than a duplicate, so anything that frees the caller's handle leaves the entry dangling");
+			Assert.That(ReadMediumInt(OnlyStoredHandle(dataObject)), Is.EqualTo(0x1234abcd),
+				"the duplicate did not carry the data over");
+
+			dataObject.Dispose();
+		}
+
+		[Test]
+		public void SetDataWithoutOwnershipShouldStoreItsOwnCopy()
+		{
+			var dataObject = new DragDropDataObject();
+			var format = MakeFormat("eto-test-unowned");
+			var medium = MakeMedium(0x0badf00d);
+			var callerHandle = medium.unionmember;
+
+			((ComDataObject)dataObject).SetData(ref format, ref medium, false);
+
+			Assert.That(OnlyStoredHandle(dataObject), Is.Not.EqualTo(callerHandle));
+			Assert.That(ReadMediumInt(OnlyStoredHandle(dataObject)), Is.EqualTo(0x0badf00d));
+
+			dataObject.Dispose();
+
+			// release == false left the handle ours to free, and disposing must not have touched it
+			Assert.That(ReadMediumInt(callerHandle), Is.EqualTo(0x0badf00d),
+				"disposing the data object released the caller's handle even though ownership was not transferred");
+			Marshal.FreeHGlobal(callerHandle);
+		}
+
+		[Test]
+		public void SharingOneHandleAcrossFormatsShouldNotShareOwnership()
+		{
+			var dataObject = new DragDropDataObject();
+			var data = (ComDataObject)dataObject;
+			var medium = MakeMedium(0x0f0f0f0f);
+			var callerHandle = medium.unionmember;
+
+			// the same handle under two formats: the entries must own separate resources, or
+			// ClearStorage releases one handle twice
+			var formatA = MakeFormat("eto-test-shared-a");
+			var formatB = MakeFormat("eto-test-shared-b");
+			data.SetData(ref formatA, ref medium, false);
+			data.SetData(ref formatB, ref medium, false);
+
+			Assert.That(dataObject.storage, Has.Count.EqualTo(2));
+			var handleA = dataObject.storage[0].Value.unionmember;
+			var handleB = dataObject.storage[1].Value.unionmember;
+
+			Assert.That(handleA, Is.Not.EqualTo(callerHandle));
+			Assert.That(handleB, Is.Not.EqualTo(callerHandle));
+			Assert.That(handleA, Is.Not.EqualTo(handleB),
+				"both entries point at one handle, so releasing storage would free it twice");
+			Assert.That(ReadMediumInt(handleA), Is.EqualTo(0x0f0f0f0f));
+			Assert.That(ReadMediumInt(handleB), Is.EqualTo(0x0f0f0f0f));
+
+			dataObject.Dispose();
+			Marshal.FreeHGlobal(callerHandle);
+		}
+
+		[Test]
+		public void GetDataForMissingFormatShouldReportAnError()
+		{
+			var dataObject = new DragDropDataObject();
+			var data = (ComDataObject)dataObject;
+			var format = MakeFormat("eto-test-missing");
+			var medium = default(ComTypes.STGMEDIUM);
+
+			// returning normally reports S_OK to a COM caller, which then treats the zeroed
+			// STGMEDIUM as valid data
+			var exception = Assert.Catch(() => data.GetData(ref format, out medium));
+			Assert.That(exception.HResult, Is.EqualTo(DV_E_FORMATETC), "expected DV_E_FORMATETC");
+			Assert.That(medium.unionmember, Is.EqualTo(IntPtr.Zero));
+			Assert.That(medium.tymed, Is.EqualTo(ComTypes.TYMED.TYMED_NULL));
+			Assert.That(data.QueryGetData(ref format), Is.Not.EqualTo(0), "QueryGetData claimed the format is present");
+
+			dataObject.Dispose();
+		}
+
+		[Test]
+		public void ConsumerReleasingItsCopyShouldNotAffectStoredData()
+		{
+			// this is the shape of RH-95450: a drop target asks for the data, releases the medium
+			// it was given, and the data object is then disposed
+			var dataObject = new DragDropDataObject();
+			var data = (ComDataObject)dataObject;
+			var format = MakeFormat("eto-test-consumer");
+			var medium = MakeMedium(0x11223344);
+			data.SetData(ref format, ref medium, true);
+
+			var storedHandle = OnlyStoredHandle(dataObject);
+
+			for (int i = 0; i < 10; i++)
+			{
+				ComTypes.STGMEDIUM copy;
+				data.GetData(ref format, out copy);
+
+				Assert.That(copy.unionmember, Is.Not.EqualTo(IntPtr.Zero));
+				Assert.That(copy.unionmember, Is.Not.EqualTo(storedHandle),
+					"GetData handed out the stored handle itself, so the consumer releasing it frees data we still own");
+				Assert.That(ReadMediumInt(copy.unionmember), Is.EqualTo(0x11223344));
+
+				ReleaseStgMedium(ref copy);
+
+				// the entry we still own has to survive the consumer releasing its copy
+				Assert.That(OnlyStoredHandle(dataObject), Is.EqualTo(storedHandle));
+				Assert.That(ReadMediumInt(storedHandle), Is.EqualTo(0x11223344), $"stored data was released by the consumer on pass {i}");
+			}
+
+			dataObject.Dispose();
+		}
+
+		[Test]
+		public void AdviseSinkShouldNotBeAbleToReleaseStoredData()
+		{
+			var dataObject = new DragDropDataObject();
+			var data = (ComDataObject)dataObject;
+			var format = MakeFormat("eto-test-advise");
+			var sink = new ReleasingAdviseSink();
+
+			int connection;
+			Assert.That(data.DAdvise(ref format, default(ComTypes.ADVF), sink, out connection), Is.EqualTo(0), "DAdvise failed");
+
+			var medium = MakeMedium(0x5a5a5a5a);
+			data.SetData(ref format, ref medium, true);
+
+			Assert.That(sink.CallCount, Is.EqualTo(1), "the sink was not notified");
+			Assert.That(sink.LastHandle, Is.Not.EqualTo(IntPtr.Zero), "the sink was handed an empty medium");
+			Assert.That(sink.LastHandle, Is.Not.EqualTo(OnlyStoredHandle(dataObject)),
+				"the sink was handed the live storage entry, so releasing it frees data the object still owns");
+			Assert.That(ReadMediumInt(OnlyStoredHandle(dataObject)), Is.EqualTo(0x5a5a5a5a),
+				"the sink releasing its medium freed the stored entry");
+
+			data.DUnadvise(connection);
+			dataObject.Dispose();
+		}
+
+		[Test]
+		public void MultipleOnlyOnceAdviseSinksShouldEachBeNotifiedOnce()
+		{
+			var dataObject = new DragDropDataObject();
+			var data = (ComDataObject)dataObject;
+			var format = MakeFormat("eto-test-onlyonce");
+			var first = new ReleasingAdviseSink();
+			var second = new ReleasingAdviseSink();
+
+			int connection;
+			data.DAdvise(ref format, ComTypes.ADVF.ADVF_ONLYONCE, first, out connection);
+			data.DAdvise(ref format, ComTypes.ADVF.ADVF_ONLYONCE, second, out connection);
+
+			// ADVF_ONLYONCE drops each connection as it fires, which must not disturb the walk
+			var medium = MakeMedium(1);
+			Assert.DoesNotThrow(() => data.SetData(ref format, ref medium, true));
+			Assert.That(first.CallCount, Is.EqualTo(1));
+			Assert.That(second.CallCount, Is.EqualTo(1));
+
+			// and both connections are spent now
+			var secondMedium = MakeMedium(2);
+			data.SetData(ref format, ref secondMedium, true);
+			Assert.That(first.CallCount, Is.EqualTo(1), "an ADVF_ONLYONCE sink fired twice");
+			Assert.That(second.CallCount, Is.EqualTo(1), "an ADVF_ONLYONCE sink fired twice");
+
+			dataObject.Dispose();
+		}
+
+		[Test]
+		public void DisposingTwiceShouldNotReleaseTwice()
+		{
+			var dataObject = new DragDropDataObject();
+			var format = MakeFormat("eto-test-dispose");
+			var medium = MakeMedium(7);
+			((ComDataObject)dataObject).SetData(ref format, ref medium, true);
+
+			dataObject.Dispose();
+			Assert.That(dataObject.storage, Is.Empty);
+
+			// a second pass must not release the handles the first pass already released
+			Assert.DoesNotThrow(() => dataObject.Dispose());
+			Assert.That(dataObject.storage, Is.Empty);
+		}
+
+		[Test]
+		public void CollectingDataObjectsShouldNotCorruptTheHeap()
+		{
+			// the finalizer used to run ClearStorage a second time after Dispose had already
+			// released everything. Mix disposed and abandoned instances, then force the finalizer.
+			var format = MakeFormat("eto-test-collect");
+			for (int i = 0; i < 50; i++)
+			{
+				var dataObject = new DragDropDataObject();
+				var medium = MakeMedium(i);
+				((ComDataObject)dataObject).SetData(ref format, ref medium, true);
+				if (i % 2 == 0)
+					dataObject.Dispose();
+			}
+
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+
+			// if the heap survived that, a fresh round trip still works
+			var survivor = new DragDropDataObject();
+			var lastMedium = MakeMedium(0x600d600d);
+			((ComDataObject)survivor).SetData(ref format, ref lastMedium, true);
+			Assert.That(ReadMediumInt(OnlyStoredHandle(survivor)), Is.EqualTo(0x600d600d));
+			survivor.Dispose();
+		}
+
+		[Test]
+		public void GetManagedDataShouldNotFreeTheMediumTwice()
+		{
+			// GetManagedData used to wrap the medium's HGLOBAL in an IStream with
+			// fDeleteOnRelease: true and also call ReleaseStgMedium on the medium, freeing the
+			// handle while the stream still owned it -- a use after free while reading, then a
+			// second free when the stream's RCW was collected.
+			const string formatName = "eto-test-managed";
+			var format = MakeFormat(formatName);
+
+			// deliberately not stamped as custom marshaled managed data, so GetManagedData runs
+			// the whole HGLOBAL -> IStream -> read path and then returns null on the stamp mismatch
+			var payload = Enumerable.Range(0, 32).Select(r => (byte)(r + 1)).ToArray();
+
+			var dataObject = new DragDropDataObject();
+			var data = (ComDataObject)dataObject;
+
+			for (int i = 0; i < 50; i++)
+			{
+				var medium = MakeMedium(payload);
+				data.SetData(ref format, ref medium, true);
+
+				Assert.That(ComTypes.ComDataObjectExtensions.GetManagedData(data, formatName), Is.Null,
+					"unstamped data should not deserialize to anything");
+
+				// the entry GetManagedData just read from has to still be intact
+				Assert.That(ReadMedium(OnlyStoredHandle(dataObject), payload.Length), Is.EqualTo(payload),
+					$"reading the managed data released the stored medium on pass {i}");
+			}
+
+			// force the stream RCWs to finalize, which is when the second free used to land
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+
+			Assert.That(ReadMedium(OnlyStoredHandle(dataObject), payload.Length), Is.EqualTo(payload));
+			dataObject.Dispose();
+		}
+
+		[Test]
+		public void GetManagedDataForMissingFormatShouldReturnNull()
+		{
+			var dataObject = new DragDropDataObject();
+			var data = (ComDataObject)dataObject;
+
+			Assert.That(ComTypes.ComDataObjectExtensions.GetManagedData(data, "eto-test-managed-missing"), Is.Null);
+
+			dataObject.Dispose();
+		}
+	}
+}

--- a/test/Eto.Test/Eto.Test.csproj
+++ b/test/Eto.Test/Eto.Test.csproj
@@ -4,7 +4,7 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <DefineConstants>$(DefineConstants);PCL</DefineConstants>
     <OutputType>Library</OutputType>
-      
+    <IsTestProject>false</IsTestProject>
   </PropertyGroup>
   
   <PropertyGroup>


### PR DESCRIPTION
This fixes crashes with the DragDropLib where it frees objects it doesn't own.  Instead it now makes copies and frees them after to avoid leaks and crashing.

This also updates the unit tests to run them via `dotnet test` and in CI on all platforms, overridable with the `--platform=gtk|wpf|winforms|mac` switch.