### PR TITLE
Update templates to detect isNetCore for net10.0

### DIFF
--- a/src/Eto.Forms.Templates/content/App-CSharp/.template.config/template.json
+++ b/src/Eto.Forms.Templates/content/App-CSharp/.template.config/template.json
@@ -125,9 +125,22 @@
 			"type": "computed",
 			"value": "(Mode == \"json\")"
 		},
+		"TargetFramework": {
+			"type": "generated",
+			"generator": "coalesce",
+			"parameters": {
+				"sourceVariableName": "TargetFrameworkOverride",
+				"fallbackVariableName": "Framework"
+			}
+		},
 		"IsNetCore": {
-			"type": "computed",
-			"value": "(Framework >= \"net5\")"
+			"type": "generated",
+			"generator": "regexMatch",
+			"dataType": "bool",
+			"parameters": {
+				"source": "TargetFramework",
+				"pattern": "^net([5-9]|[1-9][0-9]+)\\."
+			}
 		},
 		"IsWindow": {
 			"type": "computed",

--- a/src/Eto.Forms.Templates/content/App-FSharp/.template.config/template.json
+++ b/src/Eto.Forms.Templates/content/App-FSharp/.template.config/template.json
@@ -125,9 +125,22 @@
 			"type": "computed",
 			"value": "(Mode == \"json\")"
 		},
+		"TargetFramework": {
+			"type": "generated",
+			"generator": "coalesce",
+			"parameters": {
+				"sourceVariableName": "TargetFrameworkOverride",
+				"fallbackVariableName": "Framework"
+			}
+		},
 		"IsNetCore": {
-			"type": "computed",
-			"value": "(Framework >= \"net5\")"
+			"type": "generated",
+			"generator": "regexMatch",
+			"dataType": "bool",
+			"parameters": {
+				"source": "TargetFramework",
+				"pattern": "^net([5-9]|[1-9][0-9]+)\\."
+			}
 		},
 		"IsWindow": {
 			"type": "computed",

--- a/src/Eto.Forms.Templates/content/App-VisualBasic/.template.config/template.json
+++ b/src/Eto.Forms.Templates/content/App-VisualBasic/.template.config/template.json
@@ -125,9 +125,22 @@
 			"type": "computed",
 			"value": "(Mode == \"json\")"
 		},
+		"TargetFramework": {
+			"type": "generated",
+			"generator": "coalesce",
+			"parameters": {
+				"sourceVariableName": "TargetFrameworkOverride",
+				"fallbackVariableName": "Framework"
+			}
+		},
 		"IsNetCore": {
-			"type": "computed",
-			"value": "(Framework >= \"net5\")"
+			"type": "generated",
+			"generator": "regexMatch",
+			"dataType": "bool",
+			"parameters": {
+				"source": "TargetFramework",
+				"pattern": "^net([5-9]|[1-9][0-9]+)\\."
+			}
 		},
 		"IsWindow": {
 			"type": "computed",


### PR DESCRIPTION
This also supports the TargetFrameworkOverride property, which is used when creating templates in VS or if you want to use a different framework than what is available.

Fixes #3044
Fixes #2931