### PR TITLE
Add Button.ImageNextToText property

### DIFF
--- a/src/Eto.Android/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Android/Forms/Controls/ButtonHandler.cs
@@ -60,6 +60,9 @@ namespace Eto.Android.Forms.Controls
 			}
 		}
 
+		// Android compound drawables are always drawn next to the text
+		public bool ImageNextToText { get; set; }
+
 		protected override void ApplyBackgroundColor(Color? value)
 		{
 			// Try to preserve Android button styling whilst still changing the color

--- a/src/Eto.Gtk/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Gtk/Forms/Controls/ButtonHandler.cs
@@ -28,6 +28,7 @@ namespace Eto.GtkSharp.Forms.Controls
 
 		internal static readonly object Image_Key = new object();
 		internal static readonly object ImagePosition_Key = new object();
+		internal static readonly object ImageNextToText_Key = new object();
 		internal static readonly object MinimumSize_Key = new object();
 
 		protected override Gtk.Button CreateControl() => new EtoButton { Handler = this };

--- a/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk2.cs
+++ b/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk2.cs
@@ -206,6 +206,13 @@ namespace Eto.GtkSharp.Forms.Controls
 			}
 		}
 
+		public bool ImageNextToText
+		{
+			// GTK2 can't center the image and label as a group, the image is always at the edge of the button
+			get { return Widget.Properties.Get<bool>(ButtonHandler.ImageNextToText_Key); }
+			set { Widget.Properties.Set(ButtonHandler.ImageNextToText_Key, value); }
+		}
+
 		public Color TextColor
 		{
 			get { return label.GetForeground(); }

--- a/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk3.cs
+++ b/src/Eto.Gtk/Forms/Controls/ButtonHandler.gtk3.cs
@@ -102,27 +102,30 @@ namespace Eto.GtkSharp.Forms.Controls
 			var showLabel = !string.IsNullOrEmpty(label.Text);
 			if (showImage && showLabel)
 			{
+				// when hugging the text, nothing in the box expands so the box gets only its natural size,
+				// which is then centered in the button.
+				var expand = !ImageNextToText;
 				Gtk.Box box;
 				switch (ImagePosition)
 				{
 					case ButtonImagePosition.Above:
 						child = box = new Gtk.Box(Gtk.Orientation.Vertical, 2);
-						box.PackStart(gtkimage, true, true, 0);
+						box.PackStart(gtkimage, expand, true, 0);
 						box.PackEnd(label, false, true, 0);
 						break;
 					case ButtonImagePosition.Below:
 						child = box = new Gtk.Box(Gtk.Orientation.Vertical, 2);
 						box.PackStart(label, false, true, 0);
-						box.PackEnd(gtkimage, true, true, 0);
+						box.PackEnd(gtkimage, expand, true, 0);
 						break;
 					case ButtonImagePosition.Left:
 						child = box = new Gtk.Box(Gtk.Orientation.Horizontal, 2);
 						box.PackStart(gtkimage, false, true, 0);
-						box.PackStart(label, true, true, 0);
+						box.PackStart(label, expand, true, 0);
 						break;
 					case ButtonImagePosition.Right:
 						child = box = new Gtk.Box(Gtk.Orientation.Horizontal, 2);
-						box.PackStart(label, true, true, 0);
+						box.PackStart(label, expand, true, 0);
 						box.PackEnd(gtkimage, false, true, 0);
 						break;
 					case ButtonImagePosition.Overlay:
@@ -142,6 +145,11 @@ namespace Eto.GtkSharp.Forms.Controls
 						break;
 					default:
 						throw new NotSupportedException();
+				}
+				if (ImageNextToText)
+				{
+					child.Halign = Gtk.Align.Center;
+					child.Valign = Gtk.Align.Center;
 				}
 			}
 			else if (showLabel)
@@ -168,6 +176,16 @@ namespace Eto.GtkSharp.Forms.Controls
 			set
 			{
 				if (Widget.Properties.TrySet(ButtonHandler.ImagePosition_Key, value))
+					SetImagePosition();
+			}
+		}
+
+		public bool ImageNextToText
+		{
+			get { return Widget.Properties.Get<bool>(ButtonHandler.ImageNextToText_Key); }
+			set
+			{
+				if (Widget.Properties.TrySet(ButtonHandler.ImageNextToText_Key, value))
 					SetImagePosition();
 			}
 		}

