### PR TITLE
Mac: Fix double extension when it starts with a "."

### DIFF
--- a/src/Eto.Mac/Forms/MacFileDialog.cs
+++ b/src/Eto.Mac/Forms/MacFileDialog.cs
@@ -110,14 +110,22 @@ namespace Eto.Mac.Forms
 				return;
 			macfilters = filters;
 
-#if MACOS_NET
-			Control.AllowedContentTypes = macfilters?.Distinct().Select(UniformTypeIdentifiers.UTType.CreateFromExtension).ToArray()
-				?? Array.Empty<UniformTypeIdentifiers.UTType>();
-#else			
+			var allowedTypes = GetNativeFileTypes(macfilters);
 
-			Control.AllowedFileTypes = macfilters?.Distinct().ToArray();
+#if MACOS_NET
+			Control.AllowedContentTypes = allowedTypes?.Distinct().Select(UniformTypeIdentifiers.UTType.CreateFromExtension).ToArray()
+				?? Array.Empty<UniformTypeIdentifiers.UTType>();
+#else
+
+			Control.AllowedFileTypes = allowedTypes?.Distinct().ToArray();
 #endif
 		}
+
+		/// <summary>
+		/// Gets the extensions to restrict the native panel to, which can differ from <see cref="MacFilters"/>
+		/// used by <see cref="SavePanelDelegate"/> to enable/disable files in the list.
+		/// </summary>
+		internal virtual List<string> GetNativeFileTypes(List<string> filters) => filters;
 
 		public int CurrentFilterIndex
 		{

--- a/src/Eto.Mac/Forms/SaveFileDialogHandler.cs
+++ b/src/Eto.Mac/Forms/SaveFileDialogHandler.cs
@@ -4,6 +4,7 @@ namespace Eto.Mac.Forms
 	{
 		bool hasShown;
 		string selectedFileName;
+		string pendingName;
 
 
 		public override string FileName
@@ -15,16 +16,38 @@ namespace Eto.Mac.Forms
 				var name = value;
 				if (!string.IsNullOrEmpty(name))
 				{
-					SetAllowedFileTypes();
 					var dir = Path.GetDirectoryName(name);
 					if (!string.IsNullOrEmpty(dir) && System.IO.Directory.Exists(dir))
 						Directory = new Uri(dir);
 					name = Path.GetFileName(name);
 				}
-				Control.NameFieldStringValue = name ?? string.Empty;
+				SetNameFieldStringValue(name);
 				hasShown = false;
 			}
 		}
+
+		/// <summary>
+		/// Sets the name field, updating the allowed file types first as macOS appends the extension
+		/// as soon as the name is set and there's no way to undo that afterwards.
+		/// </summary>
+		void SetNameFieldStringValue(string name)
+		{
+			pendingName = name;
+			SetAllowedFileTypes();
+			pendingName = null;
+			Control.NameFieldStringValue = name ?? string.Empty;
+		}
+
+		internal override List<string> GetNativeFileTypes(List<string> filters)
+		{
+			// macOS doesn't consider a leading period to be an extension, so NSSavePanel appends the
+			// filter's extension to a name like ".gitignore", showing ".gitignore.gitignore".
+			// Leave the panel unrestricted in that case so the name is shown as-is, the delegate
+			// still filters which files are enabled in the list.
+			return IsExtensionOnlyName(pendingName ?? Control.NameFieldStringValue) ? null : filters;
+		}
+
+		static bool IsExtensionOnlyName(string name) => !string.IsNullOrEmpty(name) && name[0] == '.' && name.IndexOf('.', 1) < 0;
 
 		protected override NSSavePanel CreateControl()
 		{
@@ -58,7 +81,8 @@ namespace Eto.Mac.Forms
 			if (extensions == null)
 				return;
 
-			var currentExtension = Path.GetExtension(Control.NameFieldStringValue);
+			var fileName = Control.NameFieldStringValue;
+			var currentExtension = Path.GetExtension(fileName);
 
 			// If the new file type supports the extension, don't change it
 			if (extensions.Select(r => r.TrimStart('*')).Any(r => r == currentExtension))
@@ -66,19 +90,16 @@ namespace Eto.Mac.Forms
 				if (!hasShown)
 				{
 					// need to reset the value, otherwise for unknown file types it doubles up the extension
-					var name = Control.NameFieldStringValue;
 					Control.NameFieldStringValue = string.Empty;
-					Control.NameFieldStringValue = name;
+					SetNameFieldStringValue(fileName);
 				}
 				return;
 			}
 			var newExtension = extensions.FirstOrDefault()?.TrimStart('*', '.');
-			if (!string.IsNullOrEmpty(newExtension))
+			if (!string.IsNullOrEmpty(newExtension) && fileName != null)
 			{
-				var fileName = Control.NameFieldStringValue;
-				if (fileName != null)
-					Control.NameFieldStringValue = $"{Path.GetFileNameWithoutExtension(fileName)}.{newExtension}";
-			}			
+				SetNameFieldStringValue($"{Path.GetFileNameWithoutExtension(fileName)}.{newExtension}");
+			}
 		}
 	}
 }

--- a/test/Eto.Test/UnitTests/Forms/FileDialogTests.cs
+++ b/test/Eto.Test/UnitTests/Forms/FileDialogTests.cs
@@ -23,6 +23,19 @@ namespace Eto.Test.UnitTests.Forms
 			fd.Filters.Add(new FileFilter("Text Files", ".txt"));
 			fd.ShowDialog(null);
 		}
+
+		[Test, ManualTest, InvokeOnUI]
+		public void DotFileNameShouldNotHaveDoubleExtension()
+		{
+			// macOS doesn't consider a leading period to be an extension, so it would append the
+			// filter's extension and show ".gitignore.gitignore"
+			var fd = new SaveFileDialog();
+			fd.Title = "Press OK to continue";
+			fd.Filters.Add(new FileFilter("Git Ignore", ".gitignore"));
+			fd.FileName = ".gitignore";
+			fd.ShowDialog(null);
+			Assert.That(Path.GetFileName(fd.FileName), Is.EqualTo(".gitignore"), "#1");
+		}
 	}
 
 	public class FileDialogTests<T> : TestBase


### PR DESCRIPTION
Setting it to `.gitignore` would result in `.gitignore.gitignore`, now it will return the correct result.  This was only a problem with the macOS build due to the use of the newer apis.