### PR TITLE
Add IsDirectionInverted to MouseEventArgs and ScrollGesture

### DIFF
--- a/src/Eto.Gtk/Forms/Controls/GestureHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/GestureHandler.cs
@@ -187,6 +187,9 @@ namespace Eto.GtkSharp.Forms.Controls
 		public SizeF Delta => _delta;
 		public PointF Velocity => _velocity;
 
+		// GDK applies natural scrolling to the deltas without saying that it did, so there is no way to tell
+		public bool IsDirectionInverted => false;
+
 		public void AttachTo(Gtk.Widget widget)
 		{
 			Detach();

--- a/src/Eto.Mac/Forms/Controls/GestureHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/GestureHandler.cs
@@ -214,6 +214,7 @@ namespace Eto.Mac.Forms.Controls
 		bool enabled = true;
 		SizeF delta;
 		PointF velocity;
+		bool isDirectionInverted;
 		double lastScrollTimestamp;
 
 		protected new Gesture.ICallback Callback => (Gesture.ICallback)((ICallbackSource)Widget).Callback;
@@ -230,6 +231,8 @@ namespace Eto.Mac.Forms.Controls
 
 		public PointF Velocity => velocity;
 
+		public bool IsDirectionInverted => isDirectionInverted;
+
 		Gesture IMacScrollWheelGestureHandler.Gesture => Widget;
 
 		public bool OnScrollWheel(NSEvent theEvent)
@@ -243,6 +246,8 @@ namespace Eto.Mac.Forms.Controls
 			delta = theEvent.HasPreciseScrollingDeltas
 				? new SizeF((float)theEvent.ScrollingDeltaX, (float)theEvent.ScrollingDeltaY)
 				: new SizeF((float)theEvent.DeltaX * ScrollGesture.DefaultWheelScrollAmount / Widget.WheelScrollAmount, (float)theEvent.DeltaY * ScrollGesture.DefaultWheelScrollAmount / Widget.WheelScrollAmount);
+
+			isDirectionInverted = theEvent.IsDirectionInvertedFromDevice;
 
 			var timestamp = theEvent.Timestamp;
 			var phase = theEvent.Phase;

--- a/src/Eto.Mac/MacConversions.cs
+++ b/src/Eto.Mac/MacConversions.cs
@@ -215,6 +215,7 @@ namespace Eto.Mac
 			PointF point;
 			Keys modifiers;
 			MouseButtons buttons;
+			bool isDirectionInverted = false;
 			if (theEvent != null)
 			{
 				NSView view = handler.ContainerControl;
@@ -240,7 +241,11 @@ namespace Eto.Mac
 				}
 					
 				if (includeWheel)
+				{
 					delta = new SizeF((float)theEvent.DeltaX, (float)theEvent.DeltaY);
+					// only valid for scroll wheel and flick events, which is all includeWheel is used for
+					isDirectionInverted = theEvent.IsDirectionInvertedFromDevice;
+				}
 				modifiers = theEvent.ModifierFlags.ToEto();
 				buttons = theEvent.GetMouseButtons();
 			}
@@ -250,7 +255,7 @@ namespace Eto.Mac
 				modifiers = Keyboard.Modifiers;
 				buttons = Mouse.Buttons;
 			}
-			return new MouseEventArgs(buttons, modifiers, point, delta);
+			return new MouseEventArgs(buttons, modifiers, point, delta, 1.0f, isDirectionInverted);
 		}
 
 		public static MouseButtons GetMouseButtons(this NSEvent theEvent)

--- a/src/Eto.WinForms/Forms/Controls/GestureHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/GestureHandler.cs
@@ -485,6 +485,9 @@ namespace Eto.WinForms.Forms.Controls
 		public SizeF Delta => _delta;
 		public PointF Velocity => _velocity;
 
