### PR TITLE
Add Window.PreviewKeyUp/Down events

### DIFF
--- a/src/Eto.Gtk/Forms/GtkWindow.cs
+++ b/src/Eto.Gtk/Forms/GtkWindow.cs
@@ -478,9 +478,35 @@ namespace Eto.GtkSharp.Forms
 				case Window.LogicalPixelSizeChangedEvent:
 					// not supported on GTK, yet.
 					break;
+				// The toplevel gets key events before it propagates them to the focused widget, so
+				// hooking it here is the capture phase. Note this won't see keys delivered straight to
+				// an embedded foreign window such as a GtkSocket.
+				case Window.PreviewKeyDownEvent:
+					EventControl.AddEvents((int)Gdk.EventMask.KeyPressMask);
+					EventControl.KeyPressEvent += Connector.HandleWindowPreviewKeyPressEvent;
+					break;
+				case Window.PreviewKeyUpEvent:
+					EventControl.AddEvents((int)Gdk.EventMask.KeyReleaseMask);
+					EventControl.KeyReleaseEvent += Connector.HandleWindowPreviewKeyReleaseEvent;
+					break;
 				default:
 					base.AttachEvent(id);
 					break;
+			}
+		}
+
+		public override bool DetachEvent(string id)
+		{
+			switch (id)
+			{
+				case Window.PreviewKeyDownEvent:
+					EventControl.KeyPressEvent -= Connector.HandleWindowPreviewKeyPressEvent;
+					return true;
+				case Window.PreviewKeyUpEvent:
+					EventControl.KeyReleaseEvent -= Connector.HandleWindowPreviewKeyReleaseEvent;
+					return true;
+				default:
+					return base.DetachEvent(id);
 			}
 		}
 
@@ -561,6 +587,30 @@ namespace Eto.GtkSharp.Forms
 					handler.Callback.OnKeyDown(handler.Widget, e);
 					args.RetVal = e.Handled;
 				}
+			}
+
+			[GLib.ConnectBefore]
+			public void HandleWindowPreviewKeyPressEvent(object o, Gtk.KeyPressEventArgs args)
+			{
+				var handler = Handler;
+				if (handler == null)
+					return;
+				var e = args.Event.ToEto();
+				if (e != null)
+					handler.Callback.OnPreviewKeyDown(handler.Widget, new KeyMonitorEventArgs(e.KeyData, KeyEventType.KeyDown));
+				// deliberately leaves args.RetVal alone, monitoring never consumes the key
+			}
+
+			[GLib.ConnectBefore]
+			public void HandleWindowPreviewKeyReleaseEvent(object o, Gtk.KeyReleaseEventArgs args)
+			{
+				var handler = Handler;
+				if (handler == null)
+					return;
+				var e = args.Event.ToEto();
+				if (e != null)
+					handler.Callback.OnPreviewKeyUp(handler.Widget, new KeyMonitorEventArgs(e.KeyData, KeyEventType.KeyUp));
+				// deliberately leaves args.RetVal alone, monitoring never consumes the key
 			}
 
 			public void HandleWindowSizeAllocated(object o, Gtk.SizeAllocatedArgs args)

--- a/src/Eto.Mac/Forms/MacWindow.cs
+++ b/src/Eto.Mac/Forms/MacWindow.cs
@@ -203,6 +203,8 @@ namespace Eto.Mac.Forms
 	{
 		internal static readonly object InitialLocation_Key = new object();
 		internal static readonly object PreferredClientSize_Key = new object();
+		internal static readonly object MonitorKeys_Key = new object();
+		internal static readonly object KeyMonitor_Key = new object();
 		internal static readonly Selector selSetStyleMask = new Selector("setStyleMask:");
 		internal static IntPtr selMainMenu = Selector.GetHandle("mainMenu");
 		internal static IntPtr selSetMainMenu = Selector.GetHandle("setMainMenu:");
@@ -425,6 +427,10 @@ namespace Eto.Mac.Forms
 					break;
 				case Eto.Forms.Control.LostFocusEvent:
 					Control.DidResignKey += HandleLostFocus;
+					break;
+				case Window.PreviewKeyDownEvent:
+				case Window.PreviewKeyUpEvent:
+					AttachKeyMonitor();
 					break;
 				case Eto.Forms.Control.SizeChangedEvent:
 					{
@@ -1158,6 +1164,8 @@ namespace Eto.Mac.Forms
 				PositionWindow();
 			}
 			base.OnLoad(e);
+			if (MonitorKeys)
+				RegisterKeyMonitor();
 		}
 
 		Size GetBorderSize()
@@ -1418,8 +1426,93 @@ namespace Eto.Mac.Forms
 			}
 		}
 
