### PR TITLE
Wpf: Fix last unit tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,6 @@ jobs:
     # assemblies would be recompiled with a different version stamp than the uploaded artifacts.
     - name: Run unit tests (Wpf)
       timeout-minutes: 30
-      continue-on-error: true # TODO: remove once the existing test failures are fixed
       run: dotnet test --project test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj -f net10.0-windows -c ${{ env.BuildConfiguration }} --no-build --filter "TestCategory!=ManualTest" -- --platform=wpf --report-trx --report-trx-filename wpf.trx
 
     - name: Test summary (Wpf)

--- a/src/Eto.Wpf/Forms/Controls/DateTimePickerHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/DateTimePickerHandler.cs
@@ -61,6 +61,10 @@ namespace Eto.Wpf.Forms.Controls
 		bool _showBorder = true;
 
 		EtoCustomComboBox _combo;
+		// hosts the stepper inside the combo box so it can be detached from it synchronously when
+		// switching modes. Clearing the combo's EditContent alone doesn't disconnect the stepper from
+		// the visual tree until the content presenter is re-measured.
+		swc.Decorator _comboEditHost;
 		swc.Calendar _calendar;
 		DateTimeMaskedTextStepper _stepper;
 		int _suppress;
@@ -83,15 +87,22 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			EnsureStepper();
 			_stepper.Mode = _mode;
+			var stepperControl = _stepper.ToNative(true);
 			if (_mode == DateTimePickerMode.Time)
 			{
+				// the stepper is shown directly, so detach it from the combo first
+				if (_comboEditHost != null)
+					_comboEditHost.Child = null;
 				_stepper.ShowStepper = true;
-				Control.Child = _stepper.ToNative(true);
+				Control.Child = stepperControl;
 			}
 			else
 			{
 				_stepper.ShowStepper = false;
 				_stepper.ShowBorder = false;
+				// the stepper goes inside the combo, so detach it from this control first
+				if (ReferenceEquals(Control.Child, stepperControl))
+					Control.Child = null;
 				EnsureCombo();
 				Control.Child = _combo;
 			}
@@ -107,12 +118,14 @@ namespace Eto.Wpf.Forms.Controls
 
 			if (_combo != null)
 			{
-				_combo.EditContent = _stepper.ToNative(true);
+				_comboEditHost.Child = _stepper.ToNative(true);
 				return;
 			}
 
 			_calendar = new swc.Calendar { SelectionMode = swc.CalendarSelectionMode.SingleDate };
 			_calendar.SelectedDatesChanged += Calendar_SelectedDatesChanged;
+
+			_comboEditHost = new swc.Decorator { Child = _stepper.ToNative(true) };
 
 			// the combo box visuals (background, border, chevron) come from the theme style in
 			// themes/generic/CustomComboBox.xaml so it follows the active WPF theme.
@@ -120,7 +133,7 @@ namespace Eto.Wpf.Forms.Controls
 			{
 				Handler = this,
 				Focusable = false,
-				EditContent = _stepper.ToNative(true),
+				EditContent = _comboEditHost,
 				DropDownContent = _calendar
 			};
 			_combo.DropDownOpened += (sender, e) => SyncCalendarFromValue();

--- a/src/Eto.Wpf/Forms/Controls/NativeControlHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/NativeControlHandler.cs
@@ -90,7 +90,12 @@ public class NativeControlHandler : WpfFrameworkElement<sw.FrameworkElement, Con
 
 sealed class EtoHwndHost : HwndHost
 {
+	// there's nothing to measure when we host our own (empty) window, so use a default size
+	// so the control still reports a sane preferred size like other Eto controls.
+	static readonly Size s_defaultSize = new Size(100, 100);
+
 	HandleRef? _hwnd;
+	readonly bool _createsOwnWindow;
 	swc.ScrollViewer _parentScrollViewer;
 	sd.Rectangle _regionRect = sd.Rectangle.Empty;
 
@@ -99,6 +104,24 @@ sealed class EtoHwndHost : HwndHost
 	public EtoHwndHost(HandleRef? hwnd)
 	{
 		_hwnd = hwnd;
+		_createsOwnWindow = hwnd == null;
+	}
+
+	protected override sw.Size MeasureOverride(sw.Size constraint)
+	{
+		var size = base.MeasureOverride(constraint);
+
+		// HwndHost cannot measure the window it hosts, so fall back to the default size for the
+		// placeholder window created in BuildWindowCore. Any user-specified size is applied by
+		// WpfFrameworkElement.SetSize() via Width/Height so it still takes precedence here.
+		if (_createsOwnWindow)
+		{
+			if (size.Width <= 0)
+				size.Width = Math.Min(s_defaultSize.Width, constraint.Width);
+			if (size.Height <= 0)
+				size.Height = Math.Min(s_defaultSize.Height, constraint.Height);
+		}
+		return size;
 	}
 
 	protected override HandleRef BuildWindowCore(HandleRef hwndParent)
@@ -106,7 +129,7 @@ sealed class EtoHwndHost : HwndHost
 		if (_hwnd == null)
 		{
 			// create a new WinForms Usercontrol to host whatever we want
-			var size = GetPreferredSize?.Invoke() ?? new Size(100, 100);
+			var size = GetPreferredSize?.Invoke() ?? s_defaultSize;
 			var ctl = new swf.UserControl();
 			ctl.Size = size.ToSD();
 			_hwnd = new HandleRef(ctl, ctl.Handle);

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -551,7 +551,9 @@ namespace Eto.Wpf.Forms
 					// handled in DoDragDrop, as it is blocking on Windows
 					break;
 				case Eto.Forms.Control.EnabledChangedEvent:
-					Control.IsEnabledChanged += Control_IsEnabledChanged;
+					// Enabled is set on the container, which isn't always the same as Control (and Control
+					// may not even be in the visual tree yet, e.g. an empty TableLayout), so watch that instead.
+					ContainerControl.IsEnabledChanged += Control_IsEnabledChanged;
 					break;
 				case Eto.Forms.Control.ThemeChangedEvent:
 					if (_needsThemeChanged)
@@ -1079,9 +1081,19 @@ namespace Eto.Wpf.Forms
 
 		System.Windows.Forms.Screen SwfScreen => Win32.GetScreenFromWindow(Widget.ParentWindow?.NativeHandle ?? IntPtr.Zero);
 
+		/// <summary>
+		/// Determines if the control can be translated to/from screen co-ordinates.
+		/// </summary>
+		/// <remarks>
+		/// WPF raises its Loaded event at <see cref="sw.Threading.DispatcherPriority.Loaded"/>, so its IsLoaded can still
+		/// be false right after a control has been added, measured and arranged (e.g. after Control.UpdateLayout()).
+		/// Eto's Loaded state is already set at that point, so check both to translate as soon as it is possible.
+		/// </remarks>
+		bool CanTranslateToScreen => ContainerControl.IsLoaded || Widget.Loaded;
+
 		public PointF PointFromScreen(PointF point)
 		{
-			if (!ContainerControl.IsLoaded)
+			if (!CanTranslateToScreen)
 				return point;
 
 			// ensure we're connected to a presentation source
@@ -1115,7 +1127,7 @@ namespace Eto.Wpf.Forms
 
 		public PointF PointToScreen(PointF point)
 		{
-			if (!ContainerControl.IsLoaded)
+			if (!CanTranslateToScreen)
 				return point;
 
 			// ensure we're connected to a presentation source


### PR DESCRIPTION
- DateTimePicker should roundtrip its selected value when changing modes
- NativeControl should report a default size when it creates its own window
- Correctly trigger EnabledChanged for TableLayout