--- a/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Mac/Forms/Controls/ButtonHandler.cs
@@ -310,6 +310,19 @@ namespace Eto.Mac.Forms.Controls
 			}
 		}
 
+		public bool ImageNextToText
+		{
+			get => Control.ImageHugsTitle;
+			set
+			{
+				if (Control.ImageHugsTitle != value)
+				{
+					Control.ImageHugsTitle = value;
+					InvalidateMeasure();
+				}
+			}
+		}
+
 		public NSBezelStyle? BezelStyle
 		{
 			get { return Widget.Properties.Get<NSBezelStyle?>(ButtonHandler.CustomBezelStyle_Key); }

--- a/src/Eto.WinForms/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.WinForms/Forms/Controls/ButtonHandler.cs
@@ -108,6 +108,15 @@ namespace Eto.WinForms.Forms.Controls
 			}
 		}
 
+		static readonly object ImageNextToText_Key = new object();
+
+		public bool ImageNextToText
+		{
+			// WinForms always splits the button into an image region at the edge and centers the text in what's left
+			get { return Widget.Properties.Get<bool>(ImageNextToText_Key); }
+			set { Widget.Properties.Set(ImageNextToText_Key, value); }
+		}
+
 		static readonly object MinimumSize_Key = new object();
 
 		public Size MinimumSize

--- a/src/Eto.WinUI/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.WinUI/Forms/Controls/ButtonHandler.cs
@@ -5,6 +5,7 @@ public class ButtonHandler : WinUIControl<muc.Button, Button, Button.ICallback>,
 	muc.TextBlock _textBlock;
 	public Image Image { get; set; }
 	public ButtonImagePosition ImagePosition { get; set; }
+	public bool ImageNextToText { get; set; }
 	public Size MinimumSize { get; set; }
 
 	public string Text

--- a/src/Eto.Wpf/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.Wpf/Forms/Controls/ButtonHandler.cs
@@ -203,32 +203,36 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			if (ImagePart == null || LabelPart == null)
 				return;
