### PR TITLE
More fixes for DragDropLib

### DIFF
--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -692,6 +692,9 @@ namespace Eto
 		[DllImport("kernel32.dll", CharSet = CharSet.Auto)]
 		public static extern int GlobalSize(IntPtr handle);
 
+		[DllImport("ole32.dll")]
+		public static extern void ReleaseStgMedium(ref System.Runtime.InteropServices.ComTypes.STGMEDIUM pmedium);
+
 
 		public enum SBB
 		{

--- a/src/Eto.Wpf/CustomControls/DragDropLib.Wpf.cs
+++ b/src/Eto.Wpf/CustomControls/DragDropLib.Wpf.cs
@@ -866,8 +866,18 @@ namespace System.Windows
 			// BitmapSource to a System.Drawing.Bitmap.
 			Bitmap bmp = GetBitmapFromBitmapSource(image, Colors.Magenta);
 
-			// Sets the drag image from a Bitmap
-			SetDragImage(dataObject, bmp, cursorOffset);
+			try
+			{
+				// Sets the drag image from a Bitmap
+				SetDragImage(dataObject, bmp, cursorOffset);
+			}
+			finally
+			{
+				// GetHbitmap() hands the drag image manager its own copy of the bits, so this
+				// intermediate Bitmap is ours to dispose. A drag sets a drag image every time, so
+				// leaking it here leaks a GDI object per drag.
+				bmp.Dispose();
+			}
 		}
 
 		/// <summary>

--- a/src/Eto.Wpf/CustomControls/DragDropLib.cs
+++ b/src/Eto.Wpf/CustomControls/DragDropLib.cs
@@ -21,6 +21,19 @@
 //   6. GetMediumFromObject sizes the HGLOBAL by the serialized length rather than the
 //      MemoryStream's capacity, so no uninitialized tail is published.
 //   7. Doc-comment typos cleaned up.
+//   8. Storage is released on the thread that created the DataObject, never on the
+//      finalizer thread. Not everything in there is plain memory -- the shell's drag image
+//      manager parks its drag context in the data object as a TYMED_ISTREAM -- and
+//      ReleaseStgMedium on such a medium calls Release straight through the raw interface
+//      pointer, with no proxy and no apartment switch. From the finalizer thread (MTA) that
+//      runs an STA object's teardown on the wrong thread, which either corrupts the heap or
+//      hangs the finalizer. See Dispose.
+//   9. That same drag context (CFSTR_DRAGCONTEXT) is now never released by this class at all.
+//      The shell hands it to SetData with release: true, but keeps the raw interface pointer
+//      without a counted reference and frees the stream itself when the next drag begins -- so
+//      releasing our entry at teardown was a second free, which is why the crash needed two
+//      drags to show up. See IsShellOwnedMedium. This, rather than fix 8, is what actually
+//      fixes RH-95450 / RH-97411.
 //
 // Deliberately NOT changed: GetData/GetDataHere still report S_OK with an empty STGMEDIUM for a
 // format that isn't present, rather than DV_E_FORMATETC. See the comment in GetDataHere.
@@ -615,6 +628,16 @@ namespace DragDropLib
 		// Guards against double-dispose / dispose-then-finalize (0 = live, 1 = disposed)
 		private int disposed;
 
