### PR TITLE
MouseUp on lost capture now passes MouseButtons.None

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,7 +101,8 @@ Only the Gtk path above has been exercised; treat the others as starting points 
 
 To exercise the *real* keypress→widget path (e.g. verifying a TextBox fires input events exactly
 once), drive a shown window with **xdotool over the real X display** — `gtk_test_widget_send_key`
-P/Invoke is a no-op here (needs a focused toplevel under a WM). There's **no window manager**, so:
+P/Invoke is a no-op here (needs a focused toplevel under a WM). Window management can't be relied
+on (see the mouse section below — the session is mutter/XWayland), so:
 
 - Launch the app (`DISPLAY=:0 GDK_BACKEND=x11`), give the target widget focus, print a `READY`
   marker, and add a `UITimer` auto-quit so the process never hangs (no `kill` — it's forbidden).
@@ -110,6 +111,33 @@ P/Invoke is a no-op here (needs a focused toplevel under a WM). There's **no win
 - `windowactivate` fails `BadWindow` without a WM; use `windowfocus --sync <id>` then inject with
   **XTEST** (`xdotool key a` / `xdotool type "ab"` — *no* `--window`, which uses XSendEvent that GTK
   ignores). XTEST goes to whatever holds X input focus, which `windowfocus` just set.
+
+## Injecting mouse events to test drag/capture behaviour (Gtk)
+
+**xdotool pointer injection does not work here** (only keyboard does): under a mutter/XWayland
+session a full-screen `mutter guard window` sits above all X clients, so XTEST `mousemove`/
+`mousedown`/`click` never reach the app (`xdotool getmouselocation` reports the root window even
+when the pointer is over your window). Also `xdotool search --name` returns both the mutter frame
+*and* the client window — the frame's geometry is offset from the client's, so clicking `frame + n`
+lands on the decoration; check `xwininfo -id <id>` (`Width`/`Height`) to pick the client.
+
+Instead synthesize GDK events and push them through GTK's real dispatch, which honours grabs
+(`gtk_grab_add` from `gtk_dialog_run`, etc.), so capture/grab behaviour is exercised faithfully:
+
+```csharp
+var ev = Gdk.EventHelper.New(Gdk.EventType.ButtonPress); // or MotionNotify/ButtonRelease
+var bev = new Gdk.EventButton(ev.Handle) { Window = eventBoxGdkWindow, SendEvent = true,
+    Time = time += 100, X = 60, Y = 60, Button = 1, State = 0,
+    Device = Gdk.Display.Default.DefaultSeat.Pointer }; // XRoot/YRoot from Window.GetOrigin
+Gtk.Main.DoEvent(ev);
+```
+
+- Get the widget to target from the handler's `EventControl` (an `EtoEventBox` for `Panel`) and use
+  its `.Window` as the event window, otherwise GTK routes the event elsewhere.
+- A modal `Dialog` blocks in a nested main loop inside your handler, so schedule each later step on
+  its **own** `GLib.Timeout` source — a single source won't re-enter while its callback is blocked.
+- Anything reading the *real* pointer (`Mouse.Position`, `Mouse.Buttons`, and so the location and
+  buttons of events Eto synthesizes itself) still reports the physical mouse, not your fake events.
 
 ## Test project layout (non-obvious)
 

--- a/src/Eto.Gtk/Forms/GtkControl.cs
+++ b/src/Eto.Gtk/Forms/GtkControl.cs
@@ -67,6 +67,7 @@ namespace Eto.GtkSharp.Forms
 		public static readonly object AllowDrop_Key = new object();
 		public static readonly object DeferMouseLeave_Key = new object();
 		public static readonly object IsMouseCaptured_Key = new object();
+		public static readonly object LostMouseCaptureAttached_Key = new object();
 		public static readonly object LastEnteredControls_Key = new object();
 		public static readonly object ShouldTranslatePoints_Key = new object();
 		internal static readonly object ContextMenu_Key = new object();
@@ -417,10 +418,12 @@ namespace Eto.GtkSharp.Forms
 					EventControl.AddEvents((int)Gdk.EventMask.ButtonPressMask);
 					EventControl.AddEvents((int)Gdk.EventMask.ButtonReleaseMask);
 					EventControl.ButtonPressEvent += Connector.HandleButtonPressEvent;
+					AttachLostMouseCaptureEvents();
 					break;
 				case Eto.Forms.Control.MouseUpEvent:
 					EventControl.AddEvents((int)Gdk.EventMask.ButtonReleaseMask);
 					EventControl.ButtonReleaseEvent += Connector.HandleButtonReleaseEvent;
+					AttachLostMouseCaptureEvents();
 					break;
 				case Eto.Forms.Control.MouseEnterEvent:
 					EventControl.AddEvents((int)Gdk.EventMask.EnterNotifyMask);
@@ -483,6 +486,43 @@ namespace Eto.GtkSharp.Forms
 					base.AttachEvent(id);
 					return;
 			}