+			// when hugging the text, only give the grid its desired size so the image ends up beside the label
+			// instead of the label taking up all the leftover space.
+			var fill = ImageNextToText ? sw.HorizontalAlignment.Center : sw.HorizontalAlignment.Stretch;
+			var fillVertical = ImageNextToText ? sw.VerticalAlignment.Center : sw.VerticalAlignment.Stretch;
 			int col, row;
 			sw.Thickness imageSpacing;
 			switch (ImagePosition)
 			{
 				case ButtonImagePosition.Left:
 					col = 0; row = 1;
-					Control.HorizontalContentAlignment = sw.HorizontalAlignment.Stretch;
+					Control.HorizontalContentAlignment = fill;
 					Control.VerticalContentAlignment = sw.VerticalAlignment.Center;
 					imageSpacing = new sw.Thickness(ImageLabelSpacing, 0, 0, 0);
 					break;
 				case ButtonImagePosition.Right:
 					col = 2; row = 1;
-					Control.HorizontalContentAlignment = sw.HorizontalAlignment.Stretch;
+					Control.HorizontalContentAlignment = fill;
 					Control.VerticalContentAlignment = sw.VerticalAlignment.Center;
 					imageSpacing = new sw.Thickness(0, 0, ImageLabelSpacing, 0);
 					break;
 				case ButtonImagePosition.Above:
 					col = 1; row = 0;
 					Control.HorizontalContentAlignment = sw.HorizontalAlignment.Center;
-					Control.VerticalContentAlignment = sw.VerticalAlignment.Stretch;
+					Control.VerticalContentAlignment = fillVertical;
 					imageSpacing = new sw.Thickness(0, ImageLabelSpacing, 0, 0);
 					break;
 				case ButtonImagePosition.Below:
 					col = 1; row = 2;
 					Control.HorizontalContentAlignment = sw.HorizontalAlignment.Center;
-					Control.VerticalContentAlignment = sw.VerticalAlignment.Stretch;
+					Control.VerticalContentAlignment = fillVertical;
 					imageSpacing = new sw.Thickness(0, 0, 0, ImageLabelSpacing);
 					break;
 				case ButtonImagePosition.Overlay:
@@ -252,6 +256,14 @@ namespace Eto.Wpf.Forms.Controls
 		{
 			get { return Widget.Properties.Get<ButtonImagePosition>(ImagePosition_Key); }
 			set { Widget.Properties.Set(ImagePosition_Key, value, SetImagePosition); }
+		}
+
+		static readonly object ImageNextToText_Key = new object();
+
+		public bool ImageNextToText
+		{
+			get { return Widget.Properties.Get<bool>(ImageNextToText_Key); }
+			set { Widget.Properties.Set(ImageNextToText_Key, value, SetImagePosition); }
 		}
 
 		public override void AttachEvent(string id)

--- a/src/Eto.Wpf/themes/none.xaml
+++ b/src/Eto.Wpf/themes/none.xaml
@@ -7,6 +7,7 @@
 
     <ResourceDictionary.MergedDictionaries>
         <e:AssemblyAbsoluteResourceDictionary Path="themes/generic.xaml" />
+        <e:AssemblyAbsoluteResourceDictionary Path="themes/none/Button.xaml" />
         <e:AssemblyAbsoluteResourceDictionary Path="themes/none/Window.xaml" />
     </ResourceDictionary.MergedDictionaries>
 

--- a/src/Eto.Wpf/themes/none/Button.xaml
+++ b/src/Eto.Wpf/themes/none/Button.xaml
@@ -1,0 +1,13 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:r="clr-namespace:Eto.Wpf.CustomControls.TreeGridView"
+    xmlns:efc="clr-namespace:Eto.Wpf.Forms.Controls"
+    xmlns:e="clr-namespace:Eto.Wpf"
+    xmlns:ef="clr-namespace:Eto.Wpf.Forms"
+    xmlns:s="clr-namespace:System;assembly=mscorlib">
+
+    <Style TargetType="efc:EtoButton">
+        <Setter Property="Padding" Value="5,2"/>
+    </Style>
+	
+</ResourceDictionary>

--- a/src/Eto.iOS/Forms/Controls/ButtonHandler.cs
+++ b/src/Eto.iOS/Forms/Controls/ButtonHandler.cs
@@ -66,5 +66,11 @@ namespace Eto.iOS.Forms.Controls
 			get;
 			set;
 		}
+
+		public bool ImageNextToText
+		{
+			get;
+			set;
+		}
 	}
 }

--- a/src/Eto/Forms/Controls/Button.cs
+++ b/src/Eto/Forms/Controls/Button.cs
@@ -117,6 +117,27 @@ public class Button : TextControl, IMnemonicControl
 	}
 
 	/// <summary>
+	/// Gets or sets a value indicating that the <see cref="Image"/> should be placed directly next to the
+	/// <see cref="TextControl.Text"/>, instead of being aligned to the edge of the button.
+	/// </summary>
+	/// <remarks>
+	/// By default the image is aligned to the edge of the button given by <see cref="ImagePosition"/>, and the text is
+	/// centered in the space that is left over. When this is <c>true</c> the image and text are kept together as a
+	/// single group, which is then centered in the button.
+	/// <br/>
+	/// This only has a visible effect when the button is larger than its content, so it makes no difference for an
+	/// auto sized button.
+	/// <br/>
+	/// Not supported on all platforms, in which case the image stays aligned to the edge of the button.
+	/// </remarks>
+	/// <value><c>true</c> to keep the image next to the text; <c>false</c> to align the image to the edge of the button. Default is <c>false</c>.</value>
+	public bool ImageNextToText
+	{
+		get { return Handler.ImageNextToText; }
+		set { Handler.ImageNextToText = value; }
+	}
+
+	/// <summary>
 	/// Gets or sets the minimum size for the button.
 	/// </summary>
 	/// <remarks>
@@ -285,6 +306,9 @@ public class Button : TextControl, IMnemonicControl
 
 		/// <inheritdoc cref="Button.ImagePosition"/>
 		ButtonImagePosition ImagePosition { get; set; }