+		bool MonitorKeys
+		{
+			get => Widget.Properties.Get<bool>(MacWindow.MonitorKeys_Key);
+			set => Widget.Properties.Set(MacWindow.MonitorKeys_Key, value);
+		}
+
+		NSObject KeyMonitor
+		{
+			get => Widget.Properties.Get<NSObject>(MacWindow.KeyMonitor_Key);
+			set => Widget.Properties.Set(MacWindow.KeyMonitor_Key, value);
+		}
+
+		/// <summary>
+		/// Key events go to the first responder and never bubble anywhere Eto can see them, so a local
+		/// event monitor is the only way to notice keys going to content hosted in the window. Both
+		/// preview key events share one monitor; raising a callback nobody subscribed to is harmless.
+		/// </summary>
+		/// <remarks>
+		/// AppKit holds the monitor block, and with it this handler, so it is deferred until the window
+		/// is loaded and removed again when it unloads. A window that is never shown never installs a
+		/// monitor, and one that is closed lets go without waiting for a Dispose that may never come.
+		/// </remarks>
+		void AttachKeyMonitor()
+		{
+			MonitorKeys = true;
+			if (Widget.Loaded)
+				RegisterKeyMonitor();
+		}
+
+		void RegisterKeyMonitor()
+		{
+			if (KeyMonitor != null)
+				return;
+			KeyMonitor = NSEvent.AddLocalMonitorForEventsMatchingMask(NSEventMask.KeyDown | NSEventMask.KeyUp, theEvent =>
+			{
+				// only keys headed for this window, and always hand the event back untouched so the
+				// responder chain still gets it
+				if (theEvent != null && theEvent.Window == Control)
+				{
+					var key = KeyMap.MapKey(theEvent.KeyCode, theEvent.ModifierFlags);
+					if (theEvent.Type == NSEventType.KeyDown)
+						Callback.OnPreviewKeyDown(Widget, new KeyMonitorEventArgs(key, KeyEventType.KeyDown));
+					else
+						Callback.OnPreviewKeyUp(Widget, new KeyMonitorEventArgs(key, KeyEventType.KeyUp));
+				}
+				return theEvent;
+			});
+		}
+
+		void DetachKeyMonitor()
+		{
+			var monitor = KeyMonitor;
+			if (monitor == null)
+				return;
+			NSEvent.RemoveMonitor(monitor);
+			KeyMonitor = null;
+		}
+
+		public override bool DetachEvent(string id)
+		{
+			switch (id)
+			{
+				case Window.PreviewKeyDownEvent:
+				case Window.PreviewKeyUpEvent:
+					// one monitor serves both, so only give it up when neither is still wanted
+					var other = id == Window.PreviewKeyDownEvent ? Window.PreviewKeyUpEvent : Window.PreviewKeyDownEvent;
+					if (!IsEventHandled(other))
+					{
+						MonitorKeys = false;
+						DetachKeyMonitor();
+					}
+					return true;
+				default:
+					return base.DetachEvent(id);
+			}
+		}
+
+		public override void OnUnLoad(EventArgs e)
+		{
+			base.OnUnLoad(e);
+			DetachKeyMonitor();
+		}
+
 		protected override void Dispose(bool disposing)
 		{
+			DetachKeyMonitor();
+
 			if (disposing && Widget.Loaded)
 			{
 				// we can't cancel closing in this case, so don't bother firing the closing event

--- a/src/Eto.WinForms/Forms/HwndFormHandler.cs
+++ b/src/Eto.WinForms/Forms/HwndFormHandler.cs
@@ -111,7 +111,7 @@ namespace Eto.WinForms.Forms
 	}
 
 
-	public class HwndFormHandler : WidgetHandler<IntPtr, Form, Form.ICallback>, Form.IHandler,
+	public class HwndFormHandler : WidgetHandler<IntPtr, Form, Form.ICallback>, Form.IHandler, Win32.KeyMonitor.ITarget,
 #if WPF
  IWpfWindow
 #elif WINFORMS
@@ -765,6 +765,15 @@ namespace Eto.WinForms.Forms
 			if (disposing)
 			{
 				_hookHelper?.RemoveHook(Control, this);
+
+				// only on the Dispose path: the registry is UI thread only, and if the finalizer is
+				// running then this handler was collected, which prunes the registration anyway
+				var keyMonitor = KeyMonitor;
+				if (keyMonitor != null)
+				{
+					keyMonitor.Dispose();
+					KeyMonitor = null;
+				}
 			}
 
 			base.Dispose(disposing);
@@ -842,6 +851,18 @@ namespace Eto.WinForms.Forms
 					};
 
 					break;
+				case Window.PreviewKeyDownEvent:
+				case Window.PreviewKeyUpEvent:
+					// Both share one registration, since the hook reports key down and key up together.
+					// Raising a callback nobody subscribed to is harmless.
+					// Unlike a window Eto owns, this one is never shown through Eto so it never loads,
+					// which rules out deferring to OnLoad and tearing down from OnUnLoad. Registering
+					// right away is fine because the monitor holds this handler weakly, matching how
+					// g_windows caches it - dropping the wrapper without disposing prunes the
+					// registration on the next key press.
+					if (KeyMonitor == null)
+						KeyMonitor = Win32.KeyMonitor.Register(this);
+					break;
 				case Window.LogicalPixelSizeChangedEvent:
 					// don't spam the output with warnings for this, many controls use it internally
 					break;
@@ -850,6 +871,48 @@ namespace Eto.WinForms.Forms
 					break;
 			}
 
+		}
+
+		static readonly object KeyMonitor_Key = new object();
+
+		IDisposable KeyMonitor
+		{
+			get => Widget.Properties.Get<IDisposable>(KeyMonitor_Key);
+			set => Widget.Properties.Set(KeyMonitor_Key, value);
+		}
+
+		public override bool DetachEvent(string id)
+		{
+			switch (id)
+			{
+				case Window.PreviewKeyDownEvent:
+				case Window.PreviewKeyUpEvent:
+					// one registration serves both, so only give it up when neither is still wanted
+					var other = id == Window.PreviewKeyDownEvent ? Window.PreviewKeyUpEvent : Window.PreviewKeyDownEvent;
+					if (!IsEventHandled(other))
+					{
+						KeyMonitor?.Dispose();
+						KeyMonitor = null;
+					}
+					return true;
+				default:
+					return base.DetachEvent(id);
+			}
+		}
+
+		IntPtr Win32.KeyMonitor.ITarget.KeyMonitorHandle => Control;
+
+		void Win32.KeyMonitor.ITarget.OnKeyMonitorKey(int virtualKey, bool isKeyDown)
+		{
+#if WPF
+			var key = swi.KeyInterop.KeyFromVirtualKey(virtualKey).ToEto();
+#elif WINFORMS
+			var key = ((swf.Keys)virtualKey).ToEto();
+#endif
+			if (isKeyDown)
+				Callback.OnPreviewKeyDown(Widget, new KeyMonitorEventArgs(key, KeyEventType.KeyDown));
+			else
+				Callback.OnPreviewKeyUp(Widget, new KeyMonitorEventArgs(key, KeyEventType.KeyUp));
 		}
 
 		public SizeF GetPreferredSize(SizeF availableSize)

