### PR TITLE
Wpf: Allow setting the TextFormattingMode mode for fonts

### DIFF
--- a/src/Eto.Wpf/Drawing/FontHandler.cs
+++ b/src/Eto.Wpf/Drawing/FontHandler.cs
@@ -16,6 +16,7 @@ namespace Eto.Wpf.Drawing
 			control.FontStretch = WpfFontStretch;
 			control.FontWeight = WpfFontWeight;
 			control.FontSize = WpfSize;
+			ApplyTextFormattingMode(control);
 			if (setDecorations != null && WpfTextDecorationsFrozen != null)
 			{
 				setDecorations(WpfTextDecorationsFrozen);
@@ -29,6 +30,7 @@ namespace Eto.Wpf.Drawing
 			control.FontStretch = WpfFontStretch;
 			control.FontWeight = WpfFontWeight;
 			control.FontSize = WpfSize;
+			ApplyTextFormattingMode(control);
 			if (setDecorations != null && WpfTextDecorationsFrozen != null)
 			{
 				setDecorations(WpfTextDecorationsFrozen);
@@ -42,6 +44,7 @@ namespace Eto.Wpf.Drawing
 			control.FontStretch = WpfFontStretch;
 			control.FontWeight = WpfFontWeight;
 			control.FontSize = WpfSize;
+			ApplyTextFormattingMode(control);
 			if (setDecorations != null && WpfTextDecorationsFrozen != null)
 			{
 				setDecorations(WpfTextDecorationsFrozen);
@@ -56,6 +59,8 @@ namespace Eto.Wpf.Drawing
 			control.ApplyPropertyValue(swd.TextElement.FontWeightProperty, WpfFontWeight);
 			control.ApplyPropertyValue(swd.TextElement.FontSizeProperty, WpfSize);
 			control.ApplyPropertyValue(swd.Inline.TextDecorationsProperty, WpfTextDecorationsFrozen);
+			// note: TextFormattingMode can't be applied to a range, WPF doesn't consider it a text formatting
+			// property.  Set it on the document or element that contains the range instead.
 		}
 
 		public void Apply(swm.FormattedText control)
@@ -66,6 +71,14 @@ namespace Eto.Wpf.Drawing
 			control.SetFontWeight(WpfFontWeight);
 			control.SetFontSize(WpfSize);
 			control.SetTextDecorations(WpfTextDecorationsFrozen);
+			// note: the formatting mode of a FormattedText is set when it is created, see CreateFormattedText
+		}
+
+		void ApplyTextFormattingMode(sw.DependencyObject element)
+		{
+			// only set it when specified, otherwise let it keep inheriting from its container as usual
+			if (TextFormattingMode != null)
+				swm.TextOptions.SetTextFormattingMode(element, TextFormattingMode.Value);
 		}
 
 		sd.Font SDFont
@@ -353,13 +366,90 @@ namespace Eto.Wpf.Drawing
 
 		static swm.SolidColorBrush measureBrush;
 
+		/// <summary>
+		/// Gets or sets the text formatting mode used to lay out text with this font, or null (the default)
+		/// to use the mode of the element the text is rendered in.
+		/// </summary>
+		/// <remarks>
+		/// WPF lays out text using the <see cref="swm.TextOptions.TextFormattingModeProperty"/> of the element
+		/// it is rendered in, which for <see cref="swm.TextFormattingMode.Display"/> snaps each glyph to whole
+		/// pixels and can be noticeably wider than the default <see cref="swm.TextFormattingMode.Ideal"/> layout.
+		/// Since text Eto measures and draws itself is not part of any element, set this to the mode your text is
+		/// rendered with so that measuring and drawing match, e.g. using a style:
+		/// <code>Style.Add&lt;FontHandler&gt;(null, h => h.TextFormattingMode = TextFormattingMode.Display);</code>
+		/// When specified, this mode is also set on the controls the font is applied to so they render the same
+		/// way, otherwise they keep inheriting the mode from their container.
+		/// </remarks>
+		public swm.TextFormattingMode? TextFormattingMode { get; set; }
+
+		/// <summary>
+		/// Gets or sets the pixels per device independent pixel (dip) used to lay out text with this font when
+		/// there is nothing to get it from, which defaults to the scale of the system dpi.
+		/// </summary>
+		/// <remarks>
+		/// This does not scale the text or the size it measures, which are always in dips.  It is the device pixel
+		/// grid that <see cref="swm.TextFormattingMode.Display"/> snaps the glyphs to, so it only has an effect with
+		/// that mode, where measuring for the wrong dpi reports a width the text isn't rendered with.
+		///
+		/// Drawing and measuring text on a <see cref="Graphics"/> uses the dpi of what is being drawn on instead of
+		/// this value, which is only used when there is no target to get it from, such as <see cref="MeasureString(string)"/>.
+		/// </remarks>
+		public double PixelsPerDip { get; set; } = SystemPixelsPerDip;
+
+		static double? systemPixelsPerDip;
+
+		static double SystemPixelsPerDip
+		{
+			get
+			{
+				if (systemPixelsPerDip == null)
+				{
+					try
+					{
+						systemPixelsPerDip = swm.VisualTreeHelper.GetDpi(new swm.DrawingVisual()).PixelsPerDip;
+					}
+					catch
+					{
+						systemPixelsPerDip = 1.0;
+					}
+				}
+				return systemPixelsPerDip.Value;
+			}
+		}
+
+		/// <summary>
+		/// Creates a WPF FormattedText for the specified text using this font, honoring its
+		/// <see cref="TextFormattingMode"/> and <see cref="PixelsPerDip"/>.
+		/// </summary>
+		/// <param name="text">Text to lay out</param>
+		/// <param name="brush">Brush to draw the text with</param>
+		/// <param name="setDecorations">True to apply the decorations of the font, false to leave them out</param>
+		/// <param name="pixelsPerDip">Pixels per dip of what the text is drawn on, or null to use <see cref="PixelsPerDip"/></param>
+		public swm.FormattedText CreateFormattedText(string text, swm.Brush brush, bool setDecorations = true, double? pixelsPerDip = null)
+		{
+			text = text ?? string.Empty;
+			var formattedText = new swm.FormattedText(
+				text,
+				CultureInfo.CurrentUICulture,
+				sw.FlowDirection.LeftToRight,
+				WpfTypeface,
+				WpfSize,
+				brush,
+				null,
+				TextFormattingMode ?? swm.TextFormattingMode.Ideal,
+				pixelsPerDip ?? PixelsPerDip);
+
+			if (setDecorations && WpfTextDecorationsFrozen != null)
+				formattedText.SetTextDecorations(WpfTextDecorationsFrozen, 0, text.Length);
+
+			return formattedText;
+		}
+
 		public SizeF MeasureString(string text)
 		{
 			if (measureBrush == null)
 				measureBrush = new swm.SolidColorBrush(swm.Colors.White);
-#pragma warning disable CS0618 // 'FormattedText.FormattedText(string, CultureInfo, FlowDirection, Typeface, double, Brush)' is obsolete: 'Use the PixelsPerDip override'
-			var formattedText = new swm.FormattedText(text, CultureInfo.CurrentUICulture, sw.FlowDirection.LeftToRight, WpfTypeface, WpfSize, measureBrush);
-#pragma warning restore CS0618 // Type or member is obsolete
+			var formattedText = CreateFormattedText(text, measureBrush, setDecorations: false);
 			return new SizeF((float)formattedText.WidthIncludingTrailingWhitespace, (float)formattedText.Height);
 		}
 	}

