### PR TITLE
Wpf: Add ability to override text formatting mode on FormattedText and Graphics

### DIFF
--- a/src/Eto.Wpf/Drawing/FontHandler.cs
+++ b/src/Eto.Wpf/Drawing/FontHandler.cs
@@ -377,6 +377,10 @@ namespace Eto.Wpf.Drawing
 		/// Since text Eto measures and draws itself is not part of any element, set this to the mode your text is
 		/// rendered with so that measuring and drawing match, e.g. using a style:
 		/// <code>Style.Add&lt;FontHandler&gt;(null, h => h.TextFormattingMode = TextFormattingMode.Display);</code>
+		/// Note this is what a <see cref="Graphics"/> falls back to: it lays text out with its own
+		/// <see cref="GraphicsHandler.TextFormattingMode"/> when one is set, and overrides display layout with
+		/// ideal layout when its transform scales or rotates what it draws, since display layout would be
+		/// rasterized for the wrong size and scaled up.
 		/// When specified, this mode is also set on the controls the font is applied to so they render the same
 		/// way, otherwise they keep inheriting the mode from their container.
 		/// </remarks>
@@ -425,7 +429,8 @@ namespace Eto.Wpf.Drawing
 		/// <param name="brush">Brush to draw the text with</param>
 		/// <param name="setDecorations">True to apply the decorations of the font, false to leave them out</param>
 		/// <param name="pixelsPerDip">Pixels per dip of what the text is drawn on, or null to use <see cref="PixelsPerDip"/></param>