+		// The thread that created this object, and its synchronization context.
+		//
+		// Not every STGMEDIUM we hold is plain memory: the shell's drag image manager stores its
+		// drag context in here as a TYMED_ISTREAM, so `storage` ends up owning raw COM interface
+		// pointers with thread affinity. ReleaseStgMedium on one of those calls IStream::Release
+		// straight through the pointer -- no proxy, no apartment switch -- so doing it from the
+		// finalizer thread runs the shell's teardown in the wrong (MTA) apartment. See Dispose.
+		private readonly SynchronizationContext ownerContext = SynchronizationContext.Current;
+		private readonly int ownerThreadId = Thread.CurrentThread.ManagedThreadId;
+
 		// Represents an advisory connection entry.
 		private class AdviseEntry
 		{
@@ -656,18 +679,102 @@ namespace DragDropLib
 		/// </remarks>
 		private void ClearStorage()
 		{
+			ClearStorage(true);
+		}
+
+		/// <summary>
+		/// Clears the internal storage array, releasing every entry it is safe to release.
+		/// </summary>
+		/// <param name="releaseComPointers">True to release entries that carry a COM interface pointer
+		/// (TYMED_ISTREAM / TYMED_ISTORAGE, or any medium with a pUnkForRelease). Pass false when running
+		/// on a thread that doesn't own those pointers -- they are leaked rather than released.</param>
+		private void ClearStorage(bool releaseComPointers)
+		{
 			if (storage == null)
 				return;
 
 			lock (storage)
 			{
-				foreach (KeyValuePair<FORMATETC, STGMEDIUM> pair in storage)
+				for (int i = storage.Count - 1; i >= 0; i--)
 				{
-					STGMEDIUM medium = pair.Value;
+					STGMEDIUM medium = storage[i].Value;
+					FORMATETC entryFormat = storage[i].Key;
+
+					if (!releaseComPointers && HoldsComPointer(ref medium))
+						continue;
+
+					// The shell frees its own drag context. Drop the entry, but don't release it --
+					// by this point the object is already gone, so even reading through the pointer
+					// is a use-after-free. See IsShellOwnedMedium.
+					if (IsShellOwnedMedium(ref entryFormat, ref medium))
+					{
+						storage.RemoveAt(i);
+						continue;
+					}
+
+					storage.RemoveAt(i);
 					ReleaseStgMedium(ref medium);
 				}
-				storage.Clear();
 			}
+		}
+
+		/// <summary>
+		/// Determines whether releasing the medium means calling Release on a COM interface pointer.
+		/// </summary>
+		/// <param name="medium">The medium to test.</param>
+		/// <returns>True if the medium's lifetime is tied to a COM object, otherwise False.</returns>
+		private static bool HoldsComPointer(ref STGMEDIUM medium)
+		{
+			return medium.pUnkForRelease != null
+				|| medium.tymed == TYMED.TYMED_ISTREAM
+				|| medium.tymed == TYMED.TYMED_ISTORAGE;
+		}
+
+		[DllImport("user32.dll", CharSet = CharSet.Unicode)]
+		private static extern uint RegisterClipboardFormat(string lpszFormat);
+
+		// CFSTR_DRAGCONTEXT. Registered lazily; 0 is not a valid registered format id, so it
+		// doubles as the "not yet looked up" sentinel.
+		private static short dragContextFormat;
+
+		private static short DragContextFormat
+		{
+			get
+			{
+				if (dragContextFormat == 0)
+					dragContextFormat = (short)RegisterClipboardFormat("DragContext");
+				return dragContextFormat;
+			}
+		}
+
+		/// <summary>
+		/// True for the shell drag image manager's private drag context stream, which we must
+		/// never release even though it was handed to us with release: true.
+		/// </summary>
+		/// <remarks>
+		/// The shell authors this IStream and passes it to SetData claiming to transfer ownership,
+		/// but keeps the raw interface pointer and frees it itself when the next drag starts -- it
+		/// never took a counted reference for that pointer, so nothing we do to our own reference
+		/// can keep the object alive. Releasing our entry at teardown is therefore a second free of
+		/// an object already gone, which corrupts the heap and surfaces as an access violation
+		/// (reported as System.ExecutionEngineException) inside ReleaseStgMedium, on the drag
+		/// *after* the one that created it. That is RH-95450 / RH-97411.
+		///
+		/// Traced refcounts for one such entry: 1 after SetData (we are the only holder, so the
+		/// shell is holding nothing countable), 2 after handing a copy to a GetData caller, then
+		/// dead by teardown -- one more release than anything in this class performed.
+		///
+		/// Declining to release it is not a leak: the shell frees the stream regardless. Scoped to
+		/// TYMED_ISTREAM deliberately -- the other shell-private formats in a drag (DragImageBits,
+		/// DragWindow, IsShowingLayered, DropDescription, ...) are all TYMED_HGLOBAL, and
+		/// CopyStgMedium genuinely duplicates an HGLOBAL, so for those our copy is a distinct
+		/// block that we do own and must free.
+		/// </remarks>
+		private static bool IsShellOwnedMedium(ref FORMATETC format, ref STGMEDIUM medium)
+		{
+			return medium.tymed == TYMED.TYMED_ISTREAM
+				&& medium.unionmember != IntPtr.Zero
+				&& format.cfFormat == DragContextFormat;
 		}
 
 		/// <summary>
@@ -691,8 +798,42 @@ namespace DragDropLib
 			if (Interlocked.Exchange(ref disposed, 1) != 0)
 				return;
 
-			// Always release unmanaged objects
-			ClearStorage();
+			// On the owning thread we can release everything right here.
+			if (Thread.CurrentThread.ManagedThreadId == ownerThreadId)
+			{
+				ClearStorage();
+				return;
+			}
+
+			// Otherwise -- almost always the finalizer thread -- get back to the thread that owns
+			// the handles before releasing them. `storage` can hold raw COM interface pointers (the
+			// shell's drag context is a TYMED_ISTREAM), and ReleaseStgMedium calls Release directly
+			// through the pointer. Doing that from the finalizer thread, which is in the MTA, runs
+			// an STA object's teardown in the wrong apartment: it either corrupts the heap -- an
+			// access violation reported as System.ExecutionEngineException, from inside
+			// ReleaseStgMedium in ClearStorage, with ~DataObject on the stack -- or wedges the
+			// finalizer thread outright. That is RH-95450 / RH-97411.
+			//
+			// Posting resurrects this instance until the callback runs, which is fine: `disposed` is
+			// already set, so nothing can queue a second pass, and ClearStorage is idempotent.
+			SynchronizationContext context = ownerContext;
+			if (context != null)
+			{
+				try
+				{
+					context.Post(state => ((DataObject)state).ClearStorage(), this);
+					return;
+				}
+				catch (Exception)
+				{
+					// The owning thread is gone (shutdown, dispatcher already torn down). Fall
+					// through and release what we safely can from here.
+				}
+			}
+
+			// No way home. Release the plain memory and leak the COM pointers -- a leak at
+			// shutdown is better than taking the process down.
+			ClearStorage(false);
 		}
 
 		#region COM IDataObject Members
