### PR TITLE
Fix regression with DragDropLib

### DIFF
--- a/src/Eto.Wpf/CustomControls/DragDropLib.cs
+++ b/src/Eto.Wpf/CustomControls/DragDropLib.cs
@@ -13,17 +13,17 @@
 //   2. DataObject.SetData always stores a *duplicate* of the medium, so nothing outside
 //      this class can end the lifetime of a resource held in `storage` and leave
 //      ClearStorage releasing a dangling handle.
-//   3. GetData / GetDataHere no longer report S_OK together with a zeroed STGMEDIUM for
-//      a format we don't have -- a COM caller (the shell's drag image manager, for one)
-//      takes that as valid data. They return DV_E_FORMATETC instead.
-//   4. Advise sinks are handed their own copy of the medium instead of the live entry
+//   3. Advise sinks are handed their own copy of the medium instead of the live entry
 //      out of `storage`.
-//   5. RaiseDataChanged no longer enumerates `connections` while ADVF_ONLYONCE handling
+//   4. RaiseDataChanged no longer enumerates `connections` while ADVF_ONLYONCE handling
 //      removes entries from it.
-//   6. Dispose is idempotent and suppresses finalization.
-//   7. GetMediumFromObject sizes the HGLOBAL by the serialized length rather than the
+//   5. Dispose is idempotent and suppresses finalization.
+//   6. GetMediumFromObject sizes the HGLOBAL by the serialized length rather than the
 //      MemoryStream's capacity, so no uninitialized tail is published.
-//   8. Doc-comment typos cleaned up.
+//   7. Doc-comment typos cleaned up.
+//
+// Deliberately NOT changed: GetData/GetDataHere still report S_OK with an empty STGMEDIUM for a
+// format that isn't present, rather than DV_E_FORMATETC. See the comment in GetDataHere.
 
 #region DragDropLibCore\DragDropHelper.cs
 
@@ -805,17 +805,22 @@ namespace DragDropLib
 		{
 			// Locate the data
 			KeyValuePair<FORMATETC, STGMEDIUM> dataEntry;
-			if (!GetDataEntry(ref format, out dataEntry))
+			if (GetDataEntry(ref format, out dataEntry))
 			{
-				// Don't hand back an empty medium with S_OK: this is a COM server, so
-				// returning normally reports success and a caller -- the shell's drag image
-				// manager, for one -- will then treat the zeroed STGMEDIUM as valid data.
-				medium = default(STGMEDIUM);
-				throw Marshal.GetExceptionForHR(DV_E_FORMATETC);
+				STGMEDIUM source = dataEntry.Value;
+				medium = CopyMedium(ref source);
+				return;
 			}
 
-			STGMEDIUM source = dataEntry.Value;
-			medium = CopyMedium(ref source);
+			// Didn't find it. Return an empty data medium.
+			//
+			// Strictly this should report DV_E_FORMATETC, since returning normally tells a COM caller
+			// S_OK. Don't: this object is handed to System.Windows.DataObject and read back through
+			// in-process *managed* calls, so an HRESULT here is raised as a COMException rather than
+			// being handled as a return code -- and neither WPF's OleConverter nor Eto's own readers
+			// (DataObjectHandler.GetStream) check QueryGetData first, so a drag/drop that probes for a
+			// format it doesn't have would fail outright. Callers must check medium.tymed before use.
+			medium = default(STGMEDIUM);
 		}
 
 		/// <summary>
@@ -894,11 +899,6 @@ namespace DragDropLib
 				else
 				{
 					sm = CopyMedium(ref medium);
-
-					// release == true transferred ownership to us; we hold a duplicate now,
-					// so let the caller's original go.
-					if (release)
-						ReleaseStgMedium(ref medium);
 				}
 
 				// If the format already exists in storage, drop the old entry.
@@ -926,6 +926,15 @@ namespace DragDropLib
 				KeyValuePair<FORMATETC, STGMEDIUM> addPair = new KeyValuePair<FORMATETC, STGMEDIUM>(formatIn, sm);
 				storage.Add(addPair);
 				RaiseDataChanged(ref addPair);
