### PR TITLE
Fix DateTimeMaskedTextProvider for non-space whitespace characters

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -159,7 +159,6 @@ jobs:
     # job for its full 6 hours. See the Wpf step above for why --no-build is used.
     - name: Run unit tests (Mac)
       timeout-minutes: 30
-      continue-on-error: true # TODO: remove once the existing test failures are fixed
       run: dotnet test --project test/Eto.Test.UnitTests/Eto.Test.UnitTests.csproj -f net10.0 -c ${{ env.BuildConfiguration }} --no-build --filter "TestCategory!=ManualTest" -- --platform=mac --report-trx --report-trx-filename mac.trx
 
     - name: Test summary (Mac)

--- a/src/Eto/Forms/MaskedTextProvider/DateTimeMaskedTextProvider.cs
+++ b/src/Eto/Forms/MaskedTextProvider/DateTimeMaskedTextProvider.cs
@@ -396,6 +396,12 @@ public class DateTimeMaskedTextProvider : IMaskedTextProvider<DateTime?>
 			_ => culture.DateTimeFormat.ShortDatePattern
 		};
 
+		// ICU-based cultures (e.g. en-US on macOS/Linux) separate the time from its AM/PM designator with a
+		// narrow no-break space, which a mask can't contain - normalize the pattern the same way the mask is so
+		// the text we format still lines up with the mask literals and can be set and parsed back.
+		// See FixedMaskedTextProvider.NormalizeWhitespace for why the character can't be kept as-is.
+		format = FixedMaskedTextProvider.NormalizeWhitespace(format);
+
 		var formatBuilder = new StringBuilder();
 		var parseBuilder = new StringBuilder();
 		var maskBuilder = new StringBuilder();

--- a/src/Eto/Forms/MaskedTextProvider/FixedMaskedTextProvider.cs
+++ b/src/Eto/Forms/MaskedTextProvider/FixedMaskedTextProvider.cs
@@ -143,7 +143,38 @@ public class FixedMaskedTextProvider : IMaskedTextProvider
 	public FixedMaskedTextProvider(string mask, CultureInfo culture = null, bool allowPromptAsInput = true, bool restrictToAscii = false)
 	{
 		handler = Platform.Instance.Create<IHandler>();
-		handler.Create(mask, culture, allowPromptAsInput, restrictToAscii);
+		handler.Create(NormalizeWhitespace(mask), culture, allowPromptAsInput, restrictToAscii);
+	}
+
+	/// <summary>
+	/// Replaces every whitespace character in <paramref name="text"/> that isn't a regular space with one.
+	/// </summary>
+	/// <remarks>
+	/// A mask can only use the regular space (U+0020) as whitespace. Any other whitespace character - such as the
+	/// narrow no-break space that ICU-based cultures use in front of the AM/PM designator - is rejected as an
+	/// invalid mask character, and cannot be escaped as a literal either, so it has to be substituted instead.
+	///
+	/// Text that is going to be set on a mask has to be normalized the same way, otherwise it no longer lines up
+	/// with the literals of the mask it was formatted for. See <see cref="DateTimeMaskedTextProvider"/>, which
+	/// normalizes the date/time format it builds from the culture for that reason.
+	/// </remarks>
+	/// <param name="text">Mask or text to normalize the whitespace of.</param>
+	/// <returns>The text with all of its whitespace characters turned into regular spaces.</returns>
+	public static string NormalizeWhitespace(string text)
+	{
+		if (string.IsNullOrEmpty(text))
+			return text;
+
+		char[] normalized = null;
+		for (int i = 0; i < text.Length; i++)
+		{
+			var ch = text[i];
+			if (ch == ' ' || !char.IsWhiteSpace(ch))
+				continue;
+			normalized ??= text.ToCharArray();
+			normalized[i] = ' ';
+		}
+		return normalized != null ? new string(normalized) : text;
 	}
 
 	/// <summary>

--- a/src/Shared/FixedMaskedTextProviderHandler.cs
+++ b/src/Shared/FixedMaskedTextProviderHandler.cs
@@ -6,8 +6,8 @@
 
 		public void Create(string mask, CultureInfo culture, bool allowPromptAsInput, bool restrictToAscii)
 		{
-			mask = mask.Replace("\u00A0", " "); // non-breaking space causes issues with the provider, so replace with regular space
-			mask = mask.Replace("\u202F", " "); // narrow non-breaking space causes issues with the provider, so remove it
+			// MaskedTextProvider rejects a mask containing any whitespace other than a regular space, so the mask
+			// is already run through FixedMaskedTextProvider.NormalizeWhitespace() before it gets here.
 			Provider = new MaskedTextProvider(mask, culture, allowPromptAsInput, '_', (char)0, restrictToAscii);
 		}
 

--- a/test/Eto.Test/UnitTests/Forms/MaskedTextProvider/DateTimeMaskedTextProviderTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/MaskedTextProvider/DateTimeMaskedTextProviderTests.cs
@@ -9,6 +9,30 @@ namespace Eto.Test.UnitTests.Forms.MaskedTextProvider
 	{
 		static readonly CultureInfo EnUS = CultureInfo.GetCultureInfo("en-US");
 
+		/// <summary>
+		/// A mask can only use regular spaces, but ICU-based cultures (macOS/Linux) use a narrow no-break space
+		/// in front of the AM/PM designator, so the format has to be normalized to match the mask it feeds.
+		/// This uses an explicit culture rather than en-US so it is covered no matter which ICU version, if any,
+		/// the platform running the tests uses.
+		/// </summary>
+		static CultureInfo NarrowSpaceCulture()
+		{
+			var culture = (CultureInfo)CultureInfo.GetCultureInfo("en-US").Clone();
+			culture.DateTimeFormat.ShortTimePattern = "h:mm\u202Ftt";
+			return culture;
+		}
+
+		[Test]
+		public void ValueShouldRoundTripWithNarrowSpaceInTimePattern()
+		{
+			var provider = new DateTimeMaskedTextProvider(DateTimePickerMode.Time, NarrowSpaceCulture());
+			provider.Value = DateTime.Today + new TimeSpan(14, 30, 0);
+			provider.CommitText();
+
+			Assert.That(provider.Text, Is.EqualTo("02:30 PM"), "#1 - the narrow no-break space should become a regular space");
+			Assert.That(provider.Value?.TimeOfDay, Is.EqualTo(new TimeSpan(14, 30, 0)), "#2");
+		}
+
 		[Test]
 		public void ValueShouldRoundTripInDateMode()
 		{


### PR DESCRIPTION
This only had issues on Mac/Linux due to using whitespace characters other than U+0020.  Now it shares the logic and exposes `FixedMaskedTextProvider.NormalizeWhitespace()` to normalize whitespace.