--- a/src/Eto.WinForms/Forms/WindowHandler.cs
+++ b/src/Eto.WinForms/Forms/WindowHandler.cs
@@ -14,6 +14,8 @@ namespace Eto.WinForms.Forms
 	{
 		internal static readonly object MovableByWindowBackground_Key = new object();
 		internal static readonly object IsClosing_Key = new object();
+		internal static readonly object MonitorKeys_Key = new object();
+		internal static readonly object KeyMonitor_Key = new object();
 		internal static readonly object Closeable_Key = new object();
 
 		public Window FromPoint(PointF point)
@@ -35,7 +37,7 @@ namespace Eto.WinForms.Forms
 		}
 	}
 
-	public abstract class WindowHandler<TControl, TWidget, TCallback> : WindowsPanel<TControl, TWidget, TCallback>, Window.IHandler, IWindowHandler
+	public abstract class WindowHandler<TControl, TWidget, TCallback> : WindowsPanel<TControl, TWidget, TCallback>, Window.IHandler, IWindowHandler, Win32.KeyMonitor.ITarget
 		where TControl : swf.Form
 		where TWidget : Window
 		where TCallback : Window.ICallback
@@ -277,10 +279,106 @@ namespace Eto.WinForms.Forms
 				case Window.LocationChangedEvent:
 					Control.LocationChanged += (sender, e) => Callback.OnLocationChanged(Widget, EventArgs.Empty);
 					break;
+				case Window.PreviewKeyDownEvent:
+				case Window.PreviewKeyUpEvent:
+					AttachKeyMonitor();
+					break;
 				default:
 					base.AttachEvent(id);
 					break;
 			}
+		}
+
+		bool MonitorKeys
+		{
+			get => Widget.Properties.Get<bool>(WindowHandler.MonitorKeys_Key);
+			set => Widget.Properties.Set(WindowHandler.MonitorKeys_Key, value);
+		}
+
+		IDisposable KeyMonitor
+		{
+			get => Widget.Properties.Get<IDisposable>(WindowHandler.KeyMonitor_Key);
+			set => Widget.Properties.Set(WindowHandler.KeyMonitor_Key, value);
+		}
+
+		/// <summary>
+		/// Both preview key events share a single registration, since the underlying hook reports key
+		/// down and key up together. Raising a callback nobody subscribed to is harmless.
+		/// </summary>
+		/// <remarks>
+		/// The registration goes in a process wide list, so it is deferred until the window is loaded
+		/// and dropped again when it unloads. A window that is never shown never registers, and one
+		/// that is closed lets go without waiting for a Dispose that may never come.
+		/// </remarks>
+		void AttachKeyMonitor()
+		{
+			MonitorKeys = true;
+			if (Widget.Loaded)
+				RegisterKeyMonitor();
+		}
+
+		void RegisterKeyMonitor()
+		{
+			if (KeyMonitor == null)
+				KeyMonitor = Win32.KeyMonitor.Register(this);
+		}
+
+		IntPtr Win32.KeyMonitor.ITarget.KeyMonitorHandle => Control.IsHandleCreated ? Control.Handle : IntPtr.Zero;
+
+		void Win32.KeyMonitor.ITarget.OnKeyMonitorKey(int virtualKey, bool isKeyDown)
+		{
+			var key = ((swf.Keys)virtualKey).ToEto();
+			if (isKeyDown)
+				Callback.OnPreviewKeyDown(Widget, new KeyMonitorEventArgs(key, KeyEventType.KeyDown));
+			else
+				Callback.OnPreviewKeyUp(Widget, new KeyMonitorEventArgs(key, KeyEventType.KeyUp));
+		}
+
+		void DetachKeyMonitor()
+		{
+			var monitor = KeyMonitor;
+			if (monitor == null)
+				return;
+			monitor.Dispose();
+			KeyMonitor = null;
+		}
+
+		public override bool DetachEvent(string id)
+		{
+			switch (id)
+			{
+				case Window.PreviewKeyDownEvent:
+				case Window.PreviewKeyUpEvent:
+					// one registration serves both, so only give it up when neither is still wanted
+					var other = id == Window.PreviewKeyDownEvent ? Window.PreviewKeyUpEvent : Window.PreviewKeyDownEvent;
+					if (!IsEventHandled(other))
+					{
+						MonitorKeys = false;
+						DetachKeyMonitor();
+					}
+					return true;
+				default:
+					return base.DetachEvent(id);
+			}
+		}
+
+		public override void OnLoad(EventArgs e)
+		{
+			base.OnLoad(e);
+			if (MonitorKeys)
+				RegisterKeyMonitor();
+		}
+
+		public override void OnUnLoad(EventArgs e)
+		{
+			base.OnUnLoad(e);
+			DetachKeyMonitor();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			DetachKeyMonitor();
+			base.Dispose(disposing);
 		}
 
 		bool IsClosing

--- a/src/Eto.WinForms/Win32.cs
+++ b/src/Eto.WinForms/Win32.cs
@@ -570,6 +570,10 @@ namespace Eto
 		[return: MarshalAs(UnmanagedType.Bool)]
 		public static extern bool UnhookWindowsHookEx(IntPtr hookId);
 
+		[DllImport("user32.dll")]
+		[return: MarshalAs(UnmanagedType.Bool)]
+		public static extern bool IsChild(IntPtr hWndParent, IntPtr hWnd);
+
 		[DllImportAttribute("user32.dll")]
 		public static extern bool ReleaseCapture();
 

