### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,6 +13,9 @@ env:
   BuildConfiguration: "Release"
   BuildParameters: 'build/Build.proj /v:Minimal /consoleLoggerParameters:NoSummary /p:Configuration=Release "/p:BuildVersion=${{ github.run_id }}" "/p:BuildBranch=${{ github.ref }}"'
 
+permissions:
+  contents: read
+
 jobs:
   build-windows:
 
@@ -248,6 +251,8 @@ jobs:
     needs: [ build-windows, build-mac, build-linux ]
     runs-on: ubuntu-latest
     if: (github.event_name == 'push' && github.ref == 'refs/heads/develop') || (github.event_name == 'release' && github.event.action == 'published' && startsWith(github.ref, 'refs/tags/'))
+    permissions:
+      contents: write
     steps:
       - name: Download nuget artifacts
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Potential fix for [https://github.com/picoe/Eto/security/code-scanning/8](https://github.com/picoe/Eto/security/code-scanning/8)

Add explicit `permissions` blocks:

- At the **workflow root** (near top-level keys like `name`, `on`, `env`, `jobs`) set a restrictive baseline, e.g.:
  - `contents: read`
- At the **`publish` job** add a job-level override granting only what that job needs to upload release assets:
  - `contents: write`

This preserves existing functionality while enforcing least privilege:
- Build/test jobs inherit read-only token scope.
- Publish job gets the minimum write scope required for `softprops/action-gh-release@v2`.

File to change: **`.github/workflows/build.yml`**  
Regions to change:
1. Insert root-level `permissions` before `jobs:`.
2. Insert `permissions` within `jobs.publish` before `steps:`.

No imports/dependencies/methods are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
