### PR TITLE
Wpf: Fix KeyDown/Up events on Form when no control has focus

### DIFF
--- a/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
+++ b/src/Eto.Wpf/Forms/WpfFrameworkElement.cs
@@ -401,6 +401,19 @@ namespace Eto.Wpf.Forms
 
 		protected virtual sw.FrameworkElement KeyEventControl => Control;
 
+		/// <summary>
+		/// An additional element to hook the key events on, for when the routed event does not pass
+		/// through <see cref="KeyEventControl"/> at all.
+		/// </summary>
+		/// <remarks>
+		/// Windows hook their key events on an inner element so they are seen before the window's own
+		/// input bindings (menu shortcuts) can mark them as handled. That element is only in the route
+		/// when something inside the content has keyboard focus, so when focus is on the window itself
+		/// the key events would otherwise never be raised. Events from this element are ignored when
+		/// they already went through <see cref="KeyEventControl"/>.
+		/// </remarks>
+		protected virtual sw.FrameworkElement FallbackKeyEventControl => null;
+
 		public virtual void Focus()
 		{
 			if (FocusControl.IsLoaded)
@@ -504,12 +517,19 @@ namespace Eto.Wpf.Forms
 						KeyEventControl.KeyDown += HandleKeyDown;
 						KeyEventControl.TextInput += HandleTextInput;
 					}
+					if (FallbackKeyEventControl is sw.FrameworkElement fallbackKeyDown)
+					{
+						fallbackKeyDown.KeyDown += HandleFallbackKeyDown;
+						fallbackKeyDown.TextInput += HandleFallbackTextInput;
+					}
 					break;
 				case Eto.Forms.Control.TextInputEvent:
 					HandleEvent(Eto.Forms.Control.KeyDownEvent);
 					break;
 				case Eto.Forms.Control.KeyUpEvent:
 					KeyEventControl.KeyUp += HandleKeyUp;
+					if (FallbackKeyEventControl is sw.FrameworkElement fallbackKeyUp)
+						fallbackKeyUp.KeyUp += HandleFallbackKeyUp;
 					break;
 				case Eto.Forms.Control.ShownEvent:
 					ContainerControl.IsVisibleChanged += HandleIsVisibleChanged;
@@ -854,8 +874,37 @@ namespace Eto.Wpf.Forms
 			return new WpfDragEventArgs(source, dragData, data.AllowedEffects.ToEto(), location, modifiers, buttons, controlObject);
 		}
 