+		// Windows applies a reversed scrolling direction to the deltas without saying that it did, so there is no way to tell
+		public bool IsDirectionInverted => false;
+
 		public override void Reset()
 		{
 			_previousTime = default;

--- a/src/Eto.Wpf/Forms/Controls/GestureHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/GestureHandler.cs
@@ -518,6 +518,9 @@ namespace Eto.Wpf.Forms.Controls
 		public SizeF Delta => _delta;
 		public PointF Velocity => _velocity;
 
+		// Windows applies a reversed scrolling direction to the deltas without saying that it did, so there is no way to tell
+		public bool IsDirectionInverted => false;
+
 		public void AttachTo(sw.UIElement element)
 		{
 			Detach();

--- a/src/Eto/Forms/Controls/MouseEventArgs.cs
+++ b/src/Eto/Forms/Controls/MouseEventArgs.cs
@@ -38,12 +38,27 @@ public class MouseEventArgs : EventArgs
 	/// <param name="delta">Delta of the scroll wheel.</param>
 	/// <param name="pressure">Pressure of a stylus or touch, if applicable. 1.0f for full pressure or not supported</param>
 	public MouseEventArgs(MouseButtons buttons, Keys modifiers, PointF location, SizeF? delta = null, float pressure = 1.0f)
+		: this(buttons, modifiers, location, delta, pressure, false)
+	{
+	}
+
+	/// <summary>
+	/// Initializes a new instance of the <see cref="Eto.Forms.MouseEventArgs"/> class.
+	/// </summary>
+	/// <param name="buttons">Buttons involved in the event.</param>
+	/// <param name="modifiers">Key modifiers such as Control, Alt, or Shift.</param>
+	/// <param name="location">Location of the mouse cursor for the event.</param>
+	/// <param name="delta">Delta of the scroll wheel.</param>
+	/// <param name="pressure">Pressure of a stylus or touch, if applicable. 1.0f for full pressure or not supported</param>
+	/// <param name="isDirectionInverted">Whether the <paramref name="delta"/> is inverted from the direction of the physical device.</param>
+	public MouseEventArgs(MouseButtons buttons, Keys modifiers, PointF location, SizeF? delta, float pressure, bool isDirectionInverted)
 	{
 		this.Modifiers = modifiers;
 		this.Buttons = buttons;
 		this.Location = location;
 		this.Pressure = pressure;
 		this.Delta = delta ?? SizeF.Empty;
+		this.IsDirectionInverted = isDirectionInverted;
 	}
 
 	/// <summary>
@@ -85,4 +100,23 @@ public class MouseEventArgs : EventArgs
 	/// </summary>
 	/// <value>The scroll wheel delta.</value>
 	public SizeF Delta { get; private set; }
+
+	/// <summary>
+	/// Gets a value indicating that the <see cref="Delta"/> is inverted from the direction of the physical device.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This is <c>true</c> when the user has turned on natural (or reverse) scrolling for the device that generated the
+	/// event, in which case the platform has already flipped the <see cref="Delta"/> so that the content follows the
+	/// user's fingers. Use this when you need to move something with the device instead of with the content, such as
+	/// panning a canvas with a two finger scroll.
+	/// </para>
+	/// <para>
+	/// Only wheel events report this, and only on platforms that expose the setting per event (currently macOS via
+	/// <c>NSEvent.isDirectionInvertedFromDevice</c>). Elsewhere this is always <c>false</c>, as the platform gives no
+	/// way to tell an inverted delta from a regular one.
+	/// </para>
+	/// </remarks>
+	/// <value><c>true</c> if the delta is inverted from the device; otherwise, <c>false</c>.</value>
+	public bool IsDirectionInverted { get; private set; }
 }

--- a/src/Eto/Forms/Gesture/ScrollGesture.cs
+++ b/src/Eto/Forms/Gesture/ScrollGesture.cs
@@ -39,6 +39,25 @@ public class ScrollGesture : Gesture
 	public PointF Velocity => Handler.Velocity;
 
 	/// <summary>
+	/// Gets a value indicating that the <see cref="Delta"/> is inverted from the direction of the physical device.
+	/// </summary>
+	/// <remarks>
+	/// <para>
+	/// This is <c>true</c> when the user has turned on natural (or reverse) scrolling for the device that generated the
+	/// input, in which case the platform has already flipped the <see cref="Delta"/> so that the content follows the
+	/// user's fingers. Use this when you need to move something with the device instead of with the content, such as
+	/// panning a canvas with a two finger scroll.
+	/// </para>
+	/// <para>
+	/// Only platforms that expose the setting per event report this (currently macOS via
+	/// <c>NSEvent.isDirectionInvertedFromDevice</c>). Elsewhere this is always <c>false</c>, as the platform gives no
+	/// way to tell an inverted delta from a regular one.
+	/// </para>
+	/// </remarks>
+	/// <seealso cref="MouseEventArgs.IsDirectionInverted"/>
+	public bool IsDirectionInverted => Handler.IsDirectionInverted;
+
+	/// <summary>
 	/// Handler interface for <see cref="ScrollGesture"/>.
 	/// </summary>
 	public new interface IHandler : Gesture.IHandler
@@ -52,5 +71,10 @@ public class ScrollGesture : Gesture
 		/// Gets the current scroll velocity for the gesture activation, in logical coordinates per second.
 		/// </summary>
 		PointF Velocity { get; }
+
+		/// <summary>
+		/// Gets a value indicating that the <see cref="Delta"/> is inverted from the direction of the physical device.
+		/// </summary>
+		bool IsDirectionInverted { get; }
 	}
 }

