### PR TITLE
Handle SegmentedItem.SelectedChangedEvent to avoid warnings in debug

### DIFF
--- a/src/Eto/Forms/ThemedControls/ThemedSegmentedButtonHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedSegmentedButtonHandler.cs
@@ -191,6 +191,8 @@ public abstract class ThemedSegmentedItemHandler<TWidget, TCallback> : WidgetHan
 		{
 			case SegmentedItem.ClickEvent:
 				break;
+			case SegmentedItem.SelectedChangedEvent:
+				break;
 			default:
 				base.AttachEvent(id);
 				break;


### PR DESCRIPTION
This fixes a warning in debug that the event isn't handled in the ThemedSegmentedItemHandler, when in fact it is.