+		/// <summary>
+		/// The routed args last seen by the primary key handlers, so the fallback handlers can tell
+		/// whether the event already went through <see cref="KeyEventControl"/>.
+		/// </summary>
+		/// <remarks>
+		/// <see cref="KeyEventControl"/> is always hit before <see cref="FallbackKeyEventControl"/>,
+		/// either as a descendant of it in the bubbling route, or via the tunneling preview event.
+		/// </remarks>
+		object _lastKeyEventArgs;
+
+		void HandleFallbackKeyDown(object sender, swi.KeyEventArgs e)
+		{
+			if (!ReferenceEquals(_lastKeyEventArgs, e))
+				HandleKeyDown(sender, e);
+		}
+
+		void HandleFallbackKeyUp(object sender, swi.KeyEventArgs e)
+		{
+			if (!ReferenceEquals(_lastKeyEventArgs, e))
+				HandleKeyUp(sender, e);
+		}
+
+		void HandleFallbackTextInput(object sender, swi.TextCompositionEventArgs e)
+		{
+			if (!ReferenceEquals(_lastKeyEventArgs, e))
+				HandleTextInput(sender, e);
+		}
+
 		void HandleTextInput(object sender, swi.TextCompositionEventArgs e)
 		{
+			_lastKeyEventArgs = e;
 			var tiargs = new TextInputEventArgs(e.Text);
 			Callback.OnTextInput(Widget, tiargs);
 			if (tiargs.Cancel)
@@ -875,6 +924,7 @@ namespace Eto.Wpf.Forms
 
 		void HandleKeyDown(object sender, swi.KeyEventArgs e)
 		{
+			_lastKeyEventArgs = e;
 			if (SuppressKeyEvents)
 				return;
 
@@ -888,9 +938,10 @@ namespace Eto.Wpf.Forms
 
 		void HandleKeyUp(object sender, swi.KeyEventArgs e)
 		{
+			_lastKeyEventArgs = e;
 			if (SuppressKeyEvents)
 				return;
-			
+
 			var args = e.ToEto(KeyEventType.KeyUp);
 			if (args.KeyData != Keys.None)
 			{

--- a/src/Eto.Wpf/Forms/WpfWindow.cs
+++ b/src/Eto.Wpf/Forms/WpfWindow.cs
@@ -84,6 +84,10 @@ namespace Eto.Wpf.Forms
 
 		protected override sw.FrameworkElement KeyEventControl => main;
 
+		// main is only in the route when something inside the window has keyboard focus, so hook the
+		// window itself as well to get the keys when focus is on the window.
+		protected override sw.FrameworkElement FallbackKeyEventControl => Control;
+
 		public bool MovableByWindowBackground
 		{
 			get => Widget.Properties.Get<bool>(WpfWindow.MovableByWindowBackground_Key);

--- a/test/Eto.Test.Wpf/UnitTests/KeyEventTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/KeyEventTests.cs
@@ -1,0 +1,75 @@
+using Eto.Test.UnitTests;
+using NUnit.Framework;
+using swi = System.Windows.Input;
+
+namespace Eto.Test.Wpf.UnitTests;
+
+[TestFixture]
+public class KeyEventTests : TestBase
+{
+	static void SendKeyDown(Window window, swi.Key key)
+	{
+		var control = (sw.Window)window.ControlObject;
+		var source = sw.PresentationSource.FromVisual(control);
+		var args = new swi.KeyEventArgs(swi.Keyboard.PrimaryDevice, source, 0, key)
+		{
+			RoutedEvent = swi.Keyboard.PreviewKeyDownEvent
+		};
+		swi.InputManager.Current.ProcessInput(args);
+	}
+
+	/// <summary>
+	/// Key events are hooked up on an inner element of the window, which is only in the routing path
+	/// when something inside the content has keyboard focus. When the window itself has focus (e.g.
+	/// when there is nothing focusable in its content) the events should still be raised.
+	/// </summary>
+	[Test]
+	public void KeyDownShouldFireWhenWindowItselfHasFocus() => Async(async () =>
+	{
+		var keys = new List<Keys>();
+		// no focusable controls, so keyboard focus stays on the window itself
+		var form = new Form { Content = new Label { Text = "Hello" } };
+		form.KeyDown += (sender, e) => keys.Add(e.KeyData);
+
+		form.Show();
+		await Task.Delay(100);
+
+		var control = (sw.Window)form.ControlObject;
+		Assert.That(swi.Keyboard.FocusedElement, Is.SameAs(control), "#1 Window itself should have keyboard focus");
+
+		SendKeyDown(form, swi.Key.Enter);
+		SendKeyDown(form, swi.Key.Escape);
+
+		Assert.That(keys, Is.EqualTo(new[] { Keys.Enter, Keys.Escape }), "#2 KeyDown should be raised once per key");
+
+		form.Close();
+	});
+
+	/// <summary>
+	/// The window is hooked up for key events twice (see <see cref="KeyDownShouldFireWhenWindowItselfHasFocus"/>),
+	/// so make sure only a single KeyDown is raised when focus is inside the content.
+	/// </summary>
+	[Test]
+	public void KeyDownShouldFireOnceWhenControlHasFocus() => Async(async () =>
+	{
+		var keys = new List<Keys>();
+		var textBox = new TextBox();
+		var form = new Form { Content = textBox };
+		form.KeyDown += (sender, e) => keys.Add(e.KeyData);
+
+		form.Show();
+		await Task.Delay(100);
+
+		textBox.Focus();
+		await Task.Delay(100);
+
+		var control = (sw.Window)form.ControlObject;
+		Assert.That(swi.Keyboard.FocusedElement, Is.Not.SameAs(control), "#1 Control should have keyboard focus");
+
+		SendKeyDown(form, swi.Key.Escape);
+
+		Assert.That(keys, Is.EqualTo(new[] { Keys.Escape }), "#2 KeyDown should only be raised once");
+
+		form.Close();
+	});
+}


### PR DESCRIPTION
We handle key events from the contents container first so we can override any menu/toolbar shortcuts, but then fallback to the window events in the event that no control has focus within the window.