--- a/src/Eto.WinForms/Win32.keymonitor.cs
+++ b/src/Eto.WinForms/Win32.keymonitor.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+
+namespace Eto
+{
+	static partial class Win32
+	{
+		/// <summary>
+		/// Reports key presses going to a window or any of its child windows, including child HWNDs
+		/// that Eto knows nothing about. Used to implement <see cref="Eto.Forms.Window.PreviewKeyDown"/>.
+		/// </summary>
+		/// <remarks>
+		/// Keys are posted straight to the focused HWND, so a window never sees keys aimed at hosted
+		/// native content. A thread wide WH_KEYBOARD hook does see them. WH_KEYBOARD is used in
+		/// preference to WH_GETMESSAGE because it only runs for keyboard messages instead of for every
+		/// message on the thread.
+		///
+		/// The hook carries no target window, so the destination is inferred from the focused window of
+		/// the thread at the time the key is dispatched. That is accurate for ordinary input but can be
+		/// wrong while a platform modal or menu tracking loop is running.
+		///
+		/// One hook is shared by every registration on a thread and is removed again once the last
+		/// registration goes away. Targets are held weakly, so forgetting to dispose a registration
+		/// costs nothing beyond the next key press, which prunes it. This is not thread safe: register,
+		/// dispose, and the hook itself all run on the UI thread.
+		/// </remarks>
+		public static class KeyMonitor
+		{
+			const int HC_ACTION = 0;
+			// bit 31 of lParam is the transition state, set when the key is being released
+			const long TransitionState = 1L << 31;
+
+			/// <summary>
+			/// Implemented by a window handler that wants to be told about key presses going to it.
+			/// </summary>
+			public interface ITarget
+			{
+				/// <summary>
+				/// The window to watch, or IntPtr.Zero when it doesn't exist yet. Read for each key
+				/// rather than cached, since a registration can outlive a particular native window.
+				/// </summary>
+				IntPtr KeyMonitorHandle { get; }
+
+				/// <summary>
+				/// Called for each key press going to that window or a child of it, with the Win32
+				/// virtual key code and whether the key went down.
+				/// </summary>
+				void OnKeyMonitorKey(int virtualKey, bool isKeyDown);
+			}
+
+			class Registration : IDisposable
+			{
+				public WeakReference<ITarget> Target;
+
+				public void Dispose() => Unregister(this);
+			}
+
+			static readonly List<Registration> s_registrations = new List<Registration>();
+			// the hook needs a strong reference for as long as it is installed
+			static HookProc s_hookProc;
+			static IntPtr s_hook;
+
+			/// <summary>
+			/// Starts reporting keys going to <paramref name="target"/>'s window.
+			/// </summary>
+			/// <param name="target">Target to report keys to. Held weakly.</param>
+			/// <returns>An object that stops the reporting when disposed.</returns>
+			public static IDisposable Register(ITarget target)
+			{
+				if (target == null)
+					throw new ArgumentNullException(nameof(target));
+
+				var registration = new Registration { Target = new WeakReference<ITarget>(target) };
+				s_registrations.Add(registration);
+				if (s_hook == IntPtr.Zero)
+				{
+					s_hookProc = HookProcedure;
+					s_hook = SetHook(WH.KEYBOARD, s_hookProc, GetCurrentThreadId());
+				}
+				return registration;
+			}
+
+			static void Unregister(Registration registration)
+			{
+				if (!s_registrations.Remove(registration))
+					return;
+				if (s_registrations.Count == 0 && s_hook != IntPtr.Zero)
+				{
+					UnhookWindowsHookEx(s_hook);
+					s_hook = IntPtr.Zero;
+					s_hookProc = null;
+				}
+			}
+
+			static IntPtr HookProcedure(int code, IntPtr wParam, IntPtr lParam)
+			{
+				// the hook can be removed while dispatching below, so pass on the handle we came in with
+				var hook = s_hook;
+
+				// HC_NOREMOVE means the message was only peeked at and will come through again,
+				// ignore it so a key isn't counted twice
+				if (code == HC_ACTION && s_registrations.Count > 0)
+				{
+					var focused = GetThreadFocusWindow();
+					var virtualKey = wParam.ToInt32();
+					var isKeyDown = (lParam.ToInt64() & TransitionState) == 0;
+
+					// iterate a snapshot, a target is free to dispose its registration while being called
+					foreach (var registration in s_registrations.ToArray())
+					{
+						if (!registration.Target.TryGetTarget(out var target))
+						{
+							// collected without being disposed, drop it and let the hook go with the last one
+							Unregister(registration);
+							continue;
+						}
+						if (focused == IntPtr.Zero)
+							continue;
+						var hwnd = target.KeyMonitorHandle;
+						if (hwnd != IntPtr.Zero && (hwnd == focused || IsChild(hwnd, focused)))
+							target.OnKeyMonitorKey(virtualKey, isKeyDown);
+					}
+				}
+				return CallNextHookEx(hook, code, wParam, lParam);
+			}
+		}
+	}
+}

--- a/src/Eto.Wpf/Eto.Wpf.csproj
+++ b/src/Eto.Wpf/Eto.Wpf.csproj
@@ -108,6 +108,9 @@ You do not need to use any of the classes of this assembly (unless customizing t
     <Compile Include="..\Eto.WinForms\Win32.cs">
       <Link>Win32.cs</Link>
     </Compile>
+    <Compile Include="..\Eto.WinForms\Win32.keymonitor.cs">
+      <Link>Win32.keymonitor.cs</Link>
+    </Compile>
     <Compile Include="..\Eto.WinForms\Win32.dpi.cs">
       <Link>Win32.dpi.cs</Link>
     </Compile>

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -32,6 +32,8 @@ namespace Eto.Wpf.Forms
 		internal static readonly object Icon_Key = new object();
 		internal static readonly object ShowSystemMenu_Key = new object();
 		internal static readonly object DidBlurBehindWindow_Key = new object();
+		internal static readonly object MonitorKeys_Key = new object();
+		internal static readonly object KeyMonitor_Key = new object();
 	}
 	
 	public class EtoWindowContent : swc.DockPanel
