### PR TITLE
Mac: Make NumericStepper properly handle Culture

### DIFF
--- a/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/NumericStepperHandler.cs
@@ -172,13 +172,18 @@ namespace Eto.Mac.Forms.Controls
 		protected override void Initialize()
 		{
 			base.Initialize();
+			// EtoNumberFormatter is what applies CultureInfo when NeedsFormat; DefaultFormatter is a plain
+			// NSNumberFormatter and can only ever format with the OS locale, so replace it up front
+			SetFormatter();
 			var size = GetNaturalSize(SizeF.PositiveInfinity);
 			Control.Frame = new CGRect(0, 0, size.Width, size.Height);
 			HandleEvent(Eto.Forms.Control.KeyDownEvent);
 			Widget.LostFocus += (sender, e) =>
 			{
+				InvalidateOSFormat();
+				EnsureFormatter();
 				var value = TextField.DoubleValue;
-				var newValue = Math.Max(MinValue, Math.Min(MaxValue, TextField.DoubleValue));
+				var newValue = Math.Max(MinValue, Math.Min(MaxValue, value));
 				if (Math.Abs(value - newValue) > double.Epsilon || string.IsNullOrEmpty(TextField.StringValue))
 				{
 					TextField.DoubleValue = newValue;
@@ -187,22 +192,39 @@ namespace Eto.Mac.Forms.Controls
 			};
 			Widget.TextInput += (sender, e) =>
 			{
-				var formatter = (NSNumberFormatter)TextField.Formatter;
-				if (NeedsFormat)
+				// with a format string the text isn't necessarily a plain number, so don't filter what can be typed
+				if (HasFormatString)
 					return;
-				if (e.Text == ".")
+
+				InvalidateOSFormat();
+				EnsureFormatter();
+
+				// filter using the symbols of whichever formatter is in effect: CultureInfo's when we format the value
+				// ourselves, and the native formatter's otherwise - those follow the OS locale, including whatever the
+				// user has customized about it.  Using CultureInfo's for the native case rejects the separator the
+				// field actually displays and parses with, so the value could not be typed at all.
+				var needsFormat = NeedsFormat;
+				var format = CultureInfo.NumberFormat;
+				var nativeFormat = (NSNumberFormatter)TextField.Formatter;
+				var decimalSeparator = needsFormat ? format.NumberDecimalSeparator : nativeFormat.DecimalSeparator;
+				var negativeSign = needsFormat ? format.NegativeSign : nativeFormat.MinusSign;
+				var positiveSign = needsFormat ? format.PositiveSign : nativeFormat.PlusSign;
+				var allowDecimal = MaximumDecimalPlaces > 0;
+
+				if (e.Text == decimalSeparator)
 				{
-					if (MaximumDecimalPlaces == 0 && DecimalPlaces == 0)
+					// only one decimal separator is allowed, unless the existing one is being replaced
+					if (!allowDecimal)
 						e.Cancel = true;
 					else
 					{
 						var str = GetStringValue();
-						e.Cancel = str.Contains(formatter.DecimalSeparator);
+						e.Cancel = str.Contains(decimalSeparator);
 						var editor = TextField.CurrentEditor;
 						if (editor != null && editor.SelectedRange.Length > 0)
 						{
 							var sub = str.Substring((int)editor.SelectedRange.Location, (int)editor.SelectedRange.Length);
-							e.Cancel &= !sub.Contains(formatter.DecimalSeparator);
+							e.Cancel &= !sub.Contains(decimalSeparator);
 						}
 					}
 				}
@@ -213,10 +235,9 @@ namespace Eto.Mac.Forms.Controls
 						if (Char.IsDigit(r))
 							continue;
 						var str = r.ToString();
-						if ((formatter.MaximumFractionDigits > 0 && str == formatter.DecimalSeparator)
-							|| (formatter.UsesGroupingSeparator && str == formatter.GroupingSeparator)
-							|| (MinValue < 0 && (str == formatter.NegativePrefix || str == formatter.NegativeSuffix))
-							|| (MaxValue > 0 && (str == formatter.PositivePrefix || str == formatter.PositiveSuffix)))
+						if ((allowDecimal && str == decimalSeparator)
+							|| (MinValue < 0 && str == negativeSign)
+							|| (MaxValue > 0 && str == positiveSign))
 							continue;
 						e.Cancel = true;
 						break;
@@ -288,6 +309,7 @@ namespace Eto.Mac.Forms.Controls
 		{
 			get
 			{
+				EnsureFormatter();
 				var str = GetStringValue();
 				var nsval = ((NSNumberFormatter)TextField.Formatter).NumberFromString(str);
 				if (nsval == null)
@@ -457,6 +479,12 @@ namespace Eto.Mac.Forms.Controls
 
 		void SetFormatter()
 		{
+			// the computed format string depends on the decimal places, which may have changed
+			Widget.Properties.Remove(ComputedFormatString_Key);
+
+			// remember what the OS was formatting like, so EnsureFormatter can tell when it has changed
+			_osFormat = OSFormat;
+
 			var formatter = new EtoNumberFormatter
 			{
 				Handler = this,
@@ -566,9 +594,107 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
-		bool NeedsFormat => HasFormatString || CultureInfo != CultureInfo.CurrentCulture;
-
 		bool HasFormatString => !string.IsNullOrEmpty(FormatString);
+
+		/// <summary>
+		/// Gets whether the value has to be formatted and parsed using <see cref="CultureInfo"/> instead of being
+		/// left to the native formatter.
+		/// </summary>
+		/// <remarks>
+		/// When the culture is the one the OS is set to, the native formatter is left to do the work so that whatever
+		/// the user has customized about their number format is respected - macOS lets the separators be changed
+		/// independently of the region, and CultureInfo cannot represent that.  Any other culture was asked for
+		/// explicitly and has to be applied, even when it happens to be what CurrentCulture is set to.
+		/// </remarks>
+		bool NeedsFormat => HasFormatString || !IsOSCulture;
+
+		/// <summary>
+		/// Gets whether <see cref="CultureInfo"/> is the culture the OS is set to.
+		/// </summary>
+		/// <remarks>
+		/// Compared by name rather than by instance: <see cref="CultureInfo.CurrentCulture"/> is not necessarily the
+		/// OS culture, since an app can set it to anything - and an explicitly assigned culture is never the same
+		/// instance as CurrentCulture even when it names the same culture.
+		/// </remarks>
+		bool IsOSCulture => string.Equals(CultureInfo.Name, OSFormat.Culture, StringComparison.OrdinalIgnoreCase);
+
+		/// <summary>
+		/// Gets the name of the OS locale's culture in the form <see cref="CultureInfo.Name"/> uses, e.g. the
+		/// identifier en_CA becomes en-CA.
+		/// </summary>
+		/// <remarks>
+		/// Read from the autoupdating locale so it follows the user changing their region.  Locale identifiers can
+		/// carry keywords (en_CA@currency=CAD) which have no CultureInfo equivalent, so those are dropped.
+		/// </remarks>
+		static string OSCultureName
+		{
+			get
+			{
+				var identifier = NSLocale.AutoUpdatingCurrentLocale.LocaleIdentifier ?? string.Empty;
+				var keyword = identifier.IndexOf('@');
+				if (keyword >= 0)
+					identifier = identifier.Substring(0, keyword);
+				return identifier.Replace('_', '-');
+			}
+		}
+
+		(string Culture, string Decimal, string Group, string Minus) _osFormat;
+
+		static (string Culture, string Decimal, string Group, string Minus)? s_osFormat;
+		static NSObject[] s_osObservers;
+
+		/// <summary>
+		/// Gets what the OS formats numbers like, to detect the user changing it.
+		/// </summary>
+		/// <remarks>
+		/// NSNumberFormatter reads its symbols from the locale when it is created and keeps them, so one built before
+		/// the user changed their number format still uses the old separators.  The text and the formatter that parses
+		/// it would then disagree, reading a "123,123" typed earlier as 123123.  The culture name is part of it as it
+		/// decides <see cref="IsOSCulture"/>, and so whether the native formatter is used at all.
+		///
+		/// Cached: reading it builds an NSNumberFormatter, which is far too slow to repeat on every value read.  It is
+		/// dropped when the locale changes or the app becomes active, and by <see cref="InvalidateOSFormat"/> whenever
+		/// the user interacts with a stepper.
+		/// </remarks>
+		static (string Culture, string Decimal, string Group, string Minus) OSFormat
+		{
+			get
+			{
+				if (s_osFormat == null)
+				{
+					// changing the number format means leaving for System Settings and coming back, so becoming
+					// active is a better signal than the locale notification, which does not report a format
+					// customized within the same locale
+					s_osObservers ??= new[]
+					{
+						NSNotificationCenter.DefaultCenter.AddObserver(NSLocale.CurrentLocaleDidChangeNotification, n => s_osFormat = null),
+						NSNotificationCenter.DefaultCenter.AddObserver(NSApplication.DidBecomeActiveNotification, n => s_osFormat = null)
+					};
+					var formatter = new NSNumberFormatter { NumberStyle = NSNumberFormatterStyle.Decimal };
+					s_osFormat = (OSCultureName, formatter.DecimalSeparator, formatter.GroupingSeparator, formatter.MinusSign);
+				}
+				return s_osFormat.Value;
+			}
+		}
+
+		/// <summary>
+		/// Discards the cached OS format, so the next read picks up a change the locale notification did not report.
+		/// </summary>
+		static void InvalidateOSFormat() => s_osFormat = null;
+
+		/// <summary>
+		/// Rebuilds the formatter when the OS number format has changed since it was created, which re-renders the
+		/// text from the value rather than leaving it to be reinterpreted with different separators.
+		/// </summary>
+		/// <remarks>
+		/// Called from the points that read the text or the formatter's symbols.  It is not called while formatting,
+		/// as that runs inside the formatter itself.
+		/// </remarks>
+		void EnsureFormatter()
+		{
+			if (_osFormat != OSFormat)
+				SetFormatter();
+		}
 
 		static readonly object CultureInfo_Key = new object();
 
@@ -577,8 +703,10 @@ namespace Eto.Mac.Forms.Controls
 			get { return Widget.Properties.Get<CultureInfo>(CultureInfo_Key, CultureInfo.CurrentCulture); }
 			set
 			{
-				Widget.Properties.Remove(ComputedFormatString_Key);
-				Widget.Properties.Set(CultureInfo_Key, value, SetFormatter, CultureInfo.CurrentCulture);
+				Widget.Properties.Set(CultureInfo_Key, value, CultureInfo.CurrentCulture);
+				// Set() removes the key when the value matches CultureInfo.CurrentCulture, so it can't report whether
+				// the effective culture changed - reformat unconditionally.
+				SetFormatter();
 			}
 		}
 

--- a/test/Eto.Test.Mac/UnitTests/NumericStepperTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/NumericStepperTests.cs
@@ -1,0 +1,300 @@
+using System.Globalization;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+
+namespace Eto.Test.Mac.UnitTests
+{
+	[TestFixture]
+	public class NumericStepperTests : TestBase
+	{
+		static NSTextField GetTextField(NumericStepper stepper) => (NSTextField)((NSView)stepper.ControlObject).Subviews[0];
+
+		/// <summary>
+		/// NSNumberFormatter formats using its NSLocale, which comes from the OS and has nothing to do with the
+		/// managed CultureInfo, so anything left to the native formatter used the OS locale's separators instead of
+		/// the culture that was asked for.
+		/// </summary>
+		[TestCase("")]
+		[TestCase("en-US")]
+		[TestCase("nl-NL")]
+		[TestCase("de-DE")]
+		public void ValueShouldBeShownUsingTheSpecifiedCulture(string cultureName)
+		{
+			Invoke(() =>
+			{
+				var culture = CultureInfo.GetCultureInfo(cultureName);
+				Assume.That(culture.Name, Is.Not.EqualTo(OSCultureName), "the OS culture is formatted by the OS - see FormattingShouldBeLeftToTheOSForItsOwnCulture");
+
+				var stepper = new NumericStepper { DecimalPlaces = 1, CultureInfo = culture };
+				stepper.Value = 90.5;
+
+				Assert.That(GetTextField(stepper).StringValue, Is.EqualTo(90.5.ToString("0.0", culture)));
+			});
+		}
+
+		/// <summary>
+		/// A culture that was asked for explicitly has to be applied even when it is also what CurrentCulture happens
+		/// to be set to.  The culture used to be compared against CurrentCulture, so an invariant culture stepper in
+		/// an app whose CurrentCulture is invariant was formatted by the OS instead - which is what RH-96796 was.
+		/// </summary>
+		[Test]
+		public void ExplicitCultureShouldBeAppliedWhenItMatchesCurrentCulture()
+		{
+			Invoke(() =>
+			{
+				var oldCulture = Thread.CurrentThread.CurrentCulture;
+				try
+				{
+					// a culture whose separator differs from the OS's, so that which one formatted the value shows
+					var culture = ForeignCulture;
+					Thread.CurrentThread.CurrentCulture = culture;
+
+					// assigning CultureInfo.CurrentCulture itself is what hit that path, as the property store
+					// compares by reference
+					var stepper = new NumericStepper { DecimalPlaces = 1, CultureInfo = CultureInfo.CurrentCulture };
+					stepper.Value = 90.5;
+
+					Assert.That(GetTextField(stepper).StringValue, Is.EqualTo(90.5.ToString("0.0", culture)));
+				}
+				finally
+				{
+					Thread.CurrentThread.CurrentCulture = oldCulture;
+				}
+			});
+		}
+
+		/// <summary>
+		/// The other half of that rule: for the OS's own culture the value is left to the native formatter, so that
+		/// whatever the user has customized about their number format is respected.  macOS lets the separators be
+		/// changed independently of the region and CultureInfo cannot represent that, so formatting such a stepper
+		/// with CultureInfo would ignore the customization.
+		/// </summary>
+		[Test]
+		public void FormattingShouldBeLeftToTheOSForItsOwnCulture()
+		{
+			Invoke(() =>
+			{
+				CultureInfo osCulture = null;
+				try
+				{
+					osCulture = CultureInfo.GetCultureInfo(OSCultureName);
+				}
+				catch (CultureNotFoundException)
+				{
+					Assume.That(false, $"the OS locale '{OSCultureName}' has no CultureInfo equivalent");
+				}
+
+				var stepper = new NumericStepper { DecimalPlaces = 1, CultureInfo = osCulture };
+				stepper.Value = 90.5;
+
+				// what the native formatter SetFormatter builds would produce
+				var expected = new NSNumberFormatter
+				{
+					NumberStyle = NSNumberFormatterStyle.Decimal,
+					UsesGroupingSeparator = false,
+					MinimumFractionDigits = 1,
+					MaximumFractionDigits = 1
+				}.StringFromNumber(new NSNumber(90.5));
+
+				Assert.That(GetTextField(stepper).StringValue, Is.EqualTo(expected));
+			});
+		}
+
+		/// <summary>
+		/// Setting the culture before the decimal places left the format string computed for the old number of
+		/// decimal places cached, showing "90" instead of "90.0".  The invariant culture is never the OS culture - a
+		/// locale identifier is never empty - so its own formatting always applies here.
+		/// </summary>
+		[Test]
+		public void DecimalPlacesShouldApplyWhenSetAfterCulture()
+		{
+			Invoke(() =>
+			{
+				var stepper = new NumericStepper { CultureInfo = CultureInfo.InvariantCulture, DecimalPlaces = 1 };
+				stepper.Value = 90;
+				Assert.That(GetTextField(stepper).StringValue, Is.EqualTo("90.0"));
+			});
+		}
+
+		/// <summary>
+		/// The decimal separator this machine's regional settings produce.  The typing tests below are written against
+		/// it rather than a hardcoded separator, since it differs per machine - and note the formatter needs an
+		/// explicit NumberStyle, as the default NoStyle reports a legacy separator instead.
+		/// </summary>
+		static string OSDecimalSeparator => new NSNumberFormatter { NumberStyle = NSNumberFormatterStyle.Decimal }.DecimalSeparator;
+
+		/// <summary>
+		/// The name of the OS locale's culture, in the form CultureInfo.Name uses.
+		/// </summary>
+		static string OSCultureName => (NSLocale.AutoUpdatingCurrentLocale.LocaleIdentifier ?? string.Empty).Split('@')[0].Replace('_', '-');
+
+		/// <summary>
+		/// A culture that is neither the OS culture nor uses its decimal separator, so that it is visible which of the
+		/// two formatted a value.  Chosen at runtime from the candidates - nothing here assumes a particular OS
+		/// setting, since that is a machine (and moment) specific thing.
+		/// </summary>
+		static CultureInfo ForeignCulture
+		{
+			get
+			{
+				var osSeparator = OSDecimalSeparator;
+				var osName = OSCultureName;
+				var candidates = new[]
+				{
+					CultureInfo.InvariantCulture,
+					CultureInfo.GetCultureInfo("nl-NL"),
+					CultureInfo.GetCultureInfo("de-DE"),
+					CultureInfo.GetCultureInfo("en-US")
+				};
+				foreach (var candidate in candidates)
+				{
+					if (candidate.NumberFormat.NumberDecimalSeparator != osSeparator
+						&& !string.Equals(candidate.Name, osName, StringComparison.OrdinalIgnoreCase))
+						return candidate;
+				}
+				Assert.Fail($"No candidate culture differs from the OS locale '{osName}', which separates decimals with '{osSeparator}'");
+				return null;
+			}
+		}
+
+		/// <summary>
+		/// Characters that aren't part of a number in the stepper's culture should not be accepted.  The OS locale's
+		/// decimal separator is not special-cased: accepting it can't work when it is also the culture's group
+		/// separator, where "1.000" is genuinely ambiguous.
+		/// </summary>
+		[Test]
+		public void TypedCharactersShouldBeFilteredByCulture()
+		{
+			var culture = ForeignCulture;
+			TypeIntoStepper(culture, null, "90x5", (stepper, editor, other) =>
+			{
+				Assert.That(editor.Value, Is.EqualTo("905"), "#1 the letter should have been rejected");
+				Assert.That(stepper.Value, Is.EqualTo(905), "#2 value");
+			});
+		}
+
+		/// <summary>
+		/// The stepper culture's decimal separator is what can be typed, whatever the OS locale uses.
+		/// </summary>
+		[Test]
+		public void CultureDecimalSeparatorShouldBeAcceptedWhenTyped()
+		{
+			var culture = ForeignCulture;
+			var separator = culture.NumberFormat.NumberDecimalSeparator;
+			TypeIntoStepper(culture, null, "90" + separator + "5", (stepper, editor, other) =>
+			{
+				Assert.That(editor.Value, Is.EqualTo("90" + separator + "5"), "#1 typed text");
+				Assert.That(stepper.Value, Is.EqualTo(90.5), "#2 value");
+			});
+		}
+
+		/// <summary>
+		/// A separator that isn't the stepper culture's is rejected even when the OS locale uses it - it would
+		/// otherwise be parsed as a group separator, turning 90,5 into 905.
+		/// </summary>
+		[Test]
+		public void OSLocaleDecimalSeparatorShouldBeRejectedWhenItIsNotTheCultures()
+		{
+			TypeIntoStepper(ForeignCulture, null, "90" + OSDecimalSeparator + "5", (stepper, editor, other) =>
+			{
+				Assert.That(editor.Value, Is.EqualTo("905"), "#1 the separator should have been rejected");
+				Assert.That(stepper.Value, Is.EqualTo(905), "#2 value");
+			});
+		}
+
+		/// <summary>
+		/// The OS culture is formatted by the native formatter, so its separator is the one the field displays and
+		/// parses with - and so the one that has to be typable.  Filtering on CultureInfo's separator instead left
+		/// the OS's own separator rejected and the only typable one unparseable, so the value could not be entered.
+		/// </summary>
+		[Test]
+		public void OSDecimalSeparatorShouldBeTypableForTheOSCulture()
+		{
+			var osCulture = OSCultureOrSkip();
+			TypeIntoStepper(osCulture, null, "123" + OSDecimalSeparator + "123", (stepper, editor, other) =>
+			{
+				Assert.That(editor.Value, Is.EqualTo("123" + OSDecimalSeparator + "123"), "#1 typed text");
+				Assert.That(stepper.Value, Is.EqualTo(123.123), "#2 value");
+			});
+		}
+
+		/// <summary>
+		/// And the value that was typed that way survives a switch to another culture, rather than the stepper being
+		/// left holding whatever it managed to parse before the separator.
+		/// </summary>
+		[Test]
+		public void ValueTypedUnderTheOSCultureShouldSurviveACultureSwitch()
+		{
+			var osCulture = OSCultureOrSkip();
+			TypeIntoStepper(osCulture, null, "123" + OSDecimalSeparator + "123", (stepper, editor, other) =>
+			{
+				var culture = ForeignCulture;
+				stepper.CultureInfo = culture;
+
+				Assert.That(stepper.Value, Is.EqualTo(123.123), "#1 value should survive the culture change");
+				Assert.That(GetTextField(stepper).StringValue, Is.EqualTo(123.123.ToString("0.#####", culture)), "#2 text should be reformatted with the new culture");
+			});
+		}
+
+		/// <summary>
+		/// The OS culture, skipping the test when its number format is not customized - the OS and CultureInfo then
+		/// agree on the separators and there is nothing to tell apart.
+		/// </summary>
+		static CultureInfo OSCultureOrSkip()
+		{
+			CultureInfo osCulture = null;
+			try
+			{
+				osCulture = CultureInfo.GetCultureInfo(OSCultureName);
+			}
+			catch (CultureNotFoundException)
+			{
+				Assume.That(false, $"the OS locale '{OSCultureName}' has no CultureInfo equivalent");
+			}
+			Assume.That(OSDecimalSeparator, Is.Not.EqualTo(osCulture.NumberFormat.NumberDecimalSeparator),
+				"the OS number format is not customized on this machine, so it cannot differ from the culture's");
+			return osCulture;
+		}
+
+		/// <summary>
+		/// Types <paramref name="text"/> a character at a time through the real field editor, so the TextInput filter
+		/// sees each keystroke the way it would from the keyboard.  <paramref name="currentCulture"/> overrides
+		/// CultureInfo.CurrentCulture for the duration when given.  The test is passed the stepper, its field editor,
+		/// and a sibling control it can move focus to.
+		/// </summary>
+		static void TypeIntoStepper(CultureInfo culture, CultureInfo currentCulture, string text, Action<NumericStepper, NSTextView, Control> test)
+		{
+			NumericStepper stepper = null;
+			TextBox other = null;
+			CultureInfo oldCulture = null;
+			Shown(form =>
+			{
+				oldCulture = Thread.CurrentThread.CurrentCulture;
+				if (currentCulture != null)
+					Thread.CurrentThread.CurrentCulture = currentCulture;
+
+				stepper = new NumericStepper { MaximumDecimalPlaces = 5, CultureInfo = culture };
+				other = new TextBox();
+				form.Content = new StackLayout { Items = { stepper, other } };
+			},
+			() =>
+			{
+				try
+				{
+					stepper.Focus();
+					var editor = GetTextField(stepper).CurrentEditor as NSTextView;
+					Assert.That(editor, Is.Not.Null, "stepper should have a field editor while focused");
+					editor.SelectAll(editor);
+					foreach (var ch in text)
+						editor.InsertText(new NSString(ch.ToString()), new NSRange(NSRange.NotFound, 0));
+
+					test(stepper, editor, other);
+				}
+				finally
+				{
+					Thread.CurrentThread.CurrentCulture = oldCulture;
+				}
+			});
+		}
+	}
+}


### PR DESCRIPTION
This ensures that when the Culture is the same as CurrentCulture, and is the same as the OS culture, it'll use the default OS formatting, which makes it respect any user settings for number formats. When setting to a different culture it will now reformat the value, and if the current culture isn't the same as the OS setting it'll format specifically for the specified culture.