+		}
+
+		/// <summary>
+		/// Attaches the events used to detect when this control loses the mouse capture.
+		/// </summary>
+		/// <remarks>
+		/// Both MouseDown and MouseUp need this, so guard against attaching them twice.
+		/// </remarks>
+		void AttachLostMouseCaptureEvents()
+		{
+			if (Widget.Properties.Get<bool>(GtkControl.LostMouseCaptureAttached_Key))
+				return;
+			Widget.Properties.Set(GtkControl.LostMouseCaptureAttached_Key, true);
+			// a gtk grab elsewhere (e.g. showing a modal dialog) shadows this control
+			EventControl.GrabNotify += Connector.HandleGrabNotify;
+			// the gdk (device) grab was taken away, e.g. by another application or a drag operation
+			EventControl.GrabBrokenEvent += Connector.HandleGrabBrokenEvent;
+		}
+
+		/// <summary>
+		/// Triggers MouseUp when the mouse capture is lost without a button release being sent.
+		/// </summary>
+		/// <remarks>
+		/// This can happen when something takes the grab away in the middle of a drag, such as showing
+		/// a dialog.  GTK sends the button release to whatever has the grab instead of this control, so
+		/// without this any dragging logic in user code would never get a chance to unwind.
+		/// This is the equivalent of WPF's LostMouseCapture.
+		/// <see cref="MouseButtons.None"/> is passed as the user may not have released the button yet, so it
+		/// isn't mistakenly taken as a mouse click.
+		/// </remarks>
+		void TriggerMouseUpForLostCapture()
+		{
+			if (!IsMouseCaptured)
+				return;
+			IsMouseCaptured = false;
+			var location = Widget.PointFromScreen(Mouse.Position);
+			Callback.OnMouseUp(Widget, new MouseEventArgs(MouseButtons.None, Keyboard.Modifiers, location));
 		}
 
 		protected new GtkControlConnector Connector { get { return (GtkControlConnector)base.Connector; } }
@@ -651,6 +691,19 @@ namespace Eto.GtkSharp.Forms
 				var mouseArgs = new MouseEventArgs(buttons, modifiers, p);
 				handler.Callback.OnMouseUp(handler.Widget, mouseArgs);
 				args.RetVal = mouseArgs.Handled;
+			}
+
+			public void HandleGrabNotify(object o, Gtk.GrabNotifyArgs args)
+			{
+				// WasGrabbed is false when a grab was added elsewhere, so this control no longer gets events
+				if (!args.WasGrabbed)
+					Handler?.TriggerMouseUpForLostCapture();
+			}
+
+			[GLib.ConnectBefore]
+			public void HandleGrabBrokenEvent(object o, Gtk.GrabBrokenEventArgs args)
+			{
+				Handler?.TriggerMouseUpForLostCapture();
 			}
 
 			[GLib.ConnectBefore]

--- a/src/Eto.Mac/Forms/DialogHandler.cs
+++ b/src/Eto.Mac/Forms/DialogHandler.cs
@@ -146,7 +146,7 @@ namespace Eto.Mac.Forms
 			ApplicationHandler.Instance.EnsureActivated(ShowInTaskbar, true, Icon);
 			Control.LayoutIfNeeded();
 			Callback.OnLoadComplete(Widget, EventArgs.Empty);