@@ -39,7 +41,7 @@ namespace Eto.Wpf.Forms
 		
 	}
 
-	public abstract class WpfWindow<TControl, TWidget, TCallback> : WpfPanel<TControl, TWidget, TCallback>, Window.IHandler, IWpfWindow, IInputBindingHost
+	public abstract class WpfWindow<TControl, TWidget, TCallback> : WpfPanel<TControl, TWidget, TCallback>, Window.IHandler, IWpfWindow, IInputBindingHost, Win32.KeyMonitor.ITarget
 		where TControl : sw.Window
 		where TWidget : Window
 		where TCallback : Window.ICallback
@@ -326,6 +328,10 @@ namespace Eto.Wpf.Forms
 				case Window.LocationChangedEvent:
 					Control.LocationChanged += (sender, e) => Callback.OnLocationChanged(Widget, EventArgs.Empty);
 					break;
+				case Window.PreviewKeyDownEvent:
+				case Window.PreviewKeyUpEvent:
+					AttachKeyMonitor();
+					break;
 				case Window.LogicalPixelSizeChangedEvent:
 					if (PerMonitorDpiHelper.BuiltInPerMonitorSupported && WpfWindow.dpiChangedEvent != null) // .NET 4.6.2 support!
 					{
@@ -405,6 +411,8 @@ namespace Eto.Wpf.Forms
 			base.OnLoad(e);
 			SetScale(false, false);
 			SetupPerMonitorDpi();
+			if (MonitorKeys)
+				RegisterKeyMonitor();
 		}
 
 		protected virtual void UpdateClientSize(Size size)
@@ -1205,8 +1213,89 @@ namespace Eto.Wpf.Forms
 			}
 		}
 
+		bool MonitorKeys
+		{
+			get => Widget.Properties.Get<bool>(WpfWindow.MonitorKeys_Key);
+			set => Widget.Properties.Set(WpfWindow.MonitorKeys_Key, value);
+		}
+
+		IDisposable KeyMonitor
+		{
+			get => Widget.Properties.Get<IDisposable>(WpfWindow.KeyMonitor_Key);
+			set => Widget.Properties.Set(WpfWindow.KeyMonitor_Key, value);
+		}
+
+		/// <summary>
+		/// Both preview key events share a single registration, since the underlying hook reports key
+		/// down and key up together. Raising a callback nobody subscribed to is harmless.
+		/// </summary>
+		/// <remarks>
+		/// The registration goes in a process wide list, so it is deferred until the window is loaded
+		/// and dropped again when it unloads. A window that is never shown never registers, and one
+		/// that is closed lets go without waiting for a Dispose that may never come.
+		/// </remarks>
+		void AttachKeyMonitor()
+		{
+			MonitorKeys = true;
+			if (Widget.Loaded)
+				RegisterKeyMonitor();
+		}
+
+		void RegisterKeyMonitor()
+		{
+			if (KeyMonitor == null)
+				KeyMonitor = Win32.KeyMonitor.Register(this);
+		}
+
+		IntPtr Win32.KeyMonitor.ITarget.KeyMonitorHandle => new swin.WindowInteropHelper(Control).Handle;
+
+		void Win32.KeyMonitor.ITarget.OnKeyMonitorKey(int virtualKey, bool isKeyDown)
+		{
+			var key = swi.KeyInterop.KeyFromVirtualKey(virtualKey).ToEto();
+			if (isKeyDown)
+				Callback.OnPreviewKeyDown(Widget, new KeyMonitorEventArgs(key, KeyEventType.KeyDown));
+			else
+				Callback.OnPreviewKeyUp(Widget, new KeyMonitorEventArgs(key, KeyEventType.KeyUp));
+		}
+
+		void DetachKeyMonitor()
+		{
+			var monitor = KeyMonitor;
+			if (monitor == null)
+				return;
+			monitor.Dispose();
+			KeyMonitor = null;
+		}
+
+		public override bool DetachEvent(string id)
+		{
+			switch (id)
+			{
+				case Window.PreviewKeyDownEvent:
+				case Window.PreviewKeyUpEvent:
+					// one registration serves both, so only give it up when neither is still wanted
+					var other = id == Window.PreviewKeyDownEvent ? Window.PreviewKeyUpEvent : Window.PreviewKeyDownEvent;
+					if (!IsEventHandled(other))
+					{
+						MonitorKeys = false;
+						DetachKeyMonitor();
+					}
+					return true;
+				default:
+					return base.DetachEvent(id);
+			}
+		}
+
+		public override void OnUnLoad(EventArgs e)
+		{
+			base.OnUnLoad(e);
+			DetachKeyMonitor();
+		}
+
 		protected override void Dispose(bool disposing)
 		{
+			DetachKeyMonitor();
+
 			// close the window when disposing from Eto explicitly
 			if (disposing)
 				Close();

--- a/src/Eto/Forms/Controls/KeyMonitorEventArgs.cs
+++ b/src/Eto/Forms/Controls/KeyMonitorEventArgs.cs
@@ -1,0 +1,45 @@
+namespace Eto.Forms;
+
+/// <summary>
+/// Arguments for key events observed by <see cref="Window.PreviewKeyDown"/> and <see cref="Window.PreviewKeyUp"/>.
+/// </summary>
+/// <remarks>
+/// Unlike <see cref="KeyEventArgs"/> there is deliberately no way to mark the event as handled.
+/// Monitoring a window's keys observes them, it never consumes them, so the focused control always
+/// goes on to receive the key press. Use <see cref="Control.KeyDown"/> when you need to handle or
+/// suppress a key.
+/// </remarks>
+public class KeyMonitorEventArgs : EventArgs
+{
+	/// <summary>
+	/// Initializes a new instance of the <see cref="KeyMonitorEventArgs"/> class.
+	/// </summary>
+	/// <param name="keyData">Key and modifiers that were pressed</param>
+	/// <param name="keyEventType">Type of key event</param>
+	public KeyMonitorEventArgs(Keys keyData, KeyEventType keyEventType)
+	{
+		KeyData = keyData;
+		KeyEventType = keyEventType;
+	}
+
+	/// <summary>
+	/// Gets the type of the key event.
+	/// </summary>
+	/// <value>The type of the key event.</value>
+	public KeyEventType KeyEventType { get; }
+
+	/// <summary>
+	/// Gets the raw key data (the combination of the <see cref="Key"/> and <see cref="Modifiers"/>)
+	/// </summary>
+	public Keys KeyData { get; }
+
+	/// <summary>
+	/// Gets the key value (without modifiers)
+	/// </summary>
+	public Keys Key => KeyData & Keys.KeyMask;
+
+	/// <summary>
+	/// Gets the modifier keys that were pressed for this event
+	/// </summary>
+	public Keys Modifiers => KeyData & Keys.ModifierMask;
+}

--- a/src/Eto/Forms/Window.cs
+++ b/src/Eto/Forms/Window.cs
@@ -190,6 +190,76 @@ public abstract class Window : Panel
 		Properties.TriggerEvent(LogicalPixelSizeChangedEvent, this, e);
 	}
 