@@ -918,8 +1059,13 @@ namespace DragDropLib
 				if (existingIndex >= 0)
 				{
 					STGMEDIUM releaseMedium = storage[existingIndex].Value;
+					FORMATETC releaseFormat = storage[existingIndex].Key;
 					storage.RemoveAt(existingIndex);
-					ReleaseStgMedium(ref releaseMedium);
+
+					// Same reasoning as ClearStorage: a re-set of the drag context must drop the old
+					// entry without releasing it. See IsShellOwnedMedium.
+					if (!IsShellOwnedMedium(ref releaseFormat, ref releaseMedium))
+						ReleaseStgMedium(ref releaseMedium);
 				}
 
 				// Add it to the internal storage

--- a/src/Eto.Wpf/Forms/DataObjectHandler.cs
+++ b/src/Eto.Wpf/Forms/DataObjectHandler.cs
@@ -545,13 +545,24 @@ namespace Eto.WinForms.Forms
 			//using the com IDataObject interface get the data using the defined FORMATETC
 			comDataObject.GetData(ref formatetc, out medium);
 
-			if (medium.tymed == TYMED.TYMED_ISTREAM)
-				return ReadIStream(medium);
+			// IDataObject.GetData hands us ownership of the medium, so it has to be released here --
+			// on this thread. A TYMED_ISTREAM medium (the shell's drag context arrives as one) holds a
+			// raw COM interface pointer, and leaving it to be released later means releasing it from
+			// whatever thread gets there first. See DragDropLib.DataObject.Dispose.
+			try
+			{
+				if (medium.tymed == TYMED.TYMED_ISTREAM)
+					return ReadIStream(medium);
 
-			if (medium.tymed == TYMED.TYMED_HGLOBAL)
-				return ReadHGlobal(medium);
+				if (medium.tymed == TYMED.TYMED_HGLOBAL)
+					return ReadHGlobal(medium);
 
-			return null;
+				return null;
+			}
+			finally
+			{
+				Win32.ReleaseStgMedium(ref medium);
+			}
 		}
 
 