+
+		/// <inheritdoc cref="Button.ImageNextToText"/>
+		bool ImageNextToText { get; set; }
 
 		/// <inheritdoc cref="Button.MinimumSize"/>
 		Size MinimumSize { get; set;}

--- a/test/Eto.Test/Sections/Controls/ButtonSection.cs
+++ b/test/Eto.Test/Sections/Controls/ButtonSection.cs
@@ -7,6 +7,7 @@
 		Bitmap largeImage = TestIcons.TestImage;
 		ButtonImagePosition imagePosition;
 		bool clearMinimumSize;
+		bool imageNextToText;
 
 		public ButtonImagePosition ImagePosition
 		{
@@ -15,6 +16,16 @@
 			{
 				imagePosition = value;
 				OnPropertyChanged(new PropertyChangedEventArgs("ImagePosition"));
+			}
+		}
+
+		public bool ImageNextToText
+		{
+			get { return imageNextToText; }
+			set
+			{
+				imageNextToText = value;
+				OnPropertyChanged(new PropertyChangedEventArgs("ImageNextToText"));
 			}
 		}
 
@@ -38,9 +49,10 @@
 			layout.AddAutoSized(ColourButton(), centered: true);
 			layout.AddAutoSized(DisabledButton(), centered: true);
 			layout.Add(StretchedButton());
-			layout.AddSeparateRow(null, new Label { Text = "Image Position:", VerticalAlignment = VerticalAlignment.Center }, ImagePositionControl(), ClearMinimumSizeControl(), null);
-			layout.AddSeparateRow(null, TableLayout.AutoSized(ImageButton(smallImage)), TableLayout.AutoSized(ImageTextButton(smallImage)), null);
-			layout.AddSeparateRow(null, TableLayout.AutoSized(ImageButton(largeImage)), TableLayout.AutoSized(ImageTextButton(largeImage)), null);
+			layout.AddSeparateRow(null, new Label { Text = "Image Position:", VerticalAlignment = VerticalAlignment.Center }, ImagePositionControl(), ClearMinimumSizeControl(), ImageNextToTextControl(), null);
+			layout.AddSeparateRow(null, TableLayout.AutoSized(ImageButton(smallImage)), TableLayout.AutoSized(ImageButton(smallImage, "Image && Text")), null);
+			layout.AddSeparateRow(null, TableLayout.AutoSized(ImageButton(largeImage)), TableLayout.AutoSized(ImageButton(largeImage, "Image && Text")), null);
+			layout.Add(ImageButton(smallImage, "Stretched Image && Text"));
 
 			layout.Add(null);
 
@@ -94,20 +106,13 @@
 			return control;
 		}
 
-		Control ImageButton(Image image)
+		Control ImageButton(Image image, string text = null)
 		{
-			var control = new Button { Image = image };
+			var control = new Button { Image = image, Text = text };
 			control.Bind(r => r.ImagePosition, this, r => r.ImagePosition);
+			control.Bind(r => r.ImageNextToText, this, r => r.ImageNextToText);
 			var defaultMinimiumSize = control.MinimumSize;
             control.Bind(r => r.MinimumSize, Binding.Property(this, r => r.ClearMinimumSize).Convert(r => r ? Size.Empty : defaultMinimiumSize));
-			LogEvents(control);
-			return control;
-		}
-
-		Control ImageTextButton(Image image)
-		{
-			var control = new Button { Text = "Image && Text Button", Image = image };
-			control.Bind(r => r.ImagePosition, this, r => r.ImagePosition);
 			LogEvents(control);
 			return control;
 		}
@@ -123,6 +128,13 @@
 		{
 			var control = new CheckBox { Text = "Clear MinimumSize" };
 			control.CheckedBinding.Bind(this, r => r.ClearMinimumSize);
+			return control;
+		}
+
+		Control ImageNextToTextControl()
+		{
+			var control = new CheckBox { Text = "ImageNextToText" };
+			control.CheckedBinding.Bind(this, r => r.ImageNextToText);
 			return control;
 		}
 


### PR DESCRIPTION
This allows the image to stay next to the text, even when the button size is larger and the text is not left or right aligned along with the image.  With it set to false (the default, and previous behaviour), the image is shown all the way to the left or right, even when the text is entered.