### PR TITLE
Wpf: Add option to disable automation for Tree/GridView for performance reasons

### DIFF
--- a/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridColumnHandler.cs
@@ -1,10 +1,10 @@
 using Eto.Wpf.Forms.Cells;
 namespace Eto.Wpf.Forms.Controls
 {
-	public interface IGridHandler
+	public interface IGridHandler : Grid.IHandler
 	{
 		EtoDataGrid Control { get; }
-		Grid Widget { get; }
+		new Grid Widget { get; }
 		bool Loaded { get; }
 		bool DisableAutoScrollToSelection { get; }
 		sw.FrameworkElement SetupCell(IGridColumnHandler column, sw.FrameworkElement defaultContent, swc.DataGridCell cell);

--- a/src/Eto.Wpf/Forms/Controls/GridHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GridHandler.cs
@@ -1,3 +1,4 @@
+using System.Windows.Automation.Peers;
 using Eto.Wpf.Forms.Cells;
 using Eto.Wpf.Forms.Menu;
 using Eto.Wpf.Drawing;
@@ -5,9 +6,49 @@ using Eto.Wpf.CustomControls.TreeGridView;
 
 namespace Eto.Wpf.Forms.Controls
 {
+	/// <summary>
+	/// Automation peer for a grid that keeps the items out of the automation tree.
+	/// </summary>
+	/// <seealso cref="EtoDataGrid.SuppressItemAutomationPeers"/>
+	class EtoDataGridAutomationPeer : FrameworkElementAutomationPeer
+	{
+		// DataGridAutomationPeer is sealed, so this derives from the plain element peer and
+		// reports itself as a data grid rather than specialising the built-in one.
+		public EtoDataGridAutomationPeer(swc.DataGrid owner)
+			: base(owner)
+		{
+		}
+
+		protected override List<AutomationPeer> GetChildrenCore() => new List<AutomationPeer>();
+
+		protected override AutomationControlType GetAutomationControlTypeCore() => AutomationControlType.DataGrid;
+
+		protected override string GetClassNameCore() => nameof(swc.DataGrid);
+	}
+
 	public class EtoDataGrid : swc.DataGrid
 	{
 		public IWpfFrameworkElement Handler { get; set; }
+
+		/// <summary>
+		/// Gets or sets a value indicating that the items of this grid should be kept out of the
+		/// automation tree.
+		/// </summary>
+		/// <remarks>
+		/// WPF's DataGrid peer builds an item peer for every item in the grid - not just the
+		/// realized rows - and holds them in a weak table that it scavenges on each lookup. When a
+		/// UI Automation client is listening, anything that invalidates the peer (scrolling, for
+		/// one) rebuilds that whole collection during the layout pass, which for a grid with a lot
+		/// of items is slow enough to lock the UI up for seconds at a time.
+		///
+		/// Set this on grids where exposing each item to automation isn't worth that cost, such as
+		/// a transient popup list whose selected value is mirrored into a text box that automation
+		/// can see anyway.
+		/// </remarks>
+		public bool SuppressItemAutomationPeers { get; set; }
+
+		protected override AutomationPeer OnCreateAutomationPeer()
+			=> SuppressItemAutomationPeers ? new EtoDataGridAutomationPeer(this) : base.OnCreateAutomationPeer();
 
 		public new void BeginUpdateSelectedItems()
 		{


### PR DESCRIPTION
This can sometimes cause a multi-second lag when the whole grid (and doesn't have to be a complicated one) needs to be refreshed.  This disables automation (e.g. screen readers) for the Tree/GridView, but sometimes the performance gain is worth it.

To use this, set the `GridHandler.Control.SuppressItemAutomationPeers  = true`, usually in a style.