+	/// <summary>
+	/// Identifier for handlers when attaching the <see cref="PreviewKeyDown"/> event.
+	/// </summary>
+	public const string PreviewKeyDownEvent = "Window.PreviewKeyDown";
+
+	/// <summary>
+	/// Occurs when a key is pressed anywhere in this window, before the focused control handles it.
+	/// </summary>
+	/// <remarks>
+	/// <see cref="Control.KeyDown"/> is raised by the control that has the keyboard focus and bubbles
+	/// up the widget tree, so it only ever sees keys that Eto itself is routing. This is raised for
+	/// every key going to the window no matter what owns the focus, including content that is not part
+	/// of the widget tree at all such as a control hosted by <see cref="NativeControlHost"/> or a
+	/// <see cref="WebView"/>, whose keys are handled entirely by the platform and never surface as Eto
+	/// events. Use it to notice that the user is typing somewhere in a window; use
+	/// <see cref="Control.KeyDown"/> to handle or suppress a key.
+	///
+	/// This only observes, it never consumes: the focused control always goes on to receive the key,
+	/// which is why <see cref="KeyMonitorEventArgs"/> has no way to mark the event as handled.
+	///
+	/// Keys are reported as pressed, ahead of any input method, so a key that only contributes to an
+	/// IME composition is still reported even though it produces no text on its own. This reports
+	/// keys, not text, and the character a key produces is deliberately not included.
+	///
+	/// Working out which window a key is destined for is best effort on some platforms. On Windows it
+	/// is inferred from the focused window at the time the key is dispatched, which can be wrong while
+	/// a platform modal or menu tracking loop is running.
+	/// </remarks>
+	public event EventHandler<KeyMonitorEventArgs> PreviewKeyDown
+	{
+		add { Properties.AddHandlerEvent(PreviewKeyDownEvent, value); }
+		remove { Properties.RemoveHandlerEvent(PreviewKeyDownEvent, value); }
+	}
+
+	/// <summary>
+	/// Raises the <see cref="PreviewKeyDown"/> event.
+	/// </summary>
+	/// <param name="e">Event arguments</param>
+	protected virtual void OnPreviewKeyDown(KeyMonitorEventArgs e)
+	{
+		Properties.TriggerEvent(PreviewKeyDownEvent, this, e);
+	}
+
+	/// <summary>
+	/// Identifier for handlers when attaching the <see cref="PreviewKeyUp"/> event.
+	/// </summary>
+	public const string PreviewKeyUpEvent = "Window.PreviewKeyUp";
+
+	/// <summary>
+	/// Occurs when a key is released anywhere in this window, before the focused control handles it.
+	/// </summary>
+	/// <remarks>
+	/// See <see cref="PreviewKeyDown"/> for how this differs from <see cref="Control.KeyUp"/>, and for
+	/// the caveats that apply to both.
+	/// </remarks>
+	public event EventHandler<KeyMonitorEventArgs> PreviewKeyUp
+	{
+		add { Properties.AddHandlerEvent(PreviewKeyUpEvent, value); }
+		remove { Properties.RemoveHandlerEvent(PreviewKeyUpEvent, value); }
+	}
+
+	/// <summary>
+	/// Raises the <see cref="PreviewKeyUp"/> event.
+	/// </summary>
+	/// <param name="e">Event arguments</param>
+	protected virtual void OnPreviewKeyUp(KeyMonitorEventArgs e)
+	{
+		Properties.TriggerEvent(PreviewKeyUpEvent, this, e);
+	}
+
 	#endregion
 
 	static Window()
@@ -199,6 +269,8 @@ public abstract class Window : Panel
 		EventLookup.Register<Window>(c => c.OnLocationChanged(null), LocationChangedEvent);
 		EventLookup.Register<Window>(c => c.OnWindowStateChanged(null), WindowStateChangedEvent);
 		EventLookup.Register<Window>(c => c.OnLogicalPixelSizeChanged(null), LogicalPixelSizeChangedEvent);
+		EventLookup.Register<Window>(c => c.OnPreviewKeyDown(null), PreviewKeyDownEvent);
+		EventLookup.Register<Window>(c => c.OnPreviewKeyUp(null), PreviewKeyUpEvent);
 	}
 		
 	/// <summary>
@@ -651,6 +723,14 @@ public abstract class Window : Panel
 		/// Raises the load complete event.
 		/// </summary>
 		void OnLoadComplete(Window widget, EventArgs e);
