### PR TITLE
Mac: Fix message box size flashing, and allow override for which image to show

### DIFF
--- a/src/Eto.Mac/Forms/MessageBoxHandler.cs
+++ b/src/Eto.Mac/Forms/MessageBoxHandler.cs
@@ -11,6 +11,8 @@ namespace Eto.Mac.Forms
 		public MessageBoxButtons Buttons { get; set; }
 
 		public MessageBoxDefaultButton DefaultButton { get; set; }
+		
+		public Image Image { get; set; }
 
 		public DialogResult ShowDialog(Control parent)
 		{
@@ -22,6 +24,7 @@ namespace Eto.Mac.Forms
 			alert.AlertStyle = Convert(Type);
 			alert.MessageText = Caption ?? string.Empty;
 			alert.InformativeText = Text ?? string.Empty;
+			alert.Icon = Image?.ToNS() ?? NSApplication.SharedApplication.ApplicationIconImage;
 			var ret = MacModal.Run(alert, parent);
 			switch (Buttons)
 			{


### PR DESCRIPTION
This works around a bug in macOS where it initially shows the message box (NSAlert) without the image, but then adds the image afterwards, causing the dialog to jump/flash with the updated image and size.  You can now also specify a particular image if you want to use something other than the application icon.