@@ -579,16 +590,24 @@ namespace Eto.WinForms.Forms
 
 		MemoryStream ReadIStream(STGMEDIUM medium)
 		{
+			// GetObjectForIUnknown adds its own reference for the RCW; the caller releases the
+			// medium's. Release the RCW here too so the stream doesn't outlive this call and get
+			// dropped from the finalizer thread.
 			var istream = (IStream)Marshal.GetObjectForIUnknown(medium.unionmember);
-			Marshal.Release(medium.unionmember);
+			try
+			{
+				var stat = new STATSTG();
+				istream.Stat(out stat, 0);
 
-			var stat = new STATSTG();
-			istream.Stat(out stat, 0);
-			
-			var bytes = new byte[stat.cbSize];
-			istream.Read(bytes, bytes.Length, IntPtr.Zero);
+				var bytes = new byte[stat.cbSize];
+				istream.Read(bytes, bytes.Length, IntPtr.Zero);
 
-			return new MemoryStream(bytes);
+				return new MemoryStream(bytes);
+			}
+			finally
+			{
+				Marshal.ReleaseComObject(istream);
+			}
 		}
 	}
 }

--- a/test/Eto.Test.Wpf/UnitTests/DragDropLibDataObjectTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/DragDropLibDataObjectTests.cs
@@ -2,6 +2,8 @@ using NUnit.Framework;
 using ComTypes = System.Runtime.InteropServices.ComTypes;
 using ComDataObject = System.Runtime.InteropServices.ComTypes.IDataObject;
 using DragDropDataObject = DragDropLib.DataObject;
+using IStream = System.Runtime.InteropServices.ComTypes.IStream;
+using STATSTG = System.Runtime.InteropServices.ComTypes.STATSTG;
 
 namespace Eto.Test.Wpf.UnitTests
 {
@@ -462,5 +464,235 @@ namespace Eto.Test.Wpf.UnitTests
 
 			dataObject.Dispose();
 		}