-			MacView.InMouseTrackingLoop = false;
+			MacView.CancelMouseTracking();
 			session = null;
 			EnsureOwner();
 			Application.Instance.AsyncInvoke(FireOnShown); // fire after dialog is shown
@@ -166,7 +166,7 @@ namespace Eto.Mac.Forms
 			ApplicationHandler.Instance.EnsureActivated(ShowInTaskbar, true, Icon);
 			Control.LayoutIfNeeded();
 			Callback.OnLoadComplete(Widget, EventArgs.Empty);
-			MacView.InMouseTrackingLoop = false;
+			MacView.CancelMouseTracking();
 			var tcs = new TaskCompletionSource<bool>();
 			session = null;
 			EnsureOwner();

--- a/src/Eto.Mac/Forms/MacView.cs
+++ b/src/Eto.Mac/Forms/MacView.cs
@@ -644,6 +644,28 @@ namespace Eto.Mac.Forms
 		/// </summary>
 		public static bool InMouseTrackingLoop;
 
+		/// <summary>
+		/// Triggers the MouseUp of the control that is currently in a mouse tracking loop, if any.
+		/// </summary>
+		internal static Action TriggerMouseUpWhenCancelled;
+
+		/// <summary>
+		/// Cancels the mouse tracking loop when the MouseUp event is going to be buried, such as when
+		/// showing a modal dialog or context menu during a mouse down or drag.
+		/// </summary>
+		/// <remarks>
+		/// This triggers the MouseUp of the control being tracked right away (with <see cref="MouseButtons.None"/>)
+		/// so user code can unwind any dragging logic before the modal loop starts, instead of getting it
+		/// only after the modal loop has finished (or not at all).
+		/// </remarks>
+		public static void CancelMouseTracking()
+		{
+			InMouseTrackingLoop = false;
+			var triggerMouseUp = TriggerMouseUpWhenCancelled;
+			TriggerMouseUpWhenCancelled = null;
+			triggerMouseUp?.Invoke();
+		}
+
 		public static IMacViewHandler CapturedControl;
 
 		public static IntPtr selViewDidMoveToWindow = Selector.GetHandle("viewDidMoveToWindow");