+		/// <summary>
+		/// Raises the preview key down event.
+		/// </summary>
+		void OnPreviewKeyDown(Window widget, KeyMonitorEventArgs e);
+		/// <summary>
+		/// Raises the preview key up event.
+		/// </summary>
+		void OnPreviewKeyUp(Window widget, KeyMonitorEventArgs e);
 	}
 
 	/// <summary>
@@ -705,6 +785,22 @@ public abstract class Window : Panel
 		{
 			using (widget.Platform.Context)
 				widget.OnLoadComplete(e);
+		}
+		/// <summary>
+		/// Raises the preview key down event.
+		/// </summary>
+		public void OnPreviewKeyDown(Window widget, KeyMonitorEventArgs e)
+		{
+			using (widget.Platform.Context)
+				widget.OnPreviewKeyDown(e);
+		}
+		/// <summary>
+		/// Raises the preview key up event.
+		/// </summary>
+		public void OnPreviewKeyUp(Window widget, KeyMonitorEventArgs e)
+		{
+			using (widget.Platform.Context)
+				widget.OnPreviewKeyUp(e);
 		}
 	}
 

--- a/src/Eto/PropertyStore.cs
+++ b/src/Eto/PropertyStore.cs
@@ -203,6 +203,43 @@ public class PropertyStore : Dictionary<object, object>
 	}
 
 	/// <summary>
+	/// Removes a handler-based event delegate with the specified <paramref name="key"/>, telling the
+	/// handler to stop listening once the last subscriber is gone.
+	/// </summary>
+	/// <remarks>
+	/// Use this in the remove accessor of an event added with <see cref="AddHandlerEvent"/> when the
+	/// platform holds onto something worth giving back while the event is attached, such as a system
+	/// wide hook. <see cref="RemoveEvent"/> leaves the event attached for the life of the widget,
+	/// which is fine and cheaper for the vast majority of events.
+	///
+	/// The handler is only told once nothing is subscribed any more, and never for an event that is
+	/// attached because the widget overrides its On[Event] method, since that has to keep firing.
+	/// A handler that can't detach the event says so, and it stays attached.
+	/// </remarks>
+	/// <param name="key">Key of the event to remove</param>
+	/// <param name="value">Delegate to remove from the event</param>
+	public void RemoveHandlerEvent(string key, Delegate value)
+	{
+		var parentWidget = Parent as Widget;
+		if (parentWidget == null)
+			throw new InvalidOperationException("Parent must subclass Widget");
+
+		if (!TryGetValue(key, out var existingDelegate))
+			return;
+
+		var remaining = Delegate.Remove((Delegate)existingDelegate, value);
+		if (remaining != null)
+		{
+			this[key] = remaining;
+			return;
+		}
+
+		Remove(key);
+		if (!EventLookup.IsDefault(parentWidget, key))
+			parentWidget.UnhandleEvent(key);
+	}
+
+	/// <summary>
 	/// Triggers an event with the specified key
 	/// </summary>
 	/// <remarks>

--- a/src/Eto/Widget.cs
+++ b/src/Eto/Widget.cs
@@ -167,6 +167,29 @@ public abstract class Widget : IHandlerSource, IDisposable, ICallbackSource
 		/// <param name="id">ID of the event to handle</param>
 		/// <param name = "defaultEvent">True if the event is default (e.g. overridden or via an event handler subscription)</param>
 		void HandleEvent(string id, bool defaultEvent = false);
+
+		/// <summary>
+		/// Called when the last subscriber to an event has been removed, so the platform can stop
+		/// listening for it.
+		/// </summary>
+		/// <remarks>
+		/// Only reached for events whose remove accessor uses
+		/// <see cref="PropertyStore.RemoveHandlerEvent"/>, and only for events that were attached
+		/// because something subscribed to them. An event attached because the widget overrides its
+		/// On[Event] method is never detached, since it has to keep firing regardless.
+		///
+		/// Most events stay attached for the life of the widget, which costs nothing. Detaching is
+		/// worth wiring up for the few that hold onto something expensive or process wide while they
+		/// are attached, such as a system wide hook. Handlers deriving from
+		/// <see cref="Eto.WidgetHandler{TWidget}"/> get an implementation of this that dispatches to
+		/// <see cref="Eto.WidgetHandler{TWidget}.DetachEvent"/>, which is what to override.
+		/// </remarks>
+		/// <param name="id">ID of the event to stop handling</param>
+#if NET
+		void UnhandleEvent(string id) { }
+#else
+		void UnhandleEvent(string id);
+#endif
 	}
 
 	/// <summary>
@@ -521,6 +544,12 @@ public abstract class Widget : IHandlerSource, IDisposable, ICallbackSource
 	/// </example>
 	/// <param name="id">ID of the event to handle.  Usually a constant in the form of [Control].[EventName]Event (e.g. TextBox.TextChangedEvent)</param>
 	internal void HandleEvent(string id) => WidgetHandler?.HandleEvent(id);
+
+	/// <summary>
+	/// Tells the handler that the last subscriber to the specified event has gone away.
+	/// </summary>
+	/// <param name="id">ID of the event to stop handling.</param>
+	internal void UnhandleEvent(string id) => WidgetHandler?.UnhandleEvent(id);
 
 	/// <summary>
 	/// Disposes of this widget, supressing the finalizer

--- a/src/Eto/WidgetHandler.cs
+++ b/src/Eto/WidgetHandler.cs
@@ -110,6 +110,50 @@ public abstract class WidgetHandler<TWidget> : Widget.IHandler, IDisposable
 	}
 
 	/// <summary>