--- a/src/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
+++ b/src/Eto/Forms/ThemedControls/ThemedTextStepperHandler.cs
@@ -336,7 +336,7 @@ public class ThemedTextStepperHandler : ThemedControlHandler<TableLayout, TextSt
 	{
 		var ctl = (Control)sender;
 		var location = Widget.PointFromScreen(ctl.PointToScreen(e.Location));
-		var args = new MouseEventArgs(e.Buttons, e.Modifiers, location, e.Delta, e.Pressure);
+		var args = new MouseEventArgs(e.Buttons, e.Modifiers, location, e.Delta, e.Pressure, e.IsDirectionInverted);
 
 		callback(Widget, args);
 		e.Handled = args.Handled;

--- a/test/Eto.Test.Mac/UnitTests/MacConversionsTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/MacConversionsTests.cs
@@ -1,4 +1,5 @@
 using Eto.Mac;
+using Eto.Mac.Forms;
 using Eto.Test.UnitTests;
 using NUnit.Framework;
 
@@ -145,6 +146,66 @@ public class MacConversionsTests : TestBase
 
 		Assert.That(args.Key, Is.EqualTo(Keys.F13));
 	}
+
+	/// <summary>
+	/// Issue: RH-97914 - MouseEventArgs.IsDirectionInverted tells you whether the user has natural scrolling
+	/// turned on for the device that generated the event, which is what AppKit reports per scroll wheel event.
+	/// </summary>
+	[TestCase(false)]
+	[TestCase(true)]
+	public void GetMouseEventShouldReportInvertedScrollDirection(bool isDirectionInverted)
+	{
+		Shown(form =>
+		{
+			var panel = new Panel { Size = new Size(100, 100) };
+			form.Content = panel;
+			return panel;
+		},
+		panel =>
+		{
+			using var scrollEvent = ScrollEvents.CreateScrollWheelEvent(3, 5, isDirectionInverted);
+			// synthesizing an inverted scroll relies on a CGEventField that isn't public API, so treat it as a
+			// precondition (inconclusive) rather than a failure if macOS ever stops honouring it.
+			Assume.That(scrollEvent.IsDirectionInvertedFromDevice, Is.EqualTo(isDirectionInverted), "Could not synthesize a scroll wheel event with an inverted direction");
+
+			var args = MacConversions.GetMouseEvent(GetViewHandler(panel), scrollEvent, true);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(args.IsDirectionInverted, Is.EqualTo(isDirectionInverted));
+				Assert.That(args.Delta, Is.EqualTo(new SizeF(3, 5)));
+			});
+		});
+	}
+
+	/// <summary>
+	/// -[NSEvent isDirectionInvertedFromDevice] is only defined for scroll wheel and flick events, so the
+	/// conversion must not go near it unless it is reading the wheel.
+	/// </summary>
+	[Test]
+	public void GetMouseEventShouldNotReportInvertedScrollDirectionForOtherEvents()
+	{
+		Shown(form =>
+		{
+			var panel = new Panel { Size = new Size(100, 100) };
+			form.Content = panel;
+			return panel;
+		},
+		panel =>
+		{
+			using var mouseEvent = NSEvent.MouseEvent(NSEventType.LeftMouseDown, CGPoint.Empty, 0, 0, 0, null, 0, 1, 0);
+
+			var args = MacConversions.GetMouseEvent(GetViewHandler(panel), mouseEvent, false);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(args.IsDirectionInverted, Is.False);
+				Assert.That(args.Delta, Is.EqualTo(SizeF.Empty));
+			});
+		});
+	}
+
+	static IMacViewHandler GetViewHandler(Control control) => (IMacViewHandler)((IHandlerSource)control).Handler;
 
 	static NSEvent CreateKeyEvent(
 		string characters,

--- a/test/Eto.Test.Mac/UnitTests/ScrollEvents.cs
+++ b/test/Eto.Test.Mac/UnitTests/ScrollEvents.cs
@@ -1,0 +1,68 @@
+using Eto.Test.UnitTests;
+
+namespace Eto.Test.Mac.UnitTests;
+
+/// <summary>
+/// Synthesizes scroll wheel <see cref="NSEvent"/>s, including ones the OS reports as coming from a device with
+/// natural (inverted) scrolling turned on.
+/// </summary>
+static class ScrollEvents
+{
+	// kCGScrollWheelEventScrollIsInverted, which is what -[NSEvent isDirectionInvertedFromDevice] reads.
+	// It isn't in the public CGEventField enum, and there is no other way to synthesize an inverted scroll.
+	const int ScrollIsInvertedField = 137;
+
+	/// <param name="precise">true to report precise (trackpad) deltas, false for wheel notch deltas</param>
+	public static NSEvent CreateScrollWheelEvent(int deltaX, int deltaY, bool isDirectionInverted, bool precise = false)
+	{
+#if MONOMAC
+		// MonoMac has no CGEvent binding, and CGEventCreateScrollWheelEvent is variadic so it can't be
+		// p/invoked portably - build a generic event and turn it into a scroll instead.
+		var cgEvent = CGEventCreate(IntPtr.Zero);
+		if (cgEvent == IntPtr.Zero)
+			throw new InvalidOperationException("Could not create scroll wheel event");
+		try
+		{
+			CGEventSetType(cgEvent, 22); // kCGEventScrollWheel
+			CGEventSetIntegerValueField(cgEvent, 11, deltaY); // kCGScrollWheelEventDeltaAxis1
+			CGEventSetIntegerValueField(cgEvent, 12, deltaX); // kCGScrollWheelEventDeltaAxis2
+			CGEventSetIntegerValueField(cgEvent, ScrollIsInvertedField, isDirectionInverted ? 1 : 0);
+			if (precise)
+			{
+				CGEventSetIntegerValueField(cgEvent, 88, 1); // kCGScrollWheelEventIsContinuous
+				CGEventSetIntegerValueField(cgEvent, 96, deltaY); // kCGScrollWheelEventPointDeltaAxis1
+				CGEventSetIntegerValueField(cgEvent, 97, deltaX); // kCGScrollWheelEventPointDeltaAxis2
+			}
+			return NSEvent.EventWithCGEvent(cgEvent);
+		}
+		finally
+		{
+			CFRelease(cgEvent);
+		}
+#else
+		using var cgEvent = new CGEvent(null, precise ? CGScrollEventUnit.Pixel : CGScrollEventUnit.Line, deltaY, deltaX);
+		cgEvent.SetValueField((CGEventField)ScrollIsInvertedField, isDirectionInverted ? 1 : 0);
+		if (precise)
+		{
+			cgEvent.SetValueField(CGEventField.ScrollWheelEventIsContinuous, 1);
+			cgEvent.SetValueField(CGEventField.ScrollWheelEventPointDeltaAxis1, deltaY);
+			cgEvent.SetValueField(CGEventField.ScrollWheelEventPointDeltaAxis2, deltaX);
+		}
+		return NSEvent.Create(cgEvent);
+#endif
+	}
+
+#if MONOMAC
+	[DllImport(Constants.CoreGraphicsLibrary)]
+	static extern IntPtr CGEventCreate(IntPtr source);
+
+	[DllImport(Constants.CoreGraphicsLibrary)]
+	static extern void CGEventSetType(IntPtr cgEvent, uint type);
+
+	[DllImport(Constants.CoreGraphicsLibrary)]
+	static extern void CGEventSetIntegerValueField(IntPtr cgEvent, uint field, long value);
+
+	[DllImport(Constants.CoreFoundationLibrary)]
+	static extern void CFRelease(IntPtr value);
+#endif
+}

--- a/test/Eto.Test.Mac/UnitTests/ScrollGestureTests.cs
+++ b/test/Eto.Test.Mac/UnitTests/ScrollGestureTests.cs
@@ -1,0 +1,36 @@
+using Eto.Mac.Forms.Controls;
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+
+namespace Eto.Test.Mac.UnitTests;
+
+[TestFixture]
+public class ScrollGestureTests : TestBase
+{
+	/// <summary>
+	/// Issue: RH-97914 - the gesture reports whether the user has natural scrolling turned on for the device
+	/// that generated the scroll, the same as <see cref="MouseEventArgs.IsDirectionInverted"/> does.
+	/// </summary>
+	[TestCase(false)]
+	[TestCase(true)]
+	[InvokeOnUI]
+	public void ScrollGestureShouldReportInvertedScrollDirection(bool isDirectionInverted)
+	{
+		var gesture = new ScrollGesture();
+		var handler = (ScrollGestureHandler)((IHandlerSource)gesture).Handler;
+		using var scrollEvent = ScrollEvents.CreateScrollWheelEvent(3, 5, isDirectionInverted, precise: true);
+
+		// synthesizing an inverted scroll relies on a CGEventField that isn't public API, so treat it as a
+		// precondition (inconclusive) rather than a failure if macOS ever stops honouring it.
+		Assume.That(scrollEvent.HasPreciseScrollingDeltas, Is.True, "Could not synthesize a trackpad scroll event");
+		Assume.That(scrollEvent.IsDirectionInvertedFromDevice, Is.EqualTo(isDirectionInverted), "Could not synthesize a scroll wheel event with an inverted direction");
+
+		Assert.That(handler.OnScrollWheel(scrollEvent), Is.True, "Scroll event was not handled by the gesture");
+
+		Assert.Multiple(() =>
+		{
+			Assert.That(gesture.IsDirectionInverted, Is.EqualTo(isDirectionInverted));
+			Assert.That(gesture.Delta, Is.EqualTo(new SizeF(3, 5)));
+		});
+	}
+}

--- a/test/Eto.Test/Sections/Behaviors/GesturesSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/GesturesSection.cs
@@ -12,6 +12,7 @@ namespace Eto.Test.Sections.Behaviors
 		readonly Label velocityLabel;
 		readonly Label scrollDeltaLabel;
 		readonly Label scrollVelocityLabel;
+		readonly Label scrollInvertedLabel;
 		readonly CheckBox allowSimultaneousGesturesCheckBox;
 		readonly MagnificationGesture magnificationGesture;
 		readonly RotationGesture rotateGesture;
@@ -26,6 +27,7 @@ namespace Eto.Test.Sections.Behaviors
 		PointF lastVelocity;
 		SizeF lastScrollDelta;
 		PointF lastScrollVelocity;
+		bool lastScrollInverted;
 
 		public GesturesSection()
 		{
@@ -37,6 +39,7 @@ namespace Eto.Test.Sections.Behaviors
 			velocityLabel = new Label();
 			scrollDeltaLabel = new Label();
 			scrollVelocityLabel = new Label();
+			scrollInvertedLabel = new Label();
 			allowSimultaneousGesturesCheckBox = new CheckBox { Text = "Allow Simultaneous Gestures", Checked = true };
 			allowSimultaneousGesturesCheckBox.CheckedChanged += (sender, e) => SetSimultaneousGestures(allowSimultaneousGesturesCheckBox.Checked == true);
 
@@ -50,7 +53,7 @@ namespace Eto.Test.Sections.Behaviors
 			drawable.MouseDown += (sender, e) => Log.Write(this, $"MouseDown: {e.Buttons} at {e.Location}");
 			// drawable.MouseMove += (sender, e) => Log.Write(this, $"MouseMove: {e.Buttons} at {e.Location}");
 			drawable.MouseUp += (sender, e) => Log.Write(this, $"MouseUp: {e.Buttons} at {e.Location}");
-			drawable.MouseWheel += (sender, e) => Log.Write(this, $"MouseWheel: {e.Delta} at {e.Location}");
+			drawable.MouseWheel += (sender, e) => Log.Write(this, $"MouseWheel: {e.Delta} at {e.Location}, Inverted: {e.IsDirectionInverted}");
 
 			if (Platform.Supports<MagnificationGesture>())
 			{
@@ -96,6 +99,7 @@ namespace Eto.Test.Sections.Behaviors
 				lastVelocity = PointF.Empty;
 				lastScrollDelta = SizeF.Empty;
 				lastScrollVelocity = PointF.Empty;
+				lastScrollInverted = false;
 				UpdateLabels();
 				drawable.Invalidate();
 			};
@@ -113,7 +117,7 @@ namespace Eto.Test.Sections.Behaviors
 						TableLayout.Horizontal(10, scaleLabel, magnificationLabel, resetButton, allowSimultaneousGesturesCheckBox, panMouseButtonsSelector, null),
 						TableLayout.Horizontal(10, angleLabel, rotationLabel, null),
 						TableLayout.Horizontal(10, translationLabel, velocityLabel, null),
-						TableLayout.Horizontal(10, scrollDeltaLabel, scrollVelocityLabel, wheelScrollAmountControl, null),
+						TableLayout.Horizontal(10, scrollDeltaLabel, scrollVelocityLabel, scrollInvertedLabel, wheelScrollAmountControl, null),
 						drawable
 					),
 					null
@@ -226,6 +230,7 @@ namespace Eto.Test.Sections.Behaviors
 		{
 			lastScrollDelta = scrollGesture.Delta;
 			lastScrollVelocity = scrollGesture.Velocity;
+			lastScrollInverted = scrollGesture.IsDirectionInverted;
 			offset += new PointF(lastScrollDelta.Width, lastScrollDelta.Height);
 			UpdateLabels();
 			drawable.Invalidate();
@@ -241,6 +246,7 @@ namespace Eto.Test.Sections.Behaviors
 			velocityLabel.Text = string.Format("Velocity: {0:+0.0;-0.0;0.0}, {1:+0.0;-0.0;0.0}", lastVelocity.X, lastVelocity.Y);
 			scrollDeltaLabel.Text = string.Format("Scroll Delta: {0:+0.0;-0.0;0.0}, {1:+0.0;-0.0;0.0}", lastScrollDelta.Width, lastScrollDelta.Height);
 			scrollVelocityLabel.Text = string.Format("Scroll Velocity: {0:+0.0;-0.0;0.0}, {1:+0.0;-0.0;0.0}", lastScrollVelocity.X, lastScrollVelocity.Y);
+			scrollInvertedLabel.Text = string.Format("Scroll Inverted: {0}", lastScrollInverted);
 		}
 
 		void Drawable_Paint(object sender, PaintEventArgs e)

--- a/test/Eto.Test/Sections/Behaviors/MouseEventsSection.cs
+++ b/test/Eto.Test/Sections/Behaviors/MouseEventsSection.cs
@@ -17,7 +17,7 @@ namespace Eto.Test.Sections.Behaviors
 			if (!showParentEvents.Checked == true && sender == this)
 				return;
 			var control = sender as Control;
-			Log.Write(sender, $"{type}, Location: {e.Location}, Buttons: {e.Buttons}, Modifiers: {e.Modifiers}, Delta: {e.Delta}, Screen: {control?.PointToScreen(e.Location)}");
+			Log.Write(sender, $"{type}, Location: {e.Location}, Buttons: {e.Buttons}, Modifiers: {e.Modifiers}, Delta: {e.Delta}, Inverted: {e.IsDirectionInverted}, Screen: {control?.PointToScreen(e.Location)}");
 			if (handleEvents.Checked == true)
 				e.Handled = true;
 		}

