### PR TITLE
Fix .NET 10 Windows template target frameworks

### DIFF
--- a/src/Eto.Forms.Templates/content/App-CSharp/.template.config/template.json
+++ b/src/Eto.Forms.Templates/content/App-CSharp/.template.config/template.json
@@ -127,7 +127,7 @@
 		},
 		"IsNetCore": {
 			"type": "computed",
-			"value": "(Framework >= \"net5\")"
+			"value": "(Framework != \"net48\" && Framework != \"net472\" && Framework != \"net462\")"
 		},
 		"IsWindow": {
 			"type": "computed",

--- a/src/Eto.Forms.Templates/content/App-FSharp/.template.config/template.json
+++ b/src/Eto.Forms.Templates/content/App-FSharp/.template.config/template.json
@@ -127,7 +127,7 @@
 		},
 		"IsNetCore": {
 			"type": "computed",
-			"value": "(Framework >= \"net5\")"
+			"value": "(Framework != \"net48\" && Framework != \"net472\" && Framework != \"net462\")"
 		},
 		"IsWindow": {
 			"type": "computed",

--- a/src/Eto.Forms.Templates/content/App-VisualBasic/.template.config/template.json
+++ b/src/Eto.Forms.Templates/content/App-VisualBasic/.template.config/template.json
@@ -127,7 +127,7 @@
 		},
 		"IsNetCore": {
 			"type": "computed",
-			"value": "(Framework >= \"net5\")"
+			"value": "(Framework != \"net48\" && Framework != \"net472\" && Framework != \"net462\")"
 		},
 		"IsWindow": {
 			"type": "computed",


### PR DESCRIPTION
Fixes #2931.

The template's `IsNetCore` expression compared framework names lexicographically, so `net10.0` was classified as a .NET Framework target. This change treats the three supported .NET Framework TFMs as the legacy cases and applies the same fix to the C#, F#, and VB templates.

Tests:
- Generated all eight supported frameworks for C#, F#, and VB from the source templates and checked the WPF and WinForms TFMs (48 assertions).
- Built `Eto.Forms.Templates` in Release (0 warnings, 0 errors).
- Installed the generated nupkg and smoke-tested net10.0 and net48 for all three languages.