--- a/src/Eto.Wpf/Drawing/FormattedTextHandler.cs
+++ b/src/Eto.Wpf/Drawing/FormattedTextHandler.cs
@@ -11,6 +11,9 @@ namespace Eto.Wpf.Drawing
 		Brush _foregroundBrush;
 		bool _hasNewLines;
 		bool _shouldClip;
+		double? _pixelsPerDip;
+		double _controlPixelsPerDip;
+		swm.TextFormattingMode _controlFormattingMode;
 		public FormattedTextWrapMode Wrap
 		{
 			get => _wrap;
@@ -57,6 +60,7 @@ namespace Eto.Wpf.Drawing
 			set
 			{
 				_font = value;
+				ValidateTextFormatting();
 				if (HasControl)
 				{
 					SetFont(Control);
@@ -103,6 +107,20 @@ namespace Eto.Wpf.Drawing
 			Control = null;
 		}
 
+		/// <summary>
+		/// The formatting mode and dpi of a FormattedText can only be specified when it is created, so it has
+		/// to be recreated whenever either of them changes.
+		/// </summary>
+		void ValidateTextFormatting()
+		{
+			if (!HasControl || !(Font?.Handler is FontHandler fontHandler))
+				return;
+
+			if ((fontHandler.TextFormattingMode ?? swm.TextFormattingMode.Ideal) != _controlFormattingMode
+				|| (_pixelsPerDip ?? fontHandler.PixelsPerDip) != _controlPixelsPerDip)
+				Invalidate();
+		}
+
 		protected override swm.FormattedText CreateControl()
 		{
 			var font = Font;
@@ -110,15 +128,12 @@ namespace Eto.Wpf.Drawing
 			text = SetWrap(text);
 			_hasNewLines = text.IndexOf('\n') != -1;
 
-#pragma warning disable CS0618 // 'FormattedText.FormattedText(string, CultureInfo, FlowDirection, Typeface, double, Brush)' is obsolete: 'Use the PixelsPerDip override'
-			var formattedText = new swm.FormattedText(
-				text,
-				CultureInfo.CurrentUICulture,
-				sw.FlowDirection.LeftToRight,
-				font.ToWpfTypeface(),
-				font.Size,
-				ForegroundBrush.ToWpf());
-#pragma warning restore CS0618 // 'FormattedText.FormattedText(string, CultureInfo, FlowDirection, Typeface, double, Brush)' is obsolete: 'Use the PixelsPerDip override'
+			var fontHandler = (FontHandler)font.Handler;
+			_controlFormattingMode = fontHandler.TextFormattingMode ?? swm.TextFormattingMode.Ideal;
+			_controlPixelsPerDip = _pixelsPerDip ?? fontHandler.PixelsPerDip;
+
+			// decorations are applied to the entire text by SetFont below
+			var formattedText = fontHandler.CreateFormattedText(text, ForegroundBrush.ToWpf(), setDecorations: false, pixelsPerDip: _controlPixelsPerDip);
 
 			// support correctly showing ellipsis when there's a single line
 			if (Wrap == FormattedTextWrapMode.None)
@@ -211,6 +226,10 @@ namespace Eto.Wpf.Drawing
 
 		public void DrawText(GraphicsHandler handler, PointF location)
 		{
+			// lay the text out for the dpi of what we're drawing on now that we know it
+			_pixelsPerDip = handler.TargetPixelsPerDip;
+			ValidateTextFormatting();
+
 			/**
 			//Doesn't do font fallbacks, so it isn't very useful at this point.
 			//Only other way appears to re-write the FormattedText class which comes along with a TON of code.

--- a/src/Eto.Wpf/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Wpf/Drawing/GraphicsHandler.cs
@@ -113,6 +113,12 @@ namespace Eto.Wpf.Drawing
 			}
 		}
 
+		/// <summary>
+		/// Gets the pixels per dip of what is being drawn on to lay out text for, or null when it can't be
+		/// determined and the font should decide.
+		/// </summary>
+		internal double? TargetPixelsPerDip => visual != null && Widget != null ? DPI : (double?)null;
+
 		public void DrawRectangle(Pen pen, float x, float y, float width, float height)
 		{
 			SetOffset(false);
@@ -311,11 +317,7 @@ namespace Eto.Wpf.Drawing
 			if (fontHandler != null)
 			{
 				var brush = b.ToWpf();
-#pragma warning disable CS0618 // 'FormattedText.FormattedText(string, CultureInfo, FlowDirection, Typeface, double, Brush)' is obsolete: 'Use the PixelsPerDip override'
-				var formattedText = new swm.FormattedText(text, CultureInfo.CurrentUICulture, sw.FlowDirection.LeftToRight, fontHandler.WpfTypeface, fontHandler.WpfSize, brush);
-#pragma warning restore CS0618 // Type or member is obsolete
-				if (fontHandler.WpfTextDecorationsFrozen != null)
-					formattedText.SetTextDecorations(fontHandler.WpfTextDecorationsFrozen, 0, text.Length);
+				var formattedText = fontHandler.CreateFormattedText(text, brush, pixelsPerDip: TargetPixelsPerDip);
 				Control.DrawText(formattedText, new sw.Point(x, y));
 			}
 		}
@@ -328,9 +330,7 @@ namespace Eto.Wpf.Drawing
 			if (fontHandler != null)
 			{
 				var brush = new swm.SolidColorBrush(swm.Colors.White);
-#pragma warning disable CS0618 // 'FormattedText.FormattedText(string, CultureInfo, FlowDirection, Typeface, double, Brush)' is obsolete: 'Use the PixelsPerDip override'
-				var formattedText = new swm.FormattedText(text, CultureInfo.CurrentUICulture, sw.FlowDirection.LeftToRight, fontHandler.WpfTypeface, fontHandler.WpfSize, brush);
-#pragma warning restore CS0618 // Type or member is obsolete
+				var formattedText = fontHandler.CreateFormattedText(text, brush, setDecorations: false, pixelsPerDip: TargetPixelsPerDip);
 				result = new SizeF((float)formattedText.WidthIncludingTrailingWhitespace, (float)formattedText.Height);
 			}
 

--- a/test/Eto.Test.Wpf/UnitTests/FontFormattingModeTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/FontFormattingModeTests.cs
@@ -1,0 +1,278 @@
+using Eto.Test.UnitTests;
+using Eto.Wpf.Drawing;
+using NUnit.Framework;
+using swd = System.Windows.Documents;
+using swm = System.Windows.Media;
+
+namespace Eto.Test.Wpf.UnitTests
+{
+	/// <summary>
+	/// Tests for laying out text with a specific <see cref="swm.TextFormattingMode"/>.
+	/// </summary>
+	/// <remarks>
+	/// WPF lays out text using the mode of the element it is rendered in, so text that Eto measures or draws
+	/// itself has to be told which mode to use, otherwise measuring reports a size the text isn't rendered with.
+	/// The difference adds up per glyph, so it is most visible with long text in a small font at 96dpi.
+	/// </remarks>
+	[TestFixture]
+	public class FontFormattingModeTests : TestBase
+	{
+		const string LongText = "RenderWindowCopyToClipboardAndThenSomeMore";
+
+		static Font CreateFont() => new Font("Segoe UI", 8.25f);
+
+		static FontHandler GetHandler(Font font) => (FontHandler)font.Handler;
+
+		/// <summary>
+		/// Lays out the text with WPF directly to compare what Eto reports against.
+		/// </summary>
+		static double ReferenceWidth(Font font, swm.TextFormattingMode mode, double pixelsPerDip, string text = LongText)
+		{
+			var handler = GetHandler(font);
+			var formattedText = new swm.FormattedText(
+				text,
+				CultureInfo.CurrentUICulture,
+				sw.FlowDirection.LeftToRight,
+				handler.WpfTypeface,
+				handler.WpfSize,
+				swm.Brushes.Black,
+				null,
+				mode,
+				pixelsPerDip);
+			return formattedText.WidthIncludingTrailingWhitespace;
+		}
+
+		[Test]
+		public void FontShouldNotSpecifyFormattingModeByDefault()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+				Assert.That(handler.TextFormattingMode, Is.Null, "#1 the mode of what the text is rendered in should be used by default");
+				Assert.That(font.MeasureString(LongText).Width, Is.EqualTo(ReferenceWidth(font, swm.TextFormattingMode.Ideal, handler.PixelsPerDip)).Within(0.01), "#2 should measure with ideal layout by default");
+			});
+		}
+
+		[Test]
+		public void MeasureStringShouldUseSpecifiedFormattingMode()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+				handler.TextFormattingMode = swm.TextFormattingMode.Display;
+				handler.PixelsPerDip = 1; // 96dpi, where display layout snaps each glyph to a whole dip
+
+				var display = ReferenceWidth(font, swm.TextFormattingMode.Display, 1);
+				Assume.That(display, Is.Not.EqualTo(ReferenceWidth(font, swm.TextFormattingMode.Ideal, 1)), "the two modes should lay this text out differently, otherwise this proves nothing");
+
+				Assert.That(font.MeasureString(LongText).Width, Is.EqualTo(display).Within(0.01));
+			});
+		}
+
+		[TestCase(swm.TextFormattingMode.Ideal)]
+		[TestCase(swm.TextFormattingMode.Display)]
+		public void MeasureStringShouldMatchWhatWpfLaysOut(swm.TextFormattingMode mode)
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+				handler.TextFormattingMode = mode;
+				// note: leave PixelsPerDip alone, a standalone element is measured for the system dpi
+
+				// measure the text the way WPF does when it renders it in an element using that mode
+				var textBlock = new swc.TextBlock { Text = LongText };
+				handler.Apply(textBlock, null);
+				textBlock.Measure(new sw.Size(double.PositiveInfinity, double.PositiveInfinity));
+
+				Assert.That(font.MeasureString(LongText).Width, Is.EqualTo(textBlock.DesiredSize.Width).Within(1.0));
+			});
+		}
+
+		[Test]
+		public void PixelsPerDipShouldNotScaleMeasuredSize()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+
+				// ideal layout doesn't snap glyphs to device pixels, so the dpi makes no difference at all..
+				handler.PixelsPerDip = 1;
+				var idealAt96 = font.MeasureString(LongText);
+				handler.PixelsPerDip = 2;
+				Assert.That(font.MeasureString(LongText), Is.EqualTo(idealAt96), "#1 ideal layout should not depend on the dpi");
+
+				// ..display layout does, but the size is still in dips rather than scaled by it
+				handler.TextFormattingMode = swm.TextFormattingMode.Display;
+				handler.PixelsPerDip = 1;
+				var displayAt96 = font.MeasureString(LongText).Width;
+				handler.PixelsPerDip = 2;
+				var displayAt192 = font.MeasureString(LongText).Width;
+				Assume.That(displayAt192, Is.Not.EqualTo(displayAt96), "display layout should depend on the dpi for this text, otherwise this proves nothing");
+				Assert.That(displayAt192, Is.EqualTo(displayAt96).Within(idealAt96.Width / 4), "#2 the size should be in dips, not scaled by the dpi");
+			});
+		}
+
+		[Test]
+		public void StyleShouldSetFormattingModeOnNewFonts()
+		{
+			Invoke(() =>
+			{
+				var provider = new DefaultStyleProvider();
+				provider.Add<FontHandler>(null, h => h.TextFormattingMode = swm.TextFormattingMode.Display);
+
+				var oldProvider = Style.Provider;
+				Style.Provider = provider;
+				try
+				{
+					Assert.That(GetHandler(CreateFont()).TextFormattingMode, Is.EqualTo(swm.TextFormattingMode.Display));
+				}
+				finally
+				{
+					Style.Provider = oldProvider;
+				}
+			});
+		}
+
+		[Test]
+		public void ApplyingFontShouldSetFormattingMode()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+				handler.TextFormattingMode = swm.TextFormattingMode.Display;
+
+				var control = new swc.TextBox();
+				handler.Apply(control, null);
+				Assert.That(swm.TextOptions.GetTextFormattingMode(control), Is.EqualTo(swm.TextFormattingMode.Display), "#1 control");
+
+				var textBlock = new swc.TextBlock();
+				handler.Apply(textBlock, null);
+				Assert.That(swm.TextOptions.GetTextFormattingMode(textBlock), Is.EqualTo(swm.TextFormattingMode.Display), "#2 text block");
+
+				var run = new swd.Run();
+				handler.Apply(run, null);
+				Assert.That(swm.TextOptions.GetTextFormattingMode(run), Is.EqualTo(swm.TextFormattingMode.Display), "#3 text element");
+			});
+		}
+
+		[Test]
+		public void ApplyingFontShouldNotSetFormattingModeWhenNotSpecified()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+				Assume.That(handler.TextFormattingMode, Is.Null);
+
+				var control = new swc.TextBox();
+				handler.Apply(control, null);
+				Assert.That(control.ReadLocalValue(swm.TextOptions.TextFormattingModeProperty), Is.EqualTo(sw.DependencyProperty.UnsetValue), "#1 should keep inheriting the mode of its container");
+
+				var label = new Label { Text = LongText, Font = font };
+				var labelControl = ((Eto.Wpf.Forms.Controls.LabelHandler)label.Handler).Control;
+				Assert.That(labelControl.ReadLocalValue(swm.TextOptions.TextFormattingModeProperty), Is.EqualTo(sw.DependencyProperty.UnsetValue), "#2 a control with a font should keep inheriting it too");
+			});
+		}
+
+		[Test]
+		public void SettingControlFontShouldSetFormattingMode()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				GetHandler(font).TextFormattingMode = swm.TextFormattingMode.Display;
+
+				var label = new Label { Text = LongText, Font = font };
+				var labelControl = ((Eto.Wpf.Forms.Controls.LabelHandler)label.Handler).Control;
+				Assert.That(swm.TextOptions.GetTextFormattingMode(labelControl), Is.EqualTo(swm.TextFormattingMode.Display), "the control should render the text the same way it is measured");
+			});
+		}
+
+		[Test]
+		public void GraphicsShouldUseFontFormattingMode()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+				handler.TextFormattingMode = swm.TextFormattingMode.Display;
+				handler.PixelsPerDip = 3; // should be ignored, the dpi of what we draw on is known
+
+				using (var bitmap = new Bitmap(400, 50, PixelFormat.Format32bppRgba))
+				using (var graphics = new Graphics(bitmap))
+				{
+					// a bitmap is its own 96dpi device, no matter what the dpi of the system or screen is
+					var expected = ReferenceWidth(font, swm.TextFormattingMode.Display, 1);
+					Assume.That(expected, Is.Not.EqualTo(ReferenceWidth(font, swm.TextFormattingMode.Display, 3)), "the dpi should matter for this text, otherwise this proves nothing");
+
+					Assert.That(graphics.MeasureString(font, LongText).Width, Is.EqualTo(expected).Within(0.01), "#1 should measure for what it is drawn on");
+					Assert.DoesNotThrow(() => graphics.DrawText(font, Colors.Black, 0, 0, LongText), "#2");
+				}
+			});
+		}
+
+		[Test]
+		public void GraphicsShouldUseDpiOfWhatIsDrawnOn()
+		{
+			Paint((drawable, e) =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+				handler.TextFormattingMode = swm.TextFormattingMode.Display;
+				handler.PixelsPerDip = 3; // should be ignored, the dpi of the drawable is known
+
+				var pixelsPerDip = ((GraphicsHandler)e.Graphics.Handler).DPI;
+				var expected = ReferenceWidth(font, swm.TextFormattingMode.Display, pixelsPerDip);
+				Assume.That(expected, Is.Not.EqualTo(ReferenceWidth(font, swm.TextFormattingMode.Display, 3)), "the dpi should matter for this text, otherwise this proves nothing");
+
+				Assert.That(e.Graphics.MeasureString(font, LongText).Width, Is.EqualTo(expected).Within(0.01));
+			});
+		}
+
+		[Test]
+		public void FormattedTextShouldUseFontFormattingMode()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+				handler.TextFormattingMode = swm.TextFormattingMode.Display;
+				handler.PixelsPerDip = 1;
+
+				var formattedText = new FormattedText { Font = font, Text = LongText, Wrap = FormattedTextWrapMode.None };
+				Assert.That(formattedText.Measure().Width, Is.EqualTo(ReferenceWidth(font, swm.TextFormattingMode.Display, 1)).Within(0.01));
+			});
+		}
+
+		[Test]
+		public void ChangingFontShouldUpdateFormattedTextFormattingMode()
+		{
+			Invoke(() =>
+			{
+				var idealFont = CreateFont();
+				GetHandler(idealFont).PixelsPerDip = 1;
+
+				var displayFont = CreateFont();
+				var displayHandler = GetHandler(displayFont);
+				displayHandler.TextFormattingMode = swm.TextFormattingMode.Display;
+				displayHandler.PixelsPerDip = 1;
+
+				var expectedIdeal = ReferenceWidth(idealFont, swm.TextFormattingMode.Ideal, 1);
+				var expectedDisplay = ReferenceWidth(displayFont, swm.TextFormattingMode.Display, 1);
+				Assume.That(expectedDisplay, Is.Not.EqualTo(expectedIdeal), "the two modes should lay this text out differently, otherwise this proves nothing");
+
+				var formattedText = new FormattedText { Font = idealFont, Text = LongText, Wrap = FormattedTextWrapMode.None };
+				Assert.That(formattedText.Measure().Width, Is.EqualTo(expectedIdeal).Within(0.01), "#1");
+
+				// the mode can only be specified when the text is created, so it has to be recreated
+				formattedText.Font = displayFont;
+				Assert.That(formattedText.Measure().Width, Is.EqualTo(expectedDisplay).Within(0.01), "#2 should use the mode of the new font");
+			});
+		}
+	}
+}


### PR DESCRIPTION
This also uses the non-obsolete `pixelsPerDip` overrides for `FormattedText` giving better precision on how text is drawn and measured.

When using TextFormattingMode.Display, the measurement of certain strings changes depending on the alignment of the text on the pixel boundaries, sometimes by a significant amount.  