+
+				// release == true transferred ownership to us, and we hold a duplicate, so drop the
+				// caller's original. This has to be the LAST thing we do: callers that pass
+				// release: true free the medium themselves if SetData throws (see
+				// SetDropDescription), so releasing it before anything that can fail would let them
+				// free an already-freed handle. Failing before this point simply leaves the caller
+				// owning its medium and us owning the duplicate, which is safe.
+				if (release && medium.unionmember != IntPtr.Zero)
+					ReleaseStgMedium(ref medium);
 			}
 		}
 

--- a/test/Eto.Test.Wpf/UnitTests/DragDropLibDataObjectTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/DragDropLibDataObjectTests.cs
@@ -34,8 +34,6 @@ namespace Eto.Test.Wpf.UnitTests
 		[DllImport("kernel32.dll")]
 		static extern bool GlobalUnlock(IntPtr hMem);
 
-		const int DV_E_FORMATETC = unchecked((int)0x80040064);
-
 		#endregion
 
 		#region Helpers
@@ -118,6 +116,20 @@ namespace Eto.Test.Wpf.UnitTests
 			public void OnClose() { }
 		}
 
+		/// <summary>
+		/// An advise sink that fails, to make SetData throw after it has already stored the data.
+		/// </summary>
+		class ThrowingAdviseSink : ComTypes.IAdviseSink
+		{
+			public void OnDataChange(ref ComTypes.FORMATETC format, ref ComTypes.STGMEDIUM stgmedium)
+				=> throw new InvalidOperationException("sink failed");
+
+			public void OnViewChange(int aspect, int index) { }
+			public void OnRename(ComTypes.IMoniker moniker) { }
+			public void OnSave() { }
+			public void OnClose() { }
+		}
+
 		#endregion
 
 		[Test]
@@ -190,19 +202,20 @@ namespace Eto.Test.Wpf.UnitTests
 		}
 
 		[Test]