--- a/test/Eto.Test/UnitTests/Forms/Behaviors/ScrollGestureTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/Behaviors/ScrollGestureTests.cs
@@ -1,0 +1,25 @@
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms.Behaviors
+{
+	[TestFixture]
+	public class ScrollGestureTests : TestBase
+	{
+		/// <summary>
+		/// Only macOS can tell an inverted scroll from a regular one, but every backend has to answer the
+		/// question without blowing up, and without claiming to be inverted before anything has scrolled.
+		/// </summary>
+		[Test]
+		public void IsDirectionInvertedShouldDefaultToFalse()
+		{
+			Invoke(() =>
+			{
+				if (!Platform.Instance.Supports<ScrollGesture>())
+					Assert.Ignore("ScrollGesture is not supported by this platform");
+
+				var gesture = new ScrollGesture();
+				Assert.That(gesture.IsDirectionInverted, Is.False);
+			});
+		}
+	}
+}

--- a/test/Eto.Test/UnitTests/Forms/MouseEventArgsTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/MouseEventArgsTests.cs
@@ -1,0 +1,68 @@
+using Eto.Forms.ThemedControls;
+using NUnit.Framework;
+
+namespace Eto.Test.UnitTests.Forms
+{
+	[TestFixture]
+	public class MouseEventArgsTests : TestBase
+	{
+		[Test]
+		public void IsDirectionInvertedShouldDefaultToFalse()
+		{
+			var args = new MouseEventArgs(MouseButtons.None, Keys.None, new PointF(10, 20), new SizeF(0, 1));
+			Assert.That(args.IsDirectionInverted, Is.False);
+		}
+
+		[TestCase(false)]
+		[TestCase(true)]
+		public void IsDirectionInvertedShouldComeFromConstructor(bool isDirectionInverted)
+		{
+			var args = new MouseEventArgs(MouseButtons.Middle, Keys.Shift, new PointF(10, 20), new SizeF(0, -1), 0.5f, isDirectionInverted);
+
+			Assert.Multiple(() =>
+			{
+				Assert.That(args.IsDirectionInverted, Is.EqualTo(isDirectionInverted));
+				// the other values must not shift with the added parameter
+				Assert.That(args.Buttons, Is.EqualTo(MouseButtons.Middle));
+				Assert.That(args.Modifiers, Is.EqualTo(Keys.Shift));
+				Assert.That(args.Location, Is.EqualTo(new PointF(10, 20)));
+				Assert.That(args.Delta, Is.EqualTo(new SizeF(0, -1)));
+				Assert.That(args.Pressure, Is.EqualTo(0.5f));
+			});
+		}
+
+		/// <summary>
+		/// Controls that forward mouse events from a child control rebuild the event args, so anything added to
+		/// <see cref="MouseEventArgs"/> has to be carried over when they do.
+		/// </summary>
+		[Test]
+		public void ThemedTextStepperShouldForwardIsDirectionInverted()
+		{
+			MouseEventArgs forwarded = null;
+			Shown(form =>
+			{
+				var stepper = new TextStepper();
+				stepper.MouseWheel += (sender, e) => forwarded = e;
+				form.Content = stepper;
+				return stepper;
+			},
+			stepper =>
+			{
+				if (!(((IHandlerSource)stepper).Handler is ThemedTextStepperHandler handler))
+					Assert.Ignore("TextStepper does not use the themed handler on this platform");
+				else
+					RaiseMouseWheel(handler.TextBox, isDirectionInverted: true);
+			});
+
+			Assert.That(forwarded, Is.Not.Null, "MouseWheel was not forwarded from the child control");
+			Assert.That(forwarded.IsDirectionInverted, Is.True);
+		}
+
+		static void RaiseMouseWheel(Control control, bool isDirectionInverted)
+		{
+			var callback = (Control.ICallback)((ICallbackSource)control).Callback;
+			var args = new MouseEventArgs(MouseButtons.None, Keys.None, PointF.Empty, new SizeF(0, 1), 1.0f, isDirectionInverted);
+			callback.OnMouseWheel(control, args);
+		}
+	}
+}


### PR DESCRIPTION
This is indicates when the user has turned on natural (or reverse) scrolling for the device that generated the event, in which case the platform has already flipped the `Delta` so that the content follows the user's fingers. Use this when you need to move something with the device instead of with the content, such as panning a canvas with a two finger scroll.