+	/// Called when the last subscriber to an event has been removed, giving
+	/// <see cref="DetachEvent"/> the chance to stop listening for it.
+	/// </summary>
+	/// <remarks>
+	/// Override <see cref="DetachEvent"/> rather than this, the same way <see cref="AttachEvent"/> is
+	/// overridden rather than <see cref="HandleEvent"/>.
+	/// </remarks>
+	/// <param name="id">ID of the event to stop handling</param>
+	public void UnhandleEvent(string id)
+	{
+		var instanceId = id + InstanceEventSuffix;
+		if (!Widget.Properties.ContainsKey(instanceId))
+			return;
+
+		// clear it first so DetachEvent sees an accurate answer from IsEventHandled
+		Widget.Properties.Remove(instanceId);
+		if (!DetachEvent(id))
+		{
+			// the platform can't take this one back, so remember it is still attached and don't
+			// attach it a second time if something subscribes again
+			Widget.Properties.Add(instanceId, true);
+		}
+	}
+
+	/// <summary>
+	/// Detaches an event from the platform-specific control, undoing <see cref="AttachEvent"/>.
+	/// </summary>
+	/// <remarks>
+	/// Implementors can override this for events that hold onto something worth giving back while
+	/// they are attached, such as a system wide hook. Most events cost nothing to leave attached for
+	/// the life of the widget, which is why the default is to refuse.
+	///
+	/// Only reached for events whose remove accessor uses
+	/// <see cref="PropertyStore.RemoveHandlerEvent"/>, and never for an event that is attached
+	/// because the widget overrides its On[Event] method.
+	/// </remarks>
+	/// <param name="id">Identifier of the event</param>
+	/// <returns>
+	/// True if the event was detached, false if this platform can't detach it, in which case it
+	/// stays attached and won't be attached again on a later subscription.
+	/// </returns>
+	public virtual bool DetachEvent(string id) => false;
+
+	/// <summary>
 	/// Called to initialize this widget after it has been constructed
 	/// </summary>
 	/// <remarks>

--- a/test/Eto.Test/UnitTests/Forms/FormTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/FormTests.cs
@@ -217,4 +217,99 @@ public class FormTests : WindowTests<Form>
 			await CloseAsync(parent);
 		}
 	});
+
+	// Whether an event is attached to the platform is tracked by this marker in the widget's property
+	// store. There is no public way to ask, and the whole point of RemoveHandlerEvent is that the
+	// answer changes, so the tests below look at it directly.
+	static bool IsAttached(Window window, string id) => window.Properties.ContainsKey(id + ".Instance");
+
+	[Test]
+	public void PreviewKeyDownShouldDetachWhenLastSubscriberRemoved()
+	{
+		Invoke(() =>
+		{
+			var form = new Form();
+			try
+			{
+				void First(object sender, KeyMonitorEventArgs e) { }
+				void Second(object sender, KeyMonitorEventArgs e) { }
+
+				Assert.That(IsAttached(form, Window.PreviewKeyDownEvent), Is.False, "Should not be attached before anything subscribes");
+
+				form.PreviewKeyDown += First;
+				Assert.That(IsAttached(form, Window.PreviewKeyDownEvent), Is.True, "Should attach for the first subscriber");
+
+				form.PreviewKeyDown += Second;
+				form.PreviewKeyDown -= Second;
+				Assert.That(IsAttached(form, Window.PreviewKeyDownEvent), Is.True, "Should stay attached while a subscriber remains");
+
+				form.PreviewKeyDown -= First;
+				Assert.That(IsAttached(form, Window.PreviewKeyDownEvent), Is.False, "Should detach when the last subscriber goes away");
+
+				// and it should come back, not be stuck detached
+				form.PreviewKeyDown += First;
+				Assert.That(IsAttached(form, Window.PreviewKeyDownEvent), Is.True, "Should attach again on a later subscription");
+				form.PreviewKeyDown -= First;
+			}
+			finally
+			{
+				form.Dispose();
+			}
+		});
+	}
+
+	[Test]
+	public void PreviewKeyDownAndUpShouldDetachIndependently()
+	{
+		Invoke(() =>
+		{
+			var form = new Form();
+			try
+			{
+				void OnKey(object sender, KeyMonitorEventArgs e) { }
+
+				form.PreviewKeyDown += OnKey;
+				form.PreviewKeyUp += OnKey;
+				Assert.That(IsAttached(form, Window.PreviewKeyUpEvent), Is.True, "Key up should attach");
+
+				// the backends share one registration between the two, so dropping one must not
+				// stop the other from being reported
+				form.PreviewKeyDown -= OnKey;
+				Assert.That(IsAttached(form, Window.PreviewKeyDownEvent), Is.False, "Key down should detach");
+				Assert.That(IsAttached(form, Window.PreviewKeyUpEvent), Is.True, "Key up should still be attached");
+
+				form.PreviewKeyUp -= OnKey;
+				Assert.That(IsAttached(form, Window.PreviewKeyUpEvent), Is.False, "Key up should detach once it is dropped too");
+			}
+			finally
+			{
+				form.Dispose();
+			}
+		});
+	}
+
+	[Test]
+	public void PreviewKeyDownShouldBeReleasedWhenClosed()
+	{
+		// Backends keep their key monitor in process wide state - a thread wide hook on Windows, an
+		// AppKit event monitor on macOS - and let go of it in OnUnLoad. Closing has to be enough,
+		// since Dispose isn't guaranteed to run, so pin down that closing really does unload.
+		Invoke(() =>
+		{
+			var form = new Form { ClientSize = new Size(100, 100) };
+			form.PreviewKeyDown += (sender, e) => { };
+			try
+			{
+				form.Show();
+				Assert.That(form.Loaded, Is.True, "Form should be loaded once shown");
+
+				form.Close();
+				Assert.That(form.Loaded, Is.False, "Closing should unload the form so the key monitor is released");
+			}
+			finally
+			{
+				form.Dispose();
+			}
+		});
+	}
 }


### PR DESCRIPTION
This adds new `PreviewKeyDown` and `PreviewKeyUp` events to `Window` to preview all keystrokes, regardless of whether a control handles them or not.