-		public void GetDataForMissingFormatShouldReportAnError()
+		public void GetDataForMissingFormatShouldReturnAnEmptyMedium()
 		{
 			var dataObject = new DragDropDataObject();
 			var data = (ComDataObject)dataObject;
 			var format = MakeFormat("eto-test-missing");
 			var medium = default(ComTypes.STGMEDIUM);
 
-			// returning normally reports S_OK to a COM caller, which then treats the zeroed
-			// STGMEDIUM as valid data
-			var exception = Assert.Catch(() => data.GetData(ref format, out medium));
-			Assert.That(exception.HResult, Is.EqualTo(DV_E_FORMATETC), "expected DV_E_FORMATETC");
-			Assert.That(medium.unionmember, Is.EqualTo(IntPtr.Zero));
+			// Must NOT raise DV_E_FORMATETC. WPF and Eto read this object through in-process managed
+			// calls without checking QueryGetData first, so an HRESULT here becomes a COMException in
+			// the middle of a drag. An empty medium (TYMED_NULL) is the contract callers rely on.
+			Assert.DoesNotThrow(() => data.GetData(ref format, out medium));
 			Assert.That(medium.tymed, Is.EqualTo(ComTypes.TYMED.TYMED_NULL));
+			Assert.That(medium.unionmember, Is.EqualTo(IntPtr.Zero));
+			Assert.That(medium.pUnkForRelease, Is.Null);
 			Assert.That(data.QueryGetData(ref format), Is.Not.EqualTo(0), "QueryGetData claimed the format is present");
 
 			dataObject.Dispose();
@@ -264,6 +277,68 @@ namespace Eto.Test.Wpf.UnitTests
 
 			data.DUnadvise(connection);
 			dataObject.Dispose();
+		}
+
+		[Test]
+		public void SetDataThatFailsShouldNotHaveReleasedTheCallersHandle()
+		{
+			// Callers that pass release: true free the medium themselves when SetData throws --
+			// ComDataObjectExtensions.SetDropDescription and SetByteData both do. So a failure must
+			// leave the caller's handle untouched, or their own cleanup double frees it.
+			var dataObject = new DragDropDataObject();
+			var data = (ComDataObject)dataObject;
+			var format = MakeFormat("eto-test-throwing-sink");
+
+			int connection;
+			data.DAdvise(ref format, default(ComTypes.ADVF), new ThrowingAdviseSink(), out connection);
+
+			var medium = MakeMedium(0x0abcdef0);
+			var callerHandle = medium.unionmember;
+
+			Assert.Throws<InvalidOperationException>(() => data.SetData(ref format, ref medium, true));
+
+			Assert.That(ReadMediumInt(callerHandle), Is.EqualTo(0x0abcdef0),
+				"SetData released the caller's medium before failing, so the caller's own cleanup would free it twice");
+
+			Marshal.FreeHGlobal(callerHandle);
+			dataObject.Dispose();
+		}
+
+		[Test]
+		public void CallerCleanupAfterSetDataFailsShouldNotLeaveStorageDangling()
+		{
+			// The shape of RH-95450 / RH-97411. Every Eto WPF drag registers an advise sink on the
+			// DropDescription format (DragSourceHelper.RegisterDefaultDragSource) and then calls
+			// SetDropDescription with release: true on every DragOver. If SetData fails after it has
+			// stored the entry, SetDropDescription's finally frees the HGLOBAL it passed in -- so if
+			// storage kept that very handle instead of a duplicate, the entry is left dangling and
+			// the ReleaseStgMedium in ClearStorage faults when the data object is finally released,
+			// which is where the reported crash lands.
+			var dataObject = new DragDropDataObject();
+			var data = (ComDataObject)dataObject;
+			var format = MakeFormat("eto-test-dangling");
+
+			int connection;
+			data.DAdvise(ref format, default(ComTypes.ADVF), new ThrowingAdviseSink(), out connection);
+
+			var medium = MakeMedium(0x0d0a0d0a);
+			var callerHandle = medium.unionmember;
+
+			Assert.Throws<InvalidOperationException>(() => data.SetData(ref format, ref medium, true));
+
+			// the entry was stored before the failure, and it must not be the caller's handle
+			Assert.That(dataObject.storage, Has.Count.EqualTo(1));
+			var storedHandle = dataObject.storage[0].Value.unionmember;
+			Assert.That(storedHandle, Is.Not.EqualTo(callerHandle),
+				"storage kept the caller's handle, so the caller's own cleanup leaves this entry dangling");
+
+			// exactly what SetDropDescription's finally does when SetData throws
+			Marshal.FreeHGlobal(callerHandle);
+
+			// so releasing storage is still safe: this is the ClearStorage call that crashed
+			Assert.That(ReadMediumInt(storedHandle), Is.EqualTo(0x0d0a0d0a),
+				"the caller's cleanup freed the handle that storage is still holding");
+			Assert.DoesNotThrow(() => dataObject.Dispose());
 		}
 
 		[Test]


### PR DESCRIPTION
This is a follow up to #3009 to fix this exception that now throws.  Technically, it should throw but it's better to be resilient.

```
System.Runtime.InteropServices.COMException (0x80040064): Invalid FORMATETC structure (0x80040064 (DV_E_FORMATETC))
  at DragDropLib.DataObject.GetDataHere(FORMATETC& format, STGMEDIUM& medium) in C:\\Users\\curtis\\Projects\\rhino9\\src4\\DotNetSDK\\Eto\\src\\Eto.Wpf\\CustomControls\\DragDropLib.cs:line 814
  at DragDropLib.DataObject.GetData(FORMATETC& format, STGMEDIUM& medium) in C:\\Users\\curtis\\Projects\\rhino9\\src4\\DotNetSDK\\Eto\\src\\Eto.Wpf\\CustomControls\\DragDropLib.cs:line 794
```