-		public swm.FormattedText CreateFormattedText(string text, swm.Brush brush, bool setDecorations = true, double? pixelsPerDip = null)
+		/// <param name="formattingMode">Mode to lay the text out with, or null to use <see cref="TextFormattingMode"/></param>
+		public swm.FormattedText CreateFormattedText(string text, swm.Brush brush, bool setDecorations = true, double? pixelsPerDip = null, swm.TextFormattingMode? formattingMode = null)
 		{
 			text = text ?? string.Empty;
 			var formattedText = new swm.FormattedText(
@@ -436,7 +441,7 @@ namespace Eto.Wpf.Drawing
 				WpfSize,
 				brush,
 				null,
-				TextFormattingMode ?? swm.TextFormattingMode.Ideal,
+				formattingMode ?? TextFormattingMode ?? swm.TextFormattingMode.Ideal,
 				pixelsPerDip ?? PixelsPerDip);
 
 			if (setDecorations && WpfTextDecorationsFrozen != null)

--- a/src/Eto.Wpf/Drawing/FormattedTextHandler.cs
+++ b/src/Eto.Wpf/Drawing/FormattedTextHandler.cs
@@ -12,8 +12,34 @@ namespace Eto.Wpf.Drawing
 		bool _hasNewLines;
 		bool _shouldClip;
 		double? _pixelsPerDip;
+		swm.TextFormattingMode? _formattingMode;
+		swm.TextFormattingMode? _targetFormattingMode;
 		double _controlPixelsPerDip;
 		swm.TextFormattingMode _controlFormattingMode;
+
+		/// <summary>
+		/// Gets or sets the mode to lay this text out with, or null (the default) to use the mode of what it
+		/// is drawn on, falling back to the mode of its <see cref="Font"/>.
+		/// </summary>
+		/// <remarks>
+		/// <see cref="Measure"/> has to lay the text out before there is anything to draw it on, so a font
+		/// using <see cref="swm.TextFormattingMode.Display"/> measures with display metrics and is then laid
+		/// out again when it turns out to be drawn on something scaled.  Set this to measure and draw the
+		/// text the same way regardless - <see cref="swm.TextFormattingMode.Ideal"/> to be independent of
+		/// both the scale and the dpi.  It can be set from a style so drawing code doesn't have to reach for
+		/// the handler itself:
+		/// <code>Style.Add&lt;FormattedTextHandler&gt;("canvas", h => h.TextFormattingMode = TextFormattingMode.Ideal);</code>
+		/// </remarks>
+		public swm.TextFormattingMode? TextFormattingMode
+		{
+			get => _formattingMode;
+			set
+			{
+				_formattingMode = value;
+				ValidateTextFormatting();
+			}
+		}
+
 		public FormattedTextWrapMode Wrap
 		{
 			get => _wrap;
@@ -108,6 +134,13 @@ namespace Eto.Wpf.Drawing
 		}
 
 		/// <summary>
+		/// The mode to lay the text out with: what was asked for explicitly, otherwise the mode of what it is
+		/// drawn on, otherwise the mode of the font.
+		/// </summary>
+		swm.TextFormattingMode FormattingModeFor(FontHandler fontHandler)
+			=> _formattingMode ?? _targetFormattingMode ?? fontHandler.TextFormattingMode ?? swm.TextFormattingMode.Ideal;
+
+		/// <summary>
 		/// The formatting mode and dpi of a FormattedText can only be specified when it is created, so it has
 		/// to be recreated whenever either of them changes.
 		/// </summary>
@@ -116,7 +149,7 @@ namespace Eto.Wpf.Drawing
 			if (!HasControl || !(Font?.Handler is FontHandler fontHandler))
 				return;
 
-			if ((fontHandler.TextFormattingMode ?? swm.TextFormattingMode.Ideal) != _controlFormattingMode
+			if (FormattingModeFor(fontHandler) != _controlFormattingMode
 				|| (_pixelsPerDip ?? fontHandler.PixelsPerDip) != _controlPixelsPerDip)
 				Invalidate();
 		}
@@ -129,11 +162,11 @@ namespace Eto.Wpf.Drawing
 			_hasNewLines = text.IndexOf('\n') != -1;
 
 			var fontHandler = (FontHandler)font.Handler;
-			_controlFormattingMode = fontHandler.TextFormattingMode ?? swm.TextFormattingMode.Ideal;
+			_controlFormattingMode = FormattingModeFor(fontHandler);
 			_controlPixelsPerDip = _pixelsPerDip ?? fontHandler.PixelsPerDip;
 
 			// decorations are applied to the entire text by SetFont below
-			var formattedText = fontHandler.CreateFormattedText(text, ForegroundBrush.ToWpf(), setDecorations: false, pixelsPerDip: _controlPixelsPerDip);
+			var formattedText = fontHandler.CreateFormattedText(text, ForegroundBrush.ToWpf(), setDecorations: false, pixelsPerDip: _controlPixelsPerDip, formattingMode: _controlFormattingMode);
 
 			// support correctly showing ellipsis when there's a single line
 			if (Wrap == FormattedTextWrapMode.None)
@@ -226,8 +259,10 @@ namespace Eto.Wpf.Drawing
 
 		public void DrawText(GraphicsHandler handler, PointF location)
 		{
-			// lay the text out for the dpi of what we're drawing on now that we know it
+			// lay the text out for the dpi and formatting mode of what we're drawing on now that we know them,
+			// unless a mode was asked for explicitly - measuring has to agree with what is drawn
 			_pixelsPerDip = handler.TargetPixelsPerDip;
+			_targetFormattingMode = handler.TargetTextFormattingMode;
 			ValidateTextFormatting();
 
 			/**

--- a/src/Eto.Wpf/Drawing/GraphicsHandler.cs
+++ b/src/Eto.Wpf/Drawing/GraphicsHandler.cs
@@ -119,6 +119,43 @@ namespace Eto.Wpf.Drawing
 		/// </summary>
 		internal double? TargetPixelsPerDip => visual != null && Widget != null ? DPI : (double?)null;
 
+		/// <summary>
+		/// Gets or sets the mode to lay out all text drawn on this graphics with, or null (the default) to
+		/// decide from its transform.
+		/// </summary>
+		/// <remarks>
+		/// <see cref="swm.TextFormattingMode.Display"/> rasterizes the glyphs for the device pixel grid its
+		/// pixels per dip describes, and the result is then scaled by the transform of the context instead of
+		/// the glyphs being rendered at the size they are actually drawn at.  That makes text on a scaled
+		/// context - a canvas the user can zoom, say - come out blurry, so by default it is only kept while
+		/// the transform is a plain translation and text is laid out ideally otherwise.
+		///
+		/// That default changes mode as soon as the transform starts scaling, so text drawn on a canvas
+		/// shifts shape and width between 100% and 120% zoom.  Set this to lay every string out the same way
+		/// whatever the transform is - <see cref="swm.TextFormattingMode.Ideal"/> for a canvas that scales,
+		/// since it renders from the outlines and is resolution independent.  It can be set from a style so
+		/// drawing code doesn't have to reach for the handler itself:
+		/// <code>Style.Add&lt;GraphicsHandler&gt;("canvas", h => h.TextFormattingMode = TextFormattingMode.Ideal);</code>
+		/// </remarks>
+		public swm.TextFormattingMode? TextFormattingMode { get; set; }
+
+		/// <summary>
+		/// Gets the mode to lay text out with for what is being drawn on, or null when the font should decide.
+		/// </summary>
+		internal swm.TextFormattingMode? TargetTextFormattingMode
+		{
+			get
+			{
+				if (TextFormattingMode != null)
+					return TextFormattingMode;
+
+				var current = transforms?.Current;
+				if (current == null || (current.Xx == 1 && current.Yy == 1 && current.Xy == 0 && current.Yx == 0))
+					return null;
+				return swm.TextFormattingMode.Ideal;
+			}
+		}
+
 		public void DrawRectangle(Pen pen, float x, float y, float width, float height)
 		{
 			SetOffset(false);
@@ -317,7 +354,7 @@ namespace Eto.Wpf.Drawing
 			if (fontHandler != null)
 			{
 				var brush = b.ToWpf();
-				var formattedText = fontHandler.CreateFormattedText(text, brush, pixelsPerDip: TargetPixelsPerDip);
+				var formattedText = fontHandler.CreateFormattedText(text, brush, pixelsPerDip: TargetPixelsPerDip, formattingMode: TargetTextFormattingMode);
 				Control.DrawText(formattedText, new sw.Point(x, y));
 			}
 		}
@@ -330,7 +367,7 @@ namespace Eto.Wpf.Drawing
 			if (fontHandler != null)
 			{
 				var brush = new swm.SolidColorBrush(swm.Colors.White);
-				var formattedText = fontHandler.CreateFormattedText(text, brush, setDecorations: false, pixelsPerDip: TargetPixelsPerDip);
+				var formattedText = fontHandler.CreateFormattedText(text, brush, setDecorations: false, pixelsPerDip: TargetPixelsPerDip, formattingMode: TargetTextFormattingMode);
 				result = new SizeF((float)formattedText.WidthIncludingTrailingWhitespace, (float)formattedText.Height);
 			}
 

--- a/test/Eto.Test.Wpf/UnitTests/FontFormattingModeTests.cs
+++ b/test/Eto.Test.Wpf/UnitTests/FontFormattingModeTests.cs
@@ -274,5 +274,230 @@ namespace Eto.Test.Wpf.UnitTests
 				Assert.That(formattedText.Measure().Width, Is.EqualTo(expectedDisplay).Within(0.01), "#2 should use the mode of the new font");
 			});
 		}
+
+		[Test]
+		public void ScaledGraphicsShouldLayTextOutIdeally()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+				handler.TextFormattingMode = swm.TextFormattingMode.Display;
+
+				var display = ReferenceWidth(font, swm.TextFormattingMode.Display, 1);
+				var ideal = ReferenceWidth(font, swm.TextFormattingMode.Ideal, 1);
+				Assume.That(display, Is.Not.EqualTo(ideal), "the two modes should lay this text out differently, otherwise this proves nothing");
+
+				using (var bitmap = new Bitmap(400, 50, PixelFormat.Format32bppRgba))
+				using (var graphics = new Graphics(bitmap))
+				{
+					Assert.That(graphics.MeasureString(font, LongText).Width, Is.EqualTo(display).Within(0.01), "#1 unscaled should keep the mode of the font");
+
+					graphics.ScaleTransform(4);
+					// display layout rasterizes the glyphs for the pixel grid it is told about and the result is
+					// then scaled, so text on a scaled context has to be laid out ideally to stay sharp
+					Assert.That(graphics.MeasureString(font, LongText).Width, Is.EqualTo(ideal).Within(0.01), "#2 scaled should lay out ideally");
+					Assert.DoesNotThrow(() => graphics.DrawText(font, Colors.Black, 0, 0, LongText), "#3");
+
+					graphics.ScaleTransform(0.25f);
+					Assert.That(graphics.MeasureString(font, LongText).Width, Is.EqualTo(display).Within(0.01), "#4 back to unscaled should use the mode of the font again");
+				}
+			});
+		}
+
+		[Test]
+		public void TranslatedGraphicsShouldKeepFontFormattingMode()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+				handler.TextFormattingMode = swm.TextFormattingMode.Display;
+
+				var display = ReferenceWidth(font, swm.TextFormattingMode.Display, 1);
+				Assume.That(display, Is.Not.EqualTo(ReferenceWidth(font, swm.TextFormattingMode.Ideal, 1)), "the two modes should lay this text out differently, otherwise this proves nothing");
+
+				using (var bitmap = new Bitmap(400, 50, PixelFormat.Format32bppRgba))
+				using (var graphics = new Graphics(bitmap))
+				{
+					// a translation doesn't change the size the glyphs are rendered at, so there's no reason to
+					// lay the text out any differently than it is measured elsewhere
+					graphics.TranslateTransform(10, 20);
+					Assert.That(graphics.MeasureString(font, LongText).Width, Is.EqualTo(display).Within(0.01));
+				}
+			});
+		}
+
+		[Test]
+		public void FormattedTextOnScaledGraphicsShouldBeLaidOutIdeally()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var handler = GetHandler(font);
+				handler.TextFormattingMode = swm.TextFormattingMode.Display;
+				handler.PixelsPerDip = 1;
+
+				var display = ReferenceWidth(font, swm.TextFormattingMode.Display, 1);
+				var ideal = ReferenceWidth(font, swm.TextFormattingMode.Ideal, 1);
+				Assume.That(display, Is.Not.EqualTo(ideal), "the two modes should lay this text out differently, otherwise this proves nothing");
+
+				var formattedText = new FormattedText { Font = font, Text = LongText, Wrap = FormattedTextWrapMode.None };
+				Assert.That(formattedText.Measure().Width, Is.EqualTo(display).Within(0.01), "#1 should use the mode of the font until we know what it is drawn on");
+
+				using (var bitmap = new Bitmap(400, 50, PixelFormat.Format32bppRgba))
+				using (var graphics = new Graphics(bitmap))
+				{
+					graphics.ScaleTransform(4);
+					graphics.DrawText(formattedText, PointF.Empty);
+				}
+
+				Assert.That(formattedText.Measure().Width, Is.EqualTo(ideal).Within(0.01), "#2 should be laid out ideally for the scaled context it was drawn on");
+			});
+		}
+
+		[Test]
+		public void ForcedFormattingModeShouldOverrideTransform()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				GetHandler(font).TextFormattingMode = swm.TextFormattingMode.Display;
+
+				var display = ReferenceWidth(font, swm.TextFormattingMode.Display, 1);
+				var ideal = ReferenceWidth(font, swm.TextFormattingMode.Ideal, 1);
+				Assume.That(display, Is.Not.EqualTo(ideal), "the two modes should lay this text out differently, otherwise this proves nothing");
+
+				using (var bitmap = new Bitmap(400, 50, PixelFormat.Format32bppRgba))
+				using (var graphics = new Graphics(bitmap))
+				{
+					var handler = (GraphicsHandler)graphics.Handler;
+					Assume.That(handler.TextFormattingMode, Is.Null, "the transform should decide by default");
+
+					// forcing a mode keeps text laid out the same way at every zoom, rather than changing the
+					// moment the transform starts scaling
+					handler.TextFormattingMode = swm.TextFormattingMode.Ideal;
+					Assert.That(graphics.MeasureString(font, LongText).Width, Is.EqualTo(ideal).Within(0.01), "#1 unscaled should use the forced mode");
+					graphics.ScaleTransform(4);
+					Assert.That(graphics.MeasureString(font, LongText).Width, Is.EqualTo(ideal).Within(0.01), "#2 scaled should use the forced mode");
+
+					handler.TextFormattingMode = swm.TextFormattingMode.Display;
+					Assert.That(graphics.MeasureString(font, LongText).Width, Is.EqualTo(display).Within(0.01), "#3 should force display layout even though it is scaled");
+					Assert.DoesNotThrow(() => graphics.DrawText(font, Colors.Black, 0, 0, LongText), "#4");
+
+					handler.TextFormattingMode = null;
+					Assert.That(graphics.MeasureString(font, LongText).Width, Is.EqualTo(ideal).Within(0.01), "#5 clearing it should go back to deciding from the transform");
+				}
+			});
+		}
+
+		[Test]
+		public void ForcedFormattingModeShouldBeSettableFromStyle()
+		{
+			Invoke(() =>
+			{
+				var provider = new DefaultStyleProvider();
+				provider.Add<GraphicsHandler>("ideal-text", h => h.TextFormattingMode = swm.TextFormattingMode.Ideal);
+
+				var font = CreateFont();
+				GetHandler(font).TextFormattingMode = swm.TextFormattingMode.Display;
+				var ideal = ReferenceWidth(font, swm.TextFormattingMode.Ideal, 1);
+				Assume.That(ideal, Is.Not.EqualTo(ReferenceWidth(font, swm.TextFormattingMode.Display, 1)), "the two modes should lay this text out differently, otherwise this proves nothing");
+
+				var oldProvider = Style.Provider;
+				Style.Provider = provider;
+				try
+				{
+					using (var bitmap = new Bitmap(400, 50, PixelFormat.Format32bppRgba))
+					using (var graphics = new Graphics(bitmap))
+					{
+						// drawing code that can't reference the platform can still ask for a mode by style
+						graphics.Style = "ideal-text";
+						Assert.That(((GraphicsHandler)graphics.Handler).TextFormattingMode, Is.EqualTo(swm.TextFormattingMode.Ideal), "#1");
+						Assert.That(graphics.MeasureString(font, LongText).Width, Is.EqualTo(ideal).Within(0.01), "#2");
+					}
+				}
+				finally
+				{
+					Style.Provider = oldProvider;
+				}
+			});
+		}
+
+		[Test]
+		public void FormattedTextForcedModeShouldOverrideFontAndTarget()
+		{
+			Invoke(() =>
+			{
+				var font = CreateFont();
+				var fontHandler = GetHandler(font);
+				fontHandler.TextFormattingMode = swm.TextFormattingMode.Display;
+				fontHandler.PixelsPerDip = 1;
+
+				var display = ReferenceWidth(font, swm.TextFormattingMode.Display, 1);
+				var ideal = ReferenceWidth(font, swm.TextFormattingMode.Ideal, 1);
+				Assume.That(display, Is.Not.EqualTo(ideal), "the two modes should lay this text out differently, otherwise this proves nothing");
+
+				var formattedText = new FormattedText { Font = font, Text = LongText, Wrap = FormattedTextWrapMode.None };
+				var handler = (FormattedTextHandler)formattedText.Handler;
+				Assume.That(handler.TextFormattingMode, Is.Null, "the font and what it is drawn on should decide by default");
+				Assert.That(formattedText.Measure().Width, Is.EqualTo(display).Within(0.01), "#1 should use the mode of the font to begin with");
+
+				// asking for a mode means Measure() agrees with what is drawn, instead of being laid out again
+				// for whatever it turns out to be drawn on
+				handler.TextFormattingMode = swm.TextFormattingMode.Ideal;
+				Assert.That(formattedText.Measure().Width, Is.EqualTo(ideal).Within(0.01), "#2 should re-lay out with the mode asked for");
+
+				using (var bitmap = new Bitmap(400, 50, PixelFormat.Format32bppRgba))
+				using (var graphics = new Graphics(bitmap))
+				{
+					// neither an unscaled target, which would fall back to the display font..
+					graphics.DrawText(formattedText, PointF.Empty);
+					Assert.That(formattedText.Measure().Width, Is.EqualTo(ideal).Within(0.01), "#3 an unscaled target should not override it");
+
+					// ..nor one that forces display itself, should change what was asked for
+					((GraphicsHandler)graphics.Handler).TextFormattingMode = swm.TextFormattingMode.Display;
+					graphics.ScaleTransform(4);
+					graphics.DrawText(formattedText, PointF.Empty);
+					Assert.That(formattedText.Measure().Width, Is.EqualTo(ideal).Within(0.01), "#4 a target forcing display should not override it either");
+				}
+
+				handler.TextFormattingMode = null;
+				Assert.That(formattedText.Measure().Width, Is.EqualTo(display).Within(0.01), "#5 clearing it should go back to the mode of the font");
+			});
+		}
+
+		[Test]
+		public void FormattedTextForcedModeShouldBeSettableFromStyle()
+		{
+			Invoke(() =>
+			{
+				var provider = new DefaultStyleProvider();
+				provider.Add<FormattedTextHandler>("ideal-text", h => h.TextFormattingMode = swm.TextFormattingMode.Ideal);
+
+				var font = CreateFont();
+				var fontHandler = GetHandler(font);
+				fontHandler.TextFormattingMode = swm.TextFormattingMode.Display;
+				fontHandler.PixelsPerDip = 1;
+
+				var ideal = ReferenceWidth(font, swm.TextFormattingMode.Ideal, 1);
+				Assume.That(ideal, Is.Not.EqualTo(ReferenceWidth(font, swm.TextFormattingMode.Display, 1)), "the two modes should lay this text out differently, otherwise this proves nothing");
+
+				var oldProvider = Style.Provider;
+				Style.Provider = provider;
+				try
+				{
+					// SystemFonts.Label() and friends can't be styled at the point they're created, but the
+					// text laid out with them can
+					var formattedText = new FormattedText { Font = font, Text = LongText, Wrap = FormattedTextWrapMode.None, Style = "ideal-text" };
+					Assert.That(((FormattedTextHandler)formattedText.Handler).TextFormattingMode, Is.EqualTo(swm.TextFormattingMode.Ideal), "#1");
+					Assert.That(formattedText.Measure().Width, Is.EqualTo(ideal).Within(0.01), "#2");
+				}
+				finally
+				{
+					Style.Provider = oldProvider;
+				}
+			});
+		}
 	}
 }


### PR DESCRIPTION
In the case you can't always set the formatting mode on all font instances, you can now override what is used for `FormattedTextHandler` and `GraphicsHandler`.