+
+		#region COM pointer / thread affinity
+
+		// Not everything in storage is plain memory. The shell's drag image manager parks its drag
+		// context in the data object as a TYMED_ISTREAM, so ReleaseStgMedium ends up calling Release
+		// straight through a raw interface pointer -- no proxy, no apartment switch. Running that on
+		// the finalizer thread (which is MTA) tears an STA object down on the wrong thread, and takes
+		// the process out with an access violation inside ReleaseStgMedium in ClearStorage, with
+		// ~DataObject on the stack. That is RH-95450 / RH-97411.
+
+		/// <summary>
+		/// A no-op IStream, only there to be handed out as a real COM pointer whose reference count
+		/// the tests can watch.
+		/// </summary>
+		class CountedStream : IStream
+		{
+			public void Clone(out IStream ppstm) => ppstm = null;
+			public void Commit(int grfCommitFlags) { }
+			public void CopyTo(IStream pstm, long cb, IntPtr pcbRead, IntPtr pcbWritten) { }
+			public void LockRegion(long libOffset, long cb, int dwLockType) { }
+			public void Read(byte[] pv, int cb, IntPtr pcbRead) { }
+			public void Revert() { }
+			public void Seek(long dlibMove, int dwOrigin, IntPtr plibNewPosition) { }
+			public void SetSize(long libNewSize) { }
+			public void Stat(out STATSTG pstatstg, int grfStatFlag) => pstatstg = new STATSTG();
+			public void UnlockRegion(long libOffset, long cb, int dwLockType) { }
+			public void Write(byte[] pv, int cb, IntPtr pcbWritten) { }
+		}
+
+		/// <summary>
+		/// Reads a COM object's reference count without changing it. Only safe while the caller holds
+		/// a reference of its own.
+		/// </summary>
+		static int RefCount(IntPtr unknown)
+		{
+			int count = Marshal.AddRef(unknown);
+			Marshal.Release(unknown);
+			return count - 1;
+		}
+
+		/// <summary>
+		/// A synchronization context that just queues, so a test can decide when the owning thread
+		/// gets to run the work posted back to it.
+		/// </summary>
+		class QueueingSynchronizationContext : SynchronizationContext
+		{
+			readonly Queue<Action> queue = new Queue<Action>();
+
+			public int Count { get { lock (queue) return queue.Count; } }
+
+			public override void Post(SendOrPostCallback d, object state)
+			{
+				lock (queue)
+					queue.Enqueue(() => d(state));
+			}
+
+			public override void Send(SendOrPostCallback d, object state) => d(state);
+
+			public int Drain()
+			{
+				int ran = 0;
+				while (true)
+				{
+					Action action;
+					lock (queue)
+					{
+						if (queue.Count == 0)
+							break;
+						action = queue.Dequeue();
+					}
+					action();
+					ran++;
+				}
+				return ran;
+			}
+		}
+
+		/// <summary>
+		/// Creates a data object on a dedicated thread, so the tests below are running somewhere
+		/// other than the thread that owns it -- the position the finalizer thread is in.
+		/// </summary>
+		static DragDropDataObject CreateOnOtherThread(SynchronizationContext context)
+		{
+			DragDropDataObject dataObject = null;
+			var thread = new Thread(() =>
+			{
+				SynchronizationContext.SetSynchronizationContext(context);
+				dataObject = new DragDropDataObject();
+			});
+			thread.IsBackground = true;
+			thread.Start();
+			Assert.That(thread.Join(TimeSpan.FromSeconds(10)), Is.True, "the owning thread did not finish");
+			return dataObject;
+		}
+
+		/// <summary>
+		/// Adds a TYMED_ISTREAM entry, as the shell's drag context does, and returns the raw pointer.
+		/// The caller keeps one reference of its own so the pointer stays valid for the assertions.
+		/// </summary>
+		static IntPtr AddStreamEntry(DragDropDataObject dataObject, string format)
+		{
+			var unknown = Marshal.GetComInterfaceForObject(new CountedStream(), typeof(IStream));
+
+			var formatetc = MakeFormat(format);
+			formatetc.tymed = ComTypes.TYMED.TYMED_ISTREAM;
+			var medium = new ComTypes.STGMEDIUM
+			{
+				tymed = ComTypes.TYMED.TYMED_ISTREAM,
+				unionmember = unknown,
+				pUnkForRelease = null
+			};
+
+			// release: false -- we keep our reference, the data object takes its own.
+			((ComDataObject)dataObject).SetData(ref formatetc, ref medium, false);
+			return unknown;
+		}
+
+		static void DisposeAsFinalizer(DragDropDataObject dataObject)
+		{
+			var dispose = typeof(DragDropDataObject).GetMethod("Dispose", BindingFlags.Instance | BindingFlags.NonPublic, null, new[] { typeof(bool) }, null);
+			Assert.That(dispose, Is.Not.Null, "DragDropLib.DataObject.Dispose(bool) is gone");
+			dispose.Invoke(dataObject, new object[] { false });
+		}
+
+		[Test]
+		public void SetDataShouldAddReferenceToStreamMedium()
+		{
+			var context = new QueueingSynchronizationContext();
+			var dataObject = CreateOnOtherThread(context);
+			var unknown = AddStreamEntry(dataObject, "eto-test-stream-ref");
+			try
+			{
+				// ours plus the data object's
+				Assert.That(RefCount(unknown), Is.EqualTo(2), "storage did not take its own reference to the stream");
+				Assert.That(dataObject.storage, Has.Count.EqualTo(1));
+				Assert.That(dataObject.storage[0].Value.tymed, Is.EqualTo(ComTypes.TYMED.TYMED_ISTREAM));
+			}
+			finally
+			{
+				dataObject.Dispose();
+				Marshal.Release(unknown);
+			}
+		}
+
+		[Test]
+		public void FinalizingOffThreadShouldNotReleaseComPointersInPlace()
+		{
+			var context = new QueueingSynchronizationContext();
+			var dataObject = CreateOnOtherThread(context);
+			var unknown = AddStreamEntry(dataObject, "eto-test-stream-finalize");
+			try
+			{
+				Assert.That(RefCount(unknown), Is.EqualTo(2));
+
+				DisposeAsFinalizer(dataObject);
+
+				Assert.That(RefCount(unknown), Is.EqualTo(2),
+					"the stream was released from the wrong thread instead of being posted back to its owner");
+				Assert.That(dataObject.storage, Has.Count.EqualTo(1), "storage was cleared from the wrong thread");
+				Assert.That(context.Count, Is.EqualTo(1), "nothing was posted back to the owning thread");
+
+				// the owning thread gets around to it
+				Assert.That(context.Drain(), Is.EqualTo(1));
+				Assert.That(RefCount(unknown), Is.EqualTo(1), "the owning thread did not release the stream");
+				Assert.That(dataObject.storage, Is.Empty);
+			}
+			finally
+			{
+				Marshal.Release(unknown);
+			}
+		}
+
+		[Test]
+		public void FinalizingWithNoWayHomeShouldFreeMemoryAndLeakComPointers()
+		{
+			// No synchronization context on the creating thread, so there is nowhere to post to.
+			var dataObject = CreateOnOtherThread(null);
+			var unknown = AddStreamEntry(dataObject, "eto-test-stream-orphan");
+			try
+			{
+				var format = MakeFormat("eto-test-orphan-memory");
+				var medium = MakeMedium(0x5150);
+				((ComDataObject)dataObject).SetData(ref format, ref medium, true);
+				Assert.That(dataObject.storage, Has.Count.EqualTo(2));
+
+				DisposeAsFinalizer(dataObject);
+
+				// The HGLOBAL is safe to free from any thread, the stream is not: leaking it beats
+				// releasing an STA object from the finalizer thread.
+				Assert.That(dataObject.storage, Has.Count.EqualTo(1), "the plain memory entry should have been released");
+				Assert.That(dataObject.storage[0].Value.tymed, Is.EqualTo(ComTypes.TYMED.TYMED_ISTREAM));
+				Assert.That(RefCount(unknown), Is.EqualTo(2), "the stream was released off its owning thread");
+			}
+			finally
+			{
+				Marshal.Release(unknown);
+			}
+		}
+
+		[Test]
+		public void DisposeOnOwningThreadShouldReleaseEverythingInPlace()
+		{
+			var context = new QueueingSynchronizationContext();
+			DragDropDataObject dataObject = null;
+			IntPtr unknown = IntPtr.Zero;
+
+			var thread = new Thread(() =>
+			{
+				SynchronizationContext.SetSynchronizationContext(context);
+				dataObject = new DragDropDataObject();
+				unknown = AddStreamEntry(dataObject, "eto-test-stream-owner");
+				dataObject.Dispose();
+			});
+			thread.IsBackground = true;
+			thread.Start();
+			Assert.That(thread.Join(TimeSpan.FromSeconds(10)), Is.True, "the owning thread did not finish");
+
+			try
+			{
+				Assert.That(dataObject.storage, Is.Empty);
+				Assert.That(context.Count, Is.EqualTo(0), "nothing needed posting -- Dispose ran on the owning thread");
+				Assert.That(RefCount(unknown), Is.EqualTo(1), "Dispose did not release the stream");
+			}
+			finally
+			{
+				Marshal.Release(unknown);
+			}
+		}
+
+		#endregion
 	}
 }


### PR DESCRIPTION
This ensures that the drag/drop doesn't release things it doesn't own, which can cause crashes.