@@ -1015,6 +1037,9 @@ namespace Eto.Mac.Forms
 				case NSEventType.OtherMouseUp:
 					{
 						var args = MacConversions.GetMouseEvent(this, evt, false);
+						// the real mouse up is being delivered, so don't trigger another one if the mouse
+						// tracking is cancelled from this event (e.g. showing a dialog during MouseUp).
+						MacView.TriggerMouseUpWhenCancelled = null;
 						Callback.OnMouseUp(Widget, args);
 						SuppressMouseTriggerCallback = true;
 						MacView.CapturedControl = null;
@@ -1215,7 +1240,7 @@ namespace Eto.Mac.Forms
 
 		public void Print()
 		{
-			MacView.InMouseTrackingLoop = false;
+			MacView.CancelMouseTracking();
 			PrintSettingsHandler.SetDefaults(NSPrintInfo.SharedPrintInfo);
 			ContainerControl.Print(ContainerControl);
 		}
@@ -1688,41 +1713,79 @@ namespace Eto.Mac.Forms
 		{
 			var app = NSApplication.SharedApplication;
 			MacView.CapturedControl = this;
+			var oldTriggerMouseUp = MacView.TriggerMouseUpWhenCancelled;
+			// when the mouse up gets buried (e.g. a dialog is shown during a drag), fire the MouseUp ourselves.
+			// only for the automatic loop, an explicit CaptureMouse() is up to the user to release.
+			if (autoRelease)
+				MacView.TriggerMouseUpWhenCancelled = TriggerMouseUpForCancelledTracking;
 			bool continueLoop;
 			// Console.WriteLine("Entered MouseTrackingLoop");
-			do
+			try
 			{
-				var evt = app.NextEvent(NSEventMask.AnyEvent, NSDate.DistantFuture, MouseTrackingRunLoopMode, true);
-
-				switch (evt.Type)
+				do
 				{
-					case NSEventType.LeftMouseUp:
-					case NSEventType.RightMouseUp:
-					case NSEventType.OtherMouseUp:
-						TriggerMouseCallback(evt);
-						if (autoRelease)
-						{
-							MacView.InMouseTrackingLoop = false;
-							MacView.CapturedControl = null;
-						}
-						break;
-					case NSEventType.LeftMouseDragged:
-					case NSEventType.RightMouseDragged:
-					case NSEventType.OtherMouseDragged:
-					case NSEventType.LeftMouseDown:
-					case NSEventType.RightMouseDown:
-					case NSEventType.OtherMouseDown:
-						TriggerMouseCallback(evt);
-						break;
-					default:
-						// not a mouse event, send it along.
-						app.SendEvent(evt);
-						break;
+					var evt = app.NextEvent(NSEventMask.AnyEvent, NSDate.DistantFuture, MouseTrackingRunLoopMode, true);
+
+					switch (evt.Type)
+					{
+						case NSEventType.LeftMouseUp:
+						case NSEventType.RightMouseUp:
+						case NSEventType.OtherMouseUp:
+							TriggerMouseCallback(evt);
+							if (autoRelease)
+							{
+								MacView.InMouseTrackingLoop = false;
+								MacView.CapturedControl = null;
+							}
+							break;
+						case NSEventType.LeftMouseDragged:
+						case NSEventType.RightMouseDragged:
+						case NSEventType.OtherMouseDragged:
+						case NSEventType.LeftMouseDown:
+						case NSEventType.RightMouseDown:
+						case NSEventType.OtherMouseDown:
+							TriggerMouseCallback(evt);
+							break;
+						default:
+							// not a mouse event, send it along.
+							app.SendEvent(evt);
+							break;
+					}
+					continueLoop = autoRelease ? MacView.InMouseTrackingLoop : CaptureLoopEnabled;
 				}
-				continueLoop = autoRelease ? MacView.InMouseTrackingLoop : CaptureLoopEnabled;
+				while (continueLoop);
 			}
-			while (continueLoop);
+			finally
+			{
+				if (autoRelease)
+					MacView.TriggerMouseUpWhenCancelled = oldTriggerMouseUp;
+			}
 			// Console.WriteLine("Exited MouseTrackingLoop");
+		}
+
+		/// <summary>
+		/// Triggers MouseUp when the mouse tracking loop is cancelled before the mouse button was released.
+		/// </summary>
+		/// <remarks>
+		/// This happens when something buries the mouse up event during a mouse down or drag, such as showing
+		/// a modal dialog or context menu.  Without this, user code would only get the MouseUp after the modal
+		/// loop finishes (if at all) so any dragging logic would never get a chance to unwind.
+		/// <see cref="MouseButtons.None"/> is passed as the user may not have released the button yet, so it
+		/// isn't mistakenly taken as a mouse click.
+		/// </remarks>
+		void TriggerMouseUpForCancelledTracking()
+		{
+			if (Widget?.IsDisposed != false)
+				return;
+
+			if (MacView.CapturedControl == this)
+				MacView.CapturedControl = null;
+
+			// don't fire MouseUp again if the real mouse up event does eventually get delivered
+			SuppressMouseUp = true;
+
+			var location = PointFromScreen(Mouse.Position);
+			Callback.OnMouseUp(Widget, new MouseEventArgs(MouseButtons.None, Keyboard.Modifiers, location));
 		}
 
 		public virtual MouseEventArgs TriggerMouseUp(NSObject obj, IntPtr sel, NSEvent theEvent)
@@ -1738,6 +1801,10 @@ namespace Eto.Mac.Forms
 			if (!SuppressMouseUp)
 			{
 				Callback.OnMouseUp(Widget, args);
+			}
+			else
+			{
+				// only suppress a single mouse up
 				SuppressMouseUp = false;
 			}
 

--- a/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
+++ b/src/Eto.Mac/Forms/Menu/ContextMenuHandler.cs
@@ -113,7 +113,7 @@ namespace Eto.Mac.Forms.Menu
 		public void Show(Control relativeTo, PointF? location)
 		{
 			var view = relativeTo?.GetContainerView();
-			MacView.InMouseTrackingLoop = false;
+			MacView.CancelMouseTracking();
 
 			if (location != null || view == null)
 			{

--- a/src/Eto.Mac/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Mac/Forms/MessageBoxHandler.cs
@@ -14,7 +14,7 @@ namespace Eto.Mac.Forms
 
 		public DialogResult ShowDialog(Control parent)
 		{
-			MacView.InMouseTrackingLoop = false;
+			MacView.CancelMouseTracking();
 			var alert = new NSAlert();
 
 			AddButtons(alert);

--- a/src/Eto.Mac/Forms/Printing/PrintDialogHandler.cs
+++ b/src/Eto.Mac/Forms/Printing/PrintDialogHandler.cs
@@ -22,7 +22,7 @@ namespace Eto.Mac.Forms.Printing
 
 		public DialogResult ShowDialog(Window parent)
 		{
-			MacView.InMouseTrackingLoop = false;
+			MacView.CancelMouseTracking();
 			int ret;
 			var docHandler = Document != null ? Document.Handler as PrintDocumentHandler : null;
 

--- a/src/Eto.Mac/Forms/SelectFolderDialogHandler.cs
+++ b/src/Eto.Mac/Forms/SelectFolderDialogHandler.cs
@@ -18,7 +18,7 @@ namespace Eto.Mac.Forms
 
 		public DialogResult ShowDialog(Window parent)
 		{
-			MacView.InMouseTrackingLoop = false;
+			MacView.CancelMouseTracking();
 			var ret = Control.RunModal();
 			return ret == 1 ? DialogResult.Ok : DialogResult.Cancel;
 		}

--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -940,7 +940,10 @@ namespace Eto.Wpf.Forms
 				// this can happen when something happens during the mouse dragging, such as showing a dialog.
 				isMouseCaptured = false;
 
-				var args = e.ToEto(ContainerControl, swi.MouseButtonState.Pressed);
+				// MouseButtons.None is passed as the user may not have released the button yet,
+				// so it isn't mistakenly taken as a mouse click.
+				var location = e.GetPosition(ContainerControl).ToEto();
+				var args = new MouseEventArgs(MouseButtons.None, swi.Keyboard.Modifiers.ToEto(), location);
 				Callback.OnMouseUp(Widget, args);
 			}
 		}

--- a/test/Eto.Test/UnitTests/Forms/Behaviors/MouseTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Behaviors/MouseTests.cs
@@ -284,5 +284,116 @@ namespace Eto.Test.UnitTests.Forms.Behaviors
 			Assert.That(panel1ShouldNeverBeCaptured, Is.False, "#5 - Panel2 should never be captured");
 			Assert.That(panel2ShouldNeverHaveMouseMoveWithoutCapturing, Is.False, "#6 - Panel2 should not have a MouseMove with a button down without being captured");
 		}
+
+		/// <summary>
+		/// Issue: RH-69389 - When a dialog is shown while dragging (e.g. a package update prompt), the mouse
+		/// capture is taken away from the control being dragged and MouseUp is never fired, so any dragging
+		/// logic never gets a chance to unwind.
+		/// </summary>
+		[Test, ManualTest]
+		public void MouseUpShouldFireWhenDialogIsShownDuringDrag()
+		{
+			var mouseDown = false;
+			string mouseDownResults = null;
+			var dialogShown = false;
+			var dialogClosed = false;
+			var mouseUpCalled = false;
+			var mouseUpBeforeDialogClosed = false;
+			var mouseUpButtons = MouseButtons.None;
+			string mouseUpResults = null;
+			string extraMouseUpResults = null;
+			ManualForm("Click and drag the blue square.\nWhen the dialog appears, release the mouse button and close the dialog.\nThe square should turn green.",
+			form =>
+			{
+				var panel = new Panel { Size = new Size(200, 200), BackgroundColor = Colors.Blue };
+
+				void CheckFinished()
+				{
+					if (mouseUpCalled && dialogClosed)
+						Application.Instance.AsyncInvoke(form.Close);
+				}
+
+				panel.MouseDown += (sender, e) =>
+				{
+					mouseDownResults = $"Panel.MouseDown: {e.Location}, Buttons: {e.Buttons}";
+					if (e.Buttons == MouseButtons.Primary)
+					{
+						mouseDown = true;
+						e.Handled = true; // capture the mouse so we get moves outside the panel
+					}
+				};
+
+				panel.MouseMove += (sender, e) =>
+				{
+					Debug.WriteLine($"Panel.MouseMove: {e.Location}");
+					if (!mouseDown || dialogShown || e.Buttons != MouseButtons.Primary)
+						return;
+
+					// simulate something showing a dialog in the middle of a drag operation, which
+					// takes the mouse capture away from the panel without a MouseUp being fired.
+					dialogShown = true;
+
+					var closeButton = new Button { Text = "Close" };
+					var dialog = new Dialog
+					{
+						Title = "Interrupting Dialog",
+						Content = new StackLayout
+						{
+							Padding = 10,
+							Spacing = 10,
+							HorizontalContentAlignment = HorizontalAlignment.Center,
+							Items =
+							{
+								"Release the mouse button, then close this dialog.",
+								closeButton
+							}
+						},
+						DefaultButton = closeButton,
+						AbortButton = closeButton
+					};
+					closeButton.Click += (s, ee) => dialog.Close();
+					dialog.Closed += (s, ee) =>
+					{
+						dialogClosed = true;
+						CheckFinished();
+					};
+					dialog.ShowModal(form);
+				};
+
+				panel.MouseUp += (sender, e) =>
+				{
+					var results = $"Panel.MouseUp: {e.Location}, Buttons: {e.Buttons}, DialogShown: {dialogShown}, DialogClosed: {dialogClosed}";
+					Debug.WriteLine(results);
+					if (mouseUpCalled)
+					{
+						// the real mouse up should be suppressed as MouseUp was already triggered when the dialog was shown
+						extraMouseUpResults = results;
+						return;
+					}
+					mouseUpResults = results;
+					mouseUpCalled = true;
+					mouseUpBeforeDialogClosed = dialogShown && !dialogClosed;
+					mouseUpButtons = e.Buttons;
+					panel.BackgroundColor = Colors.Green;
+					CheckFinished();
+				};
+
+				return panel;
+			}, allowPass: false);
+
+			Assert.That(dialogShown, Is.True, "#1 - Dialog was not shown, the blue square was not dragged");
+			Assert.That(mouseUpCalled, Is.True, "#2 - MouseUp was not fired after a dialog was shown during a drag");
+			if (mouseUpBeforeDialogClosed)
+			{
+				// the button may not have been released yet, so it shouldn't be mistaken for a click
+				Assert.That(mouseUpButtons, Is.EqualTo(MouseButtons.None), "#3 - MouseUp triggered when the dialog was shown should pass MouseButtons.None");
+				// the real mouse up gets delivered when the modal loop is done, which would also be mistaken for a click
+				Assert.That(extraMouseUpResults, Is.Null, $"#4 - MouseUp should only be triggered once, but was also triggered after the dialog was closed: {extraMouseUpResults}");
+			}
+			// not asserted, only logged: some platforms may only fire the MouseUp after the dialog is dismissed
+			Console.WriteLine(mouseDownResults ?? "No MouseDown event"); // so it shows in the test output for verification
+			Console.WriteLine(mouseUpResults ?? "No MouseUp event"); // so it shows in the test output for verification
+			Console.WriteLine($"MouseUp fired {(mouseUpBeforeDialogClosed ? "while the dialog was shown" : "after the dialog was closed")}");
+		}
 	}
 }


### PR DESCRIPTION
All platforms now fire MouseUp the instant the capture is lost after a MouseDown, and MouseEventArgs.Buttons is set to MouseButtons.None as the buttons aren't actually released, which with normal